### PR TITLE
Support SPIR-V 'SubgroupSize' and enable cl_intel_required_subgroup_size by default

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
@@ -2821,6 +2821,29 @@ class OpBuildNDRange : public OpResult {
   static const spv::Op ClassCode = spv::OpBuildNDRange;
 };
 
+class OpGetKernelLocalSizeForSubgroupCount : public OpResult {
+ public:
+  OpGetKernelLocalSizeForSubgroupCount(OpCode const &other)
+      : OpResult(other, spv::OpGetKernelLocalSizeForSubgroupCount) {}
+  spv::Id SubgroupCount() const;
+  spv::Id Invoke() const;
+  spv::Id Param() const;
+  spv::Id ParamSize() const;
+  spv::Id ParamAlign() const;
+  static const spv::Op ClassCode = spv::OpGetKernelLocalSizeForSubgroupCount;
+};
+
+class OpGetKernelMaxNumSubgroups : public OpResult {
+ public:
+  OpGetKernelMaxNumSubgroups(OpCode const &other)
+      : OpResult(other, spv::OpGetKernelMaxNumSubgroups) {}
+  spv::Id Invoke() const;
+  spv::Id Param() const;
+  spv::Id ParamSize() const;
+  spv::Id ParamAlign() const;
+  static const spv::Op ClassCode = spv::OpGetKernelMaxNumSubgroups;
+};
+
 class OpImageSparseSampleImplicitLod : public OpResult {
  public:
   OpImageSparseSampleImplicitLod(OpCode const &other)

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -1058,6 +1058,12 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
       case spv::OpBuildNDRange:
         error = builder.create<OpBuildNDRange>(op);
         break;
+      case spv::OpGetKernelLocalSizeForSubgroupCount:
+        error = builder.create<OpGetKernelLocalSizeForSubgroupCount>(op);
+        break;
+      case spv::OpGetKernelMaxNumSubgroups:
+        error = builder.create<OpGetKernelMaxNumSubgroups>(op);
+        break;
       case spv::OpImageSparseSampleImplicitLod:
         error = builder.create<OpImageSparseSampleImplicitLod>(op);
         break;

--- a/modules/compiler/spirv-ll/source/opcodes.cpp
+++ b/modules/compiler/spirv-ll/source/opcodes.cpp
@@ -136,6 +136,8 @@ bool OpCode::hasResult() const {
     case spv::OpBitwiseOr:
     case spv::OpBitwiseXor:
     case spv::OpBuildNDRange:
+    case spv::OpGetKernelLocalSizeForSubgroupCount:
+    case spv::OpGetKernelMaxNumSubgroups:
     case spv::OpCompositeConstruct:
     case spv::OpCompositeExtract:
     case spv::OpCompositeInsert:
@@ -1903,6 +1905,35 @@ spv::Id OpBuildNDRange::GlobalWorkSize() const { return getValueAtOffset(3); }
 spv::Id OpBuildNDRange::LocalWorkSize() const { return getValueAtOffset(4); }
 
 spv::Id OpBuildNDRange::GlobalWorkOffset() const { return getValueAtOffset(5); }
+
+spv::Id OpGetKernelLocalSizeForSubgroupCount::SubgroupCount() const {
+  return getValueAtOffset(3);
+}
+spv::Id OpGetKernelLocalSizeForSubgroupCount::Invoke() const {
+  return getValueAtOffset(4);
+}
+spv::Id OpGetKernelLocalSizeForSubgroupCount::Param() const {
+  return getValueAtOffset(5);
+}
+spv::Id OpGetKernelLocalSizeForSubgroupCount::ParamSize() const {
+  return getValueAtOffset(6);
+}
+spv::Id OpGetKernelLocalSizeForSubgroupCount::ParamAlign() const {
+  return getValueAtOffset(7);
+}
+
+spv::Id OpGetKernelMaxNumSubgroups::Invoke() const {
+  return getValueAtOffset(3);
+}
+spv::Id OpGetKernelMaxNumSubgroups::Param() const {
+  return getValueAtOffset(4);
+}
+spv::Id OpGetKernelMaxNumSubgroups::ParamSize() const {
+  return getValueAtOffset(5);
+}
+spv::Id OpGetKernelMaxNumSubgroups::ParamAlign() const {
+  return getValueAtOffset(6);
+}
 
 spv::Id OpImageSparseSampleImplicitLod::SampledImage() const {
   return getValueAtOffset(3);

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2360,6 +2360,7 @@ set(SPVASM_FILES
   intel_arbitrary_precision_integers.spvasm
   op_opencl_arg_md.spvasm
   unsupported_capability.spvasm
+  op_get_kernel_preferred_work_group_size_multiple.spvasm
   )
 
 if(SpirvAsVersionYear GREATER 2019)
@@ -2374,16 +2375,43 @@ if (SpirvAsVersionYear GREATER_EQUAL 2022)
     intel_opt_none.spvasm)
 endif()
 
+# Test files that require SPIR-V v1.1
+# TODO: It might be more convenient to support a system like UnitCL where test
+# files declare their own requirements.
+set(SPVASM_V1_1_FILES
+  op_execution_mode_subgroup_size.spvasm
+  op_execution_mode_subgroups_per_workgroup.spvasm
+  op_get_default_queue.spvasm
+  op_get_kernel_max_num_subgroups.spvasm
+)
+
 # Remove obsolete lit test inputs from the binary directory.
 file(GLOB obsoleteTests ${CMAKE_CURRENT_BINARY_DIR}/*.spvasm)
-foreach(testFile ${SPVASM_FILES})
+foreach(testFile ${SPVASM_FILES} ${SPVASM_V1_1_FILES})
   list(REMOVE_ITEM obsoleteTests ${CMAKE_CURRENT_BINARY_DIR}/${testFile})
 endforeach()
 if(obsoleteTests)
   file(REMOVE ${obsoleteTests})
 endif()
 
-foreach(spvasm ${SPVASM_FILES})
+# ca_assemble_spirv_ll_lit_test
+#
+# Assembles a .spvasm test file to a SPIR-V binary and registers it as a
+# dependency in the global CA_SPIRV_LL_SPVASM_TEST_FILES list.
+#
+# Arguments:
+#   * ``ARGN`` - SPIR-V assembly file to assemble.
+#
+# Keyword Arguments:
+#   * ``TGT_ENV`` - Version of SPIR-V to assemble to
+function(ca_assemble_spirv_ll_lit_test)
+  cmake_parse_arguments(args "" "TGT_ENV" "" ${ARGN})
+  if(NOT args_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Must pass spvasm file to assemble")
+  endif()
+
+  set(spvasm "${args_UNPARSED_ARGUMENTS}")
+
   get_filename_component(name ${spvasm} NAME_WE)
 
   set(test ${CMAKE_CURRENT_BINARY_DIR}/${spvasm})
@@ -2393,11 +2421,13 @@ foreach(spvasm ${SPVASM_FILES})
     message(FATAL_ERROR "spirv-ll input spvasm does not exist: ${spvasm}")
   endif()
 
+  get_property(LitTestFiles GLOBAL PROPERTY CA_SPIRV_LL_SPVASM_TEST_FILES)
+
   if(SPVASM_UNSUPPORTED STREQUAL False)
     # Generate .spv from .spvasm source.
     file(RELATIVE_PATH spvOut ${CMAKE_BINARY_DIR} ${spv})
     add_custom_command(OUTPUT ${spv}
-      COMMAND spirv::spirv-as --target-env spv1.0 -o ${spv} ${spvasm}
+      COMMAND spirv::spirv-as --target-env ${args_TGT_ENV} -o ${spv} ${spvasm}
       DEPENDS spirv::spirv-as ${spvasm}
       COMMENT "Building SPIR-V ${spvOut}")
     list(APPEND LitTestFiles ${spv})
@@ -2405,6 +2435,18 @@ foreach(spvasm ${SPVASM_FILES})
 
   add_ca_copy_file(INPUT ${spvasm} OUTPUT ${test})
   list(APPEND LitTestFiles ${test})
+
+  set_property(GLOBAL PROPERTY CA_SPIRV_LL_SPVASM_TEST_FILES ${LitTestFiles})
+endfunction()
+
+foreach(spvasm ${SPVASM_FILES})
+  ca_assemble_spirv_ll_lit_test(${spvasm} TGT_ENV spv1.0)
 endforeach()
+
+foreach(spvasm ${SPVASM_V1_1_FILES})
+  ca_assemble_spirv_ll_lit_test(${spvasm} TGT_ENV spv1.1)
+endforeach()
+
+get_property(LitTestFiles GLOBAL PROPERTY CA_SPIRV_LL_SPVASM_TEST_FILES)
 
 add_custom_target(spirv-ll-spvasm-lit DEPENDS ${LitTestFiles})

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_subgroup_size.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_subgroup_size.spvasm
@@ -1,0 +1,37 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env spv1.1 -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SubgroupDispatch %spv_file_s | FileCheck %s
+                             OpCapability Kernel
+                             OpCapability Addresses
+                             OpCapability SubgroupDispatch
+                        %1 = OpExtInstImport "OpenCL.std"
+                             OpMemoryModel Physical64 OpenCL
+                             OpEntryPoint Kernel %must_have_sg_size8 "must_have_sg_size8"
+                             OpExecutionMode %must_have_sg_size8 SubgroupSize 8
+                             OpSource OpenCL_C 300000
+
+                   %void_t = OpTypeVoid
+  %must_have_sg_size8_fn_t = OpTypeFunction %void_t
+
+; CHECK: define spir_kernel void @must_have_sg_size8(){{.*}} !intel_reqd_sub_group_size [[SG_MD:\![0-9]+]]
+       %must_have_sg_size8 = OpFunction %void_t None %must_have_sg_size8_fn_t
+                        %2 = OpLabel
+                             OpReturn
+                             OpFunctionEnd
+
+; CHECK: [[SG_MD]] = !{i32 8}

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_subgroups_per_workgroup.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_subgroups_per_workgroup.spvasm
@@ -1,0 +1,38 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env spv1.1 -o %spv_file_s %s %}
+; RUN: not spirv-ll-tool -a OpenCL -b 64 -c SubgroupDispatch %spv_file_s 2>&1 | FileCheck %s
+
+; Check that we don't silently ignore this execution mode.
+; CHECK: Execution Mode SubgroupsPerWorkgroup is not supported.
+
+                             OpCapability Kernel
+                             OpCapability Addresses
+                             OpCapability SubgroupDispatch
+                        %1 = OpExtInstImport "OpenCL.std"
+                             OpMemoryModel Physical64 OpenCL
+                             OpEntryPoint Kernel %must_have_sg_size8 "must_have_sg_size8"
+                             OpExecutionMode %must_have_sg_size8 SubgroupsPerWorkgroup 8
+                             OpSource OpenCL_C 300000
+
+                   %void_t = OpTypeVoid
+  %must_have_sg_size8_fn_t = OpTypeFunction %void_t
+
+       %must_have_sg_size8 = OpFunction %void_t None %must_have_sg_size8_fn_t
+                        %2 = OpLabel
+                             OpReturn
+                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_get_default_queue.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_get_default_queue.spvasm
@@ -1,0 +1,42 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Note that OpTypeQueue and OpGetDefaultQueue are 1.0, but in this test we hide
+; the capability behind SubgroupDispatch.
+; RUN: %if online-spirv-as %{ spirv-as --target-env spv1.1 -o %spv_file_s %s %}
+; RUN: not spirv-ll-tool -a OpenCL -b 64 -c SubgroupDispatch %spv_file_s 2>&1 | FileCheck %s
+
+; Check that we don't silently ignore this op/type.
+; CHECK: OpTypeQueue is not supported.
+
+                             OpCapability Int8
+                             OpCapability Kernel
+                             OpCapability Addresses
+                             OpCapability SubgroupDispatch
+                        %1 = OpExtInstImport "OpenCL.std"
+                             OpMemoryModel Physical64 OpenCL
+                             OpEntryPoint Kernel %foo "foo"
+                             OpSource OpenCL_C 300000
+
+                   %void_t = OpTypeVoid
+                  %queue_t = OpTypeQueue
+                 %foo_fn_t = OpTypeFunction %void_t
+
+                      %foo = OpFunction %void_t None %foo_fn_t
+                        %4 = OpLabel
+                       %10 = OpGetDefaultQueue %queue_t
+                             OpReturn
+                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_get_kernel_max_num_subgroups.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_get_kernel_max_num_subgroups.spvasm
@@ -1,0 +1,52 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env spv1.1 -o %spv_file_s %s %}
+; RUN: not spirv-ll-tool -a OpenCL -b 64 -c SubgroupDispatch %spv_file_s 2>&1 | FileCheck %s
+
+; Check that we don't silently ignore this op.
+; CHECK: OpGetKernelMaxNumSubgroups is not supported.
+
+                             OpCapability Int8
+                             OpCapability Kernel
+                             OpCapability Addresses
+                             OpCapability SubgroupDispatch
+                        %1 = OpExtInstImport "OpenCL.std"
+                             OpMemoryModel Physical64 OpenCL
+                             OpEntryPoint Kernel %foo "foo"
+                             OpSource OpenCL_C 300000
+
+                   %void_t = OpTypeVoid
+                     %u8_t = OpTypeInt 8 0
+                    %u32_t = OpTypeInt 32 0
+                 %u8_ptr_t = OpTypePointer CrossWorkgroup %u8_t
+               %param_size = OpConstant %u32_t 4
+              %param_align = OpConstant %u32_t 4
+               %null_param = OpConstantNull %u8_ptr_t
+                 %foo_fn_t = OpTypeFunction %void_t
+              %invoke_fn_t = OpTypeFunction %void_t %u8_ptr_t
+
+                   %invoke = OpFunction %void_t None %invoke_fn_t
+                        %2 = OpFunctionParameter %u8_ptr_t
+                        %3 = OpLabel
+                             OpReturn
+                             OpFunctionEnd
+
+                      %foo = OpFunction %void_t None %foo_fn_t
+                        %4 = OpLabel
+                       %10 = OpGetKernelMaxNumSubgroups %u32_t %invoke %null_param %param_size %param_align
+                             OpReturn
+                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_get_kernel_preferred_work_group_size_multiple.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_get_kernel_preferred_work_group_size_multiple.spvasm
@@ -1,0 +1,52 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: not spirv-ll-tool -a OpenCL -b 64 -c DeviceEnqueue %spv_file_s 2>&1 | FileCheck %s
+
+; Check that we don't silently ignore this op.
+; CHECK: OpGetKernelPreferredWorkGroupSizeMultiple is not supported.
+
+                             OpCapability Int8
+                             OpCapability Kernel
+                             OpCapability Addresses
+                             OpCapability DeviceEnqueue
+                        %1 = OpExtInstImport "OpenCL.std"
+                             OpMemoryModel Physical64 OpenCL
+                             OpEntryPoint Kernel %foo "foo"
+                             OpSource OpenCL_C 300000
+
+                   %void_t = OpTypeVoid
+                     %u8_t = OpTypeInt 8 0
+                    %u32_t = OpTypeInt 32 0
+                 %u8_ptr_t = OpTypePointer CrossWorkgroup %u8_t
+               %param_size = OpConstant %u32_t 4
+              %param_align = OpConstant %u32_t 4
+               %null_param = OpConstantNull %u8_ptr_t
+                 %foo_fn_t = OpTypeFunction %void_t
+              %invoke_fn_t = OpTypeFunction %void_t %u8_ptr_t
+
+                   %invoke = OpFunction %void_t None %invoke_fn_t
+                        %2 = OpFunctionParameter %u8_ptr_t
+                        %3 = OpLabel
+                             OpReturn
+                             OpFunctionEnd
+
+                      %foo = OpFunction %void_t None %foo_fn_t
+                        %4 = OpLabel
+                       %10 = OpGetKernelPreferredWorkGroupSizeMultiple %u32_t %invoke %null_param %param_size %param_align
+                             OpReturn
+                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -351,7 +351,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
   for (auto cap : capabilities) {
     if (auto capability = spirv_ll::getCapabilityFromString(cap.data())) {
       // SPIR-V 1.0 list of capabilities.
-      static std::unordered_set<spv::Capability> supported_capabilities = {
+      static std::unordered_set<spv::Capability> supported_v1_0_capabilities = {
           spv::CapabilityMatrix,
           spv::CapabilityShader,
           spv::CapabilityGeometry,
@@ -446,7 +446,13 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
           spv::CapabilityArbitraryPrecisionIntegersINTEL,
           spv::CapabilityOptNoneINTEL};
 
-      if (supported_capabilities.count(*capability)) {
+      // SPIR-V 1.1 list of capabilities.
+      static std::unordered_set<spv::Capability> supported_v1_1_capabilities = {
+          spv::CapabilitySubgroupDispatch,
+      };
+
+      if (supported_v1_0_capabilities.count(*capability) ||
+          supported_v1_1_capabilities.count(*capability)) {
         deviceInfo.capabilities.push_back(*capability);
       } else {
         std::cerr << "error: unsupported capability: "

--- a/source/cl/source/binary/source/spirv.cpp
+++ b/source/cl/source/binary/source/spirv.cpp
@@ -134,6 +134,14 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
       return cargo::make_unexpected(result);
     }
   }
+  if (device_info->max_sub_group_count) {
+    // Note: This is something of a lie, as we don't support DeviceEnqueue,
+    // but we must support the 'SubgroupSize' ExecutionMode for SYCL 2020 and
+    // that is lumped in with SubgroupDispatch.
+    if ((result = spvCapabilities.push_back(spv::CapabilitySubgroupDispatch))) {
+      return cargo::make_unexpected(result);
+    }
+  }
   for (const std::string &extension : supported_extensions) {
     if ((result = spvDeviceInfo.extensions.push_back(extension))) {
       return cargo::make_unexpected(result);

--- a/source/cl/source/extension/CMakeLists.txt
+++ b/source/cl/source/extension/CMakeLists.txt
@@ -59,11 +59,9 @@ endforeach()
 # Create an individual option for each extension in the list.
 foreach(extension ${RUNTIME_EXTENSIONS} ${COMPILER_EXTENSIONS})
   if(${extension} STREQUAL "khr_command_buffer"
-    OR ${extension} STREQUAL "khr_command_buffer_mutable_dispatch"
-    OR ${extension} STREQUAL "intel_required_subgroup_size")
+    OR ${extension} STREQUAL "khr_command_buffer_mutable_dispatch")
     # TODO Enable `khr_command_buffer` and any layered extensions
     # by default once complete.
-    # TODO Enable `intel_required_subgroup_size` by default once complete.
     ca_option(OCL_EXTENSION_cl_${extension} BOOL
         "OpenCL extension cl_${extension}" OFF)
   else()

--- a/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.spvasm32
+++ b/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.spvasm32
@@ -1,0 +1,181 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 86
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Groups
+               OpCapability SubgroupDispatch
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %size8 "size8" %__spirv_BuiltInGlobalLinearId %__spirv_BuiltInSubgroupId %__spirv_BuiltInNumEnqueuedSubgroups %__spirv_BuiltInWorkgroupId %__spirv_BuiltInNumWorkgroups %__spirv_BuiltInSubgroupLocalInvocationId
+               OpExecutionMode %size8 SubgroupSize 8
+               OpSource OpenCL_C 300000
+               OpName %__spirv_BuiltInGlobalLinearId "__spirv_BuiltInGlobalLinearId"
+               OpName %__spirv_BuiltInSubgroupId "__spirv_BuiltInSubgroupId"
+               OpName %__spirv_BuiltInNumEnqueuedSubgroups "__spirv_BuiltInNumEnqueuedSubgroups"
+               OpName %__spirv_BuiltInWorkgroupId "__spirv_BuiltInWorkgroupId"
+               OpName %__spirv_BuiltInNumWorkgroups "__spirv_BuiltInNumWorkgroups"
+               OpName %__spirv_BuiltInSubgroupLocalInvocationId "__spirv_BuiltInSubgroupLocalInvocationId"
+               OpName %size8 "size8"
+               OpName %in_a "in_a"
+               OpName %in_b "in_b"
+               OpName %out_a "out_a"
+               OpName %out_b "out_b"
+               OpName %entry "entry"
+               OpName %in_a_addr "in_a.addr"
+               OpName %in_b_addr "in_b.addr"
+               OpName %out_a_addr "out_a.addr"
+               OpName %out_b_addr "out_b.addr"
+               OpName %glid "glid"
+               OpName %sgid "sgid"
+               OpName %call "call"
+               OpName %call1 "call1"
+               OpName %call2 "call2"
+               OpName %call3 "call3"
+               OpName %call4 "call4"
+               OpName %call5 "call5"
+               OpName %mul "mul"
+               OpName %add "add"
+               OpName %call6 "call6"
+               OpName %call7 "call7"
+               OpName %mul8 "mul8"
+               OpName %call9 "call9"
+               OpName %mul10 "mul10"
+               OpName %add11 "add11"
+               OpName %mul12 "mul12"
+               OpName %add13 "add13"
+               OpName %arrayidx "arrayidx"
+               OpName %call14 "call14"
+               OpName %arrayidx15 "arrayidx15"
+               OpName %arrayidx16 "arrayidx16"
+               OpName %arrayidx17 "arrayidx17"
+               OpName %call18 "call18"
+               OpName %arrayidx19 "arrayidx19"
+               OpName %in_a_0 "in_a"
+               OpName %in_b_0 "in_b"
+               OpName %out_a_0 "out_a"
+               OpName %out_b_0 "out_b"
+               OpDecorate %__spirv_BuiltInGlobalLinearId LinkageAttributes "__spirv_BuiltInGlobalLinearId" Import
+               OpDecorate %__spirv_BuiltInGlobalLinearId Constant
+               OpDecorate %__spirv_BuiltInGlobalLinearId BuiltIn GlobalLinearId
+               OpDecorate %__spirv_BuiltInSubgroupId LinkageAttributes "__spirv_BuiltInSubgroupId" Import
+               OpDecorate %__spirv_BuiltInSubgroupId Constant
+               OpDecorate %__spirv_BuiltInSubgroupId BuiltIn SubgroupId
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups LinkageAttributes "__spirv_BuiltInNumEnqueuedSubgroups" Import
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups Constant
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups BuiltIn NumEnqueuedSubgroups
+               OpDecorate %__spirv_BuiltInWorkgroupId LinkageAttributes "__spirv_BuiltInWorkgroupId" Import
+               OpDecorate %__spirv_BuiltInWorkgroupId Constant
+               OpDecorate %__spirv_BuiltInWorkgroupId BuiltIn WorkgroupId
+               OpDecorate %__spirv_BuiltInNumWorkgroups LinkageAttributes "__spirv_BuiltInNumWorkgroups" Import
+               OpDecorate %__spirv_BuiltInNumWorkgroups Constant
+               OpDecorate %__spirv_BuiltInNumWorkgroups BuiltIn NumWorkgroups
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId LinkageAttributes "__spirv_BuiltInSubgroupLocalInvocationId" Import
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId Constant
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId BuiltIn SubgroupLocalInvocationId
+               OpDecorate %size8 LinkageAttributes "size8" Export
+               OpDecorate %in_a Alignment 4
+               OpDecorate %in_b Alignment 4
+               OpDecorate %out_a Alignment 8
+               OpDecorate %out_b Alignment 4
+               OpDecorate %in_a_addr Alignment 4
+               OpDecorate %in_b_addr Alignment 4
+               OpDecorate %out_a_addr Alignment 4
+               OpDecorate %out_b_addr Alignment 4
+               OpDecorate %glid Alignment 4
+               OpDecorate %sgid Alignment 4
+               OpDecorate %in_a_0 Alignment 4
+               OpDecorate %in_b_0 Alignment 4
+               OpDecorate %out_a_0 Alignment 8
+               OpDecorate %out_b_0 Alignment 4
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+%_ptr_Input_uint = OpTypePointer Input %uint
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+     %v2uint = OpTypeVector %uint 2
+%_ptr_CrossWorkgroup_v2uint = OpTypePointer CrossWorkgroup %v2uint
+         %57 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_v2uint %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_uint = OpTypePointer Function %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_v2uint = OpTypePointer Function %_ptr_CrossWorkgroup_v2uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%__spirv_BuiltInGlobalLinearId = OpVariable %_ptr_Input_uint Input
+%__spirv_BuiltInSubgroupId = OpVariable %_ptr_Input_uint Input
+%__spirv_BuiltInNumEnqueuedSubgroups = OpVariable %_ptr_Input_uint Input
+%__spirv_BuiltInWorkgroupId = OpVariable %_ptr_Input_v3uint Input
+%__spirv_BuiltInNumWorkgroups = OpVariable %_ptr_Input_v3uint Input
+%__spirv_BuiltInSubgroupLocalInvocationId = OpVariable %_ptr_Input_uint Input
+%size8 = OpFunction %void DontInline %57
+       %in_a = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+       %in_b = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %out_a = OpFunctionParameter %_ptr_CrossWorkgroup_v2uint
+      %out_b = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+  %in_a_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+  %in_b_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+ %out_a_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_v2uint Function
+ %out_b_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+       %glid = OpVariable %_ptr_Function_uint Function
+       %sgid = OpVariable %_ptr_Function_uint Function
+               OpStore %in_a_addr %in_a Aligned 4
+               OpStore %in_b_addr %in_b Aligned 4
+               OpStore %out_a_addr %out_a Aligned 4
+               OpStore %out_b_addr %out_b Aligned 4
+       %call = OpLoad %uint %__spirv_BuiltInGlobalLinearId Aligned 4
+               OpStore %glid %call Aligned 4
+      %call1 = OpLoad %uint %__spirv_BuiltInSubgroupId Aligned 4
+      %call2 = OpLoad %uint %__spirv_BuiltInNumEnqueuedSubgroups Aligned 4
+         %61 = OpLoad %v3uint %__spirv_BuiltInWorkgroupId Aligned 16
+      %call3 = OpCompositeExtract %uint %61 0
+         %62 = OpLoad %v3uint %__spirv_BuiltInWorkgroupId Aligned 16
+      %call4 = OpCompositeExtract %uint %62 1
+         %63 = OpLoad %v3uint %__spirv_BuiltInNumWorkgroups Aligned 16
+      %call5 = OpCompositeExtract %uint %63 0
+        %mul = OpIMul %uint %call4 %call5
+        %add = OpIAdd %uint %call3 %mul
+         %64 = OpLoad %v3uint %__spirv_BuiltInWorkgroupId Aligned 16
+      %call6 = OpCompositeExtract %uint %64 2
+         %65 = OpLoad %v3uint %__spirv_BuiltInNumWorkgroups Aligned 16
+      %call7 = OpCompositeExtract %uint %65 0
+       %mul8 = OpIMul %uint %call6 %call7
+         %66 = OpLoad %v3uint %__spirv_BuiltInNumWorkgroups Aligned 16
+      %call9 = OpCompositeExtract %uint %66 1
+      %mul10 = OpIMul %uint %mul8 %call9
+      %add11 = OpIAdd %uint %add %mul10
+      %mul12 = OpIMul %uint %call2 %add11
+      %add13 = OpIAdd %uint %call1 %mul12
+               OpStore %sgid %add13 Aligned 4
+         %67 = OpLoad %uint %sgid Aligned 4
+         %68 = OpLoad %_ptr_CrossWorkgroup_v2uint %out_a_addr Aligned 4
+         %69 = OpLoad %uint %glid Aligned 4
+   %arrayidx = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2uint %68 %69
+         %70 = OpLoad %v2uint %arrayidx Aligned 8
+         %71 = OpCompositeInsert %v2uint %67 %70 0
+               OpStore %arrayidx %71 Aligned 8
+     %call14 = OpLoad %uint %__spirv_BuiltInSubgroupLocalInvocationId Aligned 4
+         %72 = OpLoad %_ptr_CrossWorkgroup_v2uint %out_a_addr Aligned 4
+         %73 = OpLoad %uint %glid Aligned 4
+ %arrayidx15 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2uint %72 %73
+         %74 = OpLoad %v2uint %arrayidx15 Aligned 8
+         %75 = OpCompositeInsert %v2uint %call14 %74 1
+               OpStore %arrayidx15 %75 Aligned 8
+         %76 = OpLoad %_ptr_CrossWorkgroup_uint %in_a_addr Aligned 4
+         %77 = OpLoad %uint %glid Aligned 4
+ %arrayidx16 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %76 %77
+         %78 = OpLoad %uint %arrayidx16 Aligned 4
+         %79 = OpLoad %_ptr_CrossWorkgroup_uint %in_b_addr Aligned 4
+         %80 = OpLoad %uint %sgid Aligned 4
+ %arrayidx17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %79 %80
+         %81 = OpLoad %uint %arrayidx17 Aligned 4
+     %call18 = OpGroupBroadcast %uint %uint_3 %78 %81
+         %82 = OpLoad %_ptr_CrossWorkgroup_uint %out_b_addr Aligned 4
+         %83 = OpLoad %uint %glid Aligned 4
+ %arrayidx19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %82 %83
+               OpStore %arrayidx19 %call18 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.spvasm64
+++ b/source/cl/test/UnitCL/kernels/ext_reqd_subgroup.01_size8.spvasm64
@@ -1,0 +1,190 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 91
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int64
+               OpCapability Groups
+               OpCapability SubgroupDispatch
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %size8 "size8" %__spirv_BuiltInGlobalLinearId %__spirv_BuiltInSubgroupId %__spirv_BuiltInNumEnqueuedSubgroups %__spirv_BuiltInWorkgroupId %__spirv_BuiltInNumWorkgroups %__spirv_BuiltInSubgroupLocalInvocationId
+               OpExecutionMode %size8 SubgroupSize 8
+               OpSource OpenCL_C 300000
+               OpName %__spirv_BuiltInGlobalLinearId "__spirv_BuiltInGlobalLinearId"
+               OpName %__spirv_BuiltInSubgroupId "__spirv_BuiltInSubgroupId"
+               OpName %__spirv_BuiltInNumEnqueuedSubgroups "__spirv_BuiltInNumEnqueuedSubgroups"
+               OpName %__spirv_BuiltInWorkgroupId "__spirv_BuiltInWorkgroupId"
+               OpName %__spirv_BuiltInNumWorkgroups "__spirv_BuiltInNumWorkgroups"
+               OpName %__spirv_BuiltInSubgroupLocalInvocationId "__spirv_BuiltInSubgroupLocalInvocationId"
+               OpName %size8 "size8"
+               OpName %in_a "in_a"
+               OpName %in_b "in_b"
+               OpName %out_a "out_a"
+               OpName %out_b "out_b"
+               OpName %entry "entry"
+               OpName %in_a_addr "in_a.addr"
+               OpName %in_b_addr "in_b.addr"
+               OpName %out_a_addr "out_a.addr"
+               OpName %out_b_addr "out_b.addr"
+               OpName %glid "glid"
+               OpName %sgid "sgid"
+               OpName %call "call"
+               OpName %call1 "call1"
+               OpName %conv "conv"
+               OpName %call2 "call2"
+               OpName %conv3 "conv3"
+               OpName %call4 "call4"
+               OpName %call5 "call5"
+               OpName %call6 "call6"
+               OpName %mul "mul"
+               OpName %add "add"
+               OpName %call7 "call7"
+               OpName %call8 "call8"
+               OpName %mul9 "mul9"
+               OpName %call10 "call10"
+               OpName %mul11 "mul11"
+               OpName %add12 "add12"
+               OpName %mul13 "mul13"
+               OpName %add14 "add14"
+               OpName %conv15 "conv15"
+               OpName %arrayidx "arrayidx"
+               OpName %call16 "call16"
+               OpName %arrayidx17 "arrayidx17"
+               OpName %arrayidx18 "arrayidx18"
+               OpName %arrayidx19 "arrayidx19"
+               OpName %call20 "call20"
+               OpName %arrayidx21 "arrayidx21"
+               OpName %in_a_0 "in_a"
+               OpName %in_b_0 "in_b"
+               OpName %out_a_0 "out_a"
+               OpName %out_b_0 "out_b"
+               OpDecorate %__spirv_BuiltInGlobalLinearId LinkageAttributes "__spirv_BuiltInGlobalLinearId" Import
+               OpDecorate %__spirv_BuiltInGlobalLinearId Constant
+               OpDecorate %__spirv_BuiltInGlobalLinearId BuiltIn GlobalLinearId
+               OpDecorate %__spirv_BuiltInSubgroupId LinkageAttributes "__spirv_BuiltInSubgroupId" Import
+               OpDecorate %__spirv_BuiltInSubgroupId Constant
+               OpDecorate %__spirv_BuiltInSubgroupId BuiltIn SubgroupId
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups LinkageAttributes "__spirv_BuiltInNumEnqueuedSubgroups" Import
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups Constant
+               OpDecorate %__spirv_BuiltInNumEnqueuedSubgroups BuiltIn NumEnqueuedSubgroups
+               OpDecorate %__spirv_BuiltInWorkgroupId LinkageAttributes "__spirv_BuiltInWorkgroupId" Import
+               OpDecorate %__spirv_BuiltInWorkgroupId Constant
+               OpDecorate %__spirv_BuiltInWorkgroupId BuiltIn WorkgroupId
+               OpDecorate %__spirv_BuiltInNumWorkgroups LinkageAttributes "__spirv_BuiltInNumWorkgroups" Import
+               OpDecorate %__spirv_BuiltInNumWorkgroups Constant
+               OpDecorate %__spirv_BuiltInNumWorkgroups BuiltIn NumWorkgroups
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId LinkageAttributes "__spirv_BuiltInSubgroupLocalInvocationId" Import
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId Constant
+               OpDecorate %__spirv_BuiltInSubgroupLocalInvocationId BuiltIn SubgroupLocalInvocationId
+               OpDecorate %size8 LinkageAttributes "size8" Export
+               OpDecorate %in_a Alignment 4
+               OpDecorate %in_b Alignment 4
+               OpDecorate %out_a Alignment 8
+               OpDecorate %out_b Alignment 4
+               OpDecorate %in_a_addr Alignment 8
+               OpDecorate %in_b_addr Alignment 8
+               OpDecorate %out_a_addr Alignment 8
+               OpDecorate %out_b_addr Alignment 8
+               OpDecorate %glid Alignment 8
+               OpDecorate %sgid Alignment 8
+               OpDecorate %in_a_0 Alignment 4
+               OpDecorate %in_b_0 Alignment 4
+               OpDecorate %out_a_0 Alignment 8
+               OpDecorate %out_b_0 Alignment 4
+      %ulong = OpTypeInt 64 0
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+%_ptr_Input_ulong = OpTypePointer Input %ulong
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %v3ulong = OpTypeVector %ulong 3
+%_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+     %v2uint = OpTypeVector %uint 2
+%_ptr_CrossWorkgroup_v2uint = OpTypePointer CrossWorkgroup %v2uint
+         %62 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_v2uint %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_uint = OpTypePointer Function %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_v2uint = OpTypePointer Function %_ptr_CrossWorkgroup_v2uint
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%__spirv_BuiltInGlobalLinearId = OpVariable %_ptr_Input_ulong Input
+%__spirv_BuiltInSubgroupId = OpVariable %_ptr_Input_uint Input
+%__spirv_BuiltInNumEnqueuedSubgroups = OpVariable %_ptr_Input_uint Input
+%__spirv_BuiltInWorkgroupId = OpVariable %_ptr_Input_v3ulong Input
+%__spirv_BuiltInNumWorkgroups = OpVariable %_ptr_Input_v3ulong Input
+%__spirv_BuiltInSubgroupLocalInvocationId = OpVariable %_ptr_Input_uint Input
+%size8 = OpFunction %void DontInline %62
+       %in_a = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+       %in_b = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %out_a = OpFunctionParameter %_ptr_CrossWorkgroup_v2uint
+      %out_b = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+  %in_a_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+  %in_b_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+ %out_a_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_v2uint Function
+ %out_b_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+       %glid = OpVariable %_ptr_Function_ulong Function
+       %sgid = OpVariable %_ptr_Function_ulong Function
+               OpStore %in_a_addr %in_a Aligned 8
+               OpStore %in_b_addr %in_b Aligned 8
+               OpStore %out_a_addr %out_a Aligned 8
+               OpStore %out_b_addr %out_b Aligned 8
+       %call = OpLoad %ulong %__spirv_BuiltInGlobalLinearId Aligned 8
+               OpStore %glid %call Aligned 8
+      %call1 = OpLoad %uint %__spirv_BuiltInSubgroupId Aligned 4
+       %conv = OpUConvert %ulong %call1
+      %call2 = OpLoad %uint %__spirv_BuiltInNumEnqueuedSubgroups Aligned 4
+      %conv3 = OpUConvert %ulong %call2
+         %66 = OpLoad %v3ulong %__spirv_BuiltInWorkgroupId Aligned 32
+      %call4 = OpCompositeExtract %ulong %66 0
+         %67 = OpLoad %v3ulong %__spirv_BuiltInWorkgroupId Aligned 32
+      %call5 = OpCompositeExtract %ulong %67 1
+         %68 = OpLoad %v3ulong %__spirv_BuiltInNumWorkgroups Aligned 32
+      %call6 = OpCompositeExtract %ulong %68 0
+        %mul = OpIMul %ulong %call5 %call6
+        %add = OpIAdd %ulong %call4 %mul
+         %69 = OpLoad %v3ulong %__spirv_BuiltInWorkgroupId Aligned 32
+      %call7 = OpCompositeExtract %ulong %69 2
+         %70 = OpLoad %v3ulong %__spirv_BuiltInNumWorkgroups Aligned 32
+      %call8 = OpCompositeExtract %ulong %70 0
+       %mul9 = OpIMul %ulong %call7 %call8
+         %71 = OpLoad %v3ulong %__spirv_BuiltInNumWorkgroups Aligned 32
+     %call10 = OpCompositeExtract %ulong %71 1
+      %mul11 = OpIMul %ulong %mul9 %call10
+      %add12 = OpIAdd %ulong %add %mul11
+      %mul13 = OpIMul %ulong %conv3 %add12
+      %add14 = OpIAdd %ulong %conv %mul13
+               OpStore %sgid %add14 Aligned 8
+         %72 = OpLoad %ulong %sgid Aligned 8
+     %conv15 = OpUConvert %uint %72
+         %73 = OpLoad %_ptr_CrossWorkgroup_v2uint %out_a_addr Aligned 8
+         %74 = OpLoad %ulong %glid Aligned 8
+   %arrayidx = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2uint %73 %74
+         %75 = OpLoad %v2uint %arrayidx Aligned 8
+         %76 = OpCompositeInsert %v2uint %conv15 %75 0
+               OpStore %arrayidx %76 Aligned 8
+     %call16 = OpLoad %uint %__spirv_BuiltInSubgroupLocalInvocationId Aligned 4
+         %77 = OpLoad %_ptr_CrossWorkgroup_v2uint %out_a_addr Aligned 8
+         %78 = OpLoad %ulong %glid Aligned 8
+ %arrayidx17 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v2uint %77 %78
+         %79 = OpLoad %v2uint %arrayidx17 Aligned 8
+         %80 = OpCompositeInsert %v2uint %call16 %79 1
+               OpStore %arrayidx17 %80 Aligned 8
+         %81 = OpLoad %_ptr_CrossWorkgroup_uint %in_a_addr Aligned 8
+         %82 = OpLoad %ulong %glid Aligned 8
+ %arrayidx18 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %81 %82
+         %83 = OpLoad %uint %arrayidx18 Aligned 4
+         %84 = OpLoad %_ptr_CrossWorkgroup_uint %in_b_addr Aligned 8
+         %85 = OpLoad %ulong %sgid Aligned 8
+ %arrayidx19 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %84 %85
+         %86 = OpLoad %uint %arrayidx19 Aligned 4
+     %call20 = OpGroupBroadcast %uint %uint_3 %83 %86
+         %87 = OpLoad %_ptr_CrossWorkgroup_uint %out_b_addr Aligned 8
+         %88 = OpLoad %ulong %glid Aligned 8
+ %arrayidx21 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %87 %88
+               OpStore %arrayidx21 %call20 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -852,6 +852,12 @@ set(spirv_test
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_regression.55_float_memcpy.spvasm64
   )
 
+if(${OCL_EXTENSION_cl_intel_required_subgroup_size})
+  list(APPEND spirv_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/ext_reqd_subgroup.01_size8.spvasm32
+    ${CMAKE_CURRENT_SOURCE_DIR}/ext_reqd_subgroup.01_size8.spvasm64)
+endif()
+
 # TODO(CA-3968): Revert when fixed.
 if(NOT CMAKE_CROSSCOMPILING)
   list(APPEND spirv_test

--- a/source/cl/test/UnitCL/source/cl_intel_required_subgroup_size/cl_intel_required_subgroup_size.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_required_subgroup_size/cl_intel_required_subgroup_size.cpp
@@ -150,8 +150,9 @@ TEST_P(cl_intel_required_subgroup_size_KernelTest, Ext_Reqd_Subgroup_01_Size8) {
   EXPECT_EQ(val_size, sizeof(mem_size));
 }
 
-static const kts::ucl::SourceType source_types[] = {kts::ucl::OPENCL_C,
-                                                    kts::ucl::OFFLINE};
+static const kts::ucl::SourceType source_types[] = {
+    kts::ucl::OPENCL_C, kts::ucl::OFFLINE, kts::ucl::SPIRV,
+    kts::ucl::OFFLINESPIRV};
 
 UCL_EXECUTION_TEST_SUITE(cl_intel_required_subgroup_size_KernelTest,
                          testing::ValuesIn(source_types));


### PR DESCRIPTION
----

[spirv-ll] Support the 'SubgroupSize' ExecutionMode

This commit extends our SPIR-V consumer to understand the `SubgroupSize`
execution mode. It does so to accomodate both higher-level standards
like SYCL 2020 which have a `reqd_sub_group_size` attribute and OpenCL
which has `intel_reqd_sub_group_size` (via an extension). Although
there's no mandate that this execution mode should encode this data,
that's what tools like DPC++ do in practice and so we should handle
that.

This is awkward for us, as `SubgroupSize` comes as part of the
`SubgroupDispatch` capability, which in turn implicitly defines the
`DeviceEnqueue` capability. The OpenCL environment spec explicitly says
we are not required to support `DeviceEnqueue` as we don't support
device-side enqueue, but it also says that environments supporting
SPIR-V v1.1 binaries should support `SubgroupDispatch` for OpenCL 3.0
devices supporting subgroups. This indicates a spec bug, and is
something we'll raise and hopefully fix in a future version of the
specs.

As a result, it's now perfectly possible for us to encounter SPIR-V
binaries that declare `SubgroupDispatch` and thus are implicitly allowed
to use device-side enqueue features. I feel it's better if we're strict
here and, rather than silently ignoring such features, we throw an error
to let users know what's going on. I've done that, and added a bit of
testing to cover it: full lit testing for each individual thing we don't
support would require a lot of noisy tests.

This also interops with the cl_intel_required_subgroup_size OpenCL
extension, meaning the extension should now also work with SPIR-V
programs. With that, the extension can be considered complete and safe
to enable by default. That will be done in a follow-up commit.

----

[CL] Enable cl_intel_required_subgroup_size by default.

Now that SPIR-V support has been plumbed in, this extension should be
good to enable by default.