### PR TITLE
[compiler] Support cl_intel_required_subgroup_size

### DIFF
--- a/doc/modules/compiler/utils.rst
+++ b/doc/modules/compiler/utils.rst
@@ -1067,6 +1067,23 @@ the ``NoUnwind`` attribute can still be generated in certain cases. This pass
 adds the ``NoUnwind`` attribute to every function in the module, for target code
 generators that can't handle exceptions.
 
+VerifyReqdSubGroupSizeLegalPass & VerifyReqdSubGroupSizeSatisfiedPass
+---------------------------------------------------------------------
+
+These passes check whether the compiler can handle, and has successfully
+handled, a kernel with a required sub-group size.
+
+The ``VerifyReqdSubGroupSizeLegalPass`` searches for any kernel with a required
+sub-group size and checks whether the device supports such a size. It does this
+using the target's ``compiler::utils::DeviceInfo`` analysis. Any unsupported
+size results in a compiler diagnostic, which the compiler can handle (usually
+via a build error).
+
+The ``VerifyReqdSubGroupSizeSatisfiedPass`` searches for any kernel entry point
+with a required sub-group size and checks whether the vectorizer was able to
+satisfy that requirement. As such, it should be run after vectorization. A
+compiler diagnostic is raised for each kernel for which this does not hold.
+
 Metadata Utilities
 ------------------
 

--- a/doc/modules/mux/changes.rst
+++ b/doc/modules/mux/changes.rst
@@ -11,6 +11,12 @@ version increases mean backward compatible bug fixes have been applied.
    Versions prior to 1.0.0 may contain breaking changes in minor
    versions as the API is still under development.
 
+0.76.0
+------
+
+* Added ``num_sub_group_sizes`` and ``sub_group_sizes`` to ``mux_device_info_s``.
+
+
 0.75.0
 ------
 

--- a/doc/overview/introduction/architecture.rst
+++ b/doc/overview/introduction/architecture.rst
@@ -237,6 +237,7 @@ OpenCL extensions:
 - cl_codeplay_performance_counters
 - cl_codeplay_soft_math
 - cl_intel_unified_shared_memory
+- cl_intel_required_subgroup_size
 
 .. note::
    Integration of custom extensions for vendor hardware is supported.

--- a/doc/source/cl/extension.rst
+++ b/doc/source/cl/extension.rst
@@ -13,7 +13,7 @@ EXT
 Vendor
   Extension defined by a single vendor, but may be implemented by
   other vendors, e.g oneAPI Construction Kit implements vendor extension
-  ``cl_intel_unified_shared_memory``.
+  ``cl_intel_unified_shared_memory`` and ``cl_intel_required_subgroup_size``.
 
 oneAPI Construction Kit implements several Codeplay vendor extensions,
 specified under the ``extension`` directory. When adding a new vendor
@@ -49,6 +49,7 @@ be contiguous.
   extension/cl_codeplay_soft_math
   extension/cl_codeplay_wfv
   extension/cl_intel_unified_shared_memory
+  extension/cl_intel_required_subgroup_size
 
 OpenCL C 1.2 - ``khr_opencl_c_1_2``
 -----------------------------------
@@ -351,3 +352,21 @@ replaced by a customer implementation where it can be accelerated.
 
 .. _cl_khr_extended_async_copies:
   https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies
+
+Required subgroup sizes for kernels - ``cl_intel_required_subgroup_size``
+-------------------------------------------------------------------------
+
+oneAPI Construction Kit implements the `cl_intel_required_subgroup_size`_
+extension.
+
+This has a default implementation which does not report any available subgroup
+sizes for any device. The compiler will report an error for any kernel given
+the ``intel_reqd_sub_group_size`` attribute with a size that is not reported by
+the device. There is currently no handling of the attribute if a target does
+report a set of sub-group sizes, as no in-tree target does so.
+
+Furthermore, all kernels report the same non-zero value for
+``CL_KERNEL_SPILL_MEM_SIZE_INTEL``.
+
+.. _cl_intel_required_subgroup_size:
+  https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_required_subgroup_size.html

--- a/doc/source/cl/extension/cl_intel_required_subgroup_size.rst
+++ b/doc/source/cl/extension/cl_intel_required_subgroup_size.rst
@@ -1,0 +1,6 @@
+Required subgroup sizes for kernels  - ``cl_intel_required_subgroup_size``
+==========================================================================
+
+The ``cl_intel_required_subgroup_size`` extension specification can be found in
+the `Khronos OpenCL registry
+<https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_required_subgroup_size.html>`_.

--- a/doc/source/cl/test/unitcl.rst
+++ b/doc/source/cl/test/unitcl.rst
@@ -504,6 +504,8 @@ Here is the full list of supported requirements for ``// REQUIRES:``:
 * ``parameters`` - Currently tests that are parameterized using macros do not
   support any offline compilation (either to IR or to executable). This
   requirement disables all but the ``Execution`` test type.
+* ``mayfail`` - Indicates that ``clc`` may fail to compile this kernel. The
+  offline binaries are therefore optional.
 
 .. warning::
 

--- a/doc/specifications/mux-compiler-spec.rst
+++ b/doc/specifications/mux-compiler-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Compiler Specification
 =================================
 
-   This is version 0.75.0 of the specification.
+   This is version 0.76.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,
@@ -1160,6 +1160,10 @@ pipeline:
        negative value (canonicalized as -1) indicates the function has no such
        parameter. Up to two additional custom parameter indices can be used by
        targets.
+   * - ``!intel_reqd_sub_group_size``
+     - i32
+     - Required sub-group size encoded as a 32-bit integer. If not present, no
+       required sub-group size is assumed.
 
 Users **should not** rely on the name, format, or operands of these metadata.
 Instead, utility functions are provided by the ``utils`` module to work with

