### PR TITLE
Produce llvm cache build for use in MR and nightly testing

### DIFF
--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -1,0 +1,79 @@
+name: cache_llvm
+
+on:
+  push:
+    branches:
+      - main
+    path: .github/workflows/create_llvm.yml
+  workflow_dispatch:
+
+jobs:
+  create_llvm_cache:
+    strategy:
+      matrix:
+        version: [15, 16]
+        os: [ubuntu-22.04]
+        build_type: [Release, RelAssert]
+        include:
+          # We want to set flags related to particular matrix dimensions. To do this
+          # we need to create default values first, and then against particular matrix
+          # dimensions.
+          # Note that we need to use RelAssert as the cache key matching can match Release against ReleaseAssert
+          - os_flags:
+          - build_type_flags:
+          - build_type: RelAssert
+            build_type_flags: -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+          - build_type: Release
+            build_type_flags: -DCMAKE_BUILD_TYPE=Release
+    
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Cache llvm
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path:
+            llvm_install/**
+          key: llvm-${{ matrix.os }}-v${{ matrix.version }}-${{ matrix.build_type }}
+
+      - name: Checkout repo
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: llvm/llvm-project
+          ref: release/${{matrix.version}}.x
+
+      - name: Install Ninja
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: llvm/actions/install-ninja@main
+
+      - name: Flags checker
+        if: steps.cache.outputs.cache-hit != 'true'
+        run:
+          echo Building on "${{ matrix.os }}" with os_flags "${{ matrix.os_flags}}" extra flags "${{ matrix.build_type_flags}}" and  build_type "${{matrix.build_type}}"
+
+      - name: Run cmake
+        if: steps.cache.outputs.cache-hit != 'true'
+        run:
+          cmake llvm
+              -DLLVM_ENABLE_DIA_SDK=OFF
+              -DCMAKE_INSTALL_PREFIX=llvm_install
+              -DLLVM_ENABLE_ZLIB=FALSE
+              -DLLVM_ENABLE_Z3_SOLVER=FALSE
+              -DLLVM_ENABLE_PROJECTS="clang;lld"
+              -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;RISCV"
+              -Bbuild
+              -GNinja
+              ${{ matrix.build_type_flags }}
+              ${{ matrix.os_flags}}
+
+      - name: Run build on llvm
+        if: steps.cache.outputs.cache-hit != 'true'
+        run:
+          cmake --build build --target install
+
+      - name: Copy lit tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          cp build/bin/FileCheck* llvm_install/bin
+          cp build/bin/not* llvm_install/bin


### PR DESCRIPTION

# Overview

This adds a matrix of operating systems, llvm versions and build types to create multiple caches which can be used in other jobs at a later point.

# Reason for change

Previously build llvm caches are required in order to run MRs as compiling llvm would take too long and specific cmake flags are used to build the right versions (including disabled zlib).

# Description of change

Added a workflow to iterate through operating systems, llvm versions and build types and create cached builds for each. Windows failed to build and this will be addressed in a later commit.

Note this must only be run on 'main' in order for MR testing to work on a pull request.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-9](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
