### PR TITLE
Add contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,7 @@ helped make this a success.
 * Omar Ahmed
 * Ori Sky Farrell
 * Petr Vesely
-* Pierre-Andre Saulais
+* Pierre-André Saulais
 * Ross Brunton
 * Ruyman Reyes
 * Verena Beckham

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@ helped make this a success.
 * Omar Ahmed
 * Ori Sky Farrell
 * Petr Vesely
+* Pierre-Andre Saulais
 * Ross Brunton
 * Ruyman Reyes
 * Verena Beckham


### PR DESCRIPTION
Add a long-term contributor after receiving his greenlight to do so. Pierre-Andre has contributed to many areas in the oneAPI Construction Kit, including starting the vecz whole-function vectorizer, clik and many more features and bug-fixes.