### PR TITLE
[cl] Add stub files for the cl_intel_required_subgroup_size extension

### DIFF
--- a/source/cl/source/extension/CMakeLists.txt
+++ b/source/cl/source/extension/CMakeLists.txt
@@ -30,6 +30,7 @@ set(RUNTIME_EXTENSIONS
   codeplay_kernel_exec_info
   codeplay_performance_counters
   codeplay_soft_math
+  intel_required_subgroup_size
   intel_unified_shared_memory
   khr_command_buffer
   khr_command_buffer_mutable_dispatch
@@ -58,9 +59,11 @@ endforeach()
 # Create an individual option for each extension in the list.
 foreach(extension ${RUNTIME_EXTENSIONS} ${COMPILER_EXTENSIONS})
   if(${extension} STREQUAL "khr_command_buffer"
-    OR ${extension} STREQUAL "khr_command_buffer_mutable_dispatch")
+    OR ${extension} STREQUAL "khr_command_buffer_mutable_dispatch"
+    OR ${extension} STREQUAL "intel_required_subgroup_size")
     # TODO Enable `khr_command_buffer` and any layered extensions
     # by default once complete.
+    # TODO Enable `intel_required_subgroup_size` by default once complete.
     ca_option(OCL_EXTENSION_cl_${extension} BOOL
         "OpenCL extension cl_${extension}" OFF)
   else()
@@ -177,9 +180,11 @@ foreach(tag ${CA_CL_RUNTIME_EXTENSION_TAGS})
 endforeach()
 
 set(EXTENSION_COMPILER_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/extension/intel_required_subgroup_size.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/extension/khr_extended_async_copies.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/extension/khr_il_program.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/extension/khr_spir.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/intel_required_subgroup_size.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/khr_extended_async_copies.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/khr_il_program.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/khr_spir.cpp)

--- a/source/cl/source/extension/include/extension/extension.h
+++ b/source/cl/source/extension/include/extension/extension.h
@@ -364,6 +364,38 @@ class extension {
                                   size_t param_value_size, void *param_value,
                                   size_t *param_value_size_ret) const;
 
+#if defined(CL_VERSION_3_0)
+  /// @brief Query for kernel subgroup info.
+  ///
+  /// @see clGetKernelSubGroupInfo.
+  ///
+  /// @param[in] kernel OpenCL kernel to query.
+  /// @param[in] device Identifies device in device list associated with @p
+  /// kernel.
+  /// @param[in] input_value_size Size in bytes of memory pointed to by
+  /// input_value.
+  /// @param[in] input_value Pointer to memory where parameterization of query
+  /// is passed from.
+  /// @param[in] param_name Specific information to query for.
+  /// @param[in] param_value_size Size of memory area pointed to by param_value.
+  /// Can be 0 if param_value is nullptr.
+  /// @param[out] param_value Memory area to store the query result in.
+  /// @param[out] param_value_size_ret Points to memory area to store the
+  /// minimally required param_value size in. Can be nullptr.
+  ///
+  /// @return Returns CL_SUCCESS if the extension accepts the param_name query
+  /// and the supplied argument values. CL_INVALID_VALUE if the extension does
+  /// not accept the param_name query. Other OpenCL error return code if the
+  /// extension accepts param_name but the supplied argument values are wrong.
+  virtual cl_int GetKernelSubGroupInfo(cl_kernel kernel, cl_device_id device,
+                                       cl_kernel_sub_group_info param_name,
+                                       size_t input_value_size,
+                                       const void *input_value,
+                                       size_t param_value_size,
+                                       void *param_value,
+                                       size_t *param_value_size_ret) const;
+#endif
+
 #if (defined(CL_VERSION_3_0) || \
      defined(OCL_EXTENSION_cl_codeplay_kernel_exec_info))
   /// @brief Passes additional information other than argument values to a
