### PR TITLE
Modify the Run Cities script to work with SYCL-CTS

### DIFF
--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -43,7 +43,7 @@ class CTSTestRun(TestRunBase):
         stream = io.BytesIO(self.output)
         # Extended pass_single_pattern. See Redmine issue #6542.
         pass_single_pattern = re.compile(
-            b"^(PASSED .+\.|.+PASSED\.?|passed .+\.|.+passed\.?)$")
+            b"^(PASSED .+\.|.+PASSED\.?|passed .+\.|.+passed\.?)|All tests passed \(.*\)$")
         pass_pair_pattern = re.compile(b"^PASSED (\d+) of (\d+) tests\.$")
         fail_single_pattern = re.compile(b"^(FAILED .+\.|.+FAILED\.?)$")
         fail_pair_pattern = re.compile(b"^FAILED (\d+) of (\d+) tests\.$")

--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -18,6 +18,7 @@ import copy
 import datetime
 import xml.etree.cElementTree as ET
 import re
+import shlex
 
 
 class TestExecutable(object):
@@ -165,7 +166,7 @@ class TestList(object):
                     arguments = []
                 else:
                     executable_name = argv[:executable_name_len]
-                    arguments = argv[executable_name_len + 1:].split(" ")
+                    arguments = shlex.split(argv[executable_name_len + 1:], False)
                 try:
                     executable = executables[executable_name]
                 except KeyError:


### PR DESCRIPTION
# Overview

Modify the City Runner test scripts for use with SYCL-CTS.

# Reason for change

SYCL-CTS tests produce a different format of output, requiring different parsing to identify passing tests. Furthermore, test names can be more complex, including whitespace and punctuation characters, so the entries in the CSV test list file need to be parsed more carefully.

# Description of change

The City Runner will now accept as passing a test that outputs "All tests passed".

The City Runner will now accept quoted and escaped strings containing spaces as part of the test command line arguments column in the CSV file.
