### PR TITLE
Add building of code for PRs to seed sccache and run some PR testing for code

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -1,0 +1,112 @@
+name: build-ock
+description: Action to build the oneapi-construction-kit
+
+# Some of these are riscv or host target specific, but it does not harm at present to
+# overset cmake values
+inputs:
+  build_type:
+    description: 'build type e.g Release, ReleaseAssert (default ReleaseAssert)'
+    default: ReleaseAssert
+  mux_targets_enable:
+    description: 'mux targets to enable e.g. riscv, host (default host)'
+    default: "host"
+  mux_compilers_enable:
+    description: 'mux compiler target to enable e.g. riscv, host (default host)'
+    default: "host"
+  usm:
+    description: 'Enable usm (default ON)'
+    default: ON
+  command_buffer:
+    description: 'Enable command buffers (default ON)'
+    default: ON
+  debug_support:
+    description: 'Enable debug support (default OFF)'
+    default: OFF
+  offline_kernel_tests:
+    description: 'Enable offline kernel testing (default ON)'
+    default: ON
+  llvm_install_dir:
+    description: 'Directory for llvm install'
+    default: ${{ github.workspace }}/llvm_install
+  build_targets:
+    description: 'cmake targets to build (default UnitCL muxc veczc clc)'
+    default: UnitCL muxc veczc clc
+  host_fp16:
+    description: 'Enable host fp16 (default OFF)'
+    default: OFF
+  host_image:
+    description: 'Enable host images (default OFF)'
+    default: OFF
+  host_enable_builtins:
+    description: 'Enable host builtins (default ON)'
+    default: ON
+  external_compiler_dirs:
+    description: 'External compiler directories, default is to empty string, which means no external directories'
+    default: ""
+  hal_description:
+    description: 'Description to be used for HAL, typically risc-v ISA (default RV64GCV)'
+    default: "RV64GCV"
+  hal_refsi_soc:
+    description: 'HAL Refsi SOC e.g. M1 or G1 default M1'
+    default: "M1"
+  riscv_enabled:
+    description: "Enable riscv target (default OFF)"
+    default: OFF
+  build_dir:
+    description: "Directory to be used for building"
+    default: build
+  extra_flags:
+    description: "Any additional cmake flags to be passed (default '')"
+    default:
+  assemble_spirv_ll_lit_test_offline:
+    description: "Enable Spir-V LL tests offline (Default OFF)"
+    default: OFF
+  enable_api:
+    description: "APIs to enable (default CL)"
+    default: cl
+  enable_rvv_scalable_vecz_check:
+    description: "Enable RVV scalable vecz check (default OFF)"
+    default: OFF
+  enable_rvv_scalable_VP_vecz_check:
+    description: "Enable RVV scalable vecz VP check (default OFF)"
+    default: OFF
+
+runs:
+  # We don't want a new docker just a list of steps, so mark as composite
+  using: "composite"
+  steps:
+    - name: cmake_ock
+      shell: bash
+      run:
+        cmake -GNinja
+              -B${{ inputs.build_dir }}
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache                
+              -DCA_MUX_TARGETS_TO_ENABLE=${{ inputs.mux_targets_enable }}
+              -DCA_ENABLE_API=${{ inputs.enable_api }}
+              -DCA_LLVM_INSTALL_DIR=${{ inputs.llvm_install_dir }}
+              -DCA_ENABLE_DEBUG_SUPPORT=${{ inputs.debug_support }}
+              -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}
+              -DCA_ENABLE_HOST_IMAGE_SUPPORT=${{ inputs.host_image }}
+              -DCA_HOST_ENABLE_BUILTIN_KERNEL=${{ inputs.debug_support }}
+              -DCA_HOST_ENABLE_BUILTINS_EXTENSION=${{ inputs.host_enable_builtins}}
+              -DCA_HOST_ENABLE_FP16=${{ inputs.host_fp16 }}
+              -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=${{ inputs.offline_kernel_tests }}
+              -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=${{ inputs.assemble_spirv_ll_lit_test_offline }}
+              -DOCL_EXTENSION_cl_intel_unified_shared_memory=${{ inputs.usm }}
+              -DOCL_EXTENSION_cl_khr_command_buffer=${{ inputs.command_buffer }}
+              -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=${{ inputs.command_buffer }}
+              -DCA_MUX_COMPILERS_TO_ENABLE=${{ inputs.mux_compilers_enable}}
+              -DCA_EXTERNAL_MUX_COMPILER_DIRS=${{ inputs.external_compiler_dirs }}
+              -DCA_CL_ENABLE_ICD_LOADER=ON
+              -DHAL_REFSI_SOC=${{ inputs.hal_refsi_soc }}
+              -DHAL_REFSI_THREAD_MODE=${{ inputs.regs_thread_mode }}
+              -DCA_RISCV_ENABLED=${{ inputs.riscv_enabled }}
+              -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vecz_check }}
+              -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vp_vecz_check }}
+               ${{ inputs.extra_flags }}
+              .      
+    - name: build_ock
+      shell: bash
+      run:
+        ninja -C ${{ inputs.build_dir }} ${{ inputs.build_targets }}