--- a/doc/specifications/mux-runtime-spec.rst
+++ b/doc/specifications/mux-runtime-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Runtime Specification
 ================================
 
-   This is version 0.75.0 of the specification.
+   This is version 0.76.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
@@ -27,6 +27,7 @@
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/replace_mem_intrinsics_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Target/TargetMachine.h>
 #include <metadata/handler/vectorize_info_metadata.h>
@@ -123,6 +124,9 @@ llvm::ModulePassManager RefSiM1Module::getLateTargetPasses(
   addPreVeczPasses(PM, tuner);
 
   PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   addLateBuiltinsPasses(PM, tuner);
 

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -33,6 +33,7 @@
 #include <compiler/utils/metadata_analysis.h>
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/Module.h>
@@ -321,6 +322,9 @@ llvm::ModulePassManager {{cookiecutter.target_name.capitalize()}}Module::getLate
   addPreVeczPasses(PM, tuner);
 
   PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   addLateBuiltinsPasses(PM, tuner);
 

--- a/modules/compiler/include/compiler/module.h
+++ b/modules/compiler/include/compiler/module.h
@@ -348,6 +348,14 @@ struct KernelInfo {
   std::array<size_t, 3> getReqdWGSizeOrZero() const {
     return reqd_work_group_size.value_or(std::array<size_t, 3>{0, 0, 0});
   }
+
+  /// @brief The required sub-group size if it exists.
+  cargo::optional<size_t> reqd_sub_group_size;
+
+  /// @brief The amount of spill memory used by a kernel.
+  ///
+  /// Zero indicates that no spill memory was used, which is not safe to assume.
+  uint64_t spill_mem_size_bytes = (uint64_t)-1;
 };  // class KernelInfo
 
 /// @brief Class for managing program information.

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -32,6 +32,7 @@
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/replace_mem_intrinsics_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/Module.h>
@@ -281,6 +282,9 @@ llvm::ModulePassManager RiscvModule::getLateTargetPasses(
   addPreVeczPasses(PM, tuner);
 
   PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   addLateBuiltinsPasses(PM, tuner);
 

--- a/modules/compiler/source/base/include/base/base_pass_machinery.h
+++ b/modules/compiler/source/base/include/base/base_pass_machinery.h
@@ -88,16 +88,8 @@ class BaseModulePassMachinery : public compiler::utils::PassMachinery {
 ///
 /// FIXME: Ideally we wouldn't have any mux in the compiler library. See
 /// CA-4236.
-static inline compiler::utils::DeviceInfo initDeviceInfoFromMux(
-    mux_device_info_t device_info) {
-  if (!device_info) {
-    return compiler::utils::DeviceInfo{};
-  }
-
-  return compiler::utils::DeviceInfo(
-      device_info->half_capabilities, device_info->float_capabilities,
-      device_info->double_capabilities, device_info->max_work_width);
-}
+compiler::utils::DeviceInfo initDeviceInfoFromMux(
+    mux_device_info_t device_info);
 
 /// @}
 }  // namespace compiler

--- a/modules/compiler/source/base/source/base_pass_registry.def
+++ b/modules/compiler/source/base/source/base_pass_registry.def
@@ -56,6 +56,10 @@ MODULE_PASS("set-convergent-attr", compiler::SetConvergentAttrPass())
 MODULE_PASS("spir-fixup", compiler::spir::SpirFixupPass())
 MODULE_PASS("transfer-kernel-metadata",
             compiler::utils::TransferKernelMetadataPass())
+MODULE_PASS("verify-reqd-sub-group-legal",
+            compiler::utils::VerifyReqdSubGroupSizeLegalPass())
+MODULE_PASS("verify-reqd-sub-group-satisfied",
+            compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass())
 
 MODULE_PASS("unique-opaque-structs", compiler::utils::UniqueOpaqueStructsPass())
 

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -54,6 +54,7 @@
 #include <compiler/utils/replace_barriers_pass.h>
 #include <compiler/utils/replace_c11_atomic_funcs_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm-c/BitWriter.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/Triple.h>
@@ -1772,6 +1773,8 @@ Result BaseModule::finalize(
           m.setTargetTriple(triple);
         }));
   }
+
+  pm.addPass(compiler::utils::VerifyReqdSubGroupSizeLegalPass());
 
   pm.addPass(llvm::createModuleToFunctionPassAdaptor(
       compiler::SoftwareDivisionPass()));

--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -16,6 +16,7 @@
 
 #include <base/macros.h>
 #include <base/program_metadata.h>
+#include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
 #include <llvm/IR/Argument.h>
 #include <llvm/IR/Constants.h>
@@ -554,6 +555,10 @@ cargo::expected<KernelInfo, Result> populateKernelInfoFromFunction(
   }
 
   populateAttributes(kernel_info, node);
+
+  if (auto sub_group_size = compiler::utils::getReqdSubgroupSize(*function)) {
+    kernel_info.reqd_sub_group_size = *sub_group_size;
+  }
 
   return kernel_info;
 }

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -38,6 +38,7 @@
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
 #include <compiler/utils/unique_opaque_structs_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <host/add_entry_hook_pass.h>
 #include <host/add_floating_point_control_pass.h>
 #include <host/disable_neon_attribute_pass.h>
@@ -249,6 +250,9 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
   addPreVeczPasses(PM, tuner);
 
   PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   addLateBuiltinsPasses(PM, tuner);
 

