### PR TITLE
[compiler] Move riscv/refsi/cookie pipeline handling into the PassMachineries

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_pass_machinery.h
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_pass_machinery.h
@@ -33,6 +33,15 @@ class RefSiG1PassMachinery : public riscv::RiscvPassMachinery {
       bool verifyEach, compiler::utils::DebugLogging debugLogging,
       bool timePasses);
 
+  bool handlePipelineElement(llvm::StringRef,
+                             llvm::ModulePassManager &AM) override;
+
+  /// @brief Returns an optimization pass pipeline to run over all kernels in a
+  /// module. @see BaseModule::getLateTargetPasses.
+  ///
+  /// @return Result ModulePassManager containing passes
+  llvm::ModulePassManager getLateTargetPasses();
+
   void addClassToPassNames() override;
   void registerPassCallbacks() override;
   void printPassNames(llvm::raw_ostream &OS) override;

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_pass_machinery.h
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_pass_machinery.h
@@ -27,8 +27,8 @@ namespace refsi_g1_wi {
 class RefSiG1PassMachinery : public riscv::RiscvPassMachinery {
  public:
   RefSiG1PassMachinery(
-      llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-      const compiler::utils::DeviceInfo &Info,
+      const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
+      llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
       compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
       bool verifyEach, compiler::utils::DebugLogging debugLogging,
       bool timePasses);

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
@@ -60,7 +60,8 @@ RefSiG1Module::createPassMachinery() {
   };
   llvm::LLVMContext &Ctx = Builtins->getContext();
   return std::make_unique<RefSiG1PassMachinery>(
-      Ctx, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), Ctx, TM, Info, Callback,
+      BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }
@@ -74,6 +75,9 @@ llvm::ModulePassManager RefSiG1Module::getLateTargetPasses(
   const auto &env_debug_prefix = getTarget().env_debug_prefix;
 
   compiler::BasePassPipelineTuner tuner(options);
+  auto env_var_opts =
+      static_cast<RefSiG1PassMachinery &>(pass_mach).processOptimizationOptions(
+          env_debug_prefix, /* vecz_mode*/ {});
 
   cargo::string_view hal_name(getTarget().riscv_hal_device_info->target_name);
 
@@ -106,7 +110,7 @@ llvm::ModulePassManager RefSiG1Module::getLateTargetPasses(
 
   PM.addPass(riscv::IRToBuiltinReplacementPass());
 
-  if (isEarlyBuiltinLinkingEnabled(env_debug_prefix)) {
+  if (env_var_opts.early_link_builtins) {
     PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
   }
 

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
@@ -15,28 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <base/pass_pipelines.h>
-#include <compiler/utils/add_kernel_wrapper_pass.h>
-#include <compiler/utils/add_metadata_pass.h>
-#include <compiler/utils/add_scheduling_parameters_pass.h>
-#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/cl_builtin_info.h>
-#include <compiler/utils/define_mux_builtins_pass.h>
-#include <compiler/utils/define_mux_dma_pass.h>
-#include <compiler/utils/encode_kernel_metadata_pass.h>
-#include <compiler/utils/link_builtins_pass.h>
-#include <compiler/utils/metadata_analysis.h>
-#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
-#include <compiler/utils/replace_mem_intrinsics_pass.h>
-#include <compiler/utils/simple_callback_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Target/TargetMachine.h>
-#include <metadata/handler/vectorize_info_metadata.h>
 #include <refsi_g1_wi/module.h>
 #include <refsi_g1_wi/refsi_mux_builtin_info.h>
 #include <refsi_g1_wi/refsi_pass_machinery.h>
 #include <refsi_g1_wi/refsi_wg_loop_pass.h>
 #include <refsi_g1_wi/target.h>
-#include <riscv/ir_to_builtins_pass.h>
 
 namespace refsi_g1_wi {
 RefSiG1Module::RefSiG1Module(RefSiG1Target &target,
@@ -72,93 +58,7 @@ llvm::ModulePassManager RefSiG1Module::getLateTargetPasses(
     llvm::EnableStatistics();
   }
 
-  const auto &env_debug_prefix = getTarget().env_debug_prefix;
-
-  compiler::BasePassPipelineTuner tuner(options);
-  auto env_var_opts =
-      static_cast<RefSiG1PassMachinery &>(pass_mach).processOptimizationOptions(
-          env_debug_prefix, /* vecz_mode*/ {});
-
-  cargo::string_view hal_name(getTarget().riscv_hal_device_info->target_name);
-
-  llvm::ModulePassManager PM;
-
-  PM.addPass(compiler::utils::TransferKernelMetadataPass());
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_G1_WI_DEMO_MODE)
-  std::string dump_ir_env_name = env_debug_prefix + "_DUMP_IR";
-  if (!env_debug_prefix.empty() && std::getenv(dump_ir_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
-  }
-#endif
-
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceMemIntrinsicsPass()));
-
-  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
-  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
-                                       llvm::Module>());
-
-  // This potentially fixes up any structs to match the spir alignment
-  // before we change to the backend layout
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-
-  // Handle the generic address space
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
-
-  PM.addPass(riscv::IRToBuiltinReplacementPass());
-
-  if (env_var_opts.early_link_builtins) {
-    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
-  }
-
-  // Bit nasty, but we must schedule a run of the DefineMuxDmaPass to define
-  // the __mux_dma_wait builtin - which defers to a work-group barrier - before
-  // we run the PrepareBarriersPass (in addPreVeczPasses).
-  // We end up running the DefineMuxDmaPass once again in
-  // addLateBuiltinsPasses, which isn't ideal.
-  PM.addPass(compiler::utils::DefineMuxDmaPass());
-
-  addPreVeczPasses(PM, tuner);
-
-  addLateBuiltinsPasses(PM, tuner);
-
-  PM.addPass(compiler::utils::AddSchedulingParametersPass());
-
-  PM.addPass(RefSiWGLoopPass());
-
-  PM.addPass(compiler::utils::DefineMuxBuiltinsPass());
-
-  compiler::utils::AddKernelWrapperPassOptions KWOpts;
-  // We don't bundle kernel arguments in a packed struct.
-  KWOpts.IsPackedStruct = false;
-  KWOpts.PassLocalBuffersBySize = false;
-  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
-
-  PM.addPass(compiler::utils::AddMetadataPass<
-             compiler::utils::VectorizeMetadataAnalysis,
-             handler::VectorizeInfoMetadataHandler>());
-
-  addLLVMDefaultPerModulePipeline(PM, pass_mach.getPB(), options);
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_G1_WI_DEMO_MODE)
-  // With all passes scheduled, add a callback pass to view the assembly/object
-  // file, if requested.
-  std::string dump_asm_env_name = env_debug_prefix + "_DUMP_ASM";
-  if (!env_debug_prefix.empty() && std::getenv(dump_asm_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [TM = pass_mach.getTM()](llvm::Module &m) {
-          // Clone the module so we leave it in the same state after we compile.
-          auto cloned_m = llvm::CloneModule(m);
-          compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
-                                    /*create_assembly*/ true);
-        }));
-  }
-#endif
-
-  return PM;
+  return static_cast<RefSiG1PassMachinery &>(pass_mach).getLateTargetPasses();
 }
 
 }  // namespace refsi_g1_wi

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
@@ -15,11 +15,25 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <base/pass_pipelines.h>
+#include <compiler/utils/add_kernel_wrapper_pass.h>
+#include <compiler/utils/add_metadata_pass.h>
+#include <compiler/utils/add_scheduling_parameters_pass.h>
+#include <compiler/utils/align_module_structs_pass.h>
+#include <compiler/utils/define_mux_builtins_pass.h>
+#include <compiler/utils/define_mux_dma_pass.h>
+#include <compiler/utils/encode_kernel_metadata_pass.h>
+#include <compiler/utils/link_builtins_pass.h>
+#include <compiler/utils/metadata_analysis.h>
+#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
+#include <compiler/utils/replace_mem_intrinsics_pass.h>
+#include <compiler/utils/simple_callback_pass.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <metadata/handler/vectorize_info_metadata.h>
 #include <multi_llvm/optional_helper.h>
 #include <refsi_g1_wi/refsi_pass_machinery.h>
 #include <refsi_g1_wi/refsi_wg_loop_pass.h>