--- a/.github/actions/do_build_ock/do_build_m1/action.yml
+++ b/.github/actions/do_build_ock/do_build_m1/action.yml
@@ -1,0 +1,22 @@
+name: build-ock-m1
+description: Action to build the oneapi-construction-kit for default riscv m1 target
+
+inputs:
+  build_type:
+    description: 'build type (Release, ReleaseAssert)'
+    default: ReleaseAssert
+
+runs:
+  # We don't want a new docker just a list of steps, so mark as composite
+  using: "composite"
+  steps:
+    - name: build_ock
+      uses: ./.github/actions/do_build_ock
+      with:
+        build_type: ${{ inputs.build_type }}
+        mux_targets_enable: riscv
+        mux_compilers_enable: refsi_m1
+        external_compiler_dirs: "${{ github.workspace }}/examples/refsi/refsi_m1/compiler/refsi_m1"
+        riscv_enabled: ON
+        enable_rvv_scalable_vecz_check: ON
+        enable_rvv_scalable_VP_vecz_check: ON

--- a/.github/actions/setup_ubuntu_build/action.yml
+++ b/.github/actions/setup_ubuntu_build/action.yml
@@ -1,0 +1,47 @@
+name: setup-ubuntu-build
+description: Setup ubuntu ready for building. Includes installs, ninja, build cache setup and loading llvm cache
+
+inputs:
+  llvm_build_type:
+    description: 'llvm Build type (Release, RelAssert) - note we need to use RelAssert for the cache pattern matching'
+    default: RelAssert
+  llvm_version:
+    description: 'Major llvm version to use for fetching llvm cache e.g. 16'
+    default: 16
+  ubuntu_version:
+    description: 'Version of ubuntu used for cache retrieval'
+    default: 22.04
+  save:
+    description: 'Save the build cache at the end - not for PR testing'
+    default: false
+
+
+runs:
+  # We don't want a new docker just a list of steps, so mark as composite
+  using: "composite"
+  steps:
+    - name: Install prerequisites
+      shell: bash    
+      run: |
+        sudo apt-get install -y spirv-tools
+        pip install lit
+
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@main
+
+    - name: load llvm
+      uses: actions/cache/restore@v3
+      with:
+        path: llvm_install/**
+        key: llvm-ubuntu-${{ inputs.ubuntu_version }}-v${{ inputs.llvm_version}}-${{ inputs.llvm_build_type }}
+        fail-on-cache-miss: true
+
+      # note the PR testing usage should set 'save' to false, to avoid PR testing creating new caches on a branch
+    - name: Setup sccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        max-size: 200M
+        key: sccache-build
+        variant: sccache
+        save: ${{ inputs.save }}
+ 

--- a/.github/workflows/build_pr_cache.yml
+++ b/.github/workflows/build_pr_cache.yml
@@ -1,0 +1,59 @@
+# Simple workflow for building sccache for PR testing
+name: Build cache for PR testing
+# Note this will currently create a new sscache file and this must be manually pruned until such time as we have a job
+# for this.
+on:
+  # Uncomment to test this path on a pull request
+  # pull_request:
+  #   paths:
+  #     - '.github/workflows/build_pr_cache.yml'
+  #     - '.github/do_build_ock/**'  
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build_pr_cache.yml'
+      - '.github/actions/do_build_ock/**'
+      - '.github/actions/setup_ubuntu_build/**'
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  build_pr_ock:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      # installs tools, ninja and installs llvm (default 16, RelAssert) and sets up cache
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          save: true
+          llvm_version: 16
+          llvm_build_type: RelAssert
+
+      - name: build host x86_64 release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          build_targets:
+
+      - name: build host x86_64 offline
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          extra_flags: -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_EXTERNAL_CLC=${{ github.workspace }}/build/bin/clc
+          build_dir: build_offline
+          assemble_spirv_ll_lit_test_offline: ON
+          build_targets:
+   
+      - name: clean_build
+        run:
+          rm -rf ${{ github.workspace }}/build*
+
+      - name: build riscv m1
+        uses: ./.github/actions/do_build_ock/do_build_m1  

--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-    path: .github/workflows/create_llvm.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ name: Build documentation
 
 on:
  pull_request:
+  paths:
+    doc/**
+    .github/workflow/docs.yml
 
   # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -1,0 +1,89 @@
+# Simple workflow for building sccache for PR testing
+name: Run ock tests for PR testing
+# Note this will currently create a new sscache file and this must be manually pruned until such time as we have a job
+# for this.
+on:
+  pull_request:
+    paths:
+      - 'source/**'
+      - 'module/**'
+      - 'examples/**'
+      - 'cmake/**'
+      - 'hal/**'
+      - '.github/actions/do_build_ock/**'
+      - '.github/actions/setup_ubuntu_build/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  # build and run host x86_64, execute UnitCL and lit tests and build and run offline
+  run_host_x86_64:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      # installs tools, ninja, installs llvm and sets up sccahe
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          llvm_version: 16
+          llvm_build_type: RelAssert        
+  
+      # These need to match the configurations of build_pr_cache to use the cache effectively
+      - name: build host x86_64 online release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+
+      - name: run just online lit
+        run:
+          ninja -C build check-all-lit
+
+      - name: run host online check
+        run:
+          ninja -C build check-UnitCL
+
+      # use the previous build for online to get clc
+      - name: build host x86_64 offline release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          extra_flags: -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_EXTERNAL_CLC=${{ github.workspace }}/build/bin/clc
+          build_dir: build_offline
+          build_targets: UnitCL
+          assemble_spirv_ll_lit_test_offline: ON
+
+      - name: run host x86_64 offline
+        run:
+          ninja -C build_offline check-UnitCL
+
+  # build and run riscv m1, execute UnitCL and lit tests
+  run_riscv_m1:  
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      # installs tools, ninja, installs llvm and sets up sccahe
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          llvm_version: 16
+          llvm_build_type: RelAssert
+
+      - name: build riscv M1
+        uses: ./.github/actions/do_build_ock/do_build_m1  
+
+      - name: run riscv M1 lit
+        run:
+          ninja -C build check-all-lit
+
+      - name: run riscv M1 UnitCL tests
+        run:
+          ninja -C build check-UnitCL


### PR DESCRIPTION
# Overview

Added PR testing for host and riscv m1 on ubuntu

# Reason for change

This is required for the improvement of PR testing on github.

# Description of change

There are two main parts to the change:
  * We run a build run on main (with some testing) to seed an sccache
  * We run PR testing on pull requests which will read the sccache only

Both use composite actions to avoid too much repetition for building
of the oneapi-construction-kit.

sccache uses an action which has an underlying usage of github caches.
This is tied to a branch, so seeding it has to be done on main to be
available to pull requests. Every time the build PR worflow is run,
this will introduce a new timestamped sccache, so this will have to be
managed. Currently this is only run either manually or when the workflow
files are updated.

Much of the complexity is in the composite actions which can be called
from the workflows and other composite actions:
  * A common action which is uses to set the cmake and build the targets
  * An action specifically for building riscv targets

Note the common action for building can mean that it overly sets cmake
variables in order to allow lots of different inputs. This may benefit
from reviewing at a future date.