--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
@@ -1,0 +1,43 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Forcibly vectorize this kernel by 8 and check that the verification pass
+; correctly picks up that we haven't satisfied the kernel's required sub-group
+; size.
+; FIXME: This is conflating vecz dimension and sub-group size but that's all we
+; can manage at the moment.
+; RUN: env CA_RISCV_VF=8 not muxc --device "%riscv_device" \
+; RUN:   --passes "run-vecz,verify-reqd-sub-group-satisfied" %s 2>&1 \
+; RUN: | FileCheck %s
+
+; CHECK: kernel.cl:10:0: kernel has required sub-group size 7 but the compiler was unable to sastify this constraint
+define void @foo_sg7() #0 !dbg !5 !intel_reqd_sub_group_size !2 {
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !4, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+
+!2 = !{i32 7}
+!3 = !{i32 6}
+
+!4 = !DIFile(filename: "kernel.cl", directory: "/oneAPI")
+!5 = distinct !DISubprogram(name: "foo_sg7", scope: !4, file: !4, line: 10, scopeLine: 10, flags: DIFlagArtificial | DIFlagPrototyped, unit: !0)
+
+attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/test/lit/passes/verify-reqd-sg-size-1.ll
+++ b/modules/compiler/test/lit/passes/verify-reqd-sg-size-1.ll
@@ -1,0 +1,40 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: not muxc --device-sg-sizes 6,7,8,9 --passes=verify-reqd-sub-group-legal %s 2>&1 | FileCheck %s
+
+; CHECK: kernel.cl:10:0: kernel has required sub-group size 5 which is not supported by this device
+define void @foo_sg5() !dbg !5 !intel_reqd_sub_group_size !2 {
+  ret void
+}
+
+; CHECK-NOT: kernel has required sub-group size 6 which is not supported by this device
+define void @foo_sg6() !dbg !6 !intel_reqd_sub_group_size !3 {
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !4, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+
+!2 = !{i32 5}
+!3 = !{i32 6}
+
+!4 = !DIFile(filename: "kernel.cl", directory: "/oneAPI")
+!5 = distinct !DISubprogram(name: "foo_sg5", scope: !4, file: !4, line: 10, scopeLine: 10, flags: DIFlagArtificial | DIFlagPrototyped, unit: !0)
+!6 = distinct !DISubprogram(name: "foo_sg6", scope: !4, file: !4, line: 12, scopeLine: 12, flags: DIFlagArtificial | DIFlagPrototyped, unit: !0)

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -86,6 +86,11 @@ static cl::opt<bool> DoubleCap(
     "device-fp64-capabilities",
     cl::desc("Enable/Disable device fp64 capabilities"), cl::init(true));
 
+static cl::list<unsigned> SGSizes(
+    "device-sg-sizes",
+    cl::desc("Comma-separated list of supported sub-group sizes"),
+    cl::CommaSeparated);
+
 int main(int argc, char **argv) {
   muxc::driver driver;
   driver.parseArguments(argc, argv);
@@ -319,7 +324,11 @@ driver::createPassMachinery() {
         FloatCap ? compiler::utils::device_floating_point_capabilities_full : 0,
         DoubleCap ? compiler::utils::device_floating_point_capabilities_full
                   : 0,
-        64);
+        /*max_work_width*/ 64);
+
+    for (const auto S : SGSizes) {
+      Info.reqd_sub_group_sizes.push_back(S);
+    }
 
     auto &BaseCtx =
         *static_cast<compiler::BaseContext *>(CompilerContext.get());

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -68,6 +68,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/simple_callback_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/unique_opaque_structs_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/vectorization_factor.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/verify_reqd_sub_group_size_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/source/add_kernel_wrapper_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/add_scheduling_parameters_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/align_module_structs_pass.cpp
@@ -113,7 +114,8 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mux_math_decls_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_wgc_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/scheduling.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/unique_opaque_structs_pass.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/unique_opaque_structs_pass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp)
 
 target_include_directories(compiler-utils PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/modules/compiler/utils/include/compiler/utils/device_info.h
+++ b/modules/compiler/utils/include/compiler/utils/device_info.h
@@ -77,6 +77,14 @@ struct DeviceInfo {
   uint32_t double_capabilities = 0;
   uint32_t max_work_width = 0;
 
+  /// @brief List of supported 'required' sub-group sizes reported by this
+  /// device.
+  ///
+  /// These are only the sub-group sizes that can be requested as 'required' for
+  /// a kernel; the compiler may produce a wide range of other sub-group sizes
+  /// on undecorated kernels, assuming sub-groups are supported by the device.
+  std::vector<uint32_t> reqd_sub_group_sizes;
+
   /// @brief Handle invalidation events from the new pass manager.
   ///
   /// @return false, as this analysis can never be invalidated.

--- a/modules/compiler/utils/include/compiler/utils/metadata.h
+++ b/modules/compiler/utils/include/compiler/utils/metadata.h
@@ -192,7 +192,7 @@ void encodeLocalSizeMetadata(llvm::Function &f,
 /// @brief Retrieves information about a function's local sizes via metadata.
 ///
 /// @param[in] f Function from which to decode the metadata
-/// @returns The local size array if presernt, else `llvm::None`
+/// @returns The local size array if present, else `llvm::None`
 multi_llvm::Optional<std::array<uint64_t, 3>> getLocalSizeMetadata(
     const llvm::Function &f);
 
@@ -269,6 +269,20 @@ struct KernelInfo {
 /// module.
 void populateKernelList(llvm::Module &m,
                         llvm::SmallVectorImpl<KernelInfo> &results);
+
+/// @brief Encodes information about a function's local work group size as
+/// metadata.
+///
+/// @param[in] f Function in which to encode the metadata.
+/// @param[in] size sub-group size information to encode.
+void encodeReqdSubgroupSizeMetadata(llvm::Function &f, uint32_t size);
+
+/// @brief Retrieves information about a function's required sub-group size via
+/// metadata.
+///
+/// @param[in] f Function from which to decode the metadata
+/// @returns The required sub-group size if present, else `llvm::None`
+multi_llvm::Optional<uint32_t> getReqdSubgroupSize(const llvm::Function &f);
 
 }  // namespace utils
 }  // namespace compiler

--- a/modules/compiler/utils/include/compiler/utils/verify_reqd_sub_group_size_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/verify_reqd_sub_group_size_pass.h
@@ -1,0 +1,55 @@
+
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef COMPILER_UTILS_VERIFY_REQD_SUB_GROUP_SIZE_PASS_H_INCLUDED
+#define COMPILER_UTILS_VERIFY_REQD_SUB_GROUP_SIZE_PASS_H_INCLUDED
+
+#include <llvm/IR/PassManager.h>
+
+namespace compiler {
+namespace utils {
+
+/// @addtogroup utils
+/// @{
+
+/// @brief This pass checks that any kernels with required sub-group sizes are
+/// using sub-group sizes that are marked as legal by the device.
+///
+/// Raises a compile diagnostic on kernel which breaches this rule.
+class VerifyReqdSubGroupSizeLegalPass
+    : public llvm::PassInfoMixin<VerifyReqdSubGroupSizeLegalPass> {
+ public:
+  VerifyReqdSubGroupSizeLegalPass() = default;
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
+};
+
+/// @brief This pass checks that any kernels with required sub-group sizes have
+/// had those sub-group sizes successfully satisfied by the compiler.
+///
+/// Raises a compile diagnostic on kernel which breaches this rule.
+class VerifyReqdSubGroupSizeSatisfiedPass
+    : public llvm::PassInfoMixin<VerifyReqdSubGroupSizeSatisfiedPass> {
+ public:
+  VerifyReqdSubGroupSizeSatisfiedPass() = default;
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
+};
+
+/// @}
+}  // namespace utils
+}  // namespace compiler
+
+#endif  // COMPILER_UTILS_VERIFY_REQD_SUB_GROUP_SIZE_PASS_H_INCLUDED

--- a/modules/compiler/utils/source/metadata.cpp
+++ b/modules/compiler/utils/source/metadata.cpp
@@ -371,5 +371,21 @@ void populateKernelList(Module &m, SmallVectorImpl<KernelInfo> &results) {
   }
 }
 
+static constexpr const char *ReqdSGSizeMD = "intel_reqd_sub_group_size";
+
+void encodeReqdSubgroupSizeMetadata(Function &f, uint32_t size) {
+  auto *const i32Ty = Type::getInt32Ty(f.getContext());
+  auto *const mdTuple = MDTuple::get(
+      f.getContext(), ConstantAsMetadata::get(ConstantInt::get(i32Ty, size)));
+  f.setMetadata(ReqdSGSizeMD, mdTuple);
+}
+
+multi_llvm::Optional<uint32_t> getReqdSubgroupSize(const Function &f) {
+  if (auto *md = f.getMetadata(ReqdSGSizeMD)) {
+    return mdconst::extract<ConstantInt>(md->getOperand(0))->getZExtValue();
+  }
+  return multi_llvm::None;
+}
+
 }  // namespace utils
 }  // namespace compiler