+#include <riscv/ir_to_builtins_pass.h>
 #include <vecz/pass.h>
 
 refsi_g1_wi::RefSiG1PassMachinery::RefSiG1PassMachinery(
@@ -54,11 +68,117 @@ void refsi_g1_wi::RefSiG1PassMachinery::registerPassCallbacks() {
       });
 }
 
+bool refsi_g1_wi::RefSiG1PassMachinery::handlePipelineElement(
+    llvm::StringRef Name, llvm::ModulePassManager &PM) {
+  if (Name.consume_front("refsi-g1-wi-late-passes")) {
+    PM.addPass(getLateTargetPasses());
+    return true;
+  }
+
+  return false;
+}
+
+llvm::ModulePassManager
+refsi_g1_wi::RefSiG1PassMachinery::getLateTargetPasses() {
+  llvm::ModulePassManager PM;
+
+  std::optional<std::string> env_debug_prefix;
+#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_G1_WI_DEMO_MODE)
+  env_debug_prefix = target.env_debug_prefix;
+#endif
+
+  compiler::BasePassPipelineTuner tuner(options);
+  auto env_var_opts =
+      processOptimizationOptions(env_debug_prefix, /* vecz_mode*/ {});
+
+  PM.addPass(compiler::utils::TransferKernelMetadataPass());
+
+  if (env_debug_prefix) {
+    std::string dump_ir_env_name = *env_debug_prefix + "_DUMP_IR";
+    if (std::getenv(dump_ir_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass(
+          [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
+    }
+  }
+
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceMemIntrinsicsPass()));
+
+  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
+  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
+                                       llvm::Module>());
+
+  // This potentially fixes up any structs to match the spir alignment
+  // before we change to the backend layout
+  PM.addPass(compiler::utils::AlignModuleStructsPass());
+
+  // Handle the generic address space
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
+
+  PM.addPass(riscv::IRToBuiltinReplacementPass());
+
+  if (env_var_opts.early_link_builtins) {
+    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
+  }
+
+  // Bit nasty, but we must schedule a run of the DefineMuxDmaPass to define
+  // the __mux_dma_wait builtin - which defers to a work-group barrier - before
+  // we run the PrepareBarriersPass (in addPreVeczPasses).
+  // We end up running the DefineMuxDmaPass once again in
+  // addLateBuiltinsPasses, which isn't ideal.
+  PM.addPass(compiler::utils::DefineMuxDmaPass());
+
+  addPreVeczPasses(PM, tuner);
+
+  addLateBuiltinsPasses(PM, tuner);
+
+  PM.addPass(compiler::utils::AddSchedulingParametersPass());
+
+  PM.addPass(RefSiWGLoopPass());
+
+  PM.addPass(compiler::utils::DefineMuxBuiltinsPass());
+
+  compiler::utils::AddKernelWrapperPassOptions KWOpts;
+  // We don't bundle kernel arguments in a packed struct.
+  KWOpts.IsPackedStruct = false;
+  KWOpts.PassLocalBuffersBySize = false;
+  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
+
+  PM.addPass(compiler::utils::AddMetadataPass<
+             compiler::utils::VectorizeMetadataAnalysis,
+             handler::VectorizeInfoMetadataHandler>());
+
+  addLLVMDefaultPerModulePipeline(PM, getPB(), options);
+
+  if (env_debug_prefix) {
+    // With all passes scheduled, add a callback pass to view the
+    // assembly/object file, if requested.
+    std::string dump_asm_env_name = *env_debug_prefix + "_DUMP_ASM";
+    if (std::getenv(dump_asm_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass([this](llvm::Module &m) {
+        // Clone the module so we leave it in the same state after we
+        // compile.
+        auto cloned_m = llvm::CloneModule(m);
+        compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
+                                  /*create_assembly*/ true);
+      }));
+    }
+  }
+
+  return PM;
+}
+
 void refsi_g1_wi::RefSiG1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   riscv::RiscvPassMachinery::printPassNames(OS);
 
-  OS << "\nRisc-v specific Target passes:\n\n";
+  OS << "\nriscv specific Target passes:\n\n";
   OS << "Module passes:\n";
 #define MODULE_PASS(NAME, CREATE_PASS) compiler::utils::printPassName(NAME, OS);
 #include "refsi_pass_registry.def"
+
+  OS << "\nriscv pipelines:\n\n";
+
+  OS << "  refsi-g1-wi-late-passes\n";
+  OS << "    Runs the pipeline for BaseModule::getLateTargetPasses\n";
 }

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
@@ -23,12 +23,12 @@
 #include <vecz/pass.h>
 
 refsi_g1_wi::RefSiG1PassMachinery::RefSiG1PassMachinery(
-    llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-    const compiler::utils::DeviceInfo &Info,
+    const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
+    llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
     compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
     bool verifyEach, compiler::utils::DebugLogging debugLogLevel,
     bool timePasses)