@@ -648,6 +680,28 @@ cl_int SetKernelArg(cl_kernel kernel, cl_uint arg_index, size_t arg_size,
 cl_int GetKernelArgInfo(cl_kernel kernel, cl_uint arg_indx,
                         cl_kernel_arg_info param_name, size_t param_value_size,
                         void *param_value, size_t *param_value_size_ret);
+
+#if defined(CL_VERSION_3_0)
+/// @brief Aggregate all kernel sub group information.
+///
+/// @param kernel Kernel to query.
+/// @param device Device being targeted.
+/// @param param_name Parameter name to query.
+/// @param input_value_size Size in bytes of memory pointed to by
+/// input_value.
+/// @param input_value Pointer to memory where parameterization of query is
+/// passed from.
+/// @param param_value_size Size of `param_value` storage.
+/// @param param_value Storage for returned value.
+/// @param param_value_size_ret Required size of `param_value`.
+///
+/// @return Returns `CL_SUCCESS` or `CL_INVALID_VALUE`.
+cl_int GetKernelSubGroupInfo(cl_kernel kernel, cl_device_id device,
+                             cl_kernel_sub_group_info param_name,
+                             size_t input_value_size, const void *input_value,
+                             size_t param_value_size, void *param_value,
+                             size_t *param_value_size_ret);
+#endif
 
 #if (defined(CL_VERSION_3_0) || \
      defined(OCL_EXTENSION_cl_codeplay_kernel_exec_info))

