### PR TITLE
[spirv-ll] Support an 'online' lit testing mode

### DIFF
--- a/modules/compiler/spirv-ll/test/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/CMakeLists.txt
@@ -15,35 +15,41 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 set(SUITE spirv-ll)
 
-find_program(glslangValidator_EXECUTABLE
-  NAMES glslangValidator PATHS ENV VULKAN_SDK PATH_SUFFIXES bin
-  CMAKE_FIND_ROOT_PATH_BOTH)
-if(glslangValidator_EXECUTABLE STREQUAL
-    glslangValidator_EXECUTABLE-NOTFOUND)
-  set(GLSL_UNSUPPORTED True)
-  message(WARNING "${SUITE} glsl lit tests unsupported: glslangValidator not found")
-else()
-  set(GLSL_UNSUPPORTED False)
-endif()
+ca_option(CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE STRING
+  "Offline-assemble spirv-ll lit spvasm/glsl test binaries" ON)
 
-find_package(SpirvTools COMPONENTS spirv-as)
-if(TARGET spirv::spirv-as)
-  # Create custom commands to assemble .spvasm files in .spv.
-  set(SPVASM_UNSUPPORTED False)
-  # Get the found spirv-as version, takes the form: v<year>.<release>
-  execute_process(
-    COMMAND ${SpirvTools_spirv-as_EXECUTABLE} --version
-    OUTPUT_VARIABLE SpirvAsVersionOutput)
-  string(REGEX MATCH "v20[0-9][0-9].[0-9]+"
-    SpirvAsVersion ${SpirvAsVersionOutput})
-  string(REGEX MATCH "20[0-9][0-9]"
-    SpirvAsVersionYear ${SpirvAsVersion})
-  string(REGEX MATCH "[0-9]+$"
-    SpirvAsVersionRelease ${SpirvAsVersion})
-  message(STATUS "spirv-as: v${SpirvAsVersionYear}.${SpirvAsVersionRelease}")
-else()
-  set(SPVASM_UNSUPPORTED True)
-  message(WARNING "${SUITE} spvasm lit tests unsupported: spirv-as not found")
+set(GLSL_UNSUPPORTED False)
+set(SPVASM_UNSUPPORTED False)
+
+# Check for tools at build time if asked to assemble everything offline.
+if(CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE)
+  find_program(glslangValidator_EXECUTABLE
+    NAMES glslangValidator PATHS ENV VULKAN_SDK PATH_SUFFIXES bin
+    CMAKE_FIND_ROOT_PATH_BOTH)
+  if(glslangValidator_EXECUTABLE STREQUAL
+      glslangValidator_EXECUTABLE-NOTFOUND)
+    set(GLSL_UNSUPPORTED True)
+    message(WARNING "${SUITE} glsl lit tests unsupported: glslangValidator not found")
+  else()
+  endif()
+
+  find_package(SpirvTools COMPONENTS spirv-as)
+  if(TARGET spirv::spirv-as)
+    # Get the found spirv-as version, takes the form: v<year>.<release>
+    execute_process(
+      COMMAND ${SpirvTools_spirv-as_EXECUTABLE} --version
+      OUTPUT_VARIABLE SpirvAsVersionOutput)
+    string(REGEX MATCH "v20[0-9][0-9].[0-9]+"
+      SpirvAsVersion ${SpirvAsVersionOutput})
+    string(REGEX MATCH "20[0-9][0-9]"
+      SpirvAsVersionYear ${SpirvAsVersion})
+    string(REGEX MATCH "[0-9]+$"
+      SpirvAsVersionRelease ${SpirvAsVersion})
+    message(STATUS "spirv-as: v${SpirvAsVersionYear}.${SpirvAsVersionRelease}")
+  else()
+    set(SPVASM_UNSUPPORTED True)
+    message(WARNING "${SUITE} spvasm lit tests unsupported: spirv-as not found")
+  endif()
 endif()
 
 # Create the test/test inputs directories and set the relevent variables
@@ -56,6 +62,7 @@ add_ca_configure_lit_site_cfg(
   MAIN_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg"
   DEFINED
   TRIPLE=${TRIPLE}
+  CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=${CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE}
   GLSL_UNSUPPORTED=${GLSL_UNSUPPORTED}
   SPVASM_UNSUPPORTED=${SPVASM_UNSUPPORTED}
   SPIRV_AS_VERSION_YEAR=${SpirvAsVersionYear})

