### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since version 2.23 (released in August 2019), git-blame has a feature
+# to ignore or bypass certain commits.
+#
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Run clang-format-9 on everything
+9d79df77ad16b3d360cec1e93e8f2b4b63b4b4ac


### PR DESCRIPTION
This new file is intended to be used to list sweeping changes such as mass reformatting or renaming. You can configure git-blame so that the command ignores commits listed in this file.

This file just follows LLVM's own version of this file.