-    : riscv::RiscvPassMachinery(Ctx, TM, Info, BICallback, verifyEach,
+    : riscv::RiscvPassMachinery(target, Ctx, TM, Info, BICallback, verifyEach,
                                 debugLogLevel, timePasses) {}
 
 void refsi_g1_wi::RefSiG1PassMachinery::addClassToPassNames() {

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
@@ -36,7 +36,9 @@
 #include <riscv/ir_to_builtins_pass.h>
 #include <vecz/pass.h>
 
-refsi_g1_wi::RefSiG1PassMachinery::RefSiG1PassMachinery(
+namespace refsi_g1_wi {
+
+RefSiG1PassMachinery::RefSiG1PassMachinery(
     const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
     llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
     compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
@@ -45,7 +47,7 @@ refsi_g1_wi::RefSiG1PassMachinery::RefSiG1PassMachinery(
     : riscv::RiscvPassMachinery(target, Ctx, TM, Info, BICallback, verifyEach,
                                 debugLogLevel, timePasses) {}
 
-void refsi_g1_wi::RefSiG1PassMachinery::addClassToPassNames() {
+void RefSiG1PassMachinery::addClassToPassNames() {
   RiscvPassMachinery::addClassToPassNames();
 // Register compiler passes
 #define MODULE_PASS(NAME, CREATE_PASS) \
@@ -53,7 +55,7 @@ void refsi_g1_wi::RefSiG1PassMachinery::addClassToPassNames() {
 #include "refsi_pass_registry.def"
 }
 
-void refsi_g1_wi::RefSiG1PassMachinery::registerPassCallbacks() {
+void RefSiG1PassMachinery::registerPassCallbacks() {
   RiscvPassMachinery::registerPassCallbacks();
   PB.registerPipelineParsingCallback(
       [](llvm::StringRef Name, llvm::ModulePassManager &PM,
@@ -68,8 +70,8 @@ void refsi_g1_wi::RefSiG1PassMachinery::registerPassCallbacks() {
       });
 }
 
-bool refsi_g1_wi::RefSiG1PassMachinery::handlePipelineElement(
-    llvm::StringRef Name, llvm::ModulePassManager &PM) {
+bool RefSiG1PassMachinery::handlePipelineElement(llvm::StringRef Name,
+                                                 llvm::ModulePassManager &PM) {
   if (Name.consume_front("refsi-g1-wi-late-passes")) {
     PM.addPass(getLateTargetPasses());
     return true;
@@ -78,8 +80,7 @@ bool refsi_g1_wi::RefSiG1PassMachinery::handlePipelineElement(
   return false;
 }
 
-llvm::ModulePassManager
-refsi_g1_wi::RefSiG1PassMachinery::getLateTargetPasses() {
+llvm::ModulePassManager RefSiG1PassMachinery::getLateTargetPasses() {
   llvm::ModulePassManager PM;
 
   std::optional<std::string> env_debug_prefix;
@@ -169,7 +170,7 @@ refsi_g1_wi::RefSiG1PassMachinery::getLateTargetPasses() {
   return PM;
 }
 
-void refsi_g1_wi::RefSiG1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
+void RefSiG1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   riscv::RiscvPassMachinery::printPassNames(OS);
 
   OS << "\nriscv specific Target passes:\n\n";
@@ -182,3 +183,5 @@ void refsi_g1_wi::RefSiG1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   OS << "  refsi-g1-wi-late-passes\n";
   OS << "    Runs the pipeline for BaseModule::getLateTargetPasses\n";
 }
+
+}  // namespace refsi_g1_wi

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/module.h
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/module.h
@@ -39,14 +39,6 @@ class RefSiM1Module final : public riscv::RiscvModule {
   /// @see Module::getLateTargetPasses
   llvm::ModulePassManager getLateTargetPasses(
       compiler::utils::PassMachinery &pass_mach) override;
-
- private:
-  /// @brief Add any final kernel passes
-  /// @note This is run just before the AddMetadataPass
-  void addFinalKernelPasses(llvm::ModulePassManager &PM);
-
-  /// @brief Modify the tuner used for the compiler pipeline
-  void modifyTuner(compiler::BasePassPipelineTuner &tuner);
 };  // class RefSiM1Module
 }  // namespace refsi_m1
 

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/refsi_pass_machinery.h
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/refsi_pass_machinery.h
@@ -36,6 +36,15 @@ class RefSiM1PassMachinery : public riscv::RiscvPassMachinery {
   void addClassToPassNames() override;
   void registerPassCallbacks() override;
   void printPassNames(llvm::raw_ostream &OS) override;
+
+  bool handlePipelineElement(llvm::StringRef,
+                             llvm::ModulePassManager &AM) override;
+
+  /// @brief Returns an optimization pass pipeline to run over all kernels in a
+  /// module. @see BaseModule::getLateTargetPasses.
+  ///
+  /// @return Result ModulePassManager containing passes
+  llvm::ModulePassManager getLateTargetPasses();
 };
 
 }  // namespace refsi_m1

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/refsi_pass_machinery.h
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/refsi_pass_machinery.h
@@ -27,8 +27,8 @@ namespace refsi_m1 {
 class RefSiM1PassMachinery : public riscv::RiscvPassMachinery {
  public:
   RefSiM1PassMachinery(
-      llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-      const compiler::utils::DeviceInfo &Info,
+      const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
+      llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
       compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
       bool verifyEach, compiler::utils::DebugLogging debugLogging,
       bool timePasses);

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
@@ -15,28 +15,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <base/pass_pipelines.h>
-#include <compiler/utils/add_kernel_wrapper_pass.h>
-#include <compiler/utils/add_metadata_pass.h>
-#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/cl_builtin_info.h>
-#include <compiler/utils/encode_kernel_metadata_pass.h>
-#include <compiler/utils/handle_barriers_pass.h>
-#include <compiler/utils/link_builtins_pass.h>
-#include <compiler/utils/metadata_analysis.h>
-#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
-#include <compiler/utils/replace_local_module_scope_variables_pass.h>
-#include <compiler/utils/replace_mem_intrinsics_pass.h>
-#include <compiler/utils/simple_callback_pass.h>
-#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Target/TargetMachine.h>
-#include <metadata/handler/vectorize_info_metadata.h>
 #include <refsi_m1/module.h>
 #include <refsi_m1/refsi_mux_builtin_info.h>
 #include <refsi_m1/refsi_pass_machinery.h>
-#include <refsi_m1/refsi_wrapper_pass.h>
 #include <refsi_m1/target.h>
-#include <riscv/ir_to_builtins_pass.h>
 #include <vecz/pass.h>
 
 namespace refsi_m1 {
@@ -67,112 +52,13 @@ RefSiM1Module::createPassMachinery() {
       BaseContext.isLLVMTimePassesEnabled());
 }
 
-void RefSiM1Module::addFinalKernelPasses(llvm::ModulePassManager &PM) {
-  cargo::string_view hal_name(getTarget().riscv_hal_device_info->target_name);
-  if (hal_name.ends_with("Tutorial")) {
-    PM.addPass(refsi_m1::RefSiM1WrapperPass());
-  }
-}
-
 llvm::ModulePassManager RefSiM1Module::getLateTargetPasses(
     compiler::utils::PassMachinery &pass_mach) {
   if (getOptions().llvm_stats) {
     llvm::EnableStatistics();
   }
 
-  const auto &env_debug_prefix = getTarget().env_debug_prefix;
-
-  compiler::BasePassPipelineTuner tuner(options);
-  auto env_var_opts =
-      static_cast<RefSiM1PassMachinery &>(pass_mach).processOptimizationOptions(
-          env_debug_prefix, /* vecz_mode*/ {});
-
-  cargo::string_view hal_name(getTarget().riscv_hal_device_info->target_name);
-
-  llvm::ModulePassManager PM;
-
-  PM.addPass(compiler::utils::TransferKernelMetadataPass());
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_M1_DEMO_MODE)
-  std::string dump_ir_env_name = env_debug_prefix + "_DUMP_IR";
-  if (!env_debug_prefix.empty() && std::getenv(dump_ir_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
-  }
-#endif
-
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceMemIntrinsicsPass()));
-
-  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
-  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
-                                       llvm::Module>());
-
-  // This potentially fixes up any structs to match the spir alignment
-  // before we change to the backend layout
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-
-  // Handle the generic address space
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
-
-  PM.addPass(riscv::IRToBuiltinReplacementPass());
-
-  if (env_var_opts.early_link_builtins) {
-    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
-  }
-
-  // TODON'T temporary fix to get subgroup tests passing while we refactor
-  // subgroup support. CA-4712 CA-4679
-  tuner.degenerate_sub_groups = true;
-  addPreVeczPasses(PM, tuner);
-
-  PM.addPass(vecz::RunVeczPass());
-
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
-  addLateBuiltinsPasses(PM, tuner);
-
-  compiler::utils::HandleBarriersOptions HBOpts;
-  HBOpts.IsDebug = options.opt_disable;
-  HBOpts.ForceNoTail = env_var_opts.force_no_tail;
-  PM.addPass(compiler::utils::HandleBarriersPass(HBOpts));
-
-  compiler::addPrepareWorkGroupSchedulingPasses(PM);
-
-  compiler::utils::AddKernelWrapperPassOptions KWOpts;
-  // We don't bundle kernel arguments in a packed struct.
-  KWOpts.IsPackedStruct = false;
-  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
-
-  PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
-
-  // RefSi M1 specific kernel passes
-  addFinalKernelPasses(PM);
-
-  PM.addPass(compiler::utils::AddMetadataPass<
-             compiler::utils::VectorizeMetadataAnalysis,
-             handler::VectorizeInfoMetadataHandler>());
-
-  addLLVMDefaultPerModulePipeline(PM, pass_mach.getPB(), options);
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_M1_DEMO_MODE)
-  // With all passes scheduled, add a callback pass to view the assembly/object
-  // file, if requested.
-  std::string dump_asm_env_name = env_debug_prefix + "_DUMP_ASM";
-  if (!env_debug_prefix.empty() && std::getenv(dump_asm_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [TM = pass_mach.getTM()](llvm::Module &m) {
-          // Clone the module so we leave it in the same state after we compile.
-          auto cloned_m = llvm::CloneModule(m);
-          compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
-                                    /*create_assembly*/ true);
-        }));
-  }
-#endif
-
-  return PM;
+  return static_cast<RefSiM1PassMachinery &>(pass_mach).getLateTargetPasses();
 }
 
 }  // namespace refsi_m1

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
@@ -15,11 +15,26 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <base/pass_pipelines.h>
+#include <compiler/utils/add_kernel_wrapper_pass.h>
+#include <compiler/utils/add_metadata_pass.h>
+#include <compiler/utils/align_module_structs_pass.h>
+#include <compiler/utils/cl_builtin_info.h>
+#include <compiler/utils/encode_kernel_metadata_pass.h>
+#include <compiler/utils/handle_barriers_pass.h>
+#include <compiler/utils/link_builtins_pass.h>
+#include <compiler/utils/metadata_analysis.h>
+#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
+#include <compiler/utils/replace_local_module_scope_variables_pass.h>
+#include <compiler/utils/replace_mem_intrinsics_pass.h>
+#include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <metadata/handler/vectorize_info_metadata.h>
 #include <multi_llvm/optional_helper.h>
 #include <refsi_m1/refsi_pass_machinery.h>
 #include <refsi_m1/refsi_wrapper_pass.h>
+#include <riscv/ir_to_builtins_pass.h>
 #include <vecz/pass.h>
 
 refsi_m1::RefSiM1PassMachinery::RefSiM1PassMachinery(
@@ -54,11 +69,124 @@ void refsi_m1::RefSiM1PassMachinery::registerPassCallbacks() {
       });
 }
 
+bool refsi_m1::RefSiM1PassMachinery::handlePipelineElement(
+    llvm::StringRef Name, llvm::ModulePassManager &PM) {
+  if (Name.consume_front("refsi-m1-late-passes")) {
+    PM.addPass(getLateTargetPasses());
+    return true;
+  }
+
+  return false;
+}
+
+llvm::ModulePassManager refsi_m1::RefSiM1PassMachinery::getLateTargetPasses() {
+  llvm::ModulePassManager PM;
+
+  std::optional<std::string> env_debug_prefix;
+#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_REFSI_M1_DEMO_MODE)
+  env_debug_prefix = target.env_debug_prefix;
+#endif
+
+  compiler::BasePassPipelineTuner tuner(options);
+  auto env_var_opts =
+      processOptimizationOptions(env_debug_prefix, /* vecz_mode*/ {});
+
+  PM.addPass(compiler::utils::TransferKernelMetadataPass());
+
+  if (env_debug_prefix) {
+    std::string dump_ir_env_name = *env_debug_prefix + "_DUMP_IR";
+    if (std::getenv(dump_ir_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass(
+          [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
+    }
+  }
+
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceMemIntrinsicsPass()));
+
+  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
+  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
+                                       llvm::Module>());
+
+  // This potentially fixes up any structs to match the spir alignment
+  // before we change to the backend layout
+  PM.addPass(compiler::utils::AlignModuleStructsPass());
+
+  // Handle the generic address space
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
+
+  PM.addPass(riscv::IRToBuiltinReplacementPass());
+
+  if (env_var_opts.early_link_builtins) {
+    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
+  }
+
+  // TODON'T temporary fix to get subgroup tests passing while we refactor
+  // subgroup support. CA-4712 CA-4679
+  tuner.degenerate_sub_groups = true;
+  addPreVeczPasses(PM, tuner);
+
+  PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
+
+  addLateBuiltinsPasses(PM, tuner);
+
+  compiler::utils::HandleBarriersOptions HBOpts;
+  HBOpts.IsDebug = options.opt_disable;
+  HBOpts.ForceNoTail = env_var_opts.force_no_tail;
+  PM.addPass(compiler::utils::HandleBarriersPass(HBOpts));
+
+  compiler::addPrepareWorkGroupSchedulingPasses(PM);
+
+  compiler::utils::AddKernelWrapperPassOptions KWOpts;
+  // We don't bundle kernel arguments in a packed struct.
+  KWOpts.IsPackedStruct = false;
+  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
+
+  PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
+
+  // RefSi M1 specific kernel passes
+  cargo::string_view hal_name(target.riscv_hal_device_info->target_name);
+  if (hal_name.ends_with("Tutorial")) {
+    PM.addPass(refsi_m1::RefSiM1WrapperPass());
+  }
+
+  PM.addPass(compiler::utils::AddMetadataPass<
+             compiler::utils::VectorizeMetadataAnalysis,
+             handler::VectorizeInfoMetadataHandler>());
+
+  addLLVMDefaultPerModulePipeline(PM, getPB(), options);
+
+  if (env_debug_prefix) {
+    // With all passes scheduled, add a callback pass to view the
+    // assembly/object file, if requested.
+    std::string dump_asm_env_name = *env_debug_prefix + "_DUMP_ASM";
+    if (std::getenv(dump_asm_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass([this](llvm::Module &m) {
+        // Clone the module so we leave it in the same state after we compile.
+        auto cloned_m = llvm::CloneModule(m);
+        compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
+                                  /*create_assembly*/ true);
+      }));
+    }
+  }
+
+  return PM;
+}
+
 void refsi_m1::RefSiM1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   riscv::RiscvPassMachinery::printPassNames(OS);
 
-  OS << "\nRisc-v specific Target passes:\n\n";
+  OS << "\nriscv specific Target passes:\n\n";
   OS << "Module passes:\n";
 #define MODULE_PASS(NAME, CREATE_PASS) compiler::utils::printPassName(NAME, OS);
 #include "refsi_pass_registry.def"
+
+  OS << "\nriscv pipelines:\n\n";
+
+  OS << "  refsi-m1-late-passes\n";
+  OS << "    Runs the pipeline for BaseModule::getLateTargetPasses\n";
 }

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
@@ -23,12 +23,12 @@
 #include <vecz/pass.h>
 
 refsi_m1::RefSiM1PassMachinery::RefSiM1PassMachinery(
-    llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-    const compiler::utils::DeviceInfo &Info,
+    const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
+    llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
     compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
     bool verifyEach, compiler::utils::DebugLogging debugLogLevel,
     bool timePasses)
-    : riscv::RiscvPassMachinery(Ctx, TM, Info, BICallback, verifyEach,
+    : riscv::RiscvPassMachinery(target, Ctx, TM, Info, BICallback, verifyEach,
                                 debugLogLevel, timePasses) {}
 
 void refsi_m1::RefSiM1PassMachinery::addClassToPassNames() {

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
@@ -37,7 +37,9 @@
 #include <riscv/ir_to_builtins_pass.h>
 #include <vecz/pass.h>
 
-refsi_m1::RefSiM1PassMachinery::RefSiM1PassMachinery(
+namespace refsi_m1 {
+
+RefSiM1PassMachinery::RefSiM1PassMachinery(
     const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
     llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
     compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
@@ -46,7 +48,7 @@ refsi_m1::RefSiM1PassMachinery::RefSiM1PassMachinery(
     : riscv::RiscvPassMachinery(target, Ctx, TM, Info, BICallback, verifyEach,
                                 debugLogLevel, timePasses) {}
 
-void refsi_m1::RefSiM1PassMachinery::addClassToPassNames() {
+void RefSiM1PassMachinery::addClassToPassNames() {
   RiscvPassMachinery::addClassToPassNames();
 // Register compiler passes
 #define MODULE_PASS(NAME, CREATE_PASS) \
@@ -54,7 +56,7 @@ void refsi_m1::RefSiM1PassMachinery::addClassToPassNames() {
 #include "refsi_pass_registry.def"
 }
 
-void refsi_m1::RefSiM1PassMachinery::registerPassCallbacks() {
+void RefSiM1PassMachinery::registerPassCallbacks() {
   RiscvPassMachinery::registerPassCallbacks();
   PB.registerPipelineParsingCallback(
       [](llvm::StringRef Name, llvm::ModulePassManager &PM,
@@ -69,8 +71,8 @@ void refsi_m1::RefSiM1PassMachinery::registerPassCallbacks() {
       });
 }
 
-bool refsi_m1::RefSiM1PassMachinery::handlePipelineElement(
-    llvm::StringRef Name, llvm::ModulePassManager &PM) {
+bool RefSiM1PassMachinery::handlePipelineElement(llvm::StringRef Name,
+                                                 llvm::ModulePassManager &PM) {
   if (Name.consume_front("refsi-m1-late-passes")) {
     PM.addPass(getLateTargetPasses());
     return true;
@@ -79,7 +81,7 @@ bool refsi_m1::RefSiM1PassMachinery::handlePipelineElement(
   return false;
 }
 
-llvm::ModulePassManager refsi_m1::RefSiM1PassMachinery::getLateTargetPasses() {
+llvm::ModulePassManager RefSiM1PassMachinery::getLateTargetPasses() {
   llvm::ModulePassManager PM;
 
   std::optional<std::string> env_debug_prefix;
@@ -151,7 +153,7 @@ llvm::ModulePassManager refsi_m1::RefSiM1PassMachinery::getLateTargetPasses() {
   // RefSi M1 specific kernel passes
   cargo::string_view hal_name(target.riscv_hal_device_info->target_name);
   if (hal_name.ends_with("Tutorial")) {
-    PM.addPass(refsi_m1::RefSiM1WrapperPass());
+    PM.addPass(RefSiM1WrapperPass());
   }
 
   PM.addPass(compiler::utils::AddMetadataPass<
@@ -177,7 +179,7 @@ llvm::ModulePassManager refsi_m1::RefSiM1PassMachinery::getLateTargetPasses() {
   return PM;
 }
 
-void refsi_m1::RefSiM1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
+void RefSiM1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   riscv::RiscvPassMachinery::printPassNames(OS);
 
   OS << "\nriscv specific Target passes:\n\n";
@@ -190,3 +192,5 @@ void refsi_m1::RefSiM1PassMachinery::printPassNames(llvm::raw_ostream &OS) {
   OS << "  refsi-m1-late-passes\n";
   OS << "    Runs the pipeline for BaseModule::getLateTargetPasses\n";
 }
+
+}  // namespace refsi_m1

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/{{cookiecutter.target_name}}_pass_machinery.h
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/{{cookiecutter.target_name}}_pass_machinery.h
@@ -22,6 +22,7 @@
 #define {{cookiecutter.target_name_capitals}}_PASS_MACHINERY_H_INCLUDED
 
 #include <base/base_pass_machinery.h>
+#include <{{cookiecutter.target_name}}/target.h>
 
 namespace {{cookiecutter.target_name}} {
 
@@ -30,11 +31,12 @@ namespace {{cookiecutter.target_name}} {
 /// by various passes as we run through the passes.
 class {{cookiecutter.target_name.capitalize()}}PassMachinery : public compiler::BaseModulePassMachinery {
  public:
-  {{cookiecutter.target_name.capitalize()}}PassMachinery(llvm::LLVMContext &Ctx,llvm::TargetMachine * TM,
-                const compiler::utils::DeviceInfo &Info,
-                compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
-                bool verifyEach, compiler::utils::DebugLogging debugLogLevel,
-                bool timePasses);
+  {{cookiecutter.target_name.capitalize()}}PassMachinery(
+      const {{cookiecutter.target_name.capitalize()}}Target &target, llvm::LLVMContext &Ctx,
+      llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
+      compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
+      bool verifyEach, compiler::utils::DebugLogging debugLogLevel,
+      bool timePasses);
 
   void addClassToPassNames() override;
 
@@ -43,6 +45,18 @@ class {{cookiecutter.target_name.capitalize()}}PassMachinery : public compiler::
   void registerPassCallbacks() override;
 
   void printPassNames(llvm::raw_ostream &OS) override;
+
+  bool handlePipelineElement(llvm::StringRef,
+                             llvm::ModulePassManager &AM) override;
+
+  /// @brief Returns an optimization pass pipeline to run over all kernels in a
+  /// module. @see BaseModule::getLateTargetPasses.
+  ///
+  /// @return Result ModulePassManager containing passes
+  llvm::ModulePassManager getLateTargetPasses();
+
+ private:
+   const {{cookiecutter.target_name.capitalize()}}Target &target;
 };
 
 }  // namespace {{cookiecutter.target_name}}

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -20,20 +20,9 @@
 
 #include <base/macros.h>
 #include <base/pass_pipelines.h>
-#include <compiler/utils/add_kernel_wrapper_pass.h>
-#include <compiler/utils/add_metadata_pass.h>
-#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/cl_builtin_info.h>
-#include <compiler/utils/encode_kernel_metadata_pass.h>
-#include <compiler/utils/handle_barriers_pass.h>
-#include <compiler/utils/link_builtins_pass.h>
 #include <compiler/utils/lld_linker.h>
 #include <compiler/utils/llvm_global_mutex.h>
-#include <compiler/utils/metadata.h>
-#include <compiler/utils/metadata_analysis.h>
-#include <compiler/utils/replace_local_module_scope_variables_pass.h>
-#include <compiler/utils/simple_callback_pass.h>
-#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/Module.h>
@@ -42,21 +31,12 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Process.h>
 #include <llvm/Target/TargetMachine.h>
-#include <metadata/handler/vectorize_info_metadata.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/optional_helper.h>
 #include <{{cookiecutter.target_name}}/module.h>
 #include <{{cookiecutter.target_name}}/target.h>
 #include <vecz/pass.h>
 #include <{{cookiecutter.target_name}}/{{cookiecutter.target_name}}_pass_machinery.h>
-{% if "replace_mem"  in cookiecutter.feature.split(";") -%}
-#include <compiler/utils/replace_mem_intrinsics_pass.h>
-{% endif -%}
-
-{% if "refsi_wrapper_pass"  in cookiecutter.feature.split(";") -%}
-// Add an additional wrapper pass for refsi
-#include <{{cookiecutter.target_name}}/refsi_wrapper_pass.h>
-{% endif -%}
 
 {% if "clmul"  in cookiecutter.feature.split(";") -%}
 #include <compiler/utils/mangling.h>
@@ -105,59 +85,6 @@ namespace {{cookiecutter.target_name}} {
   };
 }
 {% endif -%}
-
-// Note: This is a legacy toggle for forcing vectorization with no scalar tail
-// based on the "VF" environment variable. Ideally we'd be setting it on a
-// per-function basis, and we'd also be setting the vectorization options
-// themselves on a per-function basis. Until we've designed a new method, keep
-// the legacy behaviour by re-parsing the "VF" environment variable and look
-// for a "v/V" toggle.
-static bool hasForceNoTail(const std::string &env_debug_prefix) {
-  if (env_debug_prefix.empty()) {
-    return false;
-  }
-  std::string env_name = env_debug_prefix + "_VF";
-  if (auto *vecz_vf_flags_env = std::getenv(env_name.c_str())) {
-    llvm::SmallVector<llvm::StringRef, 4> flags;
-    llvm::StringRef vf_flags_ref(vecz_vf_flags_env);
-    vf_flags_ref.split(flags, ',');
-    for (auto r : flags) {
-      if (r == "V" || r == "v") {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-static bool isEarlyBuiltinLinkingEnabled(const std::string &env_debug_prefix) {
-  if (env_debug_prefix.empty()) {
-    return false;
-  }
-
-  // Allow any decisions made on early link builtins to be overridden
-  // with an env variable
-  std::string env_name = env_debug_prefix + "_EARLY_LINK_BUILTINS";
-  if (const char *early_link_builtins_env = getenv(env_name.c_str())) {
-    return atoi(early_link_builtins_env);
-  }
-
-  // Else, check whether we're scalably-vectorizing. This should be kept in
-  // sync with {{cookiecutter.target_name}}::processVeczFlags!
-  env_name = env_debug_prefix + "_VF";
-  if (auto *vecz_vf_flags_env = std::getenv(env_name.c_str())) {
-    llvm::SmallVector<llvm::StringRef, 4> flags;
-    llvm::StringRef vf_flags_ref(vecz_vf_flags_env);
-    vf_flags_ref.split(flags, ',');
-    for (auto r : flags) {
-      if (r == "S" || r == "s") {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
 
 namespace {{cookiecutter.target_name}} {
 {{cookiecutter.target_name.capitalize()}}Module::{{cookiecutter.target_name.capitalize()}}Module({{cookiecutter.target_name.capitalize()}}Target &target, compiler::BaseContext &context,
@@ -284,92 +211,7 @@ llvm::ModulePassManager {{cookiecutter.target_name.capitalize()}}Module::getLate
     llvm::EnableStatistics();
   }
 
-  const auto &env_debug_prefix = getTarget().env_debug_prefix;
-
-  compiler::BasePassPipelineTuner tuner(options);
-
-  llvm::ModulePassManager PM;
-
-  PM.addPass(compiler::utils::TransferKernelMetadataPass());
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_{{cookiecutter.target_name_capitals}}_DEMO_MODE)
-  std::string dump_ir_env_name = env_debug_prefix + "_DUMP_IR";
-  if (!env_debug_prefix.empty() && std::getenv(dump_ir_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
-  }
-#endif
-
-  {% if "replace_mem"  in cookiecutter.feature.split(";") -%}
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceMemIntrinsicsPass()));
-  {% endif -%} 
-
-  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
-  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
-                                       llvm::Module>());
-
-  // This potentially fixes up any structs to match the spir alignment
-  // before we change to the backend layout
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-
-  // Add builtin replacement passes here directly to PM if needed
-
-  if (isEarlyBuiltinLinkingEnabled(env_debug_prefix)) {
-    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
-  }
-
-  addPreVeczPasses(PM, tuner);
-
-  PM.addPass(vecz::RunVeczPass());
-
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
-  addLateBuiltinsPasses(PM, tuner);
-
-  compiler::utils::HandleBarriersOptions HBOpts;
-  HBOpts.IsDebug = options.opt_disable;
-  HBOpts.ForceNoTail = hasForceNoTail(env_debug_prefix);
-  PM.addPass(compiler::utils::HandleBarriersPass(HBOpts));
-
-  compiler::addPrepareWorkGroupSchedulingPasses(PM);
-
-  compiler::utils::AddKernelWrapperPassOptions KWOpts;
-  // We don't bundle kernel arguments in a packed struct.
-  KWOpts.IsPackedStruct = false;
-  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
-
-  PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
-
-  // Add final passes here by adding directly to PM as needed
-{% if "refsi_wrapper_pass"  in cookiecutter.feature.split(";") -%}
-  // Add an additional wrapper pass for refsi
-  PM.addPass({{cookiecutter.target_name}}::RefSiM1WrapperPass());
-{% endif -%}
-
-  PM.addPass(compiler::utils::AddMetadataPass<
-             compiler::utils::VectorizeMetadataAnalysis,
-             handler::VectorizeInfoMetadataHandler>());
-
-  addLLVMDefaultPerModulePipeline(PM, pass_mach.getPB(), options);
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
-  // With all passes scheduled, add a callback pass to view the assembly/object
-  // file, if requested.
-  std::string dump_asm_env_name = env_debug_prefix + "_DUMP_ASM";
-  if (!env_debug_prefix.empty() && std::getenv(dump_asm_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [TM = pass_mach.getTM()](llvm::Module &m) {
-          // Clone the module so we leave it in the same state after we compile.
-          auto cloned_m = llvm::CloneModule(m);
-          compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
-                                    /*create_assembly*/ true);
-        }));
-  }
-#endif
-
-  return PM;
+  return static_cast<{{cookiecutter.target_name.capitalize()}}PassMachinery &>(pass_mach).getLateTargetPasses();
 }
 
 static llvm::TargetMachine *createTargetMachine(const {{cookiecutter.target_name_capitalize}}Target &target) {
@@ -421,7 +263,8 @@ std::unique_ptr<compiler::utils::PassMachinery> {{cookiecutter.target_name.capit
   };
   llvm::LLVMContext &Ctx = Builtins->getContext();
   return std::make_unique<{{cookiecutter.target_name.capitalize()}}PassMachinery>(
-      Ctx, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), Ctx, TM, Info, Callback,
+      BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }

--- a/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/optional_helper.h
@@ -24,9 +24,7 @@
 #include <llvm/ADT/Optional.h>
 #endif
 
-#if (LLVM_VERSION_MAJOR >= 16)
 #include <optional>
-#endif
 
 namespace multi_llvm {
 
@@ -63,6 +61,13 @@ class Optional : public llvm::Optional<T> {
 
   inline constexpr bool has_value() const {
     return llvm::Optional<T>::hasValue();
+  }
+
+  // Provide implicit conversions to the future proof std::optional.
+  inline constexpr operator std::optional<T>() const {
+    return llvm::Optional<T>::hasValue()
+               ? std::optional<T>(llvm::Optional<T>::getValue())
+               : std::nullopt;
   }
 };
 

--- a/modules/compiler/riscv/include/riscv/module.h
+++ b/modules/compiler/riscv/include/riscv/module.h
@@ -80,20 +80,6 @@ class RiscvModule : public compiler::BaseModule {
 
   const riscv::RiscvTarget &getTarget() const;
 
-  /// @brief Legacy helper function based off env variables to decode whether to
-  /// force "no tail". Checks for comma separated 'V' in <env_debug_prefix>_VF
-  /// @param env_debug_prefix
-  /// @return true if found
-  bool hasForceNoTail(const std::string &env_debug_prefix);
-
-  /// @brief Legacy helper function based off env variables to decode whether to
-  /// early linking is enabled. Checks for comma separated 'S' in
-  /// <env_debug_prefix>_VF or <env_debug_prefix>_EARLY_LINK_BUILTINS being set
-  /// to non-zero.
-  /// @param env_debug_prefix
-  /// @return true if found
-  bool isEarlyBuiltinLinkingEnabled(const std::string &env_debug_prefix);
-
  private:
   cargo::dynamic_array<uint8_t> object_code;
 

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -16,23 +16,12 @@
 
 #include <base/macros.h>
 #include <base/pass_pipelines.h>
-#include <compiler/utils/add_kernel_wrapper_pass.h>
-#include <compiler/utils/add_metadata_pass.h>
-#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/cl_builtin_info.h>
 #include <compiler/utils/device_info.h>
-#include <compiler/utils/encode_kernel_metadata_pass.h>
-#include <compiler/utils/handle_barriers_pass.h>
-#include <compiler/utils/link_builtins_pass.h>
 #include <compiler/utils/lld_linker.h>
 #include <compiler/utils/llvm_global_mutex.h>
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/metadata_analysis.h>
-#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
-#include <compiler/utils/replace_local_module_scope_variables_pass.h>
-#include <compiler/utils/replace_mem_intrinsics_pass.h>
-#include <compiler/utils/simple_callback_pass.h>
-#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/Module.h>
@@ -41,7 +30,6 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Process.h>
 #include <llvm/Target/TargetMachine.h>
-#include <metadata/handler/vectorize_info_metadata.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/optional_helper.h>
 #include <riscv/ir_to_builtins_pass.h>
@@ -51,59 +39,6 @@
 #include <vecz/pass.h>
 
 namespace riscv {
-// Note: This is a legacy toggle for forcing vectorization with no scalar tail
-// based on the "VF" environment variable. Ideally we'd be setting it on a
-// per-function basis, and we'd also be setting the vectorization options
-// themselves on a per-function basis. Until we've designed a new method, keep
-// the legacy behaviour by re-parsing the "VF" environment variable and look
-// for a "v/V" toggle.
-bool RiscvModule::hasForceNoTail(const std::string &env_debug_prefix) {
-  if (env_debug_prefix.empty()) {
-    return false;
-  }
-  std::string env_name = env_debug_prefix + "_VF";
-  if (auto *vecz_vf_flags_env = std::getenv(env_name.c_str())) {
-    llvm::SmallVector<llvm::StringRef, 4> flags;
-    llvm::StringRef vf_flags_ref(vecz_vf_flags_env);
-    vf_flags_ref.split(flags, ',');
-    for (auto r : flags) {
-      if (r == "V" || r == "v") {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-bool RiscvModule::isEarlyBuiltinLinkingEnabled(
-    const std::string &env_debug_prefix) {
-  if (env_debug_prefix.empty()) {
-    return false;
-  }
-
-  // Allow any decisions made on early link builtins to be overridden
-  // with an env variable
-  std::string env_name = env_debug_prefix + "_EARLY_LINK_BUILTINS";
-  if (const char *early_link_builtins_env = getenv(env_name.c_str())) {
-    return atoi(early_link_builtins_env);
-  }
-
-  // Else, check whether we're scalably-vectorizing. This should be kept in
-  // sync with riscv::processVeczFlags!
-  env_name = env_debug_prefix + "_VF";
-  if (auto *vecz_vf_flags_env = std::getenv(env_name.c_str())) {
-    llvm::SmallVector<llvm::StringRef, 4> flags;
-    llvm::StringRef vf_flags_ref(vecz_vf_flags_env);
-    vf_flags_ref.split(flags, ',');
-    for (auto r : flags) {
-      if (r == "S" || r == "s") {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
 
 RiscvModule::RiscvModule(RiscvTarget &target, compiler::BaseContext &context,
                          uint32_t &num_errors, std::string &log)
@@ -236,94 +171,7 @@ llvm::ModulePassManager RiscvModule::getLateTargetPasses(
     llvm::EnableStatistics();
   }
 
-  const auto &env_debug_prefix = getTarget().env_debug_prefix;
-
-  compiler::BasePassPipelineTuner tuner(options);
-
-  cargo::string_view hal_name(getTarget().riscv_hal_device_info->target_name);
-
-  llvm::ModulePassManager PM;
-
-  PM.addPass(compiler::utils::TransferKernelMetadataPass());
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
-  std::string dump_ir_env_name = env_debug_prefix + "_DUMP_IR";
-  if (std::getenv(dump_ir_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
-  }
-#endif
-
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceMemIntrinsicsPass()));
-
-  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
-  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
-                                       llvm::Module>());
-
-  // This potentially fixes up any structs to match the spir alignment
-  // before we change to the backend layout
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-
-  // Handle the generic address space
-  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
-      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
-
-  PM.addPass(riscv::IRToBuiltinReplacementPass());
-
-  if (isEarlyBuiltinLinkingEnabled(env_debug_prefix)) {
-    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
-  }
-
-  // When degenerate sub-groups are enabled here, any kernel that uses sub-group
-  // functions will be cloned to give a version using degenerate sub-groups and
-  // a version using non-degenerate sub-groups, for selection by the runtime.
-  tuner.degenerate_sub_groups = true;
-  addPreVeczPasses(PM, tuner);
-
-  PM.addPass(vecz::RunVeczPass());
-
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
-  addLateBuiltinsPasses(PM, tuner);
-
-  compiler::utils::HandleBarriersOptions HBOpts;
-  HBOpts.IsDebug = options.opt_disable;
-  HBOpts.ForceNoTail = hasForceNoTail(env_debug_prefix);
-  PM.addPass(compiler::utils::HandleBarriersPass(HBOpts));
-
-  compiler::addPrepareWorkGroupSchedulingPasses(PM);
-
-  compiler::utils::AddKernelWrapperPassOptions KWOpts;
-  // We don't bundle kernel arguments in a packed struct.
-  KWOpts.IsPackedStruct = false;
-  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
-
-  PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
-
-  PM.addPass(compiler::utils::AddMetadataPass<
-             compiler::utils::VectorizeMetadataAnalysis,
-             handler::VectorizeInfoMetadataHandler>());
-
-  addLLVMDefaultPerModulePipeline(PM, pass_mach.getPB(), options);
-
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
-  // With all passes scheduled, add a callback pass to view the assembly/object
-  // file, if requested.
-  std::string dump_asm_env_name = env_debug_prefix + "_DUMP_ASM";
-  if (std::getenv(dump_asm_env_name.c_str())) {
-    PM.addPass(compiler::utils::SimpleCallbackPass(
-        [TM = pass_mach.getTM()](llvm::Module &m) {
-          // Clone the module so we leave it in the same state after we compile.
-          auto cloned_m = llvm::CloneModule(m);
-          compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
-                                    /*create_assembly*/ true);
-        }));
-  }
-#endif
-
-  return PM;
+  return static_cast<RiscvPassMachinery &>(pass_mach).getLateTargetPasses();
 }
 
 static llvm::TargetMachine *createTargetMachine(
@@ -367,8 +215,10 @@ RiscvModule::createPassMachinery() {
   };
 
   llvm::LLVMContext &Ctx = Builtins->getContext();
+
   return std::make_unique<riscv::RiscvPassMachinery>(
-      Ctx, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), Ctx, TM, Info, Callback,
+      BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }

--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -15,29 +15,44 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <base/pass_pipelines.h>
+#include <compiler/utils/add_kernel_wrapper_pass.h>
+#include <compiler/utils/add_metadata_pass.h>
+#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/attributes.h>
+#include <compiler/utils/encode_kernel_metadata_pass.h>
+#include <compiler/utils/handle_barriers_pass.h>
+#include <compiler/utils/link_builtins_pass.h>
 #include <compiler/utils/metadata.h>
+#include <compiler/utils/metadata_analysis.h>
+#include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
+#include <compiler/utils/replace_local_module_scope_variables_pass.h>
+#include <compiler/utils/replace_mem_intrinsics_pass.h>
+#include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <metadata/handler/vectorize_info_metadata.h>
 #include <multi_llvm/optional_helper.h>
 #include <riscv/ir_to_builtins_pass.h>
 #include <riscv/riscv_pass_machinery.h>
-#include <vecz/pass.h>
 
 riscv::RiscvPassMachinery::RiscvPassMachinery(
-    llvm::LLVMContext &Ctx, llvm::TargetMachine *TM,
-    const compiler::utils::DeviceInfo &Info,
+    const riscv::RiscvTarget &target, llvm::LLVMContext &Ctx,
+    llvm::TargetMachine *TM, const compiler::utils::DeviceInfo &Info,
     compiler::utils::BuiltinInfoAnalysis::CallbackFn BICallback,
     bool verifyEach, compiler::utils::DebugLogging debugLogLevel,
     bool timePasses)
     : compiler::BaseModulePassMachinery(Ctx, TM, Info, BICallback, verifyEach,
-                                        debugLogLevel, timePasses) {}
+                                        debugLogLevel, timePasses),
+      target(target) {}
 
-// Process vecz flags based off build options and environment variables
-// return true if we want to vectorize
-llvm::SmallVector<vecz::VeczPassOptions> processVeczFlags(
-    multi_llvm::Optional<compiler::VectorizationMode> vecz_mode) {
-  llvm::SmallVector<vecz::VeczPassOptions> vecz_options_vec;
+// Process various compiler options based off compiler build options and common
+// environment variables
+riscv::RiscvPassMachinery::OptimizationOptions
+riscv::RiscvPassMachinery::processOptimizationOptions(
+    std::optional<std::string> env_debug_prefix,
+    std::optional<compiler::VectorizationMode> vecz_mode) {
+  OptimizationOptions env_var_opts;
   vecz::VeczPassOptions vecz_opts;
   // The minimum number of elements to vectorize for. For a fixed-length VF,
   // this is the exact number of elements to vectorize by. For scalable VFs,
@@ -69,10 +84,16 @@ llvm::SmallVector<vecz::VeczPassOptions> processVeczFlags(
       if (r == "A" || r == "a") {
         vecz_opts.vecz_auto = true;
       } else if (r == "V" || r == "v") {
-        // 'V is no longer a vectorization choice but is legally found as part
-        // of this variable. See hasForceNoTail, below.
+        // Note: This is a legacy toggle for forcing vectorization with no
+        // scalar tail based on the "VF" environment variable. Ideally we'd be
+        // setting it on a per-function basis, and we'd also be setting the
+        // vectorization options themselves on a per-function basis. Until we've
+        // designed a new method, keep the legacy behaviour by re-parsing the
+        // "VF" environment variable and look for a "v/V" toggle.
+        env_var_opts.force_no_tail = true;
       } else if (r == "S" || r == "s") {
         vecz_opts.factor.setIsScalable(true);
+        env_var_opts.early_link_builtins = true;
       } else if (isdigit(r[0])) {
         vecz_opts.factor.setKnownMin(std::stoi(r.str()));
       } else if (r == "VP" || r == "vp") {
@@ -84,7 +105,8 @@ llvm::SmallVector<vecz::VeczPassOptions> processVeczFlags(
         // later.
         add_vvp = true;
       } else {
-        return {};
+        // An error - just stop processing the environment variable now.
+        break;
       }
     }
   }
@@ -98,13 +120,22 @@ llvm::SmallVector<vecz::VeczPassOptions> processVeczFlags(
     }
   }
 
-  vecz_options_vec.push_back(vecz_opts);
+  env_var_opts.vecz_pass_opts.push_back(vecz_opts);
   if (add_vvp) {
     vecz_opts.choices.enable(vecz::VectorizationChoices::eVectorPredication);
-    vecz_options_vec.push_back(vecz_opts);
+    env_var_opts.vecz_pass_opts.push_back(vecz_opts);
   }
 
-  return vecz_options_vec;
+  // Allow any decisions made on early linking builtins to be overridden
+  // with an env variable
+  if (env_debug_prefix) {
+    std::string env_name = *env_debug_prefix + "_EARLY_LINK_BUILTINS";
+    if (const char *early_link_builtins_env = getenv(env_name.c_str())) {
+      env_var_opts.early_link_builtins = atoi(early_link_builtins_env) != 0;
+    }
+  }
+
+  return env_var_opts;
 }
 
 bool riscvVeczPassOpts(llvm::Function &F, llvm::ModuleAnalysisManager &,
@@ -115,11 +146,12 @@ bool riscvVeczPassOpts(llvm::Function &F, llvm::ModuleAnalysisManager &,
       vecz_mode == compiler::VectorizationMode::NEVER) {
     return false;
   }
-  auto vecz_options_vec = processVeczFlags(vecz_mode);
-  if (vecz_options_vec.empty()) {
+  auto env_var_opts = riscv::RiscvPassMachinery::processOptimizationOptions(
+      /*env_debug_prefix*/ {}, vecz_mode);
+  if (env_var_opts.vecz_pass_opts.empty()) {
     return false;
   }
-  PassOpts.assign(vecz_options_vec);
+  PassOpts.assign(env_var_opts.vecz_pass_opts);
   return true;
 }
 
@@ -141,6 +173,99 @@ void riscv::RiscvPassMachinery::registerPasses() {
   compiler::BaseModulePassMachinery::registerPasses();
 }
 
+llvm::ModulePassManager riscv::RiscvPassMachinery::getLateTargetPasses() {
+  llvm::ModulePassManager PM;
+
+  std::optional<std::string> env_debug_prefix;
+#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
+  env_debug_prefix = target.env_debug_prefix;
+#endif
+
+  compiler::BasePassPipelineTuner tuner(options);
+  auto env_var_opts =
+      processOptimizationOptions(env_debug_prefix, /* vecz_mode*/ {});
+
+  PM.addPass(compiler::utils::TransferKernelMetadataPass());
+
+  if (env_debug_prefix) {
+    std::string dump_ir_env_name = *env_debug_prefix + "_DUMP_IR";
+    if (std::getenv(dump_ir_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass(
+          [](llvm::Module &m) { m.print(llvm::dbgs(), /*AAW*/ nullptr); }));
+    }
+  }
+
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceMemIntrinsicsPass()));
+
+  // Forcibly compute the BuiltinInfoAnalysis so that cached retrievals work.
+  PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
+                                       llvm::Module>());
+
+  // This potentially fixes up any structs to match the spir alignment
+  // before we change to the backend layout
+  PM.addPass(compiler::utils::AlignModuleStructsPass());
+
+  // Handle the generic address space
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));
+
+  PM.addPass(riscv::IRToBuiltinReplacementPass());
+
+  if (env_var_opts.early_link_builtins) {
+    PM.addPass(compiler::utils::LinkBuiltinsPass(/*EarlyLinking*/ true));
+  }
+
+  // When degenerate sub-groups are enabled here, any kernel that uses sub-group
+  // functions will be cloned to give a version using degenerate sub-groups and
+  // a version using non-degenerate sub-groups, for selection by the runtime.
+  tuner.degenerate_sub_groups = true;
+  addPreVeczPasses(PM, tuner);
+
+  PM.addPass(vecz::RunVeczPass());
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
+
+  addLateBuiltinsPasses(PM, tuner);
+
+  compiler::utils::HandleBarriersOptions HBOpts;
+  HBOpts.IsDebug = options.opt_disable;
+  HBOpts.ForceNoTail = env_var_opts.force_no_tail;
+  PM.addPass(compiler::utils::HandleBarriersPass(HBOpts));
+
+  compiler::addPrepareWorkGroupSchedulingPasses(PM);
+
+  compiler::utils::AddKernelWrapperPassOptions KWOpts;
+  // We don't bundle kernel arguments in a packed struct.
+  KWOpts.IsPackedStruct = false;
+  PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
+
+  PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
+
+  PM.addPass(compiler::utils::AddMetadataPass<
+             compiler::utils::VectorizeMetadataAnalysis,
+             handler::VectorizeInfoMetadataHandler>());
+
+  addLLVMDefaultPerModulePipeline(PM, getPB(), options);
+
+  if (env_debug_prefix) {
+    // With all passes scheduled, add a callback pass to view the
+    // assembly/object file, if requested.
+    std::string dump_asm_env_name = *env_debug_prefix + "_DUMP_ASM";
+    if (std::getenv(dump_asm_env_name.c_str())) {
+      PM.addPass(compiler::utils::SimpleCallbackPass([this](llvm::Module &m) {
+        // Clone the module so we leave it in the same state after we compile.
+        auto cloned_m = llvm::CloneModule(m);
+        compiler::emitCodeGenFile(*cloned_m, TM, llvm::outs(),
+                                  /*create_assembly*/ true);
+      }));
+    }
+  }
+
+  return PM;
+}
+
 void riscv::RiscvPassMachinery::registerPassCallbacks() {
   BaseModulePassMachinery::registerPassCallbacks();
   PB.registerPipelineParsingCallback(
@@ -156,10 +281,20 @@ void riscv::RiscvPassMachinery::registerPassCallbacks() {
       });
 }
 
+bool riscv::RiscvPassMachinery::handlePipelineElement(
+    llvm::StringRef Name, llvm::ModulePassManager &PM) {
+  if (Name.consume_front("riscv-late-passes")) {
+    PM.addPass(getLateTargetPasses());
+    return true;
+  }
+
+  return false;
+}
+
 void riscv::RiscvPassMachinery::printPassNames(llvm::raw_ostream &OS) {
   BaseModulePassMachinery::printPassNames(OS);
 
-  OS << "\nRisc-v specific Target passes:\n\n";
+  OS << "\nriscv specific Target passes:\n\n";
   OS << "Module passes:\n";
 #define MODULE_PASS(NAME, CREATE_PASS) compiler::utils::printPassName(NAME, OS);
 #include "riscv_pass_registry.def"
@@ -168,4 +303,9 @@ void riscv::RiscvPassMachinery::printPassNames(llvm::raw_ostream &OS) {
 #define MODULE_ANALYSIS(NAME, CREATE_PASS) \
   compiler::utils::printPassName(NAME, OS);
 #include "riscv_pass_registry.def"
+
+  OS << "\nriscv pipelines:\n\n";
+
+  OS << "  riscv-late-passes\n";
+  OS << "    Runs the pipeline for BaseModule::getLateTargetPasses\n";
 }

--- a/modules/compiler/targets/riscv/test/lit/passes/late-passes-pipeline.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/late-passes-pipeline.ll
@@ -1,0 +1,38 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: ca_llvm_options
+
+; RUN: muxc --device "%riscv_device" --passes riscv-late-passes --debug-pass-manager %s 2>&1 \
+; RUN:   | FileCheck %s
+
+; Check only a selection of passes to make sure this is doing roughly the right
+; thing without being too specific.
+
+; CHECK: Running pass: compiler::utils::TransferKernelMetadataPass on [module]
+
+; CHECK: Running pass: compiler::utils::AlignModuleStructsPass on [module]
+; CHECK: Running pass: compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass on add (1 instruction)
+; CHECK: Running pass: riscv::IRToBuiltinReplacementPass on [module]
+
+; CHECK: Running pass: compiler::utils::DefineMuxBuiltinsPass on [module]
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define spir_kernel void @add(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  ret void
+}


### PR DESCRIPTION
This mimics the host target and centralizes pass pipeline construction
while also giving users of muxc access to the same pipeline
functionality.

It also allows us to centralize the parsing of `CA_RISCV_VF`, which was
done in two different places whose logic had to match, otherwise bad
things would happen.