--- a/modules/compiler/spirv-ll/test/README.md
+++ b/modules/compiler/spirv-ll/test/README.md
@@ -3,4 +3,48 @@
 To invoke this test suite use the `check-spirv-ll-lit` CMake target to run
 [lit][lit] on the configured test inputs residing in the build directory.
 
+## Modes
+
+You can build this suite in one of two modes: online and offline (the default)
+
+### Offline Mode
+
+In offline mode - the default, or when `CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE`
+is enabled in cmake - the test suite will build its SPIR-V binaries ahead of
+time.
+
+This mode requires `spirv-as` to build the `spvasm` test binaries, and
+`glslangValidator` to build the `glsl` test binaries. Both are optional: if
+either tool is not found the tests will be disabled at runtime.
+
+### Online Mode
+
+In offline mode - when `CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE`
+is disable in cmake - the test suite will build its SPIR-V binaries at test
+runtime. Each test builds its own binary.
+
+This mode is suited to systems where the tools are not necessarily known at
+build time. It also enables quick turn-around time for developers when
+iterating on tests, as there are no dependencies on test execution except the
+test files themselves.
+
+### Switching Between Modes
+
+It is possible to switch between modes at runtime by setting the
+``spirv-ll-online`` parameter:
+
+```
+> # With ca-lit
+> ca-lit --param spirv-ll-online=0 modules/compiler/spirv-ll/test
+> # Or LLVM's lit
+> /usr/bin/lit --param spirv-ll-online=1 build/modules/compiler/spirv-ll/test
+> # Or with the check target via the LIT_OPTS environment variable
+> LIT_OPTS="--param spirv-ll-online=1" ninja check-spirv-ll-lit
+```
+
+Explicitly enabling the option with a truthy value forcibly enables the online
+mode. Explicitly disabling the option with a falsy value forcibly enables
+offline mode. Omitting the option leaves the behaviour to the default enabled
+by CMake.
+
 [lit]: https://pypi.org/project/lit/

