### PR TITLE
[spirv-ll] Add support for SPV_INTEL_optnone

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1652,9 +1652,11 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
 
   if (op->FunctionControl() & spv::FunctionControlInlineMask) {
     linkage = llvm::Function::LinkageTypes::LinkOnceODRLinkage;
-    llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
-    llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
-    llvmFunction->addFnAttr(llvm::Attribute::NoInline);
+    if (module.isExtensionEnabled("SPV_INTEL_optnone")) {
+      llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
+      llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
+      llvmFunction->addFnAttr(llvm::Attribute::NoInline);
+    }
   } else if (auto linkageInfo = getLinkage(module, op->IdResult())) {
     if (linkageInfo->first == spv::LinkageTypeImport ||
         linkageInfo->first == spv::LinkageTypeExport ||

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1652,6 +1652,9 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
 
   if (op->FunctionControl() & spv::FunctionControlInlineMask) {
     linkage = llvm::Function::LinkageTypes::LinkOnceODRLinkage;
+    llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
+    llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
+    llvmFunction->addFnAttr(llvm::Attribute::NoInline);
   } else if (auto linkageInfo = getLinkage(module, op->IdResult())) {
     if (linkageInfo->first == spv::LinkageTypeImport ||
         linkageInfo->first == spv::LinkageTypeExport ||

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1946,13 +1946,11 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
 
   if (op->FunctionControl() & spv::FunctionControlOptNoneINTELMask) {
     SPIRV_LL_ASSERT(
-            module.isExtensionEnabled("SPV_INTEL_optnone"),
-            "SPV_INTEL_optnone must be enabled.");
-    if (module.isExtensionEnabled("SPV_INTEL_optnone")) {
-      llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
-      llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
-      llvmFunction->addFnAttr(llvm::Attribute::NoInline);
-    }
+            module.hasCapability(spv::CapabilityOptNoneINTEL),
+            "CapabilityOptNoneINTEL must be enabled.");
+    llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
+    llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
+    llvmFunction->addFnAttr(llvm::Attribute::NoInline);
   }
 
   function->setCallingConv(CC);

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1652,11 +1652,6 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
 
   if (op->FunctionControl() & spv::FunctionControlInlineMask) {
     linkage = llvm::Function::LinkageTypes::LinkOnceODRLinkage;
-    if (module.isExtensionEnabled("SPV_INTEL_optnone")) {
-      llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
-      llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
-      llvmFunction->addFnAttr(llvm::Attribute::NoInline);
-    }
   } else if (auto linkageInfo = getLinkage(module, op->IdResult())) {
     if (linkageInfo->first == spv::LinkageTypeImport ||
         linkageInfo->first == spv::LinkageTypeExport ||
@@ -1948,6 +1943,17 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
   }
 
   SPIRV_LL_ASSERT_PTR(function);
+
+  if (op->FunctionControl() & spv::FunctionControlOptNoneINTELMask) {
+    SPIRV_LL_ASSERT(
+            module.isExtensionEnabled("SPV_INTEL_optnone"),
+            "SPV_INTEL_optnone must be enabled.");
+    if (module.isExtensionEnabled("SPV_INTEL_optnone")) {
+      llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
+      llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
+      llvmFunction->addFnAttr(llvm::Attribute::NoInline);
+    }
+  }
 
   function->setCallingConv(CC);
   setCurrentFunction(function);

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1948,9 +1948,8 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
     SPIRV_LL_ASSERT(
             module.hasCapability(spv::CapabilityOptNoneINTEL),
             "CapabilityOptNoneINTEL must be enabled.");
-    llvm::Function *llvmFunction = IRBuilder.GetInsertBlock()->getParent();
-    llvmFunction->addFnAttr(llvm::Attribute::OptimizeNone);
-    llvmFunction->addFnAttr(llvm::Attribute::NoInline);
+    function->addFnAttr(llvm::Attribute::OptimizeNone);
+    function->addFnAttr(llvm::Attribute::NoInline);
   }
 
   function->setCallingConv(CC);

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2354,6 +2354,7 @@ set(SPVASM_FILES
   intel_arbitrary_precision_integers.spvasm
   op_opencl_arg_md.spvasm
   unsupported_capability.spvasm
+  intel_opt_none.spvasm
   )
 
 if(SpirvAsVersionYear GREATER 2019)

--- a/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
@@ -1,0 +1,36 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability OptNoneINTEL
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %4 "foo"
+               OpExecutionMode %4 VecTypeHint 0
+          %6 = OpString "kernel_arg_type.foo."
+               OpSource OpenCL_C 102000
+               OpName %entry "entry"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void OptNoneINTEL %3
+      %entry = OpLabel
+               OpReturn
+               OpFunctionEnd
+; CHECK-LABEL: foo
+; CHECK: attributes #0 = { noinline optnone }

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -286,6 +286,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
         spv::CapabilityVector16,
         spv::CapabilityKernelAttributesINTEL,
         spv::CapabilityExpectAssumeKHR,
+        spv::CapabilityOptNoneINTEL,
     });
     if (enableAll) {
       // Add the optional OpenCL capabilities if this flag was set.
@@ -442,7 +443,8 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
           spv::CapabilityAtomicFloat64AddEXT,
           spv::CapabilityAtomicFloat32MinMaxEXT,
           spv::CapabilityAtomicFloat64MinMaxEXT,
-          spv::CapabilityArbitraryPrecisionIntegersINTEL};
+          spv::CapabilityArbitraryPrecisionIntegersINTEL,
+          spv::CapabilityOptNoneINTEL};
 
       if (supported_capabilities.count(*capability)) {
         deviceInfo.capabilities.push_back(*capability);
@@ -468,6 +470,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
         "SPV_KHR_expect_assume",
         "SPV_KHR_linkonce_odr",
         "SPV_KHR_uniform_group_instructions",
+        "SPV_INTEL_optnone",
     });
   } else {
     for (auto extension : extensions) {

--- a/source/cl/source/binary/source/spirv.cpp
+++ b/source/cl/source/binary/source/spirv.cpp
@@ -28,7 +28,7 @@ namespace binary {
 // TODO: add a proper mechanism for extending spirv-ll and reporting extension
 // support. We don't actually support the generic storage class extension on
 // all core targets. See CA-3067.
-const std::array<const std::string, 8> supported_extensions = {
+const std::array<const std::string, 9> supported_extensions = {
     {
         "SPV_KHR_no_integer_wrap_decoration",
         "SPV_INTEL_kernel_attributes",
@@ -38,6 +38,7 @@ const std::array<const std::string, 8> supported_extensions = {
         "SPV_KHR_linkonce_odr",
         "SPV_KHR_uniform_group_instructions",
         "SPV_INTEL_arbitrary_precision_integers",
+        "SPV_INTEL_optnone",
     },
 };
 
@@ -49,7 +50,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
   auto &spvCapabilities = spvDeviceInfo.capabilities;
 
   // A set of capabilities shared between the OpenCL profiles we support.
-  static std::array<spv::Capability, 12> sharedCapabilities = {
+  static std::array<spv::Capability, 13> sharedCapabilities = {
       spv::CapabilityAddresses,
       spv::CapabilityFloat16Buffer,
       spv::CapabilityGroups,
@@ -62,6 +63,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
       spv::CapabilityExpectAssumeKHR,
       spv::CapabilityGroupUniformArithmeticKHR,
       spv::CapabilityArbitraryPrecisionIntegersINTEL,
+      spv::CapabilityOptNoneINTEL,
   };
 
   if (profile == "FULL_PROFILE") {


### PR DESCRIPTION
# Overview


# Reason for change

To be able to run tests with yet to release oneAPI packages, support for SPV_INTEL_optnone is required

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-9](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
