### PR TITLE
Add pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,32 @@
+# Overview
+
+*Provide a brief overview of what your changes do, summarizing their effects
+and consequences.*
+
+# Reason for change
+
+*Describe how the current behaviour of the project is causing problems for you
+or is otherwise unsatisfactory for your use case.*
+
+# Description of change
+
+*Describe the intended behaviour your changes are meant to introduce to the
+project and explain how they resolve the problem stated above. Detail any
+relevant changes that may affect other users of the project, such as
+compilation options, runtime flags, expected inputs and outputs, API entry
+points, etc.*
+
+*If you have added new testing, provide details on what tests you have added
+and what the purpose of them is.*
+
+# Anything else we should know?
+
+*If there's any other relevant information we should know that may help us in
+understanding and verifying your patch, please include it here.*
+
+# Checklist
+
+* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
+* Make sure the project builds successfully with your changes.
+* Run relevant testing locally to avoid regressions.
+* Run [clang-format-9](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.


### PR DESCRIPTION
This patch adds a pull request template in order to make it clearer what information should be included when opening pull requests with code contributions.