--- a/source/cl/source/extension/include/extension/intel_required_subgroup_size.h
+++ b/source/cl/source/extension/include/extension/intel_required_subgroup_size.h
@@ -1,0 +1,125 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+/// @file
+///
+/// @brief Functions for cl_intel_required_subgroup_size extension.
+
+#ifndef EXTENSION_INTEL_REQUIRED_SUBGROUP_SIZE_H_INCLUDED
+#define EXTENSION_INTEL_REQUIRED_SUBGROUP_SIZE_H_INCLUDED
+
+#include <extension/extension.h>
+
+namespace extension {
+/// @addtogroup cl_extension
+/// @{
+
+/// @brief Definition of the cl_intel_required_subgroup_size extension.
+class intel_required_subgroup_size final : public extension {
+ public:
+  /// @brief Default constructor.
+  intel_required_subgroup_size();
+
+  /// @brief Queries for extension provided device info.
+  ///
+  /// If enabled, then `GetDeviceInfo` queries for `CL_DEVICE_EXTENSIONS` return
+  /// `"cl_intel_required_subgroup_size"` as the query value. Queries for
+  /// `CL_DEVICE_SUB_GROUP_SIZES_INTEL` return an array of `size_t` values with
+  /// the supported sub-group sizes.
+  ///
+  /// @see `::extension::extension::GetDeviceInfo` for more detailed
+  /// explanations.
+  ///
+  /// @param[in] device OpenCL device to query.
+  /// @param[in] param_name Information to query for, e.g.:
+  /// * CL_DEVICE_EXTENSIONS
+  /// * CL_DEVICE_SUB_GROUP_SIZES_INTEL
+  /// @param[in] param_value_size Size in bytes of the memory area param_value
+  /// points to.
+  /// @param[in] param_value Memory area to copy the queried info in or nullptr
+  /// to not receive the info value.
+  /// @param[out] param_value_size_ret References variable where to store the
+  /// size of the info value or nullptr to not receive the info value.
+  ///
+  /// @return Returns an OpenCL error code.
+  /// @retval `CL_SUCCESS` if the extension accepts the param_name query
+  /// and the supplied argument values.
+  /// @retval `CL_INVALID_VALUE` if the extension does not accept the
+  /// `param_name` query.
+  cl_int GetDeviceInfo(cl_device_id device, cl_device_info param_name,
+                       size_t param_value_size, void *param_value,
+                       size_t *param_value_size_ret) const override;
+
+  /// @brief Query for extension provided kernel work group info.
+  ///
+  /// @see `::extension::extension::GetKernelWorkGroupInfo` for more detailed
+  /// explanations.
+  ///
+  /// @param[in] kernel OpenCL kernel to query.
+  /// @param[in] device Specific device to take into account for kernel work
+  /// group information.
+  /// @param[in] param_name Specific information to query for.
+  /// @param[in] param_value_size Size of memory area pointed to by param_value.
+  /// Can be 0 if param_value is nullptr.
+  /// @param[out] param_value Memory area to store the query result in.
+  /// @param[out] param_value_size_ret Points to memory area to store the
+  /// minimally required param_value size in. Can be nullptr.
+  ///
+  /// @return Returns CL_SUCCESS if the extension accepts the param_name query
+  /// and the supplied argument values. CL_INVALID_VALUE if the extension does
+  /// not accept the param_name query. Other OpenCL error return code if the
+  /// extension accepts param_name but the supplied argument values are wrong.
+  virtual cl_int GetKernelWorkGroupInfo(
+      cl_kernel kernel, cl_device_id device,
+      cl_kernel_work_group_info param_name, size_t param_value_size,
+      void *param_value, size_t *param_value_size_ret) const override;
+
+#if defined(CL_VERSION_3_0)
+  /// @brief Query for extension provided kernel subgroup info.
+  ///
+  /// @see `::extension::extension::GetKernelSubGroupInfo` for more detailed
+  /// explanations.
+  ///
+  /// @param[in] kernel OpenCL kernel to query.
+  /// @param[in] device Identifies device in device list associated with @p
+  /// kernel.
+  /// @param[in] param_name Specific information to query for.
+  /// @param[in] input_value_size Size in bytes of memory pointed to by
+  /// input_value.
+  /// @param[in] input_value Pointer to memory where parameterization of query
+  /// is passed from.
+  /// @param[in] param_value_size Size of memory area pointed to by param_value.
+  /// Can be 0 if param_value is nullptr.
+  /// @param[out] param_value Memory area to store the query result in.
+  /// @param[out] param_value_size_ret Points to memory area to store the
+  /// minimally required param_value size in. Can be nullptr.
+  ///
+  /// @return Returns CL_SUCCESS if the extension accepts the param_name query
+  /// and the supplied argument values. CL_INVALID_VALUE if the extension does
+  /// not accept the param_name query. Other OpenCL error return code if the
+  /// extension accepts param_name but the supplied argument values are wrong.
+  virtual cl_int GetKernelSubGroupInfo(
+      cl_kernel kernel, cl_device_id device,
+      cl_kernel_sub_group_info param_name, size_t input_value_size,
+      const void *input_value, size_t param_value_size, void *param_value,
+      size_t *param_value_size_ret) const override;
+#endif
+};
+
+/// @}
+}  // namespace extension
+
+#endif  // EXTENSION_INTEL_REQUIRED_SUBGROUP_SIZE_H_INCLUDED

--- a/source/cl/source/extension/source/extension.cpp.in
+++ b/source/cl/source/extension/source/extension.cpp.in
@@ -102,6 +102,13 @@ inline cl_int GetObjectDetailExtensionInfoSingleValue(
     T object, D detail, N param_name, const size_t param_value_size,
     void* param_value, size_t* param_value_size_ret, F get_info_fn);
 
