### PR TITLE
Anticipate some changes coming up in llvm 17

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
@@ -44,7 +44,7 @@ namespace {{cookiecutter.target_name}} {
 
 // Process vecz flags based off build options and environment variables
 // return true if we want to vectorize
-llvm::Optional<vecz::VeczPassOptions> processVeczFlags() {
+multi_llvm::Optional<vecz::VeczPassOptions> processVeczFlags() {
   vecz::VeczPassOptions vecz_options;
   // The minimum number of elements to vectorize for. For a fixed-length VF,
   // this is the exact number of elements to vectorize by. For scalable VFs,
@@ -109,7 +109,7 @@ bool {{cookiecutter.target_name.capitalize()}}VeczPassOpts(
       vecz_mode == compiler::VectorizationMode::NEVER) {
     return false;
   }
-  llvm::Optional<vecz::VeczPassOptions> vecz_options = processVeczFlags();
+  multi_llvm::Optional<vecz::VeczPassOptions> vecz_options = processVeczFlags();
   if (!vecz_options.has_value()) {
     return false;
   }

--- a/modules/compiler/multi_llvm/include/multi_llvm/multi_llvm.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/multi_llvm.h
@@ -18,7 +18,6 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/IVDescriptors.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/IR/BasicBlock.h>
@@ -26,6 +25,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <multi_llvm/llvm_version.h>
+#include <multi_llvm/triple.h>
 
 namespace multi_llvm {
 

--- a/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
@@ -17,8 +17,12 @@
 #ifndef MULTI_LLVM_OPTIONAL_HELPER_H_INCLUDED
 #define MULTI_LLVM_OPTIONAL_HELPER_H_INCLUDED
 
+#include <multi_llvm/llvm_version.h>
+
+#if (LLVM_VERSION_MAJOR < 17)
 #include <llvm/ADT/None.h>
 #include <llvm/ADT/Optional.h>
+#endif
 
 #if (LLVM_VERSION_MAJOR >= 16)
 #include <optional>

--- a/modules/compiler/multi_llvm/include/multi_llvm/triple.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/triple.h
@@ -1,0 +1,27 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef MULTI_LLVM_TRIPLE_H_INCLUDED
+#define MULTI_LLVM_TRIPLE_H_INCLUDED
+
+#include <multi_llvm/llvm_version.h>
+
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Triple.h>
+#else
+#include <llvm/ADT/Triple.h>
+#endif
+
+#endif  // MULTI_LLVM_TRIPLE_H_INCLUDED

--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -36,7 +36,7 @@ riscv::RiscvPassMachinery::RiscvPassMachinery(
 // Process vecz flags based off build options and environment variables
 // return true if we want to vectorize
 llvm::SmallVector<vecz::VeczPassOptions> processVeczFlags(
-    llvm::Optional<compiler::VectorizationMode> vecz_mode) {
+    multi_llvm::Optional<compiler::VectorizationMode> vecz_mode) {
   llvm::SmallVector<vecz::VeczPassOptions> vecz_options_vec;
   vecz::VeczPassOptions vecz_opts;
   // The minimum number of elements to vectorize for. For a fixed-length VF,

--- a/modules/compiler/source/base/include/base/base_pass_machinery.h
+++ b/modules/compiler/source/base/include/base/base_pass_machinery.h
@@ -41,7 +41,7 @@ class BaseModulePassMachinery : public compiler::utils::PassMachinery {
  public:
   BaseModulePassMachinery(
       llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-      llvm::Optional<compiler::utils::DeviceInfo> Info,
+      multi_llvm::Optional<compiler::utils::DeviceInfo> Info,
       compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
       bool verifyEach, compiler::utils::DebugLogging debugLogging,
       bool timePasses)
@@ -75,7 +75,7 @@ class BaseModulePassMachinery : public compiler::utils::PassMachinery {
 
   /// @brief Device-specific information about the ComputeMux target being
   /// compiled for.
-  llvm::Optional<compiler::utils::DeviceInfo> Info;
+  multi_llvm::Optional<compiler::utils::DeviceInfo> Info;
 
   /// @brief An optional callback function that provides target-specific
   /// BuiltinInfo information to supply to the BuiltinInfoAnalysis analysis

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -57,7 +57,6 @@
 #include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm-c/BitWriter.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/CallGraph.h>
 #include <llvm/Analysis/Passes.h>
@@ -92,6 +91,7 @@
 #include <llvm/Transforms/Vectorize/SLPVectorizer.h>
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/optional_helper.h>
+#include <multi_llvm/triple.h>
 #include <mux/mux.hpp>
 #include <spirv-ll/module.h>
 

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -30,12 +30,12 @@
 #include <llvm/IR/Type.h>
 #include <llvm/Support/FormatVariadic.h>
 #include <multi_llvm/opaque_pointers.h>
-#include <multi_llvm/optional_helper.h>
 #include <multi_llvm/vector_type_helper.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <iterator>
+#include <optional>
 
 #define PASS_NAME "replace-printf"
 
@@ -325,7 +325,7 @@ Error scalarizeAndCheckFormatString(const std::string &str,
   return Error::success();
 }
 
-Optional<std::string> getPointerToStringAsString(Value *op) {
+std::optional<std::string> getPointerToStringAsString(Value *op) {
   // Check whether the value is being passed directly as the GlobalVariable.
   // This is possible with opaque pointers so will eventually become the
   // default assumption.
@@ -373,7 +373,7 @@ Optional<std::string> getPointerToStringAsString(Value *op) {
   }
 
   if (!var || !var->hasInitializer()) {
-    return multi_llvm::None;
+    return std::nullopt;
   }
 
   Constant *const string_const = var->getInitializer();
@@ -382,7 +382,7 @@ Optional<std::string> getPointerToStringAsString(Value *op) {
     return array_string->getAsString().str();
   }
 
-  return multi_llvm::None;
+  return std::nullopt;
 }
 
 /// @brief A small wrapper function around IRBuilder<>::CreateCall that
@@ -473,7 +473,7 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   OptimizationRemarkEmitter ORE(ci->getFunction());
 
   // get the format string
-  Optional<std::string> format_string =
+  std::optional<std::string> format_string =
       getPointerToStringAsString(ci->getArgOperand(0));
 
   if (!format_string) {

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -19,11 +19,11 @@
 #ifndef SPIRV_LL_SPV_BUILDER_H_INCLUDED
 #define SPIRV_LL_SPV_BUILDER_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
 #include <multi_llvm/multi_llvm.h>
+#include <multi_llvm/optional_helper.h>
 #include <multi_llvm/vector_type_helper.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
@@ -666,7 +666,7 @@ class Builder {
     /// @brief The argument index of the substitutable type.
     std::size_t index;
     /// @brief The opcode of the substitutable type.
-    llvm::Optional<MangleInfo> mangleInfo;
+    multi_llvm::Optional<MangleInfo> mangleInfo;
   };
 
   /// @brief Checks if function parameter can be substituted.
@@ -679,7 +679,7 @@ class Builder {
   /// nullptr if the function parameter can not be substituted.
   const SubstitutableType *substitutableArg(
       llvm::Type *ty, const llvm::ArrayRef<SubstitutableType> &subTys,
-      llvm::Optional<MangleInfo> mangleInfo);
+      multi_llvm::Optional<MangleInfo> mangleInfo);
 
   /// @brief Generate the mangled name for a function parameter type.
   ///
@@ -689,7 +689,7 @@ class Builder {
   ///
   /// @return Returns a string containing the mangled name.
   std::string getMangledTypeName(llvm::Type *ty,
-                                 llvm::Optional<MangleInfo> mangleInfo,
+                                 multi_llvm::Optional<MangleInfo> mangleInfo,
                                  llvm::ArrayRef<SubstitutableType> subTys);
 
   /// @brief Creates a declaration for a builtin function inside of the current

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1089,7 +1089,7 @@ std::string spirv_ll::Builder::getMangledFunctionName(
   for (size_t index = 0; index < args.size(); index++) {
     auto argTy = args[index]->getType();
 
-    llvm::Optional<MangleInfo> mangleInfo;
+    multi_llvm::Optional<MangleInfo> mangleInfo;
     if (!argMangleInfo.empty()) {
       mangleInfo = argMangleInfo[index];
     }
@@ -1114,7 +1114,7 @@ std::string spirv_ll::Builder::getMangledFunctionName(
           // attempt to get the OpCode object for our element type, this is
           // basically so we can check signedness if element type is a vector of
           // ints
-          llvm::Optional<MangleInfo> pointeeMangleInfo;
+          multi_llvm::Optional<MangleInfo> pointeeMangleInfo;
           if (spvPtrTy->isPointerType()) {
             pointeeMangleInfo = *mangleInfo;
             pointeeMangleInfo->typeQuals = 0;
@@ -1131,7 +1131,7 @@ std::string spirv_ll::Builder::getMangledFunctionName(
 
 const spirv_ll::Builder::SubstitutableType *spirv_ll::Builder::substitutableArg(
     llvm::Type *ty, const llvm::ArrayRef<SubstitutableType> &subTys,
-    llvm::Optional<MangleInfo> mangleInfo) {
+    multi_llvm::Optional<MangleInfo> mangleInfo) {
   for (const SubstitutableType &subTy : subTys) {
     if (ty != subTy.ty) {
       continue;
@@ -1159,7 +1159,7 @@ const spirv_ll::Builder::SubstitutableType *spirv_ll::Builder::substitutableArg(
 }
 
 std::string spirv_ll::Builder::getMangledTypeName(
-    llvm::Type *ty, llvm::Optional<MangleInfo> mangleInfo,
+    llvm::Type *ty, multi_llvm::Optional<MangleInfo> mangleInfo,
     llvm::ArrayRef<SubstitutableType> subTys) {
   auto subTyArg = substitutableArg(ty, subTys, mangleInfo);
   if (subTyArg != nullptr) {
@@ -1188,7 +1188,7 @@ std::string spirv_ll::Builder::getMangledTypeName(
     // Assume signed integer when no opcode is provided
     return getMangledIntName(ty, signedness.value_or(true));
   } else if (ty->isVectorTy()) {
-    llvm::Optional<MangleInfo> componentMangleInfo;
+    multi_llvm::Optional<MangleInfo> componentMangleInfo;
     if (mangleInfo) {
       componentMangleInfo = *mangleInfo;
       componentMangleInfo->id =
@@ -1239,7 +1239,7 @@ std::string spirv_ll::Builder::getMangledTypeName(
       return mangled + getMangledTypeName(elementTy, pointeeMangleInfo, subTys);
     }
   } else if (ty->isArrayTy()) {
-    llvm::Optional<MangleInfo> eltMangleInfo;
+    multi_llvm::Optional<MangleInfo> eltMangleInfo;
     if (mangleInfo) {
       eltMangleInfo = *mangleInfo;
       eltMangleInfo->id =

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1621,7 +1621,7 @@ llvm::Type *getBufferSizeTy(llvm::LLVMContext &ctx) {
 }
 }  // namespace
 
-static llvm::Optional<std::pair<uint32_t, const char *>> getLinkage(
+static std::optional<std::pair<uint32_t, const char *>> getLinkage(
     Module &module, spv::Id id) {
   if (auto decoration =
           module.getFirstDecoration(id, spv::DecorationLinkageAttributes)) {
@@ -1632,7 +1632,7 @@ static llvm::Optional<std::pair<uint32_t, const char *>> getLinkage(
         decoration->getValueAtOffset(linkageOffset),
         spirv_ll::cast<const OpDecorate>(decoration)->getDecorationString());
   }
-  return multi_llvm::None;
+  return std::nullopt;
 }
 
 template <>

--- a/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
+++ b/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
@@ -18,13 +18,13 @@
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
 #include <host/add_floating_point_control_pass.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicsARM.h>
 #include <llvm/IR/IntrinsicsX86.h>
+#include <multi_llvm/triple.h>
 
 using namespace llvm;
 

--- a/modules/compiler/targets/host/source/DisableNeonAttribute.cpp
+++ b/modules/compiler/targets/host/source/DisableNeonAttribute.cpp
@@ -15,9 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <host/disable_neon_attribute_pass.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
+#include <multi_llvm/triple.h>
 #include <multi_llvm/vector_type_helper.h>
 
 using namespace llvm;

--- a/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
+++ b/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
@@ -20,6 +20,8 @@
 #include <host/host_mux_builtin_info.h>
 #include <multi_llvm/multi_llvm.h>
 
+#include <optional>
+
 using namespace host;
 using namespace llvm;
 
@@ -148,8 +150,8 @@ Function *HostBIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
 
   bool HasRankArg = true;
   size_t DefaultVal = 0;
-  Optional<unsigned> ParamIdx;
-  Optional<unsigned> WGFieldIdx;
+  std::optional<unsigned> ParamIdx;
+  std::optional<unsigned> WGFieldIdx;
 
   switch (ID) {
     default:

--- a/modules/compiler/targets/host/source/RemoveByValAttributes.cpp
+++ b/modules/compiler/targets/host/source/RemoveByValAttributes.cpp
@@ -15,11 +15,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <host/remove_byval_attributes_pass.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
+#include <multi_llvm/triple.h>
 #include <multi_llvm/vector_type_helper.h>
 
 using namespace llvm;

--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -44,7 +44,6 @@
 #include <host/target.h>
 #include <llvm-c/BitWriter.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/CallGraph.h>
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
@@ -54,6 +53,7 @@
 #include <llvm/Support/CrashRecoveryContext.h>
 #include <llvm/Transforms/IPO/GlobalDCE.h>
 #include <multi_llvm/optional_helper.h>
+#include <multi_llvm/triple.h>
 #include <mux/mux.hpp>
 
 #include <cstdint>

--- a/modules/compiler/utils/include/compiler/utils/attributes.h
+++ b/modules/compiler/utils/include/compiler/utils/attributes.h
@@ -17,7 +17,6 @@
 #ifndef COMPILER_UTILS_ATTRIBUTES_H_INCLUDED
 #define COMPILER_UTILS_ATTRIBUTES_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/StringRef.h>
 #include <multi_llvm/optional_helper.h>
 

--- a/modules/compiler/utils/include/compiler/utils/encode_builtin_range_metadata_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/encode_builtin_range_metadata_pass.h
@@ -21,7 +21,6 @@
 #ifndef COMPILER_UTILS_ENCODE_BUILTIN_RANGE_METADATA_PASS_H_INCLUDED
 #define COMPILER_UTILS_ENCODE_BUILTIN_RANGE_METADATA_PASS_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/IR/PassManager.h>
 #include <multi_llvm/optional_helper.h>
 

--- a/modules/compiler/utils/include/compiler/utils/encode_kernel_metadata_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/encode_kernel_metadata_pass.h
@@ -21,7 +21,6 @@
 #ifndef COMPILER_UTILS_ENCODE_KERNEL_METADATA_PASS_H_INCLUDED
 #define COMPILER_UTILS_ENCODE_KERNEL_METADATA_PASS_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/PassManager.h>
 #include <multi_llvm/optional_helper.h>

--- a/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
+++ b/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
@@ -21,7 +21,6 @@
 #ifndef COMPILER_UTILS_GROUP_COLLECTIVE_HELPERS_H_INCLUDED
 #define COMPILER_UTILS_GROUP_COLLECTIVE_HELPERS_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/optional_helper.h>
 

--- a/modules/compiler/utils/include/compiler/utils/metadata.h
+++ b/modules/compiler/utils/include/compiler/utils/metadata.h
@@ -17,7 +17,6 @@
 #ifndef COMPILER_UTILS_METADATA_H_INCLUDED
 #define COMPILER_UTILS_METADATA_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/Metadata.h>
 #include <multi_llvm/optional_helper.h>

--- a/modules/compiler/utils/source/cl_builtin_info.cpp
+++ b/modules/compiler/utils/source/cl_builtin_info.cpp
@@ -18,7 +18,6 @@
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
 #include <llvm/ADT/StringSwitch.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Intrinsics.h>
@@ -31,6 +30,7 @@
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/opaque_pointers.h>
 #include <multi_llvm/optional_helper.h>
+#include <multi_llvm/triple.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include <cmath>

--- a/modules/compiler/utils/source/mangling.cpp
+++ b/modules/compiler/utils/source/mangling.cpp
@@ -26,6 +26,7 @@
 #include <multi_llvm/vector_type_helper.h>
 
 #include <cstring>
+#include <optional>
 
 namespace compiler {
 namespace utils {
@@ -456,12 +457,12 @@ struct PointerASQuals {
   TypeQualifier Qual;
 };
 
-static Optional<PointerASQuals> demanglePointerQuals(Lexer &L) {
+static std::optional<PointerASQuals> demanglePointerQuals(Lexer &L) {
   TypeQualifier PointerQual = eTypeQualNone;
 
   // Parse the optional pointer qualifier.
   if (L.Current() < 0) {
-    return multi_llvm::None;
+    return std::nullopt;
   }
 
   // Parse the optional address space qualifier.
@@ -470,7 +471,7 @@ static Optional<PointerASQuals> demanglePointerQuals(Lexer &L) {
 
   if (L.Consume("U3AS")) {
     if (!L.ConsumeInteger(AddressSpace)) {
-      return multi_llvm::None;
+      return std::nullopt;
     }
     DemangledAS = true;
   }
@@ -493,7 +494,7 @@ static Optional<PointerASQuals> demanglePointerQuals(Lexer &L) {
   }
 
   if (!DemangledAS && L.Consume("U3AS") && !L.ConsumeInteger(AddressSpace)) {
-    return multi_llvm::None;
+    return std::nullopt;
   }
 
   return PointerASQuals{AddressSpace, PointerQual};

--- a/modules/compiler/utils/source/mux_builtin_info.cpp
+++ b/modules/compiler/utils/source/mux_builtin_info.cpp
@@ -22,6 +22,8 @@
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/opaque_pointers.h>
 
+#include <optional>
+
 #if LLVM_VERSION_GREATER_EQUAL(16, 0)
 #include <llvm/Support/ModRef.h>
 #endif
@@ -44,7 +46,7 @@ static Function *defineLocalWorkItemBuiltin(BIMuxInfoConcept &BI, BuiltinID ID,
   // Simple 'local' work-item getters and setters.
   bool IsSetter = false;
   bool HasRankArg = false;
-  Optional<WorkItemInfoStructField::Type> WIFieldIdx;
+  std::optional<WorkItemInfoStructField::Type> WIFieldIdx;
   switch (ID) {
     default:
       return nullptr;
@@ -104,7 +106,7 @@ static Function *defineLocalWorkGroupBuiltin(BIMuxInfoConcept &BI, BuiltinID ID,
   // Simple work-group getters
   bool HasRankArg = true;
   size_t DefaultVal = 0;
-  Optional<WorkGroupInfoStructField::Type> WGFieldIdx;
+  std::optional<WorkGroupInfoStructField::Type> WGFieldIdx;
   switch (ID) {
     default:
       return nullptr;

--- a/modules/compiler/utils/source/optimal_builtin_replacement_pass.cpp
+++ b/modules/compiler/utils/source/optimal_builtin_replacement_pass.cpp
@@ -20,7 +20,6 @@
 #include <compiler/utils/optimal_builtin_replacement_pass.h>
 #include <llvm/ADT/PriorityWorklist.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/CGSCCPassManager.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InstIterator.h>
@@ -28,6 +27,7 @@
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Intrinsics.h>
 #include <multi_llvm/creation_apis_helper.h>
+#include <multi_llvm/triple.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #define DEBUG_TYPE "ca-optimal-builtins"

--- a/modules/compiler/vecz/include/vecz/pass.h
+++ b/modules/compiler/vecz/include/vecz/pass.h
@@ -22,7 +22,6 @@
 #define VECZ_PASS_H
 
 #include <compiler/utils/vectorization_factor.h>
-#include <llvm/ADT/Optional.h>
 #include <llvm/IR/PassManager.h>
 
 #include <cstdint>
@@ -61,7 +60,7 @@ struct VeczPassOptions {
   /// @brief Index of vectorization dimension to use (0 => x, 1 => y, 2 => z).
   uint32_t vec_dim_idx;
 
-  /// @param local_size Value specifying the local size for the function (0 is
+  /// @brief local_size Value specifying the local size for the function (0 is
   /// unknown)
   uint64_t local_size;
 };

--- a/modules/compiler/vecz/source/include/debugging.h
+++ b/modules/compiler/vecz/source/include/debugging.h
@@ -21,7 +21,6 @@
 #ifndef VECZ_DEBUGGING_H_INCLUDED
 #define VECZ_DEBUGGING_H_INCLUDED
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/Function.h>

--- a/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
+++ b/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
@@ -1100,7 +1100,7 @@ bool ControlFlowConversionState::Impl::applyMask(BasicBlock &BB, Value *mask) {
     if (tryApplyMaskToBinOp(I, mask, toDelete, safeDivisors)) {
       continue;
     }
-    Optional<MemOp> memOp = MemOp::get(&I);
+    multi_llvm::Optional<MemOp> memOp = MemOp::get(&I);
     // Turn loads and stores into masked loads and stores.
     if (memOp && (memOp->isLoad() || memOp->isStore())) {
       if (!tryApplyMaskToMemOp(*memOp, mask, toDelete)) {

--- a/modules/compiler/vecz/source/transform/interleaved_group_combine_pass.cpp
+++ b/modules/compiler/vecz/source/transform/interleaved_group_combine_pass.cpp
@@ -260,7 +260,7 @@ PreservedAnalyses InterleavedGroupCombinePass::run(
         continue;
       }
 
-      Optional<MemOp> Op = MemOp::get(CI);
+      multi_llvm::Optional<MemOp> Op = MemOp::get(CI);
       // We can't optimize interleaved memops if we don't know the stride at
       // runtime, since we need to check if the stride and the group size match.
       if (!Op || !Op->isStrideConstantInt()) {
@@ -324,7 +324,7 @@ PreservedAnalyses InterleavedGroupCombinePass::run(
             Group.Kind == eMaskedInterleavedLoad) {
           Masks.reserve(Group.Data.size());
           for (auto *V : Group.Data) {
-            Optional<MemOp> Op = MemOp::get(cast<Instruction>(V));
+            multi_llvm::Optional<MemOp> Op = MemOp::get(cast<Instruction>(V));
             assert(Op && "Unanalyzable interleaved access?");
             Masks.push_back(Op->getMaskOperand());
           }
@@ -455,7 +455,7 @@ bool InterleavedGroupCombinePass::findGroup(
           CanMove = canMoveUp(Group.Data, cast<Instruction>(InfoN.Op));
 
           if (InfoN.Kind == eMaskedInterleavedLoad) {
-            Optional<MemOp> Op = MemOp::get(InfoN.Op);
+            multi_llvm::Optional<MemOp> Op = MemOp::get(InfoN.Op);
             assert(Op && "Unanalyzable load?");
             if (auto *MaskInst = dyn_cast<Instruction>(Op->getMaskOperand())) {
               CanMove &= Group.canDeinterleaveMask(*MaskInst);

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -38,10 +38,10 @@
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/opaque_pointers.h>
-#include <multi_llvm/optional_helper.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include <memory>
+#include <optional>
 
 #include "analysis/instantiation_analysis.h"
 #include "analysis/packetization_analysis.h"
@@ -1662,13 +1662,13 @@ ValuePacket Packetizer::Impl::packetizeSubgroupScan(
   // operations. The value 'None' here represents an operation where the sign
   // of the operands is unimportant, such as floating-point operations, or
   // integer addition.
-  multi_llvm::Optional<bool> optIsSignedInt;
+  std::optional<bool> optIsSignedInt;
   bool isInt = Tys[0]->isIntOrIntVectorTy();
 
   // Determine whether this is a signed or unsigned integer min/max scan.
-  const auto isSignedArg0 = [isInt, fnName, &mangler]() -> Optional<bool> {
+  const auto isSignedArg0 = [isInt, fnName, &mangler]() -> std::optional<bool> {
     if (!isInt) {
-      return multi_llvm::None;
+      return std::nullopt;
     }
     // Demangle the function name to get the type qualifiers.
     SmallVector<Type *, 2> types;

--- a/modules/compiler/vecz/source/transform/passes.cpp
+++ b/modules/compiler/vecz/source/transform/passes.cpp
@@ -86,7 +86,8 @@ PreservedAnalyses SimplifyMaskedMemOpsPass::run(Function &F,
   TargetInfo &VTI = Ctx.targetInfo();
   std::vector<Instruction *> ToDelete;
   for (Function &Builtin : F.getParent()->functions()) {
-    Optional<MemOpDesc> BuiltinDesc = MemOpDesc::analyzeMaskedMemOp(Builtin);
+    multi_llvm::Optional<MemOpDesc> BuiltinDesc =
+        MemOpDesc::analyzeMaskedMemOp(Builtin);
     if (!BuiltinDesc) {
       continue;
     }

--- a/modules/compiler/vecz/source/vector_target_info.cpp
+++ b/modules/compiler/vecz/source/vector_target_info.cpp
@@ -14,7 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
@@ -22,6 +21,7 @@
 #include <llvm/Target/TargetMachine.h>
 #include <multi_llvm/creation_apis_helper.h>
 #include <multi_llvm/opaque_pointers.h>
+#include <multi_llvm/triple.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include "debugging.h"


### PR DESCRIPTION
    [compiler] Replace all uses of llvm::Optional

    Since llvm::Optional is removed in LLVM 17, we need to migrate away from
    it. Where it forms part of our public APIs I've moved to
    multi_llvm::Optional, and for internal uses I've moved to std::optional.

and

    [multi_llvm] Add Triple.h wrapper

    Triple.h moves in LLVM 17, so this provides a stable point with which to
    include that header.
