### PR TITLE
Update construction kit to build with LLVM 17

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/opaque_pointers.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/opaque_pointers.h
@@ -27,28 +27,18 @@ inline bool isOpaquePointerTy(llvm::Type *Ty) {
   return false;
 }
 
-inline bool isOpaqueOrPointeeTypeMatches(llvm::PointerType *PTy,
-                                         llvm::Type *EltTy) {
-#if LLVM_VERSION_MAJOR >= 15
-  (void)EltTy;
+inline bool isOpaqueOrPointeeTypeMatches(llvm::PointerType *PTy, llvm::Type *) {
   (void)PTy;
   assert(PTy->isOpaque() && "No support for typed pointers in LLVM 15+");
   return true;
-#else
-  return PTy->isOpaque() || PTy->getPointerElementType() == EltTy;
-#endif
 }
 
 inline llvm::Type *getPtrElementType(llvm::PointerType *PTy) {
   if (PTy->isOpaque()) {
     return nullptr;
   }
-#if LLVM_VERSION_MAJOR >= 15
-  assert(false && "No support for typed pointers in LLVM 15+");
+  assert(false && "No support for typed pointers");
   return nullptr;
-#else
-  return PTy->getPointerElementType();
-#endif
 }
 
 };  // namespace multi_llvm

--- a/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
@@ -64,18 +64,6 @@ class Optional : public llvm::Optional<T> {
   inline constexpr bool has_value() const {
     return llvm::Optional<T>::hasValue();
   }
-
-#if (LLVM_VERSION_MAJOR <= 14)
-  inline constexpr const T &value() const {
-    return llvm::Optional<T>::getValue();
-  }
-  inline constexpr T &value() { return llvm::Optional<T>::getValue(); }
-
-  template <typename U>
-  constexpr T value_or(U &&alt) const & {
-    return llvm::Optional<T>::getValueOr(alt);
-  }
-#endif
 };
 
 #endif

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -302,8 +302,10 @@ std::unordered_map<std::string, CallingConv::ID> CallConvMap = {
     {"X86_64_SysV", CallingConv::X86_64_SysV},
     {"Win64", CallingConv::Win64},
     {"X86_VectorCall", CallingConv::X86_VectorCall},
+#if LLVM_VERSION_LESS(17, 0)
     {"HHVM", CallingConv::HHVM},
     {"HHVM_C", CallingConv::HHVM_C},
+#endif
     {"X86_INTR", CallingConv::X86_INTR},
     {"AVR_INTR", CallingConv::AVR_INTR},
     {"AVR_SIGNAL", CallingConv::AVR_SIGNAL},
@@ -320,9 +322,15 @@ std::unordered_map<std::string, CallingConv::ID> CallConvMap = {
     {"AMDGPU_ES", CallingConv::AMDGPU_ES},
     {"AArch64_VectorCall", CallingConv::AArch64_VectorCall},
     {"AArch64_SVE_VectorCall", CallingConv::AArch64_SVE_VectorCall},
+    {"WASM_EmscriptenInvoke", CallingConv::WASM_EmscriptenInvoke},
     {"AMDGPU_Gfx", CallingConv::AMDGPU_Gfx},
     {"M68k_INTR", CallingConv::M68k_INTR},
-    {"WASM_EmscriptenInvoke", CallingConv::WASM_EmscriptenInvoke},
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+    {"AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0",
+     CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0},
+    {"AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2",
+     CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2},
+#endif
 };
 
 // For parseFixupCallingConventionPassOptions we check the param against

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -985,11 +985,15 @@ void BaseModule::populateCodeGenOpts(clang::CodeGenOptions &codeGenOpts) const {
 
   codeGenOpts.EmitOpenCLArgMetadata = options.kernel_arg_info;
   if (options.debug_info) {
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+    codeGenOpts.setDebugInfo(llvm::codegenoptions::FullDebugInfo);
+#else
     codeGenOpts.setDebugInfo(clang::codegenoptions::FullDebugInfo);
+#endif
   }
-#if (LLVM_VERSION_MAJOR >= 15)
+#if LLVM_VERSION_LESS(17, 0)
   codeGenOpts.OpaquePointers = true;
-#endif  // LLVM_VERSION_MAJOR >= 15
+#endif
 }
 
 void BaseModule::addDefaultOpenCLPreprocessorOpts(
@@ -1319,13 +1323,8 @@ Result BaseModule::setOpenCLInstanceDefaults(
   clang::LangStandard::Kind standard = setClangOpenCLStandard(lang_opts);
 
   llvm::Triple triple(spir_triple);
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
   clang::LangOptions::setLangDefaults(lang_opts, OpenCLInputKind, triple,
                                       pp_opts.Includes, standard);
-#else
-  instance.getInvocation().setLangDefaults(lang_opts, OpenCLInputKind, triple,
-                                           pp_opts.Includes, standard);
-#endif
   setDefaultOpenCLLangOpts(lang_opts);
 
   return Result::SUCCESS;

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -2369,14 +2369,8 @@ cargo::optional<Error> Builder::create<OpFunctionCall>(
               i, llvm::Attribute::get(ctx, kind, callee->getParamByRefType(i)));
           break;
         case llvm::Attribute::StructRet:
-#if LLVM_VERSION_MAJOR >= 15
           call->addParamAttr(i, llvm::Attribute::get(
                                     ctx, kind, call->getParamStructRetType(i)));
-#else
-          call->addParamAttr(
-              i, llvm::Attribute::get(ctx, kind,
-                                      operand_ty->getPointerElementType()));
-#endif
           break;
         default:
           SPIRV_LL_ASSERT(!llvm::Attribute::isTypeAttrKind(kind),

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -46,6 +46,7 @@
 #include <host/remove_byval_attributes_pass.h>
 #include <host/target.h>
 #include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/bit.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
@@ -103,7 +104,11 @@ bool hostVeczPassOpts(llvm::Function &F, llvm::ModuleAnalysisManager &MAM,
   // and dynamic work width must not exceed the device's maximum
   // work width, so cap it before we even attempt vectorization.
   // Only try to vectorize to widths of powers of two.
+#if LLVM_VERSION_GREATER_EQUAL(16, 0)
+  const uint32_t SIMDWidth = llvm::bit_floor(
+#else
   const uint32_t SIMDWidth = llvm::PowerOf2Floor(
+#endif
       local_size != 0 ? std::min(local_size, work_width) : work_width);
 
   vecz_options.factor =

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -346,8 +346,13 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
         target.orc_engine->getDataLayout());
 
     for (const auto &reloc : host::utils::getRelocations()) {
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+      symbols[mangle(reloc.first)] = {llvm::orc::ExecutorAddr(reloc.second),
+                                      llvm::JITSymbolFlags::Exported};
+#else
       symbols[mangle(reloc.first)] = llvm::JITEvaluatedSymbol(
           reloc.second, llvm::JITSymbolFlags::Exported);
+#endif
     }
 
     // Define our runtime library symbols required for the JIT to successfully

--- a/modules/compiler/utils/include/compiler/utils/StructTypeRemapper.h
+++ b/modules/compiler/utils/include/compiler/utils/StructTypeRemapper.h
@@ -26,10 +26,7 @@
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
-
-#include "multi_llvm/multi_llvm.h"
-#include "multi_llvm/opaque_pointers.h"
-#include "multi_llvm/vector_type_helper.h"
+#include <multi_llvm/vector_type_helper.h>
 
 namespace compiler {
 namespace utils {
@@ -63,15 +60,8 @@ class StructTypeRemapper final : public llvm::ValueMapTypeRemapper {
       if (ptrType->isOpaque()) {
         return srcType;
       }
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
-      assert(ptrType->isOpaque() &&
-             "Can only remap opaque pointers as of LLVM 15");
+      assert(ptrType->isOpaque() && "Can only remap opaque pointers");
       return srcType;
-#else
-      auto *ptrElementType = ptrType->getPointerElementType();
-      auto addressSpace = ptrType->getAddressSpace();
-      return llvm::PointerType::get(remapType(ptrElementType), addressSpace);
-#endif
     } else if (auto *arrayType = llvm::dyn_cast<llvm::ArrayType>(srcType)) {
       auto *arrayElementType = arrayType->getElementType();
       auto numElements = arrayType->getNumElements();

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -740,7 +740,11 @@ void compiler::utils::Barrier::MakeLiveVariableMemType() {
 
     // Check if the alloca has a debug info source variable attached. If
     // so record this and the matching byte offset into the struct.
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+    auto DbgIntrinsics = FindDbgDeclareUses(member.value);
+#else
     auto DbgIntrinsics = FindDbgAddrUses(member.value);
+#endif
     for (auto DII : DbgIntrinsics) {
       if (auto dbgDeclare = dyn_cast<DbgDeclareInst>(DII)) {
         debug_intrinsics_.push_back(std::make_pair(dbgDeclare, offset));

--- a/modules/compiler/utils/source/mangling.cpp
+++ b/modules/compiler/utils/source/mangling.cpp
@@ -257,21 +257,7 @@ bool NameMangler::mangleType(raw_ostream &O, Type *Ty, TypeQualifiers Quals,
       manglePointerQuals(O, Qual, AddressSpace);
       return true;
     }
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
     return false;
-#else
-    // Catch builtin types which are technically a pointer to a struct but
-    // aren't seen that way from the perspective of mangling
-    if (const char *MangledBuiltinType =
-            mangleOpenCLBuiltinType(PtrTy->getPointerElementType())) {
-      O << MangledBuiltinType;
-      return true;
-    }
-    O << "P";
-    manglePointerQuals(O, Qual, AddressSpace);
-    return mangleType(O, PtrTy->getPointerElementType(), Quals, PrevTys,
-                      PrevQuals);
-#endif
   } else {
     return false;
   }

--- a/modules/compiler/utils/source/pass_machinery.cpp
+++ b/modules/compiler/utils/source/pass_machinery.cpp
@@ -105,7 +105,11 @@ void PassMachinery::initializeFinish() {
   registerPassCallbacks();
 
   // Register pass instrumentation
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+  SI->registerCallbacks(PIC, &MAM);
+#else
   SI->registerCallbacks(PIC, &FAM);
+#endif
 }
 
 void PassMachinery::buildDefaultAAPipeline() {

--- a/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
+++ b/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
@@ -32,7 +32,6 @@
 #include <llvm/IR/Type.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
-#include <multi_llvm/llvm_version.h>
 
 // For debug output when --debug-only=replace_c11_atomics
 #define DEBUG_TYPE "replace_c11_atomics"
@@ -246,22 +245,19 @@ void replaceFetchKey(CallInst *C11FetchKey) {
   auto Key = BuiltinName.substr(KeyStartIndex, KeyEndIndex - KeyStartIndex);
 
   bool const IsFloat = C11FetchKey->getType()->isFloatTy();
-  AtomicRMWInst::BinOp KeyOpCode {
-    IsFloat ? StringSwitch<AtomicRMWInst::BinOp>(Key)
-                  .Case("add", AtomicRMWInst::FAdd)
-#if LLVM_VERSION_MAJOR >= 15
-                  .Case("min", AtomicRMWInst::FMin)
-                  .Case("max", AtomicRMWInst::FMax)
-#endif
-            : StringSwitch<AtomicRMWInst::BinOp>(Key)
-                  .Case("add", AtomicRMWInst::Add)
-                  .Case("sub", AtomicRMWInst::Sub)
-                  .Case("or", AtomicRMWInst::Or)
-                  .Case("xor", AtomicRMWInst::Xor)
-                  .Case("and", AtomicRMWInst::And)
-                  .Case("min", AtomicRMWInst::Min)
-                  .Case("max", AtomicRMWInst::Max)
-  };
+  AtomicRMWInst::BinOp KeyOpCode{IsFloat
+                                     ? StringSwitch<AtomicRMWInst::BinOp>(Key)
+                                           .Case("add", AtomicRMWInst::FAdd)
+                                           .Case("min", AtomicRMWInst::FMin)
+                                           .Case("max", AtomicRMWInst::FMax)
+                                     : StringSwitch<AtomicRMWInst::BinOp>(Key)
+                                           .Case("add", AtomicRMWInst::Add)
+                                           .Case("sub", AtomicRMWInst::Sub)
+                                           .Case("or", AtomicRMWInst::Or)
+                                           .Case("xor", AtomicRMWInst::Xor)
+                                           .Case("and", AtomicRMWInst::And)
+                                           .Case("min", AtomicRMWInst::Min)
+                                           .Case("max", AtomicRMWInst::Max)};
 
   // We need to make sure we distinguish between signed and unsigned integer
   // comparisons for min and max since they are different operations in

--- a/modules/compiler/utils/source/replace_mem_intrinsics_pass.cpp
+++ b/modules/compiler/utils/source/replace_mem_intrinsics_pass.cpp
@@ -18,6 +18,8 @@
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/Transforms/Utils/LowerMemIntrinsics.h>
+#include <multi_llvm/llvm_version.h>
+
 using namespace llvm;
 
 namespace compiler {
@@ -58,7 +60,11 @@ PreservedAnalyses ReplaceMemIntrinsicsPass::run(Function &F,
         expandMemSetAsLoop(cast<MemSetInst>(CI));
         break;
       case Intrinsic::memmove:
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+        expandMemMoveAsLoop(cast<MemMoveInst>(CI), TTI);
+#else
         expandMemMoveAsLoop(cast<MemMoveInst>(CI));
+#endif
         break;
     }
     CI->eraseFromParent();

--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -182,7 +182,11 @@ bool BasicMem2RegPass::promoteAlloca(AllocaInst *Alloca) const {
       StoredValue = Store->getValueOperand();
       ToDelete.push_back(Store);
       DIBuilder DIB(*Alloca->getModule(), /*AllowUnresolved*/ false);
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+      auto DbgIntrinsics = FindDbgDeclareUses(Alloca);
+#else
       auto DbgIntrinsics = FindDbgAddrUses(Alloca);
+#endif
       for (auto oldDII : DbgIntrinsics) {
         ConvertDebugDeclareToDebugValue(oldDII, Store, DIB);
       }

--- a/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
+++ b/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
@@ -31,8 +31,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
-#include <multi_llvm/multi_llvm.h>
-#include <multi_llvm/vector_type_helper.h>
+#include <multi_llvm/optional_helper.h>
 
 #include <queue>
 #include <utility>
@@ -3064,11 +3063,7 @@ bool ControlFlowConversionState::Impl::simplifyMasks() {
         if (I.use_empty()) {
           toDelete.push_back(&I);
         } else {
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
           Value *simpleMask = simplifyInstruction(&I, Q);
-#else
-          Value *simpleMask = SimplifyInstruction(&I, Q);
-#endif
           if (simpleMask && simpleMask != &I) {
             I.replaceAllUsesWith(simpleMask);
             toDelete.push_back(&I);

--- a/modules/compiler/vecz/source/transform/scalarizer.cpp
+++ b/modules/compiler/vecz/source/transform/scalarizer.cpp
@@ -27,7 +27,6 @@
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
-#include <multi_llvm/llvm_version.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/vector_type_helper.h>
 
@@ -667,11 +666,7 @@ SimdPacket *Scalarizer::extractLanes(llvm::Value *V, PacketMask PM) {
     }
 
     Value *Idx = B.getInt32(i);
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
     Value *Extract = simplifyExtractElementInst(V, Idx, Q);
-#else
-    Value *Extract = SimplifyExtractElementInst(V, Idx, Q);
-#endif
     if (!Extract) {
       Extract = B.CreateExtractElement(V, Idx);
     }

--- a/modules/compiler/vecz/source/vector_target_info_riscv.cpp
+++ b/modules/compiler/vecz/source/vector_target_info_riscv.cpp
@@ -360,10 +360,8 @@ llvm::Value *TargetInfoRISCV::createScalableExtractElement(
                                  indices, zero);
 
   SmallVector<Value *, 4> ops;
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
-  // LLVM 15+ has a pass-through operand - we set it to undef.
+  // Add the a pass-through operand - we set it to undef.
   ops.push_back(UndefValue::get(srcTy));
-#endif
   ops.push_back(src);
   ops.push_back(indices);
   ops.push_back(avl);
@@ -428,10 +426,8 @@ llvm::Value *TargetInfoRISCV::createScalableBroadcast(llvm::IRBuilder<> &B,
   auto *const avl = getIntrinsicVL(B, VL, wideTy, getTargetMachine());
 
   SmallVector<Value *, 4> ops;
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
-  // LLVM 15+ has a pass-through operand - we set it to undef.
+  // Add the pass-through operand - we set it to undef.
   ops.push_back(UndefValue::get(vs2->getType()));
-#endif
   ops.push_back(vs2);
   ops.push_back(vs1);
   ops.push_back(avl);
@@ -641,10 +637,8 @@ llvm::Value *TargetInfoRISCV::createVectorShuffle(llvm::IRBuilder<> &B,
   auto *const avl = getIntrinsicVL(B, VL, gatherTy, getTargetMachine());
 
   SmallVector<Value *, 4> ops;
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
-  // LLVM 15+ has a pass-through operand - we set it to undef.
+  // Add the pass-through operand - we set it to undef.
   ops.push_back(UndefValue::get(gatherTy));
-#endif
   ops.push_back(src);
   ops.push_back(mask);
   ops.push_back(avl);
@@ -676,10 +670,8 @@ llvm::Value *TargetInfoRISCV::createVectorSlideUp(llvm::IRBuilder<> &B,
   auto *const avl = getIntrinsicVL(B, VL, srcTy, getTargetMachine());
 
   SmallVector<Value *, 4> ops;
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
-  // LLVM 15+ has a pass-through operand - we set it to undef.
+  // Add the pass-through operand - we set it to undef.
   ops.push_back(UndefValue::get(srcTy));
-#endif
   ops.push_back(src);
   ops.push_back(insert);
   ops.push_back(avl);

--- a/modules/compiler/vecz/source/vector_target_info_riscv.cpp
+++ b/modules/compiler/vecz/source/vector_target_info_riscv.cpp
@@ -745,7 +745,11 @@ Value *TargetInfoRISCV::createVPKernelWidth(IRBuilder<> &B,
   auto *const I64Ty = Type::getInt64Ty(B.getContext());
 
   auto *const VL =
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+      B.CreateIntrinsic(Intrinsic::RISCVIntrinsics::riscv_vsetvli, {I64Ty},
+#else
       B.CreateIntrinsic(Intrinsic::RISCVIntrinsics::riscv_vsetvli_opt, {I64Ty},
+#endif
                         {RemainingIters, VSEW, VLMul});
 
   return B.CreateTrunc(VL, I32Ty);

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -46,7 +46,6 @@
 
 #include <string>
 
-#include "multi_llvm/multi_llvm.h"
 #include "vecz/pass.h"
 #include "vecz/vecz_target_info.h"
 
@@ -287,9 +286,8 @@ int main(const int argc, const char *const argv[]) {
 
   llvm::SMDiagnostic err;
   llvm::LLVMContext context;
-#if LLVM_VERSION_GREATER_EQUAL(15, 0)
   context.setOpaquePointers(true);
-#endif
+
   std::unique_ptr<llvm::Module> module =
       llvm::parseIRFile(InputFilename, err, context);
 


### PR DESCRIPTION
This fixes all of the known *compile time* issues when building the construction kit with LLVM llvm/lllvm-project@89f4933. There are known issues when running, so it is not advised or advertised as working.