+template <typename T, typename D, typename N, typename F>
+inline cl_int GetObjectDetailExtensionInfoSingleInputValue(
+    const size_t num_extensions, const extension::extension *const *extensions,
+    T object, D detail, N param_name, const size_t input_value_size,
+    const void *input_value, const size_t param_value_size, void *param_value,
+    size_t *param_value_size_ret, F get_info_fn);
+
 template <typename T, typename N, typename F>
 inline cl_int GetObjectExtensionInfoAggregatedCString(
     const size_t num_extensions, const extension::extension* const* extensions,
@@ -242,6 +249,85 @@ cl_int GetObjectDetailExtensionInfoSingleValue(
                               num_extensions - ext_idx - 1,
                               extensions + ext_idx + 1, object, detail,
                               param_name, 0, nullptr, nullptr, get_info_fn),
+        "More than one extension should not support the same info query, "
+        "otherwise results are order dependent which is confusing.");
+
+    // One extension supporting the info query or one error is enough to stop
+    // the search.
+    break;
+  }
+
+  return retcode;
+}
+
+/// @brief Query all passed in extensions via the get_info_fn functor/lambda
+/// until one accepts the query.
+///
+/// Query for details from OpenCL objects, e.g., applicable to the following
+/// info queries:
+/// * clGetKernelSubGroupInfo,
+///
+/// If no extension in extensions accepts the param_name query, then
+/// CL_INVALID_VALUE is returned.
+///
+/// @see OpenCL clGet...Info calls listed above for more in-detail explanations
+/// of param_name, param_value_size, param_value, param_value_size_ret, and
+/// possible return codes.
+///
+/// @tparam T Type of the OpenCL object, e.g., cl_platform.
+/// @tparam D Type of the detail info to query for.
+/// @tparam N Type of the param_name to query for.
+/// @tparam F Type of the function/functor/lambda to use for the
+///                  query.
+/// @param[in] num_extensions Number of extensions to query.
+/// @param[in] extensions Contiguous memory area containing num_extensions
+/// Extension pointers to query.
+/// @param[in] object OpenCL object to query.
+/// @param[in] detail Detail info to query for.
+/// @param[in] param_name Specific information to query for.
+/// @param[in] param_value_size Size of memory area pointed to by param_value.
+/// Can be 0 if param_value is nullptr.
+/// @param[out] param_value Memory area to store the query result in.
+/// @param[out] param_value_size_ret Points to memory area to store the
+/// minimally required param_value size in. Can be nullptr.
+/// @param[in] get_info_fn Function pointer, functor, or lambda which is called
+/// for every extension.
+///
+/// @return Returns CL_SUCCESS if an extension accepts the param_name query and
+/// the supplied argument values. CL_INVALID_VALUE if no extension accepts the
+/// param_name query. Other OpenCL error return code if an extension accepts
+/// param_name but the supplied argument values are wrong.
+template <typename T, typename D, typename N, typename F>
+cl_int GetObjectDetailExtensionInfoSingleInputValue(
+    const size_t num_extensions, const extension::extension *const *extensions,
+    T object, D detail, N param_name, const size_t input_value_size,
+    const void *input_value, const size_t param_value_size, void *param_value,
+    size_t *param_value_size_ret, F get_info_fn) {
+  cl_int retcode = CL_INVALID_VALUE;
+  size_t ext_idx = 0;
+  for (ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
+    cl_int supported_retcode =
+        get_info_fn(extensions[ext_idx], object, detail, param_name, 0, nullptr,
+                    0, nullptr, nullptr);
+    if (CL_SUCCESS != supported_retcode) {
+      // This extension does not support the info query, keep searching.
+      continue;
+    }
+
+    // Do query.
+    retcode = get_info_fn(extensions[ext_idx], object, detail, param_name,
+                          input_value_size, input_value, param_value_size,
+                          param_value, param_value_size_ret);
+
+    // More than one extension shouldn't support the same info query,
+    // otherwise results are order dependent which is confusing.
+    OCL_ASSERT(
+        CL_SUCCESS != retcode ||
+            CL_SUCCESS != GetObjectDetailExtensionInfoSingleInputValue(
+                              num_extensions - ext_idx - 1,
+                              extensions + ext_idx + 1, object, detail,
+                              param_name, 0, nullptr, 0, nullptr, nullptr,
+                              get_info_fn),
         "More than one extension should not support the same info query, "
         "otherwise results are order dependent which is confusing.");
 
@@ -653,6 +739,15 @@ cl_int extension::extension::GetKernelArgInfo(cl_kernel, cl_uint,
   return CL_INVALID_VALUE;
 }
 
+#if defined(CL_VERSION_3_0)
+cl_int extension::extension::GetKernelSubGroupInfo(cl_kernel, cl_device_id,
+                                                   cl_kernel_sub_group_info,
+                                                   size_t, const void *, size_t,
+                                                   void *, size_t *) const {
+  return CL_INVALID_VALUE;
+}
+#endif
+
 #if (defined(CL_VERSION_3_0) || \
      defined(OCL_EXTENSION_cl_codeplay_kernel_exec_info))
 cl_int extension::extension::SetKernelExecInfo(cl_kernel, cl_kernel_exec_info_codeplay,
@@ -953,6 +1048,28 @@ cl_int extension::GetKernelArgInfo(cl_kernel kernel, cl_uint arg_indx,
       param_name, param_value_size, param_value, param_value_size_ret,
       query_fn);
 }
+
+#if defined(CL_VERSION_3_0)
+cl_int extension::GetKernelSubGroupInfo(
+    cl_kernel kernel, cl_device_id device, cl_kernel_sub_group_info param_name,
+    size_t input_value_size, const void *input_value, size_t param_value_size,
+    void *param_value, size_t *param_value_size_ret) {
+  auto query_fn = [](const extension *extension, cl_kernel object,
+                     cl_device_id detail, cl_kernel_sub_group_info param_name,
+                     size_t input_value_size, const void *input_value,
+                     size_t param_value_size, void *param_value,
+                     size_t *param_value_size_ret) {
+    return extension->GetKernelSubGroupInfo(
+        object, detail, param_name, input_value_size, input_value,
+        param_value_size, param_value, param_value_size_ret);
+  };
+
+  return GetObjectDetailExtensionInfoSingleInputValue(
+      getExtensions().size(), getExtensions().data(), kernel, device,
+      param_name, input_value_size, input_value, param_value_size, param_value,
+      param_value_size_ret, query_fn);
+}
+#endif
 
 #if (defined(CL_VERSION_3_0) || \
      defined(OCL_EXTENSION_cl_codeplay_kernel_exec_info))

