### PR TITLE
Add contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ helped make this a success.
 * Jefferson le Quellec
 * Kenneth Benzie
 * Luke Drummond
+* Mark Miller
 * Martin Morrison-Grant
 * Marya Sharf
 * Neil Henning


### PR DESCRIPTION
Add another long-term contributor after receiving his approval.

Amongst other things, Mark worked on the host target's image support, Vulkan support, the compiler library, and lots of testing, benchmarking, and performance investigations.