--- a/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
+++ b/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/attributes.h>
+#include <compiler/utils/device_info.h>
+#include <compiler/utils/metadata.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/Module.h>
+
+using namespace llvm;
+
+namespace {
+class DiagnosticInfoReqdSGSize : public DiagnosticInfoWithLocationBase {
+  uint32_t SGSize;
+
+ public:
+  static int DK_FailedReqdSGSize;
+  static int DK_UnsupportedReqdSGSize;
+
+  DiagnosticInfoReqdSGSize(const Function &F, uint32_t SGSize, int Kind)
+      : DiagnosticInfoWithLocationBase(static_cast<DiagnosticKind>(Kind),
+                                       DS_Error, F, F.getSubprogram()),
+        SGSize(SGSize) {
+    assert(Kind == DK_FailedReqdSGSize || Kind == DK_UnsupportedReqdSGSize);
+  }
+
+  static bool classof(const DiagnosticInfo *DI) {
+    return DI->getKind() == DK_FailedReqdSGSize ||
+           DI->getKind() == DK_UnsupportedReqdSGSize;
+  }
+
+  void print(DiagnosticPrinter &DP) const override {
+    DP << getLocationStr() << ": kernel has required sub-group size " << SGSize;
+    if (getKind() == DK_FailedReqdSGSize) {
+      DP << " but the compiler was unable to sastify this constraint";
+    } else {
+      DP << " which is not supported by this device";
+    }
+  }
+};
+
+int DiagnosticInfoReqdSGSize::DK_FailedReqdSGSize =
+    getNextAvailablePluginDiagnosticKind();
+int DiagnosticInfoReqdSGSize::DK_UnsupportedReqdSGSize =
+    getNextAvailablePluginDiagnosticKind();
+}  // namespace
+
+namespace compiler {
+namespace utils {
+PreservedAnalyses VerifyReqdSubGroupSizeLegalPass::run(
+    Module &M, ModuleAnalysisManager &AM) {
+  auto &DI = AM.getResult<DeviceInfoAnalysis>(M);
+  const auto &SGSizes = DI.reqd_sub_group_sizes;
+  for (auto &F : M) {
+    auto const ReqdSGSize = getReqdSubgroupSize(F);
+    if (!ReqdSGSize) {
+      continue;
+    }
+    // If this sub-group size is not supported by the device, we can emit a
+    // diagnostic at compile-time.
+    if (std::find(SGSizes.begin(), SGSizes.end(), *ReqdSGSize) ==
+        SGSizes.end()) {
+      M.getContext().diagnose(DiagnosticInfoReqdSGSize(
+          F, *ReqdSGSize, DiagnosticInfoReqdSGSize::DK_UnsupportedReqdSGSize));
+    }
+  }
+  return PreservedAnalyses::all();
+}
+
+PreservedAnalyses VerifyReqdSubGroupSizeSatisfiedPass::run(
+    Module &M, ModuleAnalysisManager &) {
+  for (auto &F : M) {
+    // We only check kernel entry points
+    if (!isKernelEntryPt(F)) {
+      continue;
+    }
+
+    auto const ReqdSGSize = getReqdSubgroupSize(F);
+    if (!ReqdSGSize) {
+      continue;
+    }
+    if (auto VeczInfo = parseVeczToOrigFnLinkMetadata(F)) {
+      if (!VeczInfo->second.vf.isScalable() &&
+          VeczInfo->second.vf.getKnownMin() == *ReqdSGSize) {
+        continue;
+      }
+    }
+    M.getContext().diagnose(DiagnosticInfoReqdSGSize(
+        F, *ReqdSGSize, DiagnosticInfoReqdSGSize::DK_FailedReqdSGSize));
+  }
+
+  return PreservedAnalyses::all();
+}
+
+}  // namespace utils
+}  // namespace compiler

