### PR TITLE
[compiler] Fix build failure on older compilers

### DIFF
--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -560,7 +560,7 @@ cargo::expected<KernelInfo, Result> populateKernelInfoFromFunction(
     kernel_info.reqd_sub_group_size = *sub_group_size;
   }
 
-  return kernel_info;
+  return std::move(kernel_info);
 }
 }  // namespace
 


### PR DESCRIPTION
Support for Ubuntu18 is deprecated but we still have some old jobs that use it. Until we drop support properly, we can workaround a compile issue with an explicit std::move.