### PR TITLE
Retrieve values from barrier struct for use in new memory barriers

### DIFF
--- a/modules/compiler/test/lit/passes/barriers-controlled-mem-fence.ll
+++ b/modules/compiler/test/lit/passes/barriers-controlled-mem-fence.ll
@@ -1,0 +1,48 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes barriers-pass,verify -S %s | FileCheck %s
+
+; It checks to make sure that the variable used by the barrier is reloaded from
+; the barrier struct for use in the newly-created Memory Barrier call in the
+; wrapper function.
+
+; CHECK-LABEL: sw.bb2:
+; CHECK-NEXT: %[[GEP:.+]] = getelementptr inbounds %test_fence_live_mem_info, ptr %live_variables, i64 0
+; CHECK-NEXT: %live_gep_secret = getelementptr %test_fence_live_mem_info, ptr %[[GEP]], i32 0, i32 0
+; CHECK-NEXT: %secret_load = load i32, ptr %live_gep_secret, align 4
+; CHECK-NEXT: call void @__mux_mem_barrier(i32 %secret_load, i32 912)
+
+; ModuleID = 'SPIR-V'
+source_filename = "SPIR-V"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-unknown-elf"
+
+; Function Attrs: convergent nounwind
+define internal void @test_fence(ptr addrspace(3) nocapture %out) local_unnamed_addr #0 {
+entry:
+  call void @mysterious_side_effect(ptr addrspace(3) %out)
+  %secret = call i32 @mysterious_secret_generator(i32 0)
+  tail call void @__mux_work_group_barrier(i32 0, i32 %secret, i32 912)
+  call void @mysterious_side_effect(ptr addrspace(3) %out)
+  ret void
+}
+
+declare i32 @mysterious_secret_generator(i32)
+declare void @mysterious_side_effect(ptr addrspace(3))
+declare void @__mux_work_group_barrier(i32, i32, i32)
+
+attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/utils/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/utils/include/compiler/utils/barrier_regions.h
@@ -174,6 +174,12 @@ class Barrier {
     llvm::Value *getGEP(const llvm::Value *live);
 
     /// @brief get a value reloaded from the barrier struct.
+    ///
+    /// @param[in] live the live value to retrieve from the barrier
+    /// @param[in] insert where to insert new instructions
+    /// @param[in] name a postfix to append to new value names
+    /// @param[in] reuse whether to generate the load for a given value only
+    /// once, returning the previously cached value on further requests.
     llvm::Value *getReload(llvm::Value *live, llvm::Instruction *insert,
                            const char *name, bool reuse = false);
   };