--- a/modules/mux/include/mux/mux.h
+++ b/modules/mux/include/mux/mux.h
@@ -37,7 +37,7 @@ extern "C" {
 /// @brief Mux major version number.
 #define MUX_MAJOR_VERSION 0
 /// @brief Mux minor version number.
-#define MUX_MINOR_VERSION 75
+#define MUX_MINOR_VERSION 76
 /// @brief Mux patch version number.
 #define MUX_PATCH_VERSION 0
 /// @brief Mux combined version number.
@@ -2370,6 +2370,12 @@ struct mux_device_info_s {
   /// @brief Boolean value indicating if the generic address space is supported
   /// by the device.
   bool supports_generic_address_space;
+  /// @brief The number of sub-group sizes supported by the device, pointed to
+  /// by sub_group_sizes.
+  size_t num_sub_group_sizes;
+  /// @brief List of sub-group sizes supported by the device, sized by
+  /// num_sub_group_sizes.
+  size_t *sub_group_sizes;
 };
 
 /// @brief Mux's device container.

--- a/modules/mux/targets/host/include/host/host.h
+++ b/modules/mux/targets/host/include/host/host.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Host major version number.
 #define HOST_MAJOR_VERSION 0
 /// @brief Host minor version number.
-#define HOST_MINOR_VERSION 75
+#define HOST_MINOR_VERSION 76
 /// @brief Host patch version number.
 #define HOST_PATCH_VERSION 0
 /// @brief Host combined version number.

--- a/modules/mux/targets/riscv/include/riscv/riscv.h
+++ b/modules/mux/targets/riscv/include/riscv/riscv.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Riscv major version number.
 #define RISCV_MAJOR_VERSION 0
 /// @brief Riscv minor version number.
-#define RISCV_MINOR_VERSION 75
+#define RISCV_MINOR_VERSION 76
 /// @brief Riscv patch version number.
 #define RISCV_PATCH_VERSION 0
 /// @brief Riscv combined version number.

--- a/modules/mux/tools/api/mux.xml
+++ b/modules/mux/tools/api/mux.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception</comment>
     <block>
       <define priority="high">${FUNCTION_PREFIX}_MAJOR_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} major version number.</brief></doxygen></define>
-      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>75</value>
+      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>76</value>
         <doxygen><brief>${Function_Prefix} minor version number.</brief></doxygen></define>
       <define priority="high">${FUNCTION_PREFIX}_PATCH_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} patch version number.</brief></doxygen></define>
@@ -2120,6 +2120,8 @@ For OpenCL, this value is used to implement clGetDeviceInfo, when asking for CL_
         <member>max_hardware_counters<type>uint32_t</type><doxygen><brief>Maximum number of hardware counters that can be active at one time.</brief></doxygen></member>
         <member>supports_work_group_collectives<type>bool</type><doxygen><brief>Boolean value indicating if work-group collective functions are supported by the device.</brief></doxygen></member>
         <member>supports_generic_address_space<type>bool</type><doxygen><brief>Boolean value indicating if the generic address space is supported by the device.</brief></doxygen></member>
+        <member>num_sub_group_sizes<type>size_t</type><doxygen><brief>The number of sub-group sizes supported by the device, pointed to by sub_group_sizes.</brief></doxygen></member>
+        <member>sub_group_sizes<type>size_t*</type><doxygen><brief>List of sub-group sizes supported by the device, sized by num_sub_group_sizes.</brief></doxygen></member>
       </scope>
       <doxygen><brief>${Prefix}'s device information container.</brief>
         <detail>Holds details about a partner device, allowing the access to them without initializing that device.</detail>

--- a/source/cl/source/binary/source/binary.cpp
+++ b/source/cl/source/binary/source/binary.cpp
@@ -357,6 +357,18 @@ bool serializeProgramInfo(md_ctx ctx, const compiler::ProgramInfo &program_info,
     }
     md_pop(stack);
 
