### PR TITLE
[muxc] Refactor creation/setup methods

### DIFF
--- a/modules/compiler/test/lit/passes/pipeline-components.ll
+++ b/modules/compiler/test/lit/passes/pipeline-components.ll
@@ -15,13 +15,13 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: ca_llvm_options
-; RUN: env CA_LLVM_OPTIONS=-debug-pass-manager muxc --passes "mux-base<late-builtins>,verify" -S %s 2>&1 \
+; RUN: muxc --passes "mux-base<late-builtins>,verify" --debug-pass-manager %s 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix LATE-BUILTINS
-; RUN: env CA_LLVM_OPTIONS=-debug-pass-manager muxc --passes "mux-base<prepare-wg-sched>,verify" -S %s 2>&1 \
+; RUN: muxc --passes "mux-base<prepare-wg-sched>,verify" --debug-pass-manager %s 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix PREPARE-WG-SCHED
-; RUN: env CA_LLVM_OPTIONS=-debug-pass-manager muxc --passes "mux-base<wg-sched>,verify" -S %s 2>&1 \
+; RUN: muxc --passes "mux-base<wg-sched>,verify" --debug-pass-manager %s 2>&1 \
 ; RUN:   | FileCheck %s --check-prefixes PREPARE-WG-SCHED,WG-SCHED
-; RUN: env CA_LLVM_OPTIONS=-debug-pass-manager muxc --passes "mux-base<pre-vecz>,verify" -S %s 2>&1 \
+; RUN: muxc --passes "mux-base<pre-vecz>,verify" --debug-pass-manager %s 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix PRE-VECZ
 
 target triple = "spir64-unknown-unknown"

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -90,6 +90,11 @@ int main(int argc, char **argv) {
   muxc::driver driver;
   driver.parseArguments(argc, argv);
 
+  if (driver.createContext()) {
+    errs() << "Could not create compiler context\n";
+    return 1;
+  }
+
   // setupContext is only needed if we have a device
   if (!DeviceName.empty() || DeviceIdx >= 0) {
     if (driver.setupContext()) {
@@ -170,10 +175,10 @@ uint32_t detectBuiltinCapabilities(mux_device_info_t device_info) {
   return caps;
 }
 
-driver::driver()
-    : CompilerInfo(nullptr),
-      CompilerContext(compiler::createContext()),
-      CompilerModule(nullptr) {}
+result driver::createContext() {
+  CompilerContext = compiler::createContext();
+  return CompilerContext ? result::success : result::failure;
+}
 
 void driver::parseArguments(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);

--- a/modules/compiler/tools/muxc/muxc.h
+++ b/modules/compiler/tools/muxc/muxc.h
@@ -36,23 +36,15 @@ class driver {
   /// @brief Loads any arguments from command-line.
   void parseArguments(int argc, char **argv);
 
-  /// @brief Initializes the compiler context
-  ///
-  /// @return Returns a `muxc::result`.
-  result createContext();
-
-  /// @brief Initializes the right platform and device
-  ///
-  /// @return Returns a `muxc::result`.
-  result setupContext();
+  /// @brief Initializes all of the compiler components and LLVMContext
+  llvm::Error setupContext();
 
   /// @brief Converts the input file to an IR module.
   llvm::Expected<std::unique_ptr<llvm::Module>> convertInputToIR();
 
   /// @brief Create the pass machinery
-  ///
-  /// @return Returns a `PassMachinery` in a `unique_ptr`.
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery();
+  llvm::Expected<std::unique_ptr<compiler::utils::PassMachinery>>
+  createPassMachinery();
 
   /// @brief Run the pass pipeline provided
   llvm::Error runPipeline(llvm::Module &, compiler::utils::PassMachinery &);

--- a/modules/compiler/tools/muxc/muxc.h
+++ b/modules/compiler/tools/muxc/muxc.h
@@ -31,7 +31,7 @@ enum result : int { success = 0, failure = 1 };
 class driver {
  public:
   /// @brief Default constructor.
-  driver();
+  driver() {}
 
   /// @brief Loads any arguments from command-line.
   void parseArguments(int argc, char **argv);


### PR DESCRIPTION
 This commit refactors how muxc sets up its machinery. It now creates
everything required by the driver in one place: setupContext. This makes
it easier to track the context and see what's intitialized when.

It also now parses the input file before creating the pass machinery.
This more closely resembles the compiler flow, allowing us to bring the
two frameworks closer together.

This allows us to use three LLVM options checked by the BaseContext
constructor in a more intuitive way, i.e., without using
CA_LLVM_OPTIONS.