### PR TITLE
Migrate to compiler::KernelInfo and introduce compiler::ProgramInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Upgrade guidance:
 
 * The mux spec has been bumped to 0.74.0 to account for changes to
   `BaseModule`. This does not affect in-tree compiler targets.
+* `cl::binary::ProgramInfo` and `cl::binary::KernelInfo` have been removed and
+  replaced with equivalent structures in the `compiler` namespace.
+* `compiler::Module::finalize` no longer takes a callback to populate program
+  info - it now takes `compiler::ProgramInfo` by pointer and populates it
+  itself if passed a non-null address.
 
 Feature additions:
 

--- a/doc/specifications/mux-compiler-spec.rst
+++ b/doc/specifications/mux-compiler-spec.rst
@@ -370,7 +370,7 @@ that handle the back-end and code generation.
       virtual Result link(cargo::array_view<Module *> input_modules);
 
       virtual Result finalize(
-          KernelInfoCallback kernel_info_callback,
+          ProgramInfo *kernel_info,
           std::vector<builtins::printf::descriptor> &printf_calls);
 
       virtual Kernel *getKernel(const std::string &name);

--- a/modules/compiler/include/compiler/module.h
+++ b/modules/compiler/include/compiler/module.h
@@ -325,9 +325,9 @@ struct ArgumentType {
 struct KernelInfo {
   /// @brief Struct representing basic kernel argument information.
   struct ArgumentInfo {
-    AddressSpace address_qual;
-    KernelArgAccess access_qual;
-    std::uint32_t type_qual;
+    AddressSpace address_qual = compiler::AddressSpace::PRIVATE;
+    KernelArgAccess access_qual = compiler::KernelArgAccess::NONE;
+    std::uint32_t type_qual = 0;
     std::string type_name;
     std::string name;
   };
@@ -339,7 +339,15 @@ struct KernelInfo {
   std::uint64_t private_mem_size;
 
   /// @brief Values of reqd_work_group_size attribute if it exists.
-  cargo::optional<std::array<size_t, 3>> work_group;
+  cargo::optional<std::array<size_t, 3>> reqd_work_group_size;
+
+  std::size_t getNumArguments() const { return argument_types.size(); }
+
+  /// @brief Returns the reqd_work_group_size if present, else an all-zeros
+  /// array.
+  std::array<size_t, 3> getReqdWGSizeOrZero() const {
+    return reqd_work_group_size.value_or(std::array<size_t, 3>{0, 0, 0});
+  }
 };  // class KernelInfo
 
 /// @brief Kernel info callback type.

--- a/modules/compiler/source/base/include/base/module.h
+++ b/modules/compiler/source/base/include/base/module.h
@@ -189,7 +189,7 @@ class BaseModule : public Module {
 
   /// @brief Generates a binary from the current program.
   ///
-  /// @param[out] kernel_info_callback Kernel info callback.
+  /// @param[out] program_info Optional ProgramInfo object to fill in.
   /// @param[out] printf_calls Output printf descriptor list.
   ///
   /// @return Return a status code.
@@ -198,7 +198,7 @@ class BaseModule : public Module {
   /// @retval `Result::FINALIZE_PROGRAM_FAILURE` when finalization failed. See
   /// the error log for more information.
   Result finalize(
-      KernelInfoCallback kernel_info_callback,
+      ProgramInfo *program_info,
       std::vector<builtins::printf::descriptor> &printf_calls) override;
 
   /// @brief Returns an object that represents a kernel contained within this

--- a/modules/compiler/source/base/include/base/program_metadata.h
+++ b/modules/compiler/source/base/include/base/program_metadata.h
@@ -33,7 +33,7 @@ namespace compiler {
 
 /// @brief Initialize information for all kernels by scanning a LLVM module.
 ///
-/// @param[in] callback Callback to return kernel information.
+/// @param[in] program_info ProgramInfo instance to populate.
 /// @param[in] module The module to extract information from.
 /// @param[in] store_argument_metadata Whether to store additional argument
 /// metadata as required by -cl-kernel-arg-info.
@@ -43,7 +43,7 @@ namespace compiler {
 /// @retval `Result::OUT_OF_MEMORY` if an allocation failed.
 /// @retval `Result::FINALIZE_PROGRAM_FAILURE` when there was a problem with the
 /// LLVM IR.
-Result moduleToProgramInfo(KernelInfoCallback callback,
+Result moduleToProgramInfo(ProgramInfo &program_info,
                            llvm::Module *const module,
                            bool store_argument_metadata);
 

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1723,7 +1723,7 @@ bool BaseModule::DiagnosticHandler::handleDiagnostics(
 }
 
 Result BaseModule::finalize(
-    KernelInfoCallback kernel_info_callback,
+    ProgramInfo *program_info,
     std::vector<builtins::printf::descriptor> &printf_calls) {
   // Lock the context, this is necessary due to analysis/pass managers being
   // owned by the LLVMContext and we are making heavy use of both below.
@@ -1875,9 +1875,9 @@ Result BaseModule::finalize(
   auto clone = std::unique_ptr<llvm::Module>(llvm::CloneModule(*m));
 
   // Generate program info.
-  if (kernel_info_callback) {
-    auto program_info_result = moduleToProgramInfo(
-        std::move(kernel_info_callback), clone.get(), options.kernel_arg_info);
+  if (program_info) {
+    auto program_info_result = moduleToProgramInfo(*program_info, clone.get(),
+                                                   options.kernel_arg_info);
     if (program_info_result != Result::SUCCESS) {
       return program_info_result;
     }

--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -288,16 +288,17 @@ void populateRequiredWGSAttribute(KernelInfo &kernel_info, llvm::MDNode *node) {
   llvm::ConstantInt *const operand3 =
       llvm::cast<llvm::ConstantInt>(vmdOp3->getValue());
   std::stringstream stream;
-  kernel_info.work_group.emplace();
-  (*kernel_info.work_group)[0] = *(operand1->getValue().getRawData());
-  (*kernel_info.work_group)[1] = *(operand2->getValue().getRawData());
-  (*kernel_info.work_group)[2] = *(operand3->getValue().getRawData());
+  kernel_info.reqd_work_group_size.emplace();
+  (*kernel_info.reqd_work_group_size)[0] = *(operand1->getValue().getRawData());
+  (*kernel_info.reqd_work_group_size)[1] = *(operand2->getValue().getRawData());
+  (*kernel_info.reqd_work_group_size)[2] = *(operand3->getValue().getRawData());
   if (!kernel_info.attributes.empty()) {
     stream << kernel_info.attributes << " ";
   }
-  stream << "reqd_work_group_size(" << kernel_info.work_group.value()[0] << ","
-         << kernel_info.work_group.value()[1] << ","
-         << kernel_info.work_group.value()[2] << ")";
+  stream << "reqd_work_group_size("
+         << kernel_info.reqd_work_group_size.value()[0] << ","
+         << kernel_info.reqd_work_group_size.value()[1] << ","
+         << kernel_info.reqd_work_group_size.value()[2] << ")";
   kernel_info.attributes.assign(stream.str());
 }
 

--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -400,26 +400,23 @@ void populateAttributes(KernelInfo &kernel_info, llvm::MDNode *node) {
 
 /// @brief Populates kernel information from its LLVM IR.
 ///
-/// @param[in] callback KernelInfo to populate.
 /// @param[in] function The kernel function.
 /// @param[in] node Kernel's subnode in the opencl.kernels metadata node.
 /// @param[in] storeArgumentMetadata Whether to store additional argument
 /// metadata as required by -cl-kernel-arg-info.
 ///
-/// @return Return a status code.
+/// @return Return a KernelInfo object, or on errro a status code.
 /// @retval `Result::SUCCESS` on success.
 /// @retval `Result::OUT_OF_MEMORY` if an allocation failed.
 /// @retval `Result::FINALIZE_PROGRAM_FAILURE` when there was a problem with the
 /// LLVM IR.
-Result populateKernelInfoFromFunction(KernelInfoCallback callback,
-                                      llvm::Function *function,
-                                      llvm::MDNode *node,
-                                      bool storeArgumentMetadata) {
+cargo::expected<KernelInfo, Result> populateKernelInfoFromFunction(
+    llvm::Function *function, llvm::MDNode *node, bool storeArgumentMetadata) {
   KernelInfo kernel_info;
   kernel_info.name = function->getName().str();
   if (cargo::success !=
       kernel_info.argument_types.alloc(function->arg_size())) {
-    return Result::OUT_OF_MEMORY;
+    return cargo::make_unexpected(Result::OUT_OF_MEMORY);
   }
 
   // Calculate the private memory size used by the kernel
@@ -444,7 +441,7 @@ Result populateKernelInfoFromFunction(KernelInfoCallback callback,
   }
 
   if (!kernel_arg_base_type_found) {
-    return Result::FINALIZE_PROGRAM_FAILURE;
+    return cargo::make_unexpected(Result::FINALIZE_PROGRAM_FAILURE);
   }
 
   // First operand contains kernel_arg_base_type.
@@ -475,7 +472,7 @@ Result populateKernelInfoFromFunction(KernelInfoCallback callback,
           if (kernel_info.argument_info->resize(mdNode->getNumOperands() - 1) !=
               cargo::success) {
             kernel_info.argument_info = cargo::nullopt;
-            return Result::OUT_OF_MEMORY;
+            return cargo::make_unexpected(Result::OUT_OF_MEMORY);
           }
         }
         KernelInfo::ArgumentInfo &info =
@@ -558,15 +555,13 @@ Result populateKernelInfoFromFunction(KernelInfoCallback callback,
 
   populateAttributes(kernel_info, node);
 
-  callback(std::move(kernel_info));
-  return Result::SUCCESS;
+  return kernel_info;
 }
 }  // namespace
 
-Result moduleToProgramInfo(KernelInfoCallback callback,
-                           llvm::Module *const module,
+Result moduleToProgramInfo(ProgramInfo &program_info, llvm::Module *const M,
                            bool store_argument_metadata) {
-  llvm::NamedMDNode *const node = module->getNamedMetadata("opencl.kernels");
+  llvm::NamedMDNode *const node = M->getNamedMetadata("opencl.kernels");
   // Having no kernels isn't a failure.
   if (!node) {
     return Result::SUCCESS;
@@ -580,10 +575,13 @@ Result moduleToProgramInfo(KernelInfoCallback callback,
       llvm::Function *const function =
           llvm::cast<llvm::Function>(vmd->getValue());
 
-      auto populate_kernel_info_result = populateKernelInfoFromFunction(
-          callback, function, subNode, store_argument_metadata);
-      if (populate_kernel_info_result != Result::SUCCESS) {
-        return populate_kernel_info_result;
+      auto kernel_info_result = populateKernelInfoFromFunction(
+          function, subNode, store_argument_metadata);
+      if (!kernel_info_result.has_value()) {
+        return kernel_info_result.error();
+      }
+      if (!program_info.addNewKernel(std::move(*kernel_info_result))) {
+        return Result::OUT_OF_MEMORY;
       }
     }
   }

--- a/modules/compiler/test/common.h
+++ b/modules/compiler/test/common.h
@@ -241,7 +241,7 @@ struct OpenCLCModuleTest : CompilerModuleTest {
                   KernelSource(), {}));
     std::vector<builtins::printf::descriptor> printf_calls;
     ASSERT_EQ(compiler::Result::SUCCESS,
-              module->finalize([](compiler::KernelInfo) {}, printf_calls));
+              module->finalize(nullptr, printf_calls));
   };
 
   /// @brief Virtual method to clean up any resources this fixture allocated.

--- a/modules/compiler/test/module.cpp
+++ b/modules/compiler/test/module.cpp
@@ -137,7 +137,7 @@ struct CompileOptionsTest : CompilerModuleTest {
                   nop_clc_source, {}));
     std::vector<builtins::printf::descriptor> printf_calls{};
     ASSERT_EQ(compiler::Result::SUCCESS,
-              module->finalize([](compiler::KernelInfo) {}, printf_calls));
+              module->finalize(nullptr, printf_calls));
     cargo::array_view<std::uint8_t> buffer;
     ASSERT_EQ(compiler::Result::SUCCESS, module->createBinary(buffer));
   }
@@ -270,7 +270,7 @@ TEST_P(SerializeModuleTest, SerializeIntermediate) {
 
   std::vector<builtins::printf::descriptor> printf_calls;
   ASSERT_EQ(compiler::Result::SUCCESS,
-            cloned_module->finalize([](compiler::KernelInfo) {}, printf_calls));
+            cloned_module->finalize(nullptr, printf_calls));
   EXPECT_EQ(cloned_module->getState(), compiler::ModuleState::EXECUTABLE);
 }
 
@@ -314,14 +314,13 @@ TEST_P(SerializeModuleTest, SerializeLibraryThenLink) {
 
   std::vector<builtins::printf::descriptor> printf_calls;
   ASSERT_EQ(compiler::Result::SUCCESS,
-            cloned_module->finalize([](compiler::KernelInfo) {}, printf_calls));
+            cloned_module->finalize(nullptr, printf_calls));
   EXPECT_EQ(cloned_module->getState(), compiler::ModuleState::EXECUTABLE);
 }
 
 TEST_P(SerializeModuleTest, SerializeFinalized) {
   std::vector<builtins::printf::descriptor> printf_calls;
-  ASSERT_EQ(compiler::Result::SUCCESS,
-            module->finalize([](compiler::KernelInfo) {}, printf_calls));
+  ASSERT_EQ(compiler::Result::SUCCESS, module->finalize(nullptr, printf_calls));
 
   size_t size = module->size();
   ASSERT_GT(size, 0);

--- a/modules/mux/test/application.cpp
+++ b/modules/mux/test/application.cpp
@@ -103,7 +103,7 @@ struct muxApplication : public ::testing::Test {
                 compiler::Result::SUCCESS);
       std::vector<builtins::printf::descriptor> printf_calls;
       ASSERT_EQ(compiler::Result::SUCCESS,
-                module->finalize([](compiler::KernelInfo) {}, printf_calls));
+                module->finalize(nullptr, printf_calls));
       cargo::array_view<std::uint8_t> buffer;
       ASSERT_EQ(module->createBinary(buffer), compiler::Result::SUCCESS);
       mux_executable_t executable = nullptr;

--- a/modules/mux/test/common.h
+++ b/modules/mux/test/common.h
@@ -353,7 +353,7 @@ struct DeviceCompilerTest : DeviceTest {
     };
 
     std::vector<builtins::printf::descriptor> printf_calls;
-    error = module->finalize([](compiler::KernelInfo) {}, printf_calls);
+    error = module->finalize(nullptr, printf_calls);
     if (compiler::Result::SUCCESS != error) {
       return error;
     }

--- a/source/cl/include/cl/kernel.h
+++ b/source/cl/include/cl/kernel.h
@@ -232,14 +232,14 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     /// `compiler::ArgumentKind::POINTER` and `address_space` of
     /// `cl::binary::AddressSpace::LOCAL`.
     /// @param local_memory_size Size of the local memory buffer argument.
-    argument(cl::binary::ArgumentType arg_type, size_t local_memory_size);
+    argument(compiler::ArgumentType arg_type, size_t local_memory_size);
 
     /// @brief Constructor to create a sampler argument.
     ///
     /// @param arg_type Type of the kernel argument, must have `kind` of
     /// `compiler::ArgumentKind::SAMPLER`.
     /// @param sampler Sampler object.
-    argument(cl::binary::ArgumentType arg_type, const cl_sampler sampler);
+    argument(compiler::ArgumentType arg_type, const cl_sampler sampler);
 
     /// @brief Constructor to create a memory buffer argument.
     ///
@@ -249,7 +249,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     /// @param type Type of the kernel argument, must be a valid type to use
     /// with a memory buffer.
     /// @param mem Memory buffer object.
-    argument(cl::binary::ArgumentType type, cl_mem mem);
+    argument(compiler::ArgumentType type, cl_mem mem);
 
     /// @brief Constructor to create an argument passed by value.
     ///
@@ -260,8 +260,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     ///
     /// @param value Value of the parameter.
     /// @param value_size Size of the data.
-    argument(cl::binary::ArgumentType type, const void *value,
-             size_t value_size);
+    argument(compiler::ArgumentType type, const void *value, size_t value_size);
 
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
     /// @brief Constructor to create an USM allocation argument.
@@ -270,7 +269,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     /// with a USM allocation, i.e a global or constant pointer.
     /// @param usm_alloc USM allocation associated with parameter.
     /// @param offset Byte offset from the start of the USM allocation.
-    argument(cl::binary::ArgumentType type,
+    argument(compiler::ArgumentType type,
              extension::usm::allocation_info *usm_alloc, size_t offset);
 #endif
 
@@ -306,7 +305,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     ~argument();
 
     // @brief Type of the argument.
-    cl::binary::ArgumentType type;
+    compiler::ArgumentType type;
 
     union {
       size_t local_memory_size;
@@ -324,7 +323,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
 #endif
     };
 
-    using info = cl::binary::KernelInfo::ArgumentInfo;
+    using info = compiler::KernelInfo::ArgumentInfo;
 
     /// @brief Enum representing the possible storage types that can be used by
     /// the kernel argument. Each of these storage type match a single field of
@@ -353,7 +352,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
   /// @param[in] name Name of the kernel in the program to create.
   /// @param[in] info Information from the compiler about the kernel.
   _cl_kernel(cl_program program, std::string name,
-             const cl::binary::KernelInfo *info);
+             const compiler::KernelInfo *info);
 
  public:
   /// @brief Deleted copy constructor.
@@ -374,7 +373,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
   /// @return Returns a kernel object on success or an error code otherwise.
   /// @retval `CL_OUT_OF_HOST_MEMORY` if an allocation failure occured.
   static cargo::expected<cl_kernel, cl_int> create(
-      cl_program program, std::string name, const cl::binary::KernelInfo *info);
+      cl_program program, std::string name, const compiler::KernelInfo *info);
 
   /// @brief Clone this kernel.
   ///
@@ -400,7 +399,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
   ///
   /// @return Return the argument type on success, CL_INVALID_ARG_INDEX
   /// otherwise.
-  cargo::expected<const cl::binary::ArgumentType &, cl_int> GetArgType(
+  cargo::expected<const compiler::ArgumentType &, cl_int> GetArgType(
       const cl_uint arg_index) const;
 
   /// @brief Set up the mux kernel execution options.
@@ -494,7 +493,7 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
   /// @brief Name of the kernel.
   std::string name;
   /// @brief Pointer to kernel information.
-  const cl::binary::KernelInfo *info;
+  const compiler::KernelInfo *info;
   /// @brief Array of arguments.
   cargo::dynamic_array<argument> saved_args;
   /// @brief Array of argument information.

--- a/source/cl/include/cl/program.h
+++ b/source/cl/include/cl/program.h
@@ -503,7 +503,7 @@ struct _cl_program final : public cl::base<_cl_program> {
   /// @param[in] name Name of the kernel to query.
   ///
   /// @return Returns the kernel description if there is one.
-  cargo::optional<const cl::binary::KernelInfo *> getKernelInfo(
+  cargo::optional<const compiler::KernelInfo *> getKernelInfo(
       cargo::string_view name) const;
 
   /// @brief Query the program for the number of kernels it contains.

--- a/source/cl/include/cl/program.h
+++ b/source/cl/include/cl/program.h
@@ -280,7 +280,7 @@ struct device_program {
   std::string compiler_log;
 
   /// @brief Program information.
-  cargo::optional<binary::ProgramInfo> program_info;
+  cargo::optional<compiler::ProgramInfo> program_info;
 
   /// @brief Printf descriptor information.
   std::vector<builtins::printf::descriptor> printf_calls;

--- a/source/cl/source/binary/include/cl/binary/argument.h
+++ b/source/cl/source/binary/include/cl/binary/argument.h
@@ -31,71 +31,6 @@
 namespace cl {
 namespace binary {
 
-/// @brief Enumeration of standard OpenCL address space values.
-enum AddressSpace : uint32_t {
-  PRIVATE = 0,
-  GLOBAL = 1,
-  CONSTANT = 2,
-  LOCAL = 3,
-};
-
-/// @brief Struct to hold type and related metadata.
-struct ArgumentType final {
-  /// @brief Default constructor.
-  ArgumentType()
-      : kind(compiler::ArgumentKind::UNKNOWN),
-        address_space(0),
-        type_name_str(),
-        vector_width(1),
-        is_other(false),
-        dereferenceable_bytes() {}
-
-  /// @brief Non-pointer constructor.
-  ///
-  /// @param kind The argument kind.
-  ArgumentType(compiler::ArgumentKind kind)
-      : kind(kind),
-        address_space(0),
-        type_name_str(),
-        vector_width(1),
-        is_other(false),
-        dereferenceable_bytes() {}
-
-  /// @brief Pointer constructor.
-  ///
-  /// @param address_space The address space of the pointer argument.
-  ArgumentType(uint32_t address_space)
-      : kind(compiler::ArgumentKind::POINTER),
-        address_space(address_space),
-        type_name_str(),
-        vector_width(1),
-        is_other(false),
-        dereferenceable_bytes() {}
-
-  /// @brief Default destructor.
-  ~ArgumentType() = default;
-
-  /// @brief The type (possibly including integer bit width and vector width).
-  compiler::ArgumentKind kind;
-  /// @brief The address space of the argument.
-  uint32_t address_space;
-  /// @brief Type name string provided by user (including vector width).
-  ///
-  /// Will start with a `u` if the type is unsigned. This is the only place
-  /// where unsigned information is stored.
-  ///
-  /// This is the string that gets reported by @a CL_KERNEL_ARG_TYPE_NAME.
-  std::string type_name_str;
-  /// @brief Vector width of type (only relevant to integer and fp types).
-  size_t vector_width;
-  /// @brief If the type is an `image*` or `sampler_t` type. Storing this
-  /// information here makes parsing easier later.
-  bool is_other;
-  /// @brief returns the amount of deferencable bytes of the argument. Note: The
-  /// argument must be a pointer type
-  cargo::optional<uint64_t> dereferenceable_bytes;
-};
-
 /// @brief Convert a parameter type string into a ArgumentType.
 ///
 /// Pointers and `structByVal` types are not supported.
@@ -103,8 +38,8 @@ struct ArgumentType final {
 /// @param[in] str string_view containing parameter info excluding name.
 ///
 /// @return An ArgumentType description of the parameter.
-ArgumentType getArgumentTypeFromParameterTypeString(
-    const cargo::string_view &str);
+std::pair<compiler::ArgumentType, std::string>
+getArgumentTypeFromParameterTypeString(const cargo::string_view &str);
 
 }  // namespace binary
 }  // namespace cl

--- a/source/cl/source/binary/include/cl/binary/binary.h
+++ b/source/cl/source/binary/include/cl/binary/binary.h
@@ -75,7 +75,7 @@ bool serializeBinary(
     cargo::dynamic_array<uint8_t> &binary,
     const cargo::array_view<const uint8_t> mux_binary,
     const std::vector<builtins::printf::descriptor> &printf_calls,
-    const cl::binary::ProgramInfo &program_info, bool kernel_arg_info,
+    const compiler::ProgramInfo &program_info, bool kernel_arg_info,
     compiler::Module *compiler_module);
 
 /// @brief Deserializes an OpenCL program binary.
@@ -89,7 +89,7 @@ bool serializeBinary(
 /// @return true if the binary was deserialized successfully, false
 bool deserializeBinary(cargo::array_view<const uint8_t> binary,
                        std::vector<builtins::printf::descriptor> &printf_calls,
-                       cl::binary::ProgramInfo &program_info,
+                       compiler::ProgramInfo &program_info,
                        cargo::dynamic_array<uint8_t> &executable,
                        bool &is_executable);
 
@@ -102,17 +102,6 @@ md_hooks getOpenCLMetadataWriteHooks();
 ///
 /// @return md_hooks
 md_hooks getOpenCLMetadataReadHooks();
-
-/// @brief Returns a compiler::KernelInfoCallback which will populate a CL
-/// ProgramInfo object.
-///
-/// @param[in,out] program_info CL ProgramInfo object to populate with the
-/// KernelInfoCallback.
-///
-/// @return A callback which will populate program_info when finalizing a
-/// compiler module.
-compiler::KernelInfoCallback populateProgramInfoCallback(
-    ProgramInfo &program_info);
 
 /// @brief Detects the OpenCL device profile string from a given Mux device.
 ///

--- a/source/cl/source/binary/include/cl/binary/kernel_info.h
+++ b/source/cl/source/binary/include/cl/binary/kernel_info.h
@@ -23,44 +23,12 @@
 #include <cargo/small_vector.h>
 #include <cargo/string_view.h>
 #include <cl/binary/argument.h>
+#include <compiler/module.h>
 
 #include <string>
 
 namespace cl {
 namespace binary {
-
-/// @brief Class for storing kernel info.
-class KernelInfo {
- public:
-  /// @brief Default constructor.
-  KernelInfo();
-
-  /// @brief Struct representing basic kernel argument information.
-  struct ArgumentInfo final {
-    ArgumentInfo();
-
-    cl_kernel_arg_address_qualifier address_qual;
-    cl_kernel_arg_access_qualifier access_qual;
-    cl_kernel_arg_type_qualifier type_qual;
-    std::string type_name;
-    std::string name;
-  };  // struct ArgumentInfo
-
-  std::string name;
-  std::string attributes;
-  uint32_t num_arguments;
-  cargo::dynamic_array<ArgumentType> argument_types;
-  cargo::optional<cargo::small_vector<ArgumentInfo, 8>> argument_info;
-  uint64_t private_mem_size;
-
-  /// @brief Values of reqd_work_group_size attribute.
-  ///
-  /// @remark *** Attention ***
-  /// Work_group should only be set if reqd_work_group_size attribute is
-  /// specified! Code in clEnqueueNDRangeKernel and clEnqueueTask relies on this
-  /// assumption.
-  std::array<size_t, 3> work_group;
-};  // class KernelInfo
 
 /// @brief Extract kernel information from a declaration string.
 ///
@@ -87,7 +55,7 @@ class KernelInfo {
 /// metadata as required by -cl-kernel-arg-info.
 ///
 /// @return Return true if successful, false on allocation failures.
-bool kernelDeclStrToKernelInfo(KernelInfo &kernel_info,
+bool kernelDeclStrToKernelInfo(compiler::KernelInfo &kernel_info,
                                const cargo::string_view decl,
                                bool store_arg_metadata);
 

--- a/source/cl/source/binary/include/cl/binary/program_info.h
+++ b/source/cl/source/binary/include/cl/binary/program_info.h
@@ -53,52 +53,53 @@ class ProgramInfo {
   /// @param[in] kernel_index Index into the list of kernel infos.
   ///
   /// @return Return kernel info if found, null otherwise.
-  KernelInfo *getKernel(size_t kernel_index);
+  compiler::KernelInfo *getKernel(size_t kernel_index);
 
   /// @brief Retrieve a kernel by index.
   ///
   /// @param[in] kernel_index Index into the list of kernel infos.
   ///
   /// @return Return kernel info if found, null otherwise.
-  const KernelInfo *getKernel(size_t kernel_index) const;
+  const compiler::KernelInfo *getKernel(size_t kernel_index) const;
 
   /// @brief Retrieve a kernel by name.
   ///
   /// @param[in] kernel_name Name of the kernel to search for.
   ///
   /// @return Return kernel info if found, null otherwise.
-  KernelInfo *getKernelByName(cargo::string_view kernel_name);
+  compiler::KernelInfo *getKernelByName(cargo::string_view kernel_name);
 
   /// @brief Retrieve a kernel by name.
   ///
   /// @param[in] kernel_name Name of the kernel to search for.
   ///
   /// @return Return kernel info if found, null otherwise.
-  const KernelInfo *getKernelByName(cargo::string_view kernel_name) const;
+  const compiler::KernelInfo *getKernelByName(
+      cargo::string_view kernel_name) const;
 
   /// @brief Retrieve the begin iterator.
   ///
   /// @return The beginning of the kernel info range.
-  KernelInfo *begin();
+  compiler::KernelInfo *begin();
 
   /// @brief Retrieve the begin iterator.
   ///
   /// @return The beginning of the kernel info range.
-  const KernelInfo *begin() const;
+  const compiler::KernelInfo *begin() const;
 
   /// @brief Retrieve the end iterator.
   ///
   /// @return Return the end iterator.
-  KernelInfo *end();
+  compiler::KernelInfo *end();
 
   /// @brief Retrieve the end iterator.
   ///
   /// @return Return the end iterator.
-  const KernelInfo *end() const;
+  const compiler::KernelInfo *end() const;
 
  private:
   /// @brief Kernel descriptions.
-  cargo::small_vector<KernelInfo, 8> kernel_descriptions;
+  cargo::small_vector<compiler::KernelInfo, 8> kernel_descriptions;
 };  // class ProgramInfo
 
 /// @brief Initialize information for all built-in kernels from their

--- a/source/cl/source/binary/include/cl/binary/program_info.h
+++ b/source/cl/source/binary/include/cl/binary/program_info.h
@@ -29,79 +29,6 @@
 namespace cl {
 namespace binary {
 
-/// @brief Class for managing program information.
-class ProgramInfo {
- public:
-  ProgramInfo();
-
-  /// @brief Add a single empty kernel info for later population.
-  bool addNewKernel();
-
-  /// @brief Initialize empty program information for a specified number of
-  /// kernels for later population.
-  ///
-  /// @param[in] numKernels Number of kernels to allocate space for.
-  bool resizeFromNumKernels(int32_t numKernels);
-
-  /// @brief  Retrieve the number of kernels.
-  ///
-  /// @return Return the number of kernels.
-  inline size_t getNumKernels() const { return kernel_descriptions.size(); }
-
-  /// @brief Retrieve a kernel by index.
-  ///
-  /// @param[in] kernel_index Index into the list of kernel infos.
-  ///
-  /// @return Return kernel info if found, null otherwise.
-  compiler::KernelInfo *getKernel(size_t kernel_index);
-
-  /// @brief Retrieve a kernel by index.
-  ///
-  /// @param[in] kernel_index Index into the list of kernel infos.
-  ///
-  /// @return Return kernel info if found, null otherwise.
-  const compiler::KernelInfo *getKernel(size_t kernel_index) const;
-
-  /// @brief Retrieve a kernel by name.
-  ///
-  /// @param[in] kernel_name Name of the kernel to search for.
-  ///
-  /// @return Return kernel info if found, null otherwise.
-  compiler::KernelInfo *getKernelByName(cargo::string_view kernel_name);
-
-  /// @brief Retrieve a kernel by name.
-  ///
-  /// @param[in] kernel_name Name of the kernel to search for.
-  ///
-  /// @return Return kernel info if found, null otherwise.
-  const compiler::KernelInfo *getKernelByName(
-      cargo::string_view kernel_name) const;
-
-  /// @brief Retrieve the begin iterator.
-  ///
-  /// @return The beginning of the kernel info range.
-  compiler::KernelInfo *begin();
-
-  /// @brief Retrieve the begin iterator.
-  ///
-  /// @return The beginning of the kernel info range.
-  const compiler::KernelInfo *begin() const;
-
-  /// @brief Retrieve the end iterator.
-  ///
-  /// @return Return the end iterator.
-  compiler::KernelInfo *end();
-
-  /// @brief Retrieve the end iterator.
-  ///
-  /// @return Return the end iterator.
-  const compiler::KernelInfo *end() const;
-
- private:
-  /// @brief Kernel descriptions.
-  cargo::small_vector<compiler::KernelInfo, 8> kernel_descriptions;
-};  // class ProgramInfo
-
 /// @brief Initialize information for all built-in kernels from their
 /// declarations.
 ///
@@ -112,7 +39,7 @@ class ProgramInfo {
 ///
 /// @return Returns a valid ProgramInfo if successful, or cargo::nullopt
 /// otherwise.
-cargo::optional<ProgramInfo> kernelDeclsToProgramInfo(
+cargo::optional<compiler::ProgramInfo> kernelDeclsToProgramInfo(
     const cargo::small_vector<std::string, 8> &decls, bool store_arg_metadata);
 
 }  // namespace binary

--- a/source/cl/source/binary/source/argument.cpp
+++ b/source/cl/source/binary/source/argument.cpp
@@ -30,9 +30,9 @@
 namespace cl {
 namespace binary {
 
-ArgumentType getArgumentTypeFromParameterTypeString(
-    const cargo::string_view &str) {
-  ArgumentType type_info;
+std::pair<compiler::ArgumentType, std::string>
+getArgumentTypeFromParameterTypeString(const cargo::string_view &str) {
+  compiler::ArgumentType type_info;
 
   auto words_v = cargo::split(str, " ");
 
@@ -44,16 +44,17 @@ ArgumentType getArgumentTypeFromParameterTypeString(
   auto &type_str = words_v.back();
 
   // If the type is unsigned, store a 'u' in the type name
+  std::string type_name_str;
   if (type_str.starts_with('u')) {
-    type_info.type_name_str = 'u';
+    type_name_str = 'u';
     type_str.remove_prefix(1);  // Remove the 'u'
   } else if (words_v.size() >= 2 &&
              !(words_v.crend() - 2)->compare("unsigned")) {
-    type_info.type_name_str = 'u';
+    type_name_str = 'u';
   }
 
   // Store the rest of the type name including vector width (if present)
-  type_info.type_name_str += cargo::as<std::string>(type_str);
+  type_name_str += cargo::as<std::string>(type_str);
 
   // Check for vector widths
   static std::regex trailing_num_re(R"((\d+)$)", std::regex::optimize);
@@ -170,7 +171,6 @@ ArgumentType getArgumentTypeFromParameterTypeString(
       type_info.kind = compiler::ArgumentKind::INT64_16;
     }
   } else {  // "other" type or an error
-    type_info.is_other = true;
     if (!type_str.compare("image1d_array_t")) {
       type_info.kind = compiler::ArgumentKind::IMAGE1D_ARRAY;
     } else if (!type_str.compare("image1d_buffer_t")) {
@@ -191,7 +191,7 @@ ArgumentType getArgumentTypeFromParameterTypeString(
     }
   }
 
-  return type_info;
+  return std::make_pair(type_info, type_name_str);
 }
 
 }  // namespace binary

--- a/source/cl/source/binary/source/binary.cpp
+++ b/source/cl/source/binary/source/binary.cpp
@@ -25,6 +25,7 @@
 #include <compiler/loader.h>
 #include <metadata/detail/md_ctx.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <fstream>
@@ -49,56 +50,6 @@ auto md_init_unique(md_hooks *hooks, void *userdata) {
   };
   auto ctx = md_init(hooks, userdata);
   return std::unique_ptr<md_ctx_, decltype(deleter)>(ctx, std::move(deleter));
-}
-
-/// @brief Converts a kernel argument address space from the compiler library to
-/// an OpenCL argument address qualifier.
-cl_kernel_arg_address_qualifier convertKernelAddressQualifier(
-    compiler::AddressSpace address) {
-  switch (address) {
-    case compiler::AddressSpace::PRIVATE:
-      return CL_KERNEL_ARG_ADDRESS_PRIVATE;
-    case compiler::AddressSpace::GLOBAL:
-      return CL_KERNEL_ARG_ADDRESS_GLOBAL;
-    case compiler::AddressSpace::CONSTANT:
-      return CL_KERNEL_ARG_ADDRESS_CONSTANT;
-    case compiler::AddressSpace::LOCAL:
-      return CL_KERNEL_ARG_ADDRESS_LOCAL;
-  }
-  return 0;
-}
-
-/// @brief Converts a kernel argument access qualifier from the compiler library
-/// to an OpenCL argument access qualifier.
-cl_kernel_arg_access_qualifier convertKernelArgAccessQualifier(
-    compiler::KernelArgAccess access) {
-  switch (access) {
-    case compiler::KernelArgAccess::NONE:
-      return CL_KERNEL_ARG_ACCESS_NONE;
-    case compiler::KernelArgAccess::READ_ONLY:
-      return CL_KERNEL_ARG_ACCESS_READ_ONLY;
-    case compiler::KernelArgAccess::WRITE_ONLY:
-      return CL_KERNEL_ARG_ACCESS_WRITE_ONLY;
-    case compiler::KernelArgAccess::READ_WRITE:
-      return CL_KERNEL_ARG_ACCESS_READ_WRITE;
-  }
-  return 0;
-}
-
-/// @brief Converts a kernel argument type qualifier from the compiler library
-/// to an OpenCL argument type qualifier.
-cl_kernel_arg_type_qualifier convertKernelArgTypeQualifier(std::uint32_t type) {
-  cl_uint cl_arg_type = 0;
-  if (type & compiler::KernelArgType::CONST) {
-    cl_arg_type |= CL_KERNEL_ARG_TYPE_CONST;
-  }
-  if (type & compiler::KernelArgType::RESTRICT) {
-    cl_arg_type |= CL_KERNEL_ARG_TYPE_RESTRICT;
-  }
-  if (type & compiler::KernelArgType::VOLATILE) {
-    cl_arg_type |= CL_KERNEL_ARG_TYPE_VOLATILE;
-  }
-  return cl_arg_type;
 }
 
 bool serializeExecutable(OpenCLWriteUserdata *cl_userdata, md_ctx ctx) {
@@ -260,7 +211,7 @@ bool serializeProgramInfo(md_ctx ctx,
     }
 
     // number of arguments
-    const int n_args_idx = md_push_uint(stack, kernel.num_arguments);
+    const int n_args_idx = md_push_uint(stack, kernel.getNumArguments());
     if (MD_CHECK_ERR(n_args_idx)) {
       return false;
     }
@@ -284,11 +235,13 @@ bool serializeProgramInfo(md_ctx ctx,
     md_pop(stack);
 
     // Arg Info
-    const int kernel_arg_arr_idx = md_push_array(stack, kernel.num_arguments);
+    const int kernel_arg_arr_idx =
+        md_push_array(stack, kernel.getNumArguments());
     if (MD_CHECK_ERR(kernel_arg_arr_idx)) {
       return false;
     }
-    for (size_t arg_idx = 0; arg_idx < kernel.num_arguments; ++arg_idx) {
+    for (size_t arg_idx = 0, e = kernel.getNumArguments(); arg_idx < e;
+         ++arg_idx) {
       // argument kind
       const int arg_kind_idx = md_push_uint(
           stack, static_cast<uint64_t>(kernel.argument_types[arg_idx].kind));
@@ -329,7 +282,8 @@ bool serializeProgramInfo(md_ctx ctx,
         md_pop(stack);
 
         // access qualifier
-        const int access_qualifier = md_push_uint(stack, arg_info.access_qual);
+        const int access_qualifier =
+            md_push_uint(stack, static_cast<uint64_t>(arg_info.access_qual));
         if (MD_CHECK_ERR(access_qualifier)) {
           return false;
         }
@@ -387,7 +341,8 @@ bool serializeProgramInfo(md_ctx ctx,
       return false;
     }
     for (size_t i = 0; i < 3; ++i) {
-      const int work_size_idx = md_push_uint(stack, kernel.work_group[i]);
+      const int work_size_idx =
+          md_push_uint(stack, kernel.getReqdWGSizeOrZero()[i]);
       if (MD_CHECK_ERR(work_size_idx)) {
         return false;
       }
@@ -595,7 +550,6 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
     if (MD_CHECK_ERR(err)) {
       return false;
     }
-    kernelInfo->num_arguments = numArguments;
 
     // has full metadata?
     md_value full_metadata_v;
@@ -662,7 +616,7 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
         return false;
       }
       kernelInfo->argument_types[kernel_arg_idx].address_space =
-          static_cast<cl::binary::AddressSpace>(arg_addr_space);
+          static_cast<compiler::AddressSpace>(arg_addr_space);
       ++cur_arg_array_idx;
 
       if (hasArgMetadata) {
@@ -681,7 +635,7 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
           return false;
         }
         arg_info.address_qual =
-            static_cast<cl_kernel_arg_address_qualifier>(arg_address_qual);
+            static_cast<compiler::AddressSpace>(arg_address_qual);
         ++cur_arg_array_idx;
 
         // arg access qualifier
@@ -697,7 +651,7 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
           return false;
         }
         arg_info.access_qual =
-            static_cast<cl_kernel_arg_access_qualifier>(arg_access_qual);
+            static_cast<compiler::KernelArgAccess>(arg_access_qual);
         ++cur_arg_array_idx;
 
         // arg type qualifier
@@ -758,6 +712,7 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
     if (MD_CHECK_ERR(err)) {
       return false;
     }
+    std::array<size_t, 3> reqd_wg_size;
     for (size_t j = 0; j < 3; ++j) {
       md_value work_size_v;
       err = md_get_array_idx(work_size_arr_v, j, &work_size_v);
@@ -769,7 +724,11 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
       if (MD_CHECK_ERR(err)) {
         return false;
       }
-      kernelInfo->work_group[j] = work_size;
+      reqd_wg_size[j] = work_size;
+    }
+    if (!std::all_of(reqd_wg_size.begin(), reqd_wg_size.end(),
+                     [](size_t v) { return v == 0; })) {
+      kernelInfo->reqd_work_group_size = reqd_wg_size;
     }
 
     // kernel name
@@ -799,7 +758,6 @@ compiler::KernelInfoCallback populateProgramInfoCallback(
 
     kernel_info.name = compiler_kernel_info.name;
     kernel_info.attributes = compiler_kernel_info.attributes;
-    kernel_info.num_arguments = compiler_kernel_info.argument_types.size();
     kernel_info.private_mem_size = compiler_kernel_info.private_mem_size;
 
     (void)kernel_info.argument_types.alloc(
@@ -821,22 +779,16 @@ compiler::KernelInfoCallback populateProgramInfoCallback(
         const auto &compiler_arg_info =
             compiler_kernel_info.argument_info.value()[i];
         auto &arg_info = kernel_info.argument_info.value()[i];
-        arg_info.address_qual =
-            convertKernelAddressQualifier(compiler_arg_info.address_qual);
-        arg_info.access_qual =
-            convertKernelArgAccessQualifier(compiler_arg_info.access_qual);
-        arg_info.type_qual =
-            convertKernelArgTypeQualifier(compiler_arg_info.type_qual);
+        arg_info.address_qual = compiler_arg_info.address_qual;
+        arg_info.access_qual = compiler_arg_info.access_qual;
+        arg_info.type_qual = compiler_arg_info.type_qual;
         arg_info.type_name = compiler_arg_info.type_name;
         arg_info.name = compiler_arg_info.name;
       }
     }
 
-    if (compiler_kernel_info.work_group.has_value()) {
-      kernel_info.work_group = *compiler_kernel_info.work_group;
-    } else {
-      kernel_info.work_group.fill(0);
-    }
+    kernel_info.reqd_work_group_size =
+        compiler_kernel_info.reqd_work_group_size;
   };
 }
 

--- a/source/cl/source/binary/source/program_info.cpp
+++ b/source/cl/source/binary/source/program_info.cpp
@@ -19,75 +19,10 @@
 namespace cl {
 namespace binary {
 
-ProgramInfo::ProgramInfo() : kernel_descriptions() {}
-
-bool ProgramInfo::addNewKernel() {
-  if (cargo::success != kernel_descriptions.emplace_back()) {
-    return false;
-  }
-  return true;
-}
-
-bool ProgramInfo::resizeFromNumKernels(int32_t numKernels) {
-  if (cargo::success != kernel_descriptions.resize(numKernels)) {
-    return false;
-  }
-  return true;
-}
-
-compiler::KernelInfo *ProgramInfo::getKernel(size_t kernel_index) {
-  if (kernel_index >= kernel_descriptions.size()) {
-    return nullptr;
-  }
-  return &kernel_descriptions[kernel_index];
-}
-
-const compiler::KernelInfo *ProgramInfo::getKernel(size_t kernel_index) const {
-  if (kernel_index >= kernel_descriptions.size()) {
-    return nullptr;
-  }
-  return &kernel_descriptions[kernel_index];
-}
-
-compiler::KernelInfo *ProgramInfo::getKernelByName(
-    cargo::string_view kernel_name) {
-  for (auto &desc : kernel_descriptions) {
-    if (kernel_name == desc.name) {
-      return &desc;
-    }
-  }
-  return nullptr;
-}
-
-const compiler::KernelInfo *ProgramInfo::getKernelByName(
-    cargo::string_view kernel_name) const {
-  for (auto &desc : kernel_descriptions) {
-    if (kernel_name == desc.name) {
-      return &desc;
-    }
-  }
-  return nullptr;
-}
-
-compiler::KernelInfo *ProgramInfo::begin() {
-  return kernel_descriptions.begin();
-}
-
-const compiler::KernelInfo *ProgramInfo::begin() const {
-  return kernel_descriptions.begin();
-}
-
-compiler::KernelInfo *ProgramInfo::end() { return kernel_descriptions.end(); }
-
-const compiler::KernelInfo *ProgramInfo::end() const {
-  return kernel_descriptions.end();
-}
-
-cargo::optional<ProgramInfo> kernelDeclsToProgramInfo(
+cargo::optional<compiler::ProgramInfo> kernelDeclsToProgramInfo(
     const cargo::small_vector<std::string, 8> &decls, bool store_arg_metadata) {
-  ProgramInfo program_info;
-  size_t num_kernels = decls.size();
-  if (!decls.empty()) {
+  compiler::ProgramInfo program_info;
+  if (size_t num_kernels = decls.size()) {
     if (!program_info.resizeFromNumKernels(num_kernels)) {
       return cargo::nullopt;
     }

--- a/source/cl/source/binary/source/program_info.cpp
+++ b/source/cl/source/binary/source/program_info.cpp
@@ -35,21 +35,22 @@ bool ProgramInfo::resizeFromNumKernels(int32_t numKernels) {
   return true;
 }
 
-KernelInfo *ProgramInfo::getKernel(size_t kernel_index) {
+compiler::KernelInfo *ProgramInfo::getKernel(size_t kernel_index) {
   if (kernel_index >= kernel_descriptions.size()) {
     return nullptr;
   }
   return &kernel_descriptions[kernel_index];
 }
 
-const KernelInfo *ProgramInfo::getKernel(size_t kernel_index) const {
+const compiler::KernelInfo *ProgramInfo::getKernel(size_t kernel_index) const {
   if (kernel_index >= kernel_descriptions.size()) {
     return nullptr;
   }
   return &kernel_descriptions[kernel_index];
 }
 
-KernelInfo *ProgramInfo::getKernelByName(cargo::string_view kernel_name) {
+compiler::KernelInfo *ProgramInfo::getKernelByName(
+    cargo::string_view kernel_name) {
   for (auto &desc : kernel_descriptions) {
     if (kernel_name == desc.name) {
       return &desc;
@@ -58,7 +59,7 @@ KernelInfo *ProgramInfo::getKernelByName(cargo::string_view kernel_name) {
   return nullptr;
 }
 
-const KernelInfo *ProgramInfo::getKernelByName(
+const compiler::KernelInfo *ProgramInfo::getKernelByName(
     cargo::string_view kernel_name) const {
   for (auto &desc : kernel_descriptions) {
     if (kernel_name == desc.name) {
@@ -68,15 +69,19 @@ const KernelInfo *ProgramInfo::getKernelByName(
   return nullptr;
 }
 
-KernelInfo *ProgramInfo::begin() { return kernel_descriptions.begin(); }
-
-const KernelInfo *ProgramInfo::begin() const {
+compiler::KernelInfo *ProgramInfo::begin() {
   return kernel_descriptions.begin();
 }
 
-KernelInfo *ProgramInfo::end() { return kernel_descriptions.end(); }
+const compiler::KernelInfo *ProgramInfo::begin() const {
+  return kernel_descriptions.begin();
+}
 
-const KernelInfo *ProgramInfo::end() const { return kernel_descriptions.end(); }
+compiler::KernelInfo *ProgramInfo::end() { return kernel_descriptions.end(); }
+
+const compiler::KernelInfo *ProgramInfo::end() const {
+  return kernel_descriptions.end();
+}
 
 cargo::optional<ProgramInfo> kernelDeclsToProgramInfo(
     const cargo::small_vector<std::string, 8> &decls, bool store_arg_metadata) {

--- a/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
@@ -130,8 +130,8 @@ cl_int createBlockingEventForKernel(cl_command_queue queue, cl_kernel kernel,
   return_event = *new_event;
 
   // USM allocation set as kernel arguments
-  for (uint32_t i = 0; i < kernel->info->num_arguments; ++i) {
-    _cl_kernel::argument& arg = kernel->saved_args[i];
+  for (size_t i = 0, e = kernel->info->getNumArguments(); i < e; ++i) {
+    _cl_kernel::argument &arg = kernel->saved_args[i];
     if (arg.stype == _cl_kernel::argument::storage_type::usm) {
       auto mux_error = arg.usm.usm_ptr->record_event(return_event);
       OCL_CHECK(mux_error, return CL_OUT_OF_RESOURCES);

--- a/source/cl/source/extension/source/intel_unified_shared_memory/usm-exports.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/usm-exports.cpp
@@ -462,7 +462,7 @@ cl_int clSetKernelArgMemPointerINTEL(cl_kernel kernel, cl_uint arg_index,
 
   OCL_CHECK(!kernel, return CL_INVALID_KERNEL);
 
-  OCL_CHECK(arg_index >= kernel->info->num_arguments,
+  OCL_CHECK(arg_index >= kernel->info->getNumArguments(),
             return CL_INVALID_ARG_INDEX);
 
   auto arg_type = kernel->GetArgType(arg_index);

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -907,7 +907,7 @@ bool _cl_program::finalize(cargo::array_view<const cl_device_id> devices) {
   return true;
 }
 
-cargo::optional<const cl::binary::KernelInfo *> _cl_program::getKernelInfo(
+cargo::optional<const compiler::KernelInfo *> _cl_program::getKernelInfo(
     cargo::string_view name) const {
   for (auto device : context->devices) {
     auto &device_program = programs.at(device);
@@ -922,7 +922,7 @@ cargo::optional<const cl::binary::KernelInfo *> _cl_program::getKernelInfo(
       OCL_ASSERT(device_program.program_info, "Program info was null!");
       auto &program_info = *device_program.program_info;
 
-      auto isRequestedKernel = [&](const cl::binary::KernelInfo &kernel_info) {
+      auto isRequestedKernel = [&](const compiler::KernelInfo &kernel_info) {
         if (device_program.type == cl::device_program_type::BUILTIN) {
           return name.find(kernel_info.name) != std::string::npos;
         }

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -153,11 +153,10 @@ bool cl::device_program::finalize(cl_device_id device) {
     }
   } else if (type == cl::device_program_type::COMPILER_MODULE) {
     // Finalise the module.
-    cl::binary::ProgramInfo program_info_to_populate;
+    compiler::ProgramInfo program_info_to_populate;
     if (compiler::Result::SUCCESS !=
-        compiler_module.module->finalize(
-            populateProgramInfoCallback(program_info_to_populate),
-            printf_calls)) {
+        compiler_module.module->finalize(&program_info_to_populate,
+                                         printf_calls)) {
       return false;
     }
     if (num_errors != 0) {
@@ -977,7 +976,7 @@ const char *_cl_program::getKernelNameByOffset(
                "OpenCL _cl_program. Error: not all kernels have been built "
                "into executables");
 
-    const cl::binary::ProgramInfo &program_info =
+    const compiler::ProgramInfo &program_info =
         device_program.program_info.value();
 
     OCL_ASSERT(kernel_index < program_info.getNumKernels(),
@@ -1543,7 +1542,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetProgramInfo(
           success = true;
           std::string name;
 
-          const cl::binary::ProgramInfo &program_info =
+          const compiler::ProgramInfo &program_info =
               *program->programs[device].program_info;
           for (size_t k = 0, e = program_info.getNumKernels(); k < e; k++) {
             OCL_ASSERT(nullptr != program_info.getKernel(k),

--- a/source/cl/tools/clc/clc.cpp
+++ b/source/cl/tools/clc/clc.cpp
@@ -693,8 +693,7 @@ result driver::buildProgram() {
 
   // Linking not needed when a single program is built.
   if (compiler::Result::SUCCESS !=
-      module->finalize(cl::binary::populateProgramInfoCallback(program_info),
-                       printf_calls)) {
+      module->finalize(&program_info, printf_calls)) {
     if (!module_log.empty() && module_log.front() != '\0') {
       std::fprintf(stderr, "%.*s", static_cast<int>(module_log.size()),
                    module_log.data());

--- a/source/cl/tools/clc/clc.h
+++ b/source/cl/tools/clc/clc.h
@@ -86,7 +86,7 @@ class driver {
   /// @brief Printf calls descriptors generated during module finalization.
   std::vector<builtins::printf::descriptor> printf_calls;
   /// @brief Program information generated during module finalization.
-  cl::binary::ProgramInfo program_info;
+  compiler::ProgramInfo program_info;
   /// @brief Storage for the compiled binary.
   std::string generated_output_file;
   /// @brief Build log for the compiler Module

--- a/source/ur/include/ur/kernel.h
+++ b/source/ur/include/ur/kernel.h
@@ -29,33 +29,6 @@
 #include "mux/mux.h"
 #include "ur/base.h"
 
-namespace ur {
-/// @brief Helper type representing kernel metadata.
-struct kernel_data_t {
-  /// @brief Helper type representing kernel argument information.
-  struct argument_info_t final {
-    /// @brief The type of the argument.
-    compiler::ArgumentKind kind;
-    /// @brief The string representation of the argument type.
-    std::string type_name;
-    /// @brief The name of the argument.
-    std::string name;
-  };
-
-  /// @brief Name of the kernel.
-  std::string name;
-  /// @brief Number of arguments to the kernel
-  uint32_t num_arguments;
-  /// @brief Attributes set on the kernel.
-  std::string attributes;
-  /// @brief The types of the arguments in the order they appear.
-  cargo::dynamic_array<argument_info_t> argument_types;
-  /// @brief Optional info about each argument.
-  cargo::optional<cargo::small_vector<argument_info_t, 8>> argument_info;
-};
-
-}  // namespace ur
-
 /// @brief Compute Mux specific implementation of the opaque
 /// ur_kernel_handle_t_ API object.
 struct ur_kernel_handle_t_ : ur::base {

--- a/source/ur/include/ur/program.h
+++ b/source/ur/include/ur/program.h
@@ -32,30 +32,6 @@
 #include "ur/device.h"
 #include "ur/kernel.h"
 
-namespace ur {
-/// @brief Helper type representing program metadata.
-struct program_info_t {
-  /// @brief Lookup kernel by index into list of kernels in program.
-  ///
-  /// @param[in] kernel_index Index of kernel in list of kernels belonging to
-  /// the program.
-  ///
-  /// @return kernel object or nullptr if `kernel_index` is out of range.
-  kernel_data_t *getKernel(size_t kernel_index);
-
-  /// @brief Lookup kernel by name in list of kernels in program.
-  ///
-  /// @param[in] name Kernel name.
-  ///
-  /// @return kernel object or nullptr if no kernel with name `name` exists in
-  /// the program.
-  kernel_data_t *getKernel(cargo::string_view name);
-
-  /// @brief Metadata about each kernel in the program.
-  cargo::small_vector<kernel_data_t, 8> kernel_descriptions;
-};
-}  // namespace ur
-
 /// @brief Compute Mux specific implementation of the opaque
 /// ur_program_handle_t_ API object.
 struct ur_program_handle_t_ : ur::base {
@@ -78,7 +54,7 @@ struct ur_program_handle_t_ : ur::base {
     /// the compiled program.
     mux_executable_t mux_executable = nullptr;
     /// @brief Info about the program that can be queried out by the runtime.
-    ur::program_info_t program_info;
+    compiler::ProgramInfo program_info;
   };
 
   /// @brief Constructor to construct program with an IL binary.
@@ -152,7 +128,7 @@ struct ur_program_handle_t_ : ur::base {
   /// data relevent to any device the program has been compiled for.
   ///
   /// @param name Name of the entry point to search for.
-  cargo::expected<const ur::kernel_data_t &, ur_result_t> getKernelData(
+  cargo::expected<const compiler::KernelInfo &, ur_result_t> getKernelData(
       const cargo::string_view name);
 
   /// @brief Context to which the program belongs.

--- a/source/ur/source/kernel.cpp
+++ b/source/ur/source/kernel.cpp
@@ -68,7 +68,7 @@ cargo::expected<ur_kernel_handle_t, ur_result_t> ur_kernel_handle_t_::create(
     return cargo::make_unexpected(kernel_data.error());
   }
   if (cargo::success !=
-      kernel->arguments.alloc(kernel_data.value().num_arguments)) {
+      kernel->arguments.alloc(kernel_data.value().getNumArguments())) {
     return cargo::make_unexpected(UR_RESULT_ERROR_OUT_OF_HOST_MEMORY);
   }
 


### PR DESCRIPTION
    [cl] Replace cl::binary::KernelInfo with compiler::KernelInfo

    We were duplicating this information across two places, which is overly
    cumbersome. Since the top-level compiler APIs are unconditionally
    included, even in 'offline' builds, we can safely use
    `compiler::KernelInfo` in all cases. At certain points we need to
    translate between CL and compiler representations, but we were doing
    that already.

----

    [compiler] Add compiler::ProgramInfo and migrate CL/UR APIs to that

    After replacing cl::binary::KernelInfo with compiler::KernelInfo, the
    program info callback we passed to Module::finalize was essentially
    redundant: it was copying compiler::KernelInfo instances to other
    compiler::KernelInfo instances.

    With that in mind, we can clean the codebase up further by introducing a
    central compiler::ProgramInfo and make Module::finalize populate that.
    Then clients can opt to use that directly (as CL and UR do) or they
    could translate the compiler data structures to their client ones.