+    // required sub-group size
+    const int reqd_sub_group_size_idx =
+        md_push_uint(stack, kernel.reqd_sub_group_size.value_or(0));
+    if (MD_CHECK_ERR(reqd_sub_group_size_idx)) {
+      return false;
+    }
+    err = md_array_append(stack, indv_kernel_idx, reqd_sub_group_size_idx);
+    if (MD_CHECK_ERR(err)) {
+      return false;
+    }
+    md_pop(stack);
+
     // kernel name
     const int kernel_name_idx = md_push_zstr(stack, kernel.name.c_str());
     if (MD_CHECK_ERR(kernel_name_idx)) {
@@ -730,9 +742,26 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
       kernelInfo->reqd_work_group_size = reqd_wg_size;
     }
 
+    // required sub-group size
+    md_value work_size_v;
+    err = md_get_array_idx(kernel_info_v, 4, &work_size_v);
+    if (MD_CHECK_ERR(err)) {
+      return false;
+    }
+
+    uint64_t reqd_sub_group_size;
+    err = md_get_uint(work_size_v, &reqd_sub_group_size);
+    if (MD_CHECK_ERR(err)) {
+      return false;
+    }
+
+    if (reqd_sub_group_size) {
+      kernelInfo->reqd_sub_group_size = reqd_sub_group_size;
+    }
+
     // kernel name
     md_value kernel_name_v;
-    err = md_get_array_idx(kernel_info_v, 4, &kernel_name_v);
+    err = md_get_array_idx(kernel_info_v, 5, &kernel_name_v);
     if (MD_CHECK_ERR(err)) {
       return false;
     }

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -255,6 +255,7 @@ add_ca_cl_executable(UnitCL
   source/cl_codeplay_wfv/wfv_kernel_info.cpp
   source/cl_codeplay_wfv/wfv_status.cpp
   source/cl_codeplay_wfv/wfv_widths.cpp
+  source/cl_intel_required_subgroup_size/cl_intel_required_subgroup_size.cpp
   source/cl_intel_unified_shared_memory/usm_allocate.cpp
   source/cl_intel_unified_shared_memory/usm_capabilties.cpp
   source/cl_intel_unified_shared_memory/usm_enqueue.cpp

--- a/source/cl/test/UnitCL/cmake/ExtractReqsOpts.cmake
+++ b/source/cl/test/UnitCL/cmake/ExtractReqsOpts.cmake
@@ -94,7 +94,7 @@ function(extract_reqs_opts)
 
   # Check for unkown requirements
   set(known_requirements
-      "noclc" "nospir" "nospirv" "double" "half" "images" "parameters")
+      "noclc" "nospir" "nospirv" "double" "half" "images" "mayfail" "parameters")
   foreach(file_req ${CLC_FILE_REQUIREMENTS})
     set(req_found FALSE)
       foreach(known_req ${known_requirements})

--- a/source/cl/test/UnitCL/include/kts/execution.h
+++ b/source/cl/test/UnitCL/include/kts/execution.h
@@ -190,6 +190,13 @@ struct BaseExecution : ::ucl::CommandQueueTest, SharedExecution {
 
   clGetKernelWFVInfoCODEPLAY_fn clGetKernelWFVInfoCODEPLAY = nullptr;
   clCreateProgramWithILKHR_fn clCreateProgramWithILKHR = nullptr;
+  /// @brief Controls whether to fail the test if BuildProgram fails.
+  ///
+  /// When set to true, BuildProgram will fail the test if any of the OpenCL
+  /// build APIs (clCreateProgramWithXXX, clBuildProgram, clCreateKernel) fail.
+  /// When set to false, BuildProgram will silently return false, leaving the
+  /// caller to handle the error.
+  bool fail_if_build_program_failed = true;
 };
 
 struct Execution : BaseExecution, testing::WithParamInterface<SourceType> {

--- a/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.cl
+++ b/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.cl
@@ -1,0 +1,33 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// CL_STD: 3.0
+// REQUIRES: mayfail
+
+__attribute__((intel_reqd_sub_group_size(8)))
+kernel void size8(global int *in, global uint2 *out_sg_ids, global int *out) {
+  const size_t glid = get_global_linear_id();
+  const size_t sgid =
+      get_sub_group_id() +
+      get_enqueued_num_sub_groups() *
+          (get_group_id(0) + get_group_id(1) * get_num_groups(0) +
+           get_group_id(2) * get_num_groups(0) * get_num_groups(1));
+
+  out[glid] = sub_group_broadcast(in[glid], 0);
+
+  out_sg_ids[glid].x = sgid;
+  out_sg_ids[glid].y = get_sub_group_local_id();
+}

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -795,6 +795,11 @@ if(${OCL_EXTENSION_cl_khr_extended_async_copies})
     ${CMAKE_CURRENT_SOURCE_DIR}/ext_async.02_simple_3d.cl)
 endif()
 
+if(${OCL_EXTENSION_cl_intel_required_subgroup_size})
+  list(APPEND KERNEL_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/ext_reqd_subgroup.01_size8.cl)
+endif()
+
 # TODO CA-1879: These kernels were originally written specifically for offline
 # testing, however, now all kernels can be made into offline tests so there may
 # be some redundancy here.