--- a/source/cl/source/extension/source/intel_required_subgroup_size.cpp
+++ b/source/cl/source/extension/source/intel_required_subgroup_size.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <CL/cl_ext.h>
+#include <cl/device.h>
+#include <cl/kernel.h>
+#include <extension/intel_required_subgroup_size.h>
+
+extension::intel_required_subgroup_size::intel_required_subgroup_size()
+    : extension("cl_intel_required_subgroup_size",
+#ifdef OCL_EXTENSION_cl_intel_required_subgroup_size
+                usage_category::DEVICE
+#else
+                usage_category::DISABLED
+#endif
+                    CA_CL_EXT_VERSION(1, 0, 0)) {
+}
+
+cl_int extension::intel_required_subgroup_size::GetDeviceInfo(
+    cl_device_id device, cl_device_info param_name, size_t param_value_size,
+    void *param_value, size_t *param_value_size_ret) const {
+  // Only report extension if the extension wasn't disabled in cmake.
+  if (usage_category::DISABLED == usage) {
+    return CL_INVALID_VALUE;
+  }
+#if !defined(CL_VERSION_3_0)
+  return CL_INVALID_VALUE;
+#endif
+
+  if (CL_DEVICE_SUB_GROUP_SIZES_INTEL == param_name) {
+    // TODO: Query the device for the sizes it reports. This just sets the sizes
+    // to zero so we report nothing.
+    uint64_t num_sizes = 0;
+    const size_t param_size = num_sizes * sizeof(size_t);
+    OCL_CHECK(param_value && (param_value_size < param_size),
+              return CL_INVALID_VALUE);
+    if (param_value) {
+      std::vector<uint32_t> sg_sizes(num_sizes);
+      std::copy_n(sg_sizes.begin(), param_value_size / sizeof(size_t),
+                  static_cast<size_t *>(param_value));
+    }
+    OCL_SET_IF_NOT_NULL(param_value_size_ret, param_size);
+    return CL_SUCCESS;
+  }
+
+  return extension::GetDeviceInfo(device, param_name, param_value_size,
+                                  param_value, param_value_size_ret);
+}
+
+cl_int extension::intel_required_subgroup_size::GetKernelWorkGroupInfo(
+    cl_kernel kernel, cl_device_id device, cl_kernel_work_group_info param_name,
+    size_t param_value_size, void *param_value,
+    size_t *param_value_size_ret) const {
+  // Only report extension if the extension wasn't disabled in cmake.
+  if (usage_category::DISABLED == usage) {
+    return CL_INVALID_VALUE;
+  }
+#if !defined(CL_VERSION_3_0)
+  return CL_INVALID_VALUE;
+#endif
+
+  if (CL_KERNEL_SPILL_MEM_SIZE_INTEL == param_name) {
+    OCL_SET_IF_NOT_NULL(param_value_size_ret, sizeof(cl_ulong));
+    OCL_CHECK(param_value && param_value_size < sizeof(cl_ulong),
+              return CL_INVALID_VALUE);
+
+    // We don't (currently) support this query, so return a garbage value. Note
+    // we can't return 0 as that would "indicate that compiler was able to
+    // compile the kernel to fit into the device’s register file without
+    // spilling registers to memory".
+    OCL_SET_IF_NOT_NULL((reinterpret_cast<cl_ulong *>(param_value)), -1);
+    return CL_SUCCESS;
+  }
+
+  return extension::GetKernelWorkGroupInfo(kernel, device, param_name,
+                                           param_value_size, param_value,
+                                           param_value_size_ret);
+}
+
+#if defined(CL_VERSION_3_0)
+cl_int extension::intel_required_subgroup_size::GetKernelSubGroupInfo(
+    cl_kernel kernel, cl_device_id device, cl_kernel_sub_group_info param_name,
+    size_t input_value_size, const void *input_value, size_t param_value_size,
+    void *param_value, size_t *param_value_size_ret) const {
+  // Only report extension if the extension wasn't disabled in cmake.
+  if (usage_category::DISABLED == usage) {
+    return CL_INVALID_VALUE;
+  }
+
+  if (CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL == param_name) {
+    OCL_SET_IF_NOT_NULL(param_value_size_ret, sizeof(size_t));
+    OCL_CHECK(param_value && param_value_size < sizeof(size_t),
+              return CL_INVALID_VALUE);
+
+    OCL_ASSERT(kernel, "No kernel was provided");
+    // TODO: Query the kernel for the attribute value it was given.
+    OCL_SET_IF_NOT_NULL((reinterpret_cast<size_t *>(param_value)), 0);
+    return CL_SUCCESS;
+  }
+
+  return extension::GetKernelSubGroupInfo(
+      kernel, device, param_name, input_value_size, input_value,
+      param_value_size, param_value, param_value_size_ret);
+}
+#endif

--- a/source/cl/source/opencl-3.0.cpp
+++ b/source/cl/source/opencl-3.0.cpp
@@ -327,9 +327,6 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetKernelSubGroupInfo(
   OCL_CHECK(0 == device->max_num_sub_groups, return CL_INVALID_OPERATION);
 
   switch (param_name) {
-    default: {
-      return CL_INVALID_VALUE;
-    }
     case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE: {
       OCL_CHECK(param_value && (param_value_size < sizeof(size_t)),
                 return CL_INVALID_VALUE);
@@ -430,6 +427,11 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetKernelSubGroupInfo(
       }
       OCL_SET_IF_NOT_NULL(param_value_size_ret, sizeof(size_t));
     } break;
+    default: {
+      return extension::GetKernelSubGroupInfo(
+          kernel, device, param_name, input_value_size, input_value,
+          param_value_size, param_value, param_value_size_ret);
+    }
   }
   return CL_SUCCESS;
 }


### PR DESCRIPTION
This requires a new extension entry-point for clGetKernelSubGroupInfo.

Disabled by default until the implementation is complete.