### PR TITLE
Remove requirement on spirv-tools

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -24,7 +24,7 @@ configuration.
 
 * `GCC <https://gcc.gnu.org/>`_
 * `Git`_
-* `CMake`_ 3.4.3+
+* `CMake`_ 3.16+
 * `Python`_ 3.6.9+
 * `Vulkan SDK`_ 1.1.97+ or `SPIRV-Tools`_ v2019.2+ for OpenCL only
 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -26,7 +26,6 @@ configuration.
 * `Git`_
 * `CMake`_ 3.16+
 * `Python`_ 3.6.9+
-* `Vulkan SDK`_ 1.1.97+ or `SPIRV-Tools`_ v2019.2+ for OpenCL only
 
 .. code-block:: console
 
@@ -206,10 +205,12 @@ SPIRV-Tools
 -----------
 
 When OpenCL support is required but Vulkan support is not, `SPIRV-Tools`_
-**must** be installed on the system :envvar:`PATH`. Follow the build
-instructions, or install the pre-built binaries in the repository. It's harder
-to pin down versions of `SPIRV-Tools`_ since they don't do releases, but we
-should support any commit from after January 2019.
+**may** optionally be installed on the system :envvar:`PATH`. This is
+recommended to achieve good coverage of SPIR-V compilation paths.
+
+Follow the build instructions, or install the pre-built binaries in the
+repository. It's harder to pin down versions of `SPIRV-Tools`_ since they don't
+do releases, but we should support any commit from after January 2019.
 
 Ubuntu 20.04 users can install ``spirv-tools`` from the package repository:
 

--- a/examples/technical_blogs/refsi_simple_blog1/Dockerfile
+++ b/examples/technical_blogs/refsi_simple_blog1/Dockerfile
@@ -28,7 +28,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Requirements
 RUN apt update -y && apt install -y build-essential git cmake libtinfo-dev python3 \
   ninja-build doxygen python3-pip
-RUN apt install -y wget spirv-tools libzstd-dev libtinfo5
+RUN apt install -y wget libzstd-dev libtinfo5
 RUN pip3 install lit virtualenv cmakelint cookiecutter
 
 # Set the appropriate env variables

--- a/modules/compiler/spirv-ll/test/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/CMakeLists.txt
@@ -15,22 +15,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 set(SUITE spirv-ll)
 
-find_package(SpirvTools COMPONENTS spirv-as)
-if(NOT TARGET spirv::spirv-as)
-  message(WARNING "${SUITE} some lit tests unsupported: spirv-as not found")
-  return()
-endif()
-
 find_program(glslangValidator_EXECUTABLE
   NAMES glslangValidator PATHS ENV VULKAN_SDK PATH_SUFFIXES bin
   CMAKE_FIND_ROOT_PATH_BOTH)
 if(glslangValidator_EXECUTABLE STREQUAL
     glslangValidator_EXECUTABLE-NOTFOUND)
   set(GLSL_UNSUPPORTED True)
+  message(WARNING "${SUITE} glsl lit tests unsupported: glslangValidator not found")
 else()
   set(GLSL_UNSUPPORTED False)
 endif()
 
+find_package(SpirvTools COMPONENTS spirv-as)
 if(TARGET spirv::spirv-as)
   # Create custom commands to assemble .spvasm files in .spv.
   set(SPVASM_UNSUPPORTED False)
@@ -47,6 +43,7 @@ if(TARGET spirv::spirv-as)
   message(STATUS "spirv-as: v${SpirvAsVersionYear}.${SpirvAsVersionRelease}")
 else()
   set(SPVASM_UNSUPPORTED True)
+  message(WARNING "${SUITE} spvasm lit tests unsupported: spirv-as not found")
 endif()
 
 # Create the test/test inputs directories and set the relevent variables

--- a/source/cl/test/UnitCL/kernels/CMakeLists.txt
+++ b/source/cl/test/UnitCL/kernels/CMakeLists.txt
@@ -18,18 +18,10 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/ExtractReqsOpts.cmake")
 find_package(SpirvTools COMPONENTS spirv-as)
 if(TARGET spirv::spirv-as)
   target_compile_definitions(UnitCL PRIVATE UNITCL_SPIRV_ENABLED)
-else()
-  if(OCL_EXTENSION_cl_khr_il_program)
-    message(FATAL_ERROR "SPIRV-Tools not found, UnitCL SPIR-V tests cannot run."
-                        " To run SPIR-V tests get SPIRV-Tools from here: "
-                        "https://github.com/KhronosGroup/SPIRV-Tools. "
-                        "Alternatively, configure with "
-                        "-DOCL_EXTENSION_cl_khr_il_program=OFF.")
-  else()
-    message(WARNING "SPIRV-Tools not found, UnitCL SPIR-V tests will not run. "
-                    "To run SPIR-V tests get SPIRV-Tools from here: "
-                    "https://github.com/KhronosGroup/SPIRV-Tools")
-  endif()
+elseif(CA_CL_ENABLE_OFFLINE_KERNEL_TESTS)
+  message(WARNING "SPIRV-Tools not found, offline UnitCL SPIR-V tests will not run. "
+                  "To run offline SPIR-V tests get SPIRV-Tools from here: "
+                  "https://github.com/KhronosGroup/SPIRV-Tools")
 endif()
 
 if(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
This is only strictly required for testing, so we can relax its
requirement somewhat.
    
The old fatal error message was referring to UnitCL SPIR-V tests which
isn't true; the SPIR-V tests will indeed run successfully, as they've
been pre-compiled to .spv files. It's the offline tests that won't,
because we can't detect spirv-as at build time.