--- a/source/cl/test/UnitCL/source/cl_intel_required_subgroup_size/cl_intel_required_subgroup_size.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_required_subgroup_size/cl_intel_required_subgroup_size.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <CL/cl_ext_codeplay.h>
+
+#include "Common.h"
+#include "kts/sub_group_helpers.h"
+
+using namespace kts::ucl;
+
+struct cl_intel_required_subgroup_size_Test : ucl::ContextTest {
+  void SetUp() override {
+    UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
+    if (!isDeviceExtensionSupported("cl_intel_required_subgroup_size")) {
+      GTEST_SKIP();
+    }
+  }
+
+  void TearDown() override { ContextTest::TearDown(); }
+};
+
+// Helper method to return the sub-group sizes reported by the device.
+static std::vector<size_t> getSubgroupSizes(cl_device_id device) {
+  size_t sub_groups_num_bytes = 0;
+  EXPECT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_SUB_GROUP_SIZES_INTEL, 0,
+                                 nullptr, &sub_groups_num_bytes));
+
+  size_t num_sub_groups = sub_groups_num_bytes / sizeof(size_t);
+  std::vector<size_t> sub_groups(num_sub_groups);
+  EXPECT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_SUB_GROUP_SIZES_INTEL,
+                                 sub_groups_num_bytes, sub_groups.data(),
+                                 nullptr));
+  return sub_groups;
+}
+
+TEST_F(cl_intel_required_subgroup_size_Test, DeviceInfo) {
+  getSubgroupSizes(device);
+}
+
+TEST_F(cl_intel_required_subgroup_size_Test, DeviceInfoBadParamValue) {
+  size_t sub_groups_num_bytes = 0;
+  EXPECT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_SUB_GROUP_SIZES_INTEL, 0,
+                                 nullptr, &sub_groups_num_bytes));
+
+  size_t num_sub_groups = sub_groups_num_bytes / sizeof(size_t);
+  std::vector<size_t> sub_groups(num_sub_groups);
+
+  // It's valid to pass in *more* bytes than required.
+  EXPECT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_SUB_GROUP_SIZES_INTEL,
+                                 sub_groups_num_bytes + sizeof(size_t),
+                                 sub_groups.data(), nullptr));
+
+  if (num_sub_groups != 0) {
+    // If we don't pass in a number of bytes large enough to cover all of the
+    // sub-group sizes reported by the device, the API should return
+    // CL_INVALID_VALUE.
+    EXPECT_EQ_ERRCODE(CL_INVALID_VALUE,
+                      clGetDeviceInfo(device, CL_DEVICE_SUB_GROUP_SIZES_INTEL,
+                                      0, sub_groups.data(), nullptr));
+  }
+}
+
+struct cl_intel_required_subgroup_size_KernelTest : public kts::ucl::Execution {
+  void SetUp() override {
+    UCL_RETURN_ON_FATAL_FAILURE(BaseExecution::SetUp());
+    if (!isDeviceExtensionSupported("cl_intel_required_subgroup_size")) {
+      GTEST_SKIP();
+    }
+
+    // Subgroups are a 3.0 feature.
+    if (!UCL::isDeviceVersionAtLeast({3, 0})) {
+      GTEST_SKIP();
+    }
+
+    // Some of these tests run small local sizes, which we don't vectorize.
+    // This is too coarse-grained, as there are some NDRanges which we can
+    // vectorize.
+    fail_if_not_vectorized_ = false;
+
+    // clGetDeviceInfo may return 0, indicating that the device does not support
+    // subgroups.
+    cl_uint max_num_subgroups;
+    ASSERT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_MAX_NUM_SUB_GROUPS,
+                                   sizeof(cl_uint), &max_num_subgroups,
+                                   nullptr));
+    if (0 == max_num_subgroups) {
+      GTEST_SKIP() << "Device does not support sub-groups, skipping test.\n";
+    }
+
+    AddBuildOption("-cl-std=CL3.0");
+
+    // These kernels may not be supported, so enable soft fail mode.
+    fail_if_build_program_failed = false;
+  }
+};
+
+TEST_P(cl_intel_required_subgroup_size_KernelTest, Ext_Reqd_Subgroup_01_Size8) {
+  constexpr size_t Size = 8;
+  auto sub_groups = getSubgroupSizes(device);
+  if (std::find(sub_groups.begin(), sub_groups.end(), Size) ==
+      sub_groups.end()) {
+    printf(
+        "Required sub-group size of %zu not supported on this device, skipping "
+        "test.\n",
+        Size);
+    GTEST_SKIP();
+  }
+
+  // We need to force a compilation to ensure we have a kernel to query
+  // kernel information from. This may fail, in which case we must skip the
+  // test.
+  if (!BuildProgram()) {
+    printf("Could not build the program, skipping test.\n");
+    GTEST_SKIP();
+  }
+
+  // Check that CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL returns the sub-group
+  // size we encoded at compile time.
+  size_t val_size;
+  size_t sub_group_size;
+  EXPECT_SUCCESS(clGetKernelSubGroupInfo(
+      kernel_, device, CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL,
+      sizeof(sub_group_size), nullptr, sizeof(sub_group_size), &sub_group_size,
+      &val_size));
+  EXPECT_EQ(val_size, sizeof(sub_group_size));
+  EXPECT_EQ(sub_group_size, Size);
+
+  // Check CL_KERNEL_SPILL_MEM_SIZE_INTEL doesn't error and returns something
+  // sensible.
+  cl_ulong mem_size;
+  EXPECT_SUCCESS(
+      clGetKernelWorkGroupInfo(kernel_, device, CL_KERNEL_SPILL_MEM_SIZE_INTEL,
+                               sizeof(mem_size), &mem_size, &val_size));
+  // Without any constraints on the what the spill size means (and none
+  // supported by the oneAPI Construction Kit) it's hard to test any more than
+  // this.
+  EXPECT_EQ(val_size, sizeof(mem_size));
+}
+
+static const kts::ucl::SourceType source_types[] = {kts::ucl::OPENCL_C,
+                                                    kts::ucl::OFFLINE};
+
+UCL_EXECUTION_TEST_SUITE(cl_intel_required_subgroup_size_KernelTest,
+                         testing::ValuesIn(source_types));