--- a/modules/compiler/spirv-ll/test/glsl/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/glsl/CMakeLists.txt
@@ -14,6 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# If we're not assembling anything offline, we can skip this early.
+if(NOT CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE)
+  add_custom_target(spirv-ll-glsl-lit)
+  return()
+endif()
+
 set(GLSL_FILES
   builtin_var_gl_GlobalInvocationID.comp
   builtin_var_gl_LocalInvocationID.comp

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_GlobalInvocationID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_GlobalInvocationID.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationID.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationIndex.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationIndex.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_NumWorkGroups.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_NumWorkGroups.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_WorkGroupID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_WorkGroupID.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/descriptor_set_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/descriptor_set_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/descriptor_set_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/descriptor_set_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/descriptor_set_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/descriptor_set_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/descriptor_set_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/descriptor_set_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/descriptor_set_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/descriptor_set_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_bool_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitcount_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitcount_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitcount_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_cmp_eq_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_cmp_eq_two_bool_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec2_to_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec2_to_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec3_to_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec3_to_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec4_to_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec4_to_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec2_to_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec2_to_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec3_to_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec3_to_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec4_to_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec4_to_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_dot_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_dot_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec2_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec3_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec4_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat2x2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat2x2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat3x3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat3x3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat4x4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dmat4x4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat2x2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat2x2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat3x3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat3x3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat4x4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_mat4x4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec2_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec3_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec4_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec2_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec3_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec4_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat2x2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat2x2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat3x3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat3x3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat4x4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dmat4x4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat2x2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat2x2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat3x3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat3x3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat4x4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_mat4x4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec2_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec3_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec4_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_double.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_double_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_double_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_float.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_float_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_float_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: WorkingFrem
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4_arm.comp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // REQUIRES: arm
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec2_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec3_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec4_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec2_double_operands.comp
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
+// // RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
+// RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450
 

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec2_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec3_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec4_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec2_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec3_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec4_scalar_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat2x2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat2x2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat3x3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat3x3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat4x4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dmat4x4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec2_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec3_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec4_double_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat2x2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat2x2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat3x3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat3x3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat4x4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_mat4x4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec2_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec3_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec4_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec2_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec3_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec4_scalar_float_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acos_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Acosh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asin_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Asinh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan2_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atan_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Atanh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ceil_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cos_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cosh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cross_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cross_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Cross_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Cross_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Degrees_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Distance_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp2_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Exp_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FAbs_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FClamp_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMax_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMin_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FMix_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FSign_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FaceForward_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindILsb_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindSMsb_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_FindUMsb_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Floor_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fma_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Fract_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_InverseSqrt_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_double_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_double_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec2_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec2_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec3_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec3_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec4_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_dvec4_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_float_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_float_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec2_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec2_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec3_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec3_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec4_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Ldexp_vec4_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Length_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log2_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Log_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NClamp_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMax_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_NMin_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Normalize_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackDouble2x32_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackDouble2x32_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackHalf2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackHalf2x16_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm2x16_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm4x8_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm4x8_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm2x16_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm4x8_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm4x8_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Pow_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Radians_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Reflect_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec2_dvec2_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec2_dvec2_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec3_dvec3_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec3_dvec3_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec4_dvec4_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_dvec4_dvec4_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec2_vec2_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec2_vec2_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec3_vec3_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec3_vec3_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec4_vec4_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Refract_vec4_vec4_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_RoundEven_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Round_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SAbs_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_int_int_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_int_int_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec2_ivec2_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec2_ivec2_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec3_ivec3_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec3_ivec3_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec4_ivec4_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SClamp_ivec4_ivec4_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_int_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_int_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec2_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec2_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec3_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec3_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec4_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMax_ivec4_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_int_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_int_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec2_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec2_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec3_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec3_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec4_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SMin_ivec4_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SSign_ivec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sin_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sinh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_double_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_double_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec2_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec2_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec3_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec3_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec4_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_dvec4_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_float_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_float_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec2_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec2_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec3_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec3_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec4_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_SmoothStep_vec4_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Sqrt_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_double_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_double_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec2_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec2_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec3_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec3_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec4_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_dvec4_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_float_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_float_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec2_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec2_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec3_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec3_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec4_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Step_vec4_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tan_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Tanh_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_dvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_Trunc_vec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uint_uint_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uint_uint_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec2_uvec2_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec2_uvec2_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec3_uvec3_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec3_uvec3_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec4_uvec4_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UClamp_uvec4_uvec4_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uint_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uint_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec2_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec2_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec3_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec3_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec4_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMax_uvec4_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uint_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uint_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec2_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec2_uvec2.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec3_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec3_uvec3.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec4_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UMin_uvec4_uvec4.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackDouble2x32_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackDouble2x32_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackHalf2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackHalf2x16_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm2x16_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm4x8_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm4x8_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm2x16_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm4x8_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm4x8_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 // CHECK: ; ModuleID = '{{.*}}'

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sge_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sge_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sgt_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sgt_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sle_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sle_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_slt_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_slt_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_uge_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_uge_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ugt_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ugt_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ule_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ule_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ult_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ult_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_isinf_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_isinf_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_isinf_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_isinf_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_isnan_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_isnan_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_isnan_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_isnan_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_bool_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_ashr_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_ashr_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_cmp_eq_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_cmp_eq_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sge_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sge_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sgt_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sgt_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sle_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sle_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_slt_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_slt_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_uge_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_uge_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ugt_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ugt_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ule_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ule_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ult_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ult_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_lshr_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_lshr_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sdiv_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sdiv_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_smod_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_smod_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_udiv_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_udiv_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_umod_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_umod_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_switch.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_switch.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_switch_default.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_switch_default.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec2_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec3_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec4_scalar_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_bool_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec2_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec3_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec4_int_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec2_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec3_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec4_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec2_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec3_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec4_scalar_uint_operands.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_bool.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_double.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_float.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_int.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_uint.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/glsl/spec_constants.comp
+++ b/modules/compiler/spirv-ll/test/glsl/spec_constants.comp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// RUN: %if online-glsl %{ glslangValidator -s -V -o %spv_file_s %s %}
 // RUN: spirv-ll-tool --spec-constants %spv_file_s | FileCheck %s
 
 #version 450

--- a/modules/compiler/spirv-ll/test/lit.cfg
+++ b/modules/compiler/spirv-ll/test/lit.cfg
@@ -18,6 +18,12 @@
 import os
 import lit.formats
 import lit.util
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+
+# Import the utils module
+sys.path.insert(0, '@CA_COMMON_LIT_BINARY_PATH@')
+import utils.tool_config
 
 # Name of the test suite.
 config.name = 'spirv-ll-tool lit test suite'
@@ -39,3 +45,27 @@ import helpers.spvlltest
 
 # Use our custom format to provide the %spv_file_s substitution.
 config.test_format = helpers.spvlltest.SpvllTestFormat(execute_external=False)
+
+if (config.explicitly_online_offline == True
+    or (not config.offline and config.explicitly_online_offline is None)):
+    # If we're not in offline mode and have been explicitly not told to be in
+    # online mode, add the features that will enable the various online
+    # compilation steps.
+    extra_tools = [
+        ToolSubst('spirv-as', unresolved='ignore'),
+        ToolSubst('glslangValidator', unresolved='ignore'),
+    ]
+
+    utils.tool_config.add_ca_tool_substitutions(config, lit_config, llvm_config, extra_tools)
+
+    if not extra_tools[0].was_resolved:
+        config.available_features.add('no-spvasm')
+        lit_config.note("Skipping spvasm tests: in online mode but SPVASM wasn't found at run time")
+    else:
+        config.available_features.add('online-spirv-as')
+
+    if not extra_tools[1].was_resolved:
+        config.available_features.add('no-glsl')
+        lit_config.note("Skipping glsl tests: in online mode but GLSL wasn't found at run time")
+    else:
+        config.available_features.add('online-glsl')

--- a/modules/compiler/spirv-ll/test/lit.site.cfg.in
+++ b/modules/compiler/spirv-ll/test/lit.site.cfg.in
@@ -31,10 +31,24 @@ if 'arm' in '@TRIPLE@' or 'arm' in machine():
 else:
     config.available_features.add('WorkingFrem')
 
-if @GLSL_UNSUPPORTED@:
+# Whether the user configured at build-time to build everything offline.
+config.offline = lit.util.pythonize_bool('@CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE@')
+
+# The user can explicitly request either online or offline mode. The default is
+# neither.
+config.explicitly_online_offline = lit_config.params.get("spirv-ll-online", None)
+if config.explicitly_online_offline is not None:
+    config.explicitly_online_offline = lit.util.pythonize_bool(config.explicitly_online_offline)
+
+# If we've explicitly assembled the binaries offline but couldn't find the
+# tools, we know we can't run these tests, unless we're explicitly told to run
+# them online.
+if @GLSL_UNSUPPORTED@ and (config.offline and config.explicitly_online_offline != True):
     config.available_features.add('no-glsl')
-if @SPVASM_UNSUPPORTED@:
+    lit_config.note("Skipping glsl tests: in offline mode but GLSL wasn't found at build time")
+if @SPVASM_UNSUPPORTED@ and (config.offline and config.explicitly_online_offline != True):
     config.available_features.add('no-spvasm')
+    lit_config.note("Skipping spvasm tests: in offline mode but SPVASM wasn't found at build time")
 
 for year in range(2016, @SPIRV_AS_VERSION_YEAR@):
     config.available_features.add('spirv-as-v' + str(year))

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -14,6 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# If we're not assembling anything offline, we can skip this early.
+if(NOT CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE)
+  add_custom_target(spirv-ll-spvasm-lit)
+  return()
+endif()
+
 set(SPVASM_FILES
   debug_info.spvasm
   ext_variable_pointers_op_variable.spvasm

--- a/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/ext_variable_pointers_function_call.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/ext_variable_pointers_function_call.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c VariablePointersStorageBuffer %spv_file_s | FileCheck %s
 ; tests that variable pointers work correctly with functions, that they can be
 ; passed as arguments and returned

--- a/modules/compiler/spirv-ll/test/spvasm/ext_variable_pointers_op_variable.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/ext_variable_pointers_op_variable.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; tests that variable pointers (pointer to pointer type) can be created and that
 ; they can be produced from an OpConstantNull in accordance with the spec

--- a/modules/compiler/spirv-ll/test/spvasm/intel_arbitrary_precision_integers.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_arbitrary_precision_integers.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -e SPV_INTEL_arbitrary_precision_integers -c ArbitraryPrecisionIntegersINTEL | FileCheck %s
 
             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/linkonce_odr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/linkonce_odr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -e SPV_KHR_linkonce_odr | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/lit.local.cfg
+++ b/modules/compiler/spirv-ll/test/spvasm/lit.local.cfg
@@ -17,5 +17,7 @@
 # File extensions for testing.
 config.suffixes = ['.spvasm']
 
+config.substitutions.append(('%spv_tgt_env', 'spv1.0'))
+
 if 'no-spvasm' in config.available_features:
     config.unsupported = True

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_generic.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_generic.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_add_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_add_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_add -c Float64 -c AtomicFloat64AddEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_add"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_max_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_max_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_min_max -c Float64 -c AtomicFloat64MinMaxEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_min_max"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_min_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_double_min_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_min_max -c Float64 -c AtomicFloat64MinMaxEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_min_max"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_generic.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_add_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_add_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_add -c AtomicFloat32AddEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_add"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_max_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_max_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_min_max -c AtomicFloat32MinMaxEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_min_max"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_min_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_float_min_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -e SPV_EXT_shader_atomic_float_min_max -c AtomicFloat32MinMaxEXT | FileCheck %s
             OpExtension "SPV_EXT_shader_atomic_float_min_max"
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_s_max_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_s_max_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_s_min_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_s_min_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global_signed.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global_signed.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
             OpCapability Shader
        %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_local.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_bitcast_double_to_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_bitcast_double_to_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_bitcast_float_to_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_bitcast_float_to_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_bitcast_int_to_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_bitcast_int_to_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_bitcast_long_to_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_bitcast_long_to_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_branch_conditional_false.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_branch_conditional_false.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_branch_conditional_true.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_branch_conditional_true.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_construct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_construct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec3.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec3.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec4.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_extract_vec4.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_insert_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_null_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_null_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_null_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_null_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_null_ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_null_ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_null_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_null_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_null_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_null_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_acquire.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_acquire.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_device.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_device.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_invocation.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_invocation.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_release.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_release.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_sequentially_consistent.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_sequentially_consistent.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_subgroup.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_subgroup.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_execution_scope.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_execution_scope.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                    OpCapability Addresses
                    OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_memory_scope.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_memory_scope.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                    OpCapability Addresses
                    OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_semantics.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_variable_semantics.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_workgroup.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_control_barrier_workgroup.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_convert_int_to_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_convert_int_to_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_convert_long_to_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_convert_long_to_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_convert_uint_to_ulong.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_convert_uint_to_ulong.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_convert_ulong_to_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_convert_ulong_to_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_sized_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_memory_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_object_constant.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_object_constant.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL %spv_file_s | FileCheck %s
 ; This is a smoke test to check that OpCopyObject propagates values correctly
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_copy_object_variable.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_copy_object_variable.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL %spv_file_s | FileCheck %s
 ; This tests for a potential bug where copying a pointer object simply makes
 ; the same pointer available through a new ID, which would make storing to it

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_local_size.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_local_size.spvasm
@@ -30,6 +30,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                   OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_local_size_hint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_local_size_hint.spvasm
@@ -30,6 +30,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                   OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_max_work_dim.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_max_work_dim.spvasm
@@ -15,6 +15,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: spirv-as-v2020
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                   OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_vec_type_hint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_vec_type_hint.spvasm
@@ -30,6 +30,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                   OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_expect_assume.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_expect_assume.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -e SPV_KHR_expect_assume %spv_file_s | FileCheck %s
 
             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_mod_half.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_mod_half.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -E %spv_file_s | FileCheck %s
                OpCapability Kernel
                OpCapability Float16

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_rem.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_rem.spvasm
@@ -15,6 +15,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: WorkingFrem
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_rem_arm.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_rem_arm.spvasm
@@ -15,6 +15,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: arm
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_rem_half.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_rem_half.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -E %spv_file_s | FileCheck %s
                OpCapability Kernel
                OpCapability Float16

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_equal.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_equal.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_greater_than.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_greater_than.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_greater_than_equal.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_greater_than_equal.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_less_than.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_less_than.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_less_than_equal.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_less_than_equal.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_f_unord_not_equal.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_f_unord_not_equal.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_double_operands.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_double_operands.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_float_operands.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_float_operands.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_Foo.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_Foo.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Addresses
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Addresses
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Addresses
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Addresses
             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_forward_pointer_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_function_call_import.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_function_call_import.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Linkage %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
@@ -18,6 +18,7 @@
 ; behaves as expected. There was a bug where resolving calls to function forward
 ; references was leaving behind invalid instructions.
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c GenericPointer %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer_builtin.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer_builtin.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c GenericPointer %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Barrier.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Barrier.spvasm
@@ -7,6 +7,7 @@
 ;
 ; with glslang version 7.10.2984
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 ; SPIR-V

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec3.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec3.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec4.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_dvec4.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec3.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec3.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec4.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_FrexpStruct_vec4.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_double_intPtr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_double_intPtr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec2_ivec2Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec2_ivec2Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec3_ivec3Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec3_ivec3Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec4_ivec4Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_dvec4_ivec4Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_float_intPtr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_float_intPtr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec2_ivec2Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec2_ivec2Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec3_ivec3Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec3_ivec3Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec4_ivec4Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Frexp_vec4_ivec4Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec3.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec3.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec4.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_dvec4.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec3.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec3.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec4.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_ModfStruct_vec4.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
 
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_double_doublePtr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_double_doublePtr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Shader
                           OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec2_dvec2Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec2_dvec2Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec3_dvec3Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec3_dvec3Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec4_dvec4Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_dvec4_dvec4Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_float_floatPtr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_float_floatPtr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec2_vec2Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec2_vec2Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec3_vec3Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec3_vec3Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec4_vec4Ptr.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_glsl_Modf_vec4_vec4Ptr.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                          OpCapability Shader
                          OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_all.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_all.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_any.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_any.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_2D.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_2D.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_3D.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_3D.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_decorate.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_decorate.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_add.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_add.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_max.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_min.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_i_add.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_i_add.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_member_decorate.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_member_decorate.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_s_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_s_max.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_s_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_s_min.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_u_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_u_max.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_u_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_u_min.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_wait_events.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_wait_events.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses -c GenericPointer %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_wrapper_clash.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_wrapper_clash.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o %t
 ; RUN: opt -S --passes=always-inline %t -o - | FileCheck -- %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_add_carry.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_add_carry.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_add_nsw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_add_nsw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_add_nuw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_add_nuw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_mul_nsw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_mul_nsw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_mul_nuw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_mul_nuw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_sub_borrow.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_sub_borrow.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_sub_nsw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_sub_nsw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_i_sub_nuw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_i_sub_nuw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_finite_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_finite_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_finite_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_finite_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_inf_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_inf_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_inf_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_inf_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_nan_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_nan_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_nan_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_nan_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_normal_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_normal_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_is_normal_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_is_normal_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_less_or_greater_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_less_or_greater_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_less_or_greater_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_less_or_greater_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
             OpCapability Kernel
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_logical_not.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_logical_not.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_loop_merge.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_loop_merge.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_member_decorate.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_member_decorate.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_acquire.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_acquire.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_acquire_release.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_acquire_release.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_const_semantics.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_const_semantics.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                 OpCapability Addresses
                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_phi.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_phi.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                 OpCapability Addresses
                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_release.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_release.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_seq_consistent.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_seq_consistent.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                OpCapability Kernel
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_memory_scope.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_memory_scope.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                 OpCapability Addresses
                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_semantics.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_semantics.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/modules/compiler/spirv-ll/test/spvasm/op_nop.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_nop.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_not.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_not.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acos_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acosh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_acospi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                         OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asin_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_asinpi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan2pi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atan_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_atanpi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_bitselect_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_call_byval_arg.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_call_byval_arg.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses -c Linkage %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cbrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ceil_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s -o - | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_copysign_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cos_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cosh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cospi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_cross_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_degrees_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_distance_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erf_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_erfc_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_exp_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_expm1_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fabs_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_distance_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_length_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fast_normalize_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fclamp_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fdim_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_floor_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fma_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_common_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmax_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_common_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmin_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fmod_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_enqueued_local_size.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_enqueued_local_size.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                 OpCapability Addresses
                                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_enqueued_num_sub_groups.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_enqueued_num_sub_groups.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                               OpCapability Addresses
                                               OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_global_linear_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_global_linear_id.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                  OpCapability Addresses
                                  OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_local_linear_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_local_linear_id.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                 OpCapability Addresses
                                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_max_sub_group_size.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_max_sub_group_size.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                   OpCapability Addresses
                                   OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_num_sub_groups.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_num_sub_groups.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                OpCapability Addresses
                                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_id.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                  OpCapability Addresses
                                  OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_local_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_local_id.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                  OpCapability Addresses
                                  OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_size.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_get_sub_group_size.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                                  OpCapability Addresses
                                  OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_cos_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_divide_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_exp_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_log_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_powr_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_recip_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_rsqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sin_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_sqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_half_tan_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_hypot_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ilogb_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_ldexp_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_length_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log1p_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_log_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_logb_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mad_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_maxmag_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -E %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_gotcha.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_gotcha.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -E %spv_file_s | FileCheck %s
 
 ; The point of this test is that it looks a lot like a memset to spirv-ll-tool

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_zero.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_zero.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -E %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_minmag_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_mix_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nan_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_cos_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_divide_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_exp_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log10_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_log_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_powr_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_recip_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                           OpCapability Kernel
                           OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_rsqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sin_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_sqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_native_tan_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_nextafter_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_normalize_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pow_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_pown_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_powr_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_printf.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_printf.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_radians_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remainder_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rint_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rootn_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_round_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_rsqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_diff_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_abs_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_add_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_bitselect_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clamp_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_clz_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_hadd_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad24_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_hi_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mad_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_max_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_min_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul24_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_mul_hi_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_popcount_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v16i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v2i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v3i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v4i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_prefetch_v8i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rhadd_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_rotate_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_select_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle2_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_shuffle_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_sub_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_s_upsample_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle2_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_shuffle_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sign_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sin_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_private_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sinpi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_smoothstep_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sqrt_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_step_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tan_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanh_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tanpi_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_tgamma_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_trunc_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_diff_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_abs_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_add_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_bitselect_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clamp_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_clz_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_ctz_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_hadd_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad24_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_hi_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mad_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_max_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_min_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul24_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_mul_hi_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_popcount_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rhadd_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_rotate_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_select_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle2_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_shuffle_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v16i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v2i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v3i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v4i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i8.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_sub_sat_v8i8.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v16i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v2i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v3i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v4i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i32.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i32.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i64.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_upsample_v8i64.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vload_halfn_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vload_halfn_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vload_halfn_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vload_halfn_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloada_halfn_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloada_halfn_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloada_halfn_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloada_halfn_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_char_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_char_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_char_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_char_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses -c Float64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses -c Float64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_int_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_int_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_int_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_int_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_long_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_long_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_long_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_long_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_short_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_short_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_short_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vloadn_short_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_r_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_r_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_r_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstore_halfn_r_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_r_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_r_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_r_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstorea_halfn_r_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_char_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_char_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_char_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_char_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_double_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses -c Float64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_double_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses -c Float64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_float_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_float_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_int_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_int_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_int_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_int_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_long_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_long_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_long_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_long_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_short_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_short_32bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 32 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_short_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_vstoren_short_64bit.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_ordered_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_ordered_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_ordered_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_ordered_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_phi.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_phi.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_quantize_to_f16.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_quantize_to_f16.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float16 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float16

--- a/modules/compiler/spirv-ll/test/spvasm/op_quantize_to_f16_vec2.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_quantize_to_f16_vec2.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float16 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float16

--- a/modules/compiler/spirv-ll/test/spvasm/op_s_mul_extended.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_s_mul_extended.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
 
 ; SPIR-V

--- a/modules/compiler/spirv-ll/test/spvasm/op_s_rem.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_s_rem.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_sat_convert_int_to_uchar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_sat_convert_int_to_uchar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_sat_convert_uint_to_char.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_sat_convert_uint_to_char.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                 OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_select_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_select_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_select_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_select_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_select_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_select_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_select_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_select_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                       OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_select_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_select_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_shift_left_logical_nsw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_shift_left_logical_nsw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_shift_left_logical_nuw.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_shift_left_logical_nuw.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -e SPV_KHR_no_integer_wrap_decoration %spv_file_s | FileCheck %s
                OpCapability Shader
                OpExtension "SPV_KHR_no_integer_wrap_decoration"

--- a/modules/compiler/spirv-ll/test/spvasm/op_sign_bit_set_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_sign_bit_set_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_sign_bit_set_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_sign_bit_set_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -c Float64 -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_source_continued.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_source_continued.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
  OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_double_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_float_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_int_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_long_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                             OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_array.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_struct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_struct.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_vec.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_composite_uint_vec.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_deps.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_deps.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_false_bool.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_false_bool.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_generic_pointer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_generic_pointer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c GenericPointer %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                       OpCapability Shader

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fadd_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fadd_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fadd_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fadd_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fdiv_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fdiv_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fdiv_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fdiv_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
              OpCapability Shader
              OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_multi_function.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_multi_function.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmul_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmul_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmul_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmul_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fsub_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fsub_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fsub_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fsub_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_true_bool.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_true_bool.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_switch_char.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_switch_char.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Int8 %spv_file_s | FileCheck %s
                OpCapability Kernel
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_switch_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_switch_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Int64 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Int64

--- a/modules/compiler/spirv-ll/test/spvasm/op_switch_short.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_switch_short.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Int16 %spv_file_s | FileCheck %s
                OpCapability Shader
                OpCapability Int16

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_forward_pointer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_forward_pointer.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
 OpTypeForwardPointer %a Function

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_image.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c SampledBuffer %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_u_mul_extended.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_u_mul_extended.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan %spv_file_s | FileCheck %s
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/modules/compiler/spirv-ll/test/spvasm/op_unordered_scalar.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_unordered_scalar.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_unordered_vector.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_unordered_vector.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -c Kernel -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/compiler/spirv-ll/test/spvasm/op_unreachable.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_unreachable.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_extract_v3uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vec_insert_v3uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_undef.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_shuffle_undef.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_double.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_float.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_int.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_long.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_uint.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_vector_swizzle_uint.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Float64

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
@@ -15,6 +15,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: spirv-as-v2020
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
@@ -15,6 +15,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; REQUIRES: spirv-as-v2020
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                         OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_max_byte_offset.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_max_byte_offset.spvasm
@@ -13,6 +13,7 @@
 ; under the License.
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_usm_generic_address_space.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_usm_generic_address_space.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -e SPV_codeplay_usm_generic_storage_class -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Linkage

--- a/modules/compiler/spirv-ll/test/spvasm/prioritize_function_names.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/prioritize_function_names.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
 ; Ensure entry point functions get priority on assignment of their names when there are normal functions with the same name

--- a/modules/compiler/spirv-ll/test/spvasm/prioritize_function_names_external.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/prioritize_function_names_external.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
 ; Tests imported and exported functions are not incorrectly re-named

--- a/modules/compiler/spirv-ll/test/spvasm/ptr_int_conversions.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/ptr_int_conversions.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a Vulkan -c Addresses -c Float64 -c Int64 %spv_file_s | FileCheck %s
             OpCapability Shader
             OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/unsupported_capability.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/unsupported_capability.spvasm
@@ -17,6 +17,7 @@
 ; This just picks an unsupported capability at random to test the quality of
 ; the error message: if we do end up supporting it, we can change this test
 ; quite easily.
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: not spirv-ll-tool -a OpenCL -b 64 %spv_file_s 2>&1 | FileCheck %s
                           OpCapability MultiViewport
 

--- a/modules/compiler/spirv-ll/test/spvasm/vec_type_hint_length_1.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/vec_type_hint_length_1.spvasm
@@ -14,6 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel

--- a/modules/lit/utils/tool_config.py
+++ b/modules/lit/utils/tool_config.py
@@ -55,9 +55,9 @@ def add_ca_tool_substitutions(config, lit_config, llvm_config, tools):
 
     llvm_config.add_tool_substitutions(tools, config.tool_search_dirs)
 
-    # Handle emulation of non-native tools by preprending any substitution with the
-    # emulator command.
-    for tool in config.tools:
+    # Handle emulation of non-native tools by prepending any substitution with
+    # the emulator command.
+    for tool in tools:
         if not tool.was_resolved:
             continue
         idx = last_substitution_by_key(config.substitutions, tool.regex)


### PR DESCRIPTION
This adds two modes to the spirv-ll lit testing infrastructure: offline and online.

The offline mode is the default, and is essentially the current behaviour - running `check-spirv-ll-lit` will build all the necessary SPIR-V binaries ahead of time and run tests which expect those to be in place.

The new online mode allows faster turnaround times on testing, and allows the project to be built without the necessary tools known at build time. In this mode, the tools for spvasm/glsl are checked for independently at runtime and a feature is enabled for each if the tools are resolved. Under this feature, a conditional RUN line is enabled to assemble the spvasm/glsl file to SPIR-V. This uses lit's built-in `%if` syntax.

A bonus for the online mode is that test binaries can now more easily be assembled individually, e.g., taking certain options on a per-test basis.

This behaviour is more intuitive for developers as iterating on individual test files no longer requires specific build targets to be built before the changes to the SPIR-V binary are made apparent.It also suits building the project in a system where the tools aren't necessarily required at build time.

Lit can be told to switch to either mode at runtime, using `--param
spirv-ll-online=1/true/0/false/`. Omitting the parameter leaves the test
suite in the mode in which it was configured at build-time.