--- a/modules/compiler/utils/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/utils/include/compiler/utils/barrier_regions.h
@@ -157,6 +157,27 @@ class Barrier {
   llvm::Function &getFunc() { return func_; }
   const llvm::Function &getFunc() const { return func_; }
 
+  /// @brief struct to help retrieval of values from the barrier struct
+  struct LiveValuesHelper {
+    Barrier &barrier;
+    llvm::DenseMap<const llvm::Value *, llvm::Value *> live_GEPs;
+    llvm::DenseMap<const llvm::Value *, llvm::Value *> reloads;
+    llvm::Instruction *insert_point = nullptr;
+    llvm::Value *barrier_struct = nullptr;
+    llvm::Value *vscale = nullptr;
+
+    LiveValuesHelper(Barrier &b, llvm::Instruction *i, llvm::Value *s)
+        : barrier(b), insert_point(i), barrier_struct(s) {}
+
+    /// @brief get a GEP instruction pointing to the given value in the barrier
+    /// struct.
+    llvm::Value *getGEP(const llvm::Value *live);
+
+    /// @brief get a value reloaded from the barrier struct.
+    llvm::Value *getReload(llvm::Value *live, llvm::Instruction *insert,
+                           const char *name, bool reuse = false);
+  };
+
  private:
   /// @brief The first is set for livein and the second is set for liveout
   using live_in_out_t =

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -343,8 +343,7 @@ Value *compiler::utils::Barrier::LiveValuesHelper::getReload(
     return mapped;
   }
 
-  Value *v = getGEP(live);
-  if (v) {
+  if (Value *v = getGEP(live)) {
     if (!isa<AllocaInst>(live)) {
       // If live variable is not allocainst, insert load.
       v = new LoadInst(live->getType(), v, Twine(live->getName(), name),
@@ -352,7 +351,9 @@ Value *compiler::utils::Barrier::LiveValuesHelper::getReload(
     }
     mapped = v;
     return v;
-  } else if (auto *I = dyn_cast<Instruction>(live)) {
+  }
+
+  if (auto *I = dyn_cast<Instruction>(live)) {
     if (!reuse || !mapped) {
       auto *clone = I->clone();
       clone->setName(I->getName());

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -1064,7 +1064,6 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
 
   if (CallInst *call_inst = dyn_cast<CallInst>(insert_point)) {
     Function *callee = call_inst->getCalledFunction();
-    dbgs() << *call_inst << "\n";
     assert(callee && "Could not get called function");
     auto const B = bi_->analyzeBuiltin(*callee);
     if (isMuxWGControlBarrierID(B.ID)) {

--- a/modules/compiler/utils/source/handle_barriers_pass.cpp
+++ b/modules/compiler/utils/source/handle_barriers_pass.cpp
@@ -1150,7 +1150,6 @@ Function *compiler::utils::HandleBarriersPass::makeWrapperFunction(
         // the barrier struct. We do this after creating the call because we
         // need an instruction to function as an insert point.
         if (!isa<Constant>(Ops[0]) || !isa<Constant>(Ops[1])) {
-          dbgs() << *Call << "\n";
           // We expect these values to be uniform so it should be safe to get
           // from the barrier struct at index zero. Barriers are convergent, so
           // there should be no chance that the value does not exist.
@@ -1166,7 +1165,7 @@ Function *compiler::utils::HandleBarriersPass::makeWrapperFunction(
           for (auto *const op : Ops) {
             if (!isa<Constant>(op)) {
               auto *const new_op =
-                  live_values.getReload(op, Call, "_load", true);
+                  live_values.getReload(op, Call, "_load", /*reuse*/ true);
               Call->setArgOperand(op_index, new_op);
             }
             ++op_index;

--- a/modules/compiler/utils/source/handle_barriers_pass.cpp
+++ b/modules/compiler/utils/source/handle_barriers_pass.cpp
@@ -1143,7 +1143,36 @@ Function *compiler::utils::HandleBarriersPass::makeWrapperFunction(
         auto *MemBarrier = BI.getOrDeclareMuxBuiltin(eMuxBuiltinMemBarrier, M);
         assert(MemBarrier);
         Value *Ops[2] = {CI->getOperand(1), CI->getOperand(2)};
-        auto *Call = B.CreateCall(MemBarrier, Ops);
+
+        auto *const Call = B.CreateCall(MemBarrier, Ops);
+
+        // Patch up any operands that were non-constants by fetching them from
+        // the barrier struct. We do this after creating the call because we
+        // need an instruction to function as an insert point.
+        if (!isa<Constant>(Ops[0]) || !isa<Constant>(Ops[1])) {
+          dbgs() << *Call << "\n";
+          // We expect these values to be uniform so it should be safe to get
+          // from the barrier struct at index zero. Barriers are convergent, so
+          // there should be no chance that the value does not exist.
+          auto *const zero =
+              Constant::getNullValue(Type::getIntNTy(context, 8 * sizeTyBytes));
+          IRBuilder<> ir(Call);
+          auto *const barrier0 = ir.CreateInBoundsGEP(
+              barrierMain.getLiveVarsType(), barrierMain.getMemSpace(), {zero});
+
+          Barrier::LiveValuesHelper live_values(barrierMain, Call, barrier0);
+
+          size_t op_index = 0;
+          for (auto *const op : Ops) {
+            if (!isa<Constant>(op)) {
+              auto *const new_op =
+                  live_values.getReload(op, Call, "_load", true);
+              Call->setArgOperand(op_index, new_op);
+            }
+            ++op_index;
+          }
+        }
+
         Call->setDebugLoc(wrapperDbgLoc);
       }
 


### PR DESCRIPTION
# Overview

The Handle Barriers Pass creates new Mux Memory Barrier calls in between barrier regions. The arguments of this call come from the arguments of the barrier calls inside the original function. When these arguments are constant integers, all is good. However, when the arguments are expressions in the IR of the original function, the result is using values from the original Function inside the wrapper Function, which is not valid IR.

# Reason for change

We should not be generating invalid IR from any of our passes.

# Description of change

When building the new Mux Memory Barrier, we now check for any non-constant arguments and pull them from the first instance of the barrier struct where necessary. The code used by the Barrier Regions to access data in the barrier struct has been made accessible through the public header (`modules/compiler/utils/include/compiler/utils/barrier_regions.h`) so that the Handle Barriers Pass can use it.