--- a/source/cl/test/UnitCL/source/kts/execution.cpp
+++ b/source/cl/test/UnitCL/source/kts/execution.cpp
@@ -294,7 +294,9 @@ bool kts::ucl::BaseExecution::BuildProgram(std::string file_prefix,
     }
 
     if (CL_SUCCESS != err) {
-      Fail("Could not create OpenCL program.", err);
+      if (fail_if_build_program_failed) {
+        Fail("Could not create OpenCL program.", err);
+      }
       return false;
     }
 
@@ -337,7 +339,9 @@ bool kts::ucl::BaseExecution::BuildProgram(std::string file_prefix,
         return false;
       }
 
-      Fail("clBuildProgram failed. Build log:\n\n" + build_log);
+      if (fail_if_build_program_failed) {
+        Fail("clBuildProgram failed. Build log:\n\n" + build_log);
+      }
       return false;
     }
   }
@@ -346,7 +350,9 @@ bool kts::ucl::BaseExecution::BuildProgram(std::string file_prefix,
   if (!kernel_) {
     kernel_ = clCreateKernel(program_, kernel_name.c_str(), &err);
     if (CL_SUCCESS != err) {
-      Fail("Could not create OpenCL kernel '" + kernel_name + "'.");
+      if (fail_if_build_program_failed) {
+        Fail("Could not create OpenCL kernel '" + kernel_name + "'.");
+      }
       return false;
     }
   }

--- a/source/cl/test/UnitCL/source/ktst_compiler.cpp
+++ b/source/cl/test/UnitCL/source/ktst_compiler.cpp
@@ -24,6 +24,16 @@ TEST_P(Execution, Attribute_01_reqd_work_group_size) {
     GTEST_SKIP();
   }
 
+  constexpr size_t global_work_size[3] = {16, 8, 4};
+
+  size_t compile_work_group_size[3];
+  EXPECT_SUCCESS(clGetKernelWorkGroupInfo(
+      this->kernel_, this->device, CL_KERNEL_COMPILE_WORK_GROUP_SIZE,
+      sizeof(size_t) * 3, compile_work_group_size, nullptr));
+  EXPECT_EQ(global_work_size[0], compile_work_group_size[0]);
+  EXPECT_EQ(global_work_size[1], compile_work_group_size[1]);
+  EXPECT_EQ(global_work_size[2], compile_work_group_size[2]);
+
   cl_int error;
   constexpr size_t buffer_size = sizeof(cl_ulong) * 3;
   cl_mem buffer = clCreateBuffer(this->context, CL_MEM_WRITE_ONLY, buffer_size,
@@ -32,7 +42,6 @@ TEST_P(Execution, Attribute_01_reqd_work_group_size) {
   EXPECT_EQ_ERRCODE(CL_SUCCESS,
                     clSetKernelArg(this->kernel_, 0, sizeof(buffer), &buffer));
 
-  constexpr size_t global_work_size[3] = {16, 8, 4};
   const auto max_work_items_sizes = this->getDeviceMaxWorkItemSizes();
   for (size_t i = 0; i < 3; i++) {
     if (global_work_size[i] > max_work_items_sizes[i]) {
@@ -73,9 +82,9 @@ TEST_P(Execution, Attribute_01_reqd_work_group_size) {
       clEnqueueReadBuffer(this->command_queue, buffer, CL_TRUE, 0, buffer_size,
                           reqd_work_group_size, 1, &ndRangeEvent, nullptr));
 
-  EXPECT_EQ(16u, reqd_work_group_size[0]);
-  EXPECT_EQ(8u, reqd_work_group_size[1]);
-  EXPECT_EQ(4u, reqd_work_group_size[2]);
+  EXPECT_EQ(global_work_size[0], reqd_work_group_size[0]);
+  EXPECT_EQ(global_work_size[1], reqd_work_group_size[1]);
+  EXPECT_EQ(global_work_size[2], reqd_work_group_size[2]);
 
   EXPECT_SUCCESS(clReleaseEvent(ndRangeEvent));
   ASSERT_SUCCESS(clReleaseMemObject(buffer));


### PR DESCRIPTION
Note: this commit does not yet enable the extension by default! See
below.

This commit adds support for the cl_intel_required_subgroup_size OpenCL
extension.

* It supports device-specific lists of sub-group sizes by adding two new
  fields to the Mux device info available to targets: a pointer to a
  list of sub-group sizes, and a size for the list. The pointer should
  point to static/managed data.
* It supports the kernel data necessary for the extension by extending
  `compiler::KernelInfo` with the (optional) required sub-group size
  and the 'spill mem size'. The required sub-group size is
  encoded/decoded through the binary header. The spill size is not, but
  that's in keeping with the private mem size - this might indicate an
  oversight for offline-compiled binaries.

The rest of the work is plumbing that data into the extension's queries,
and adding testing coverage.

Two new compiler passes have been added to force the compiler into
failing if the required sub-group size is not supported by the device,
or if the requirement has not been satisfied by the compiler. Both of
these are always true as none of our targets advertise any sub-group
sizes, and never force the vectorizer into vectorizing to that size.

The `muxc` compiler tool can be given supported sub-group sizes via a
command-line option to ensure these compiler passes can be tested in a
device-agnostic way.

Note that this doesn't include support for this extension when the
program was compiled with SPIR-V (clCreateProgramWithILKHR). In a strict
reading of the extension spec, `CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL`
only reports the value of the attribute and thus has no meaning for
SPIR-V, but we can be charitable here.

It is expected that this property will manifest itself via the
`SubgroupSize` execution mode, but more work needs to be done here. For
that reason the extension is left disabled until SPIR-V support is
added.
