### PR TITLE
[compiler] Accommodate Target Extension Types in metadata & mangling

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
@@ -28,7 +28,7 @@ using namespace refsi_g1_wi;
 
 StructType *RefSiG1BIMuxInfo::getExecStateStruct(Module &M) {
   static constexpr const char *StructName = "exec_state";
-  if (auto *ty = multi_llvm::getStructTypeByName(M, StructName)) {
+  if (auto *ty = multi_llvm::getStructTypeByName(M.getContext(), StructName)) {
     return ty;
   }
 

--- a/modules/compiler/multi_llvm/include/multi_llvm/multi_llvm.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/multi_llvm.h
@@ -63,9 +63,9 @@ inline llvm::InlineResult InlineFunction(llvm::CallInst *CI,
 #endif
 }
 
-inline llvm::StructType *getStructTypeByName(llvm::Module &module,
+inline llvm::StructType *getStructTypeByName(llvm::LLVMContext &ctx,
                                              llvm::StringRef name) {
-  return llvm::StructType::getTypeByName(module.getContext(), name);
+  return llvm::StructType::getTypeByName(ctx, name);
 }
 
 inline llvm::DILocation *getDILocation(unsigned Line, unsigned Column,

--- a/modules/compiler/source/base/source/spir_fixup_pass.cpp
+++ b/modules/compiler/source/base/source/spir_fixup_pass.cpp
@@ -212,7 +212,7 @@ PreservedAnalyses compiler::spir::SpirFixupPass::run(llvm::Module &M,
       // done so
       if (nullptr == SamplerTypePtr) {
         auto *samplerType =
-            multi_llvm::getStructTypeByName(M, "opencl.sampler_t");
+            multi_llvm::getStructTypeByName(M.getContext(), "opencl.sampler_t");
 
         if (nullptr == samplerType) {
           samplerType = StructType::create(M.getContext(), "opencl.sampler_t");

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -455,7 +455,7 @@ cargo::optional<Error> Builder::create<OpTypeImage>(const OpTypeImage *op) {
   // llvm::Context, creating a new StructType when one already exists with the
   // same name results in .1 being appended to the struct name causing issues.
   auto *namedTy =
-      multi_llvm::getStructTypeByName(*module.llvmModule, imageTypeName);
+      multi_llvm::getStructTypeByName(*context.llvmContext, imageTypeName);
   if (namedTy) {
     structTy = namedTy;
   } else {

--- a/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
+++ b/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
@@ -35,7 +35,8 @@ enum {
 
 StructType *HostBIMuxInfo::getMiniWGInfoStruct(Module &M) {
   static constexpr const char *HostStructName = "MiniWGInfo";
-  if (auto *ty = multi_llvm::getStructTypeByName(M, HostStructName)) {
+  if (auto *ty =
+          multi_llvm::getStructTypeByName(M.getContext(), HostStructName)) {
     return ty;
   }
 
@@ -52,7 +53,8 @@ StructType *HostBIMuxInfo::getMiniWGInfoStruct(Module &M) {
 
 StructType *HostBIMuxInfo::getScheduleInfoStruct(Module &M) {
   static constexpr const char *HostStructName = "Mux_schedule_info_s";
-  if (auto *ty = multi_llvm::getStructTypeByName(M, HostStructName)) {
+  if (auto *ty =
+          multi_llvm::getStructTypeByName(M.getContext(), HostStructName)) {
     return ty;
   }
   auto &Ctx = M.getContext();

--- a/modules/compiler/test/CMakeLists.txt
+++ b/modules/compiler/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_ca_executable(UnitCompiler
   ${CMAKE_CURRENT_SOURCE_DIR}/info.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/kernel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/library.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mangling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/module.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/target.cpp
   $<$<PLATFORM_ID:Windows>:${BUILTINS_RC_FILE}>)
@@ -28,7 +29,7 @@ target_include_directories(UnitCompiler PRIVATE
   ${PROJECT_SOURCE_DIR}/modules/compiler/include)
 
 target_link_libraries(UnitCompiler PRIVATE cargo
-  compiler-static mux ca_gtest_main)
+  compiler-static mux ca_gtest_main compiler-utils)
 
 target_resources(UnitCompiler NAMESPACES ${BUILTINS_NAMESPACES})
 

--- a/modules/compiler/test/mangling.cpp
+++ b/modules/compiler/test/mangling.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/mangling.h>
+#include <compiler/utils/target_extension_types.h>
+#include <llvm/AsmParser/Parser.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/Support/SourceMgr.h>
+#include <multi_llvm/llvm_version.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "common.h"
+#include "compiler/module.h"
+
+using namespace compiler::utils;
+
+struct ManglingTest : ::testing::Test {
+  void SetUp() override { M = std::make_unique<llvm::Module>("ID", Context); }
+
+  std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
+    llvm::SMDiagnostic Error;
+    auto M = llvm::parseAssemblyString(Assembly, Error, Context);
+
+    std::string ErrMsg;
+    llvm::raw_string_ostream OS(ErrMsg);
+    Error.print("", OS);
+    EXPECT_TRUE(M) << OS.str();
+
+    return M;
+  }
+
+  llvm::LLVMContext Context;
+  std::unique_ptr<llvm::Module> M;
+};
+
+TEST_F(ManglingTest, MangleBuiltinTypes) {
+  // With opaque pointers, before LLVM 17 we can't actually mangle OpenCL
+  // builtin types because our APIs don't expose the ability to mangle a pointer
+  // based on its element type.
+  // This is never a problem in the compiler as we don't generate such functions
+  // on the fly, but it is a weakness in the API. We could fix this, or wait it
+  // out until LLVM 17 becomes the minimum version, at which point target
+  // extension types save the day.
+#if LLVM_VERSION_LESS(17, 0)
+  GTEST_SKIP();
+#else
+  NameMangler Mangler(&Context, M.get());
+
+  std::pair<llvm::Type *, const char *> TypesToMangle[] = {
+      {tgtext::getEventTy(Context), "9ocl_event"},
+      {tgtext::getSamplerTy(Context), "11ocl_sampler"},
+      {tgtext::getImage1DTy(Context), "11ocl_image1d"},
+      {tgtext::getImage1DTy(Context), "11ocl_image1d"},
+      {tgtext::getImage2DTy(Context), "11ocl_image2d"},
+      {tgtext::getImage3DTy(Context), "11ocl_image3d"},
+      {tgtext::getImage1DArrayTy(Context), "16ocl_image1darray"},
+      {tgtext::getImage1DBufferTy(Context), "17ocl_image1dbuffer"},
+      {tgtext::getImage2DArrayTy(Context), "16ocl_image2darray"},
+      {tgtext::getImage2DTy(Context, /*Depth*/ true, /*MS*/ false),
+       "16ocl_image2ddepth"},
+      {tgtext::getImage2DTy(Context, /*Depth*/ false, /*MS*/ true),
+       "15ocl_image2dmsaa"},
+      {tgtext::getImage2DTy(Context, /*Depth*/ true, /*MS*/ true),
+       "20ocl_image2dmsaadepth"},
+      {tgtext::getImage2DArrayTy(Context, /*Depth*/ true, /*MS*/ false),
+       "21ocl_image2darraydepth"},
+      {tgtext::getImage2DArrayTy(Context, /*Depth*/ false, /*MS*/ true),
+       "20ocl_image2darraymsaa"},
+      {tgtext::getImage2DArrayTy(Context, /*Depth*/ true, /*MS*/ true),
+       "25ocl_image2darraymsaadepth"},
+  };
+
+  std::string Name;
+  llvm::raw_string_ostream OS(Name);
+
+  for (auto &[Ty, ExpName] : TypesToMangle) {
+    Name.clear();
+    EXPECT_TRUE(Mangler.mangleType(OS, Ty, TypeQualifiers{}));
+    EXPECT_EQ(Name, ExpName);
+  }
+#endif
+}
+
+TEST_F(ManglingTest, DemangleImage1DTy) {
+  auto M = parseModule(R"(
+  declare void @_Z4test11ocl_image1d(ptr %img)
+  )");
+
+  NameMangler Mangler(&Context, M.get());
+
+  auto *F = M->getFunction("_Z4test11ocl_image1d");
+  EXPECT_TRUE(F);
+
+  llvm::SmallVector<llvm::Type *> Tys;
+  llvm::SmallVector<TypeQualifiers> Quals;
+  auto DemangledName = Mangler.demangleName(F->getName(), Tys, Quals);
+  EXPECT_EQ(DemangledName, "test");
+
+  EXPECT_EQ(Tys.size(), 1);
+  EXPECT_EQ(Quals.size(), 1);
+
+  auto *ImgTy = Tys[0];
+  EXPECT_TRUE(ImgTy);
+
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+  EXPECT_TRUE(ImgTy->isTargetExtTy());
+  auto *TgtTy = llvm::cast<llvm::TargetExtType>(ImgTy);
+  EXPECT_EQ(TgtTy->getName(), "spirv.Image");
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTyDimensionalityIdx),
+            tgtext::ImageDim1D);
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTyDepthIdx),
+            tgtext::ImageDepthNone);
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTyArrayedIdx),
+            tgtext::ImageNonArrayed);
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTyMSIdx),
+            tgtext::ImageMSSingleSampled);
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTySampledIdx),
+            tgtext::ImageSampledRuntime);
+  EXPECT_EQ(TgtTy->getIntParameter(tgtext::ImageTyAccessQualIdx),
+            tgtext::ImageAccessQualReadOnly);
+#else
+  EXPECT_TRUE(ImgTy->isStructTy());
+  EXPECT_EQ(llvm::cast<llvm::StructType>(ImgTy)->getName(), "opencl.image1d_t");
+#endif
+}

--- a/modules/compiler/test/mangling.cpp
+++ b/modules/compiler/test/mangling.cpp
@@ -32,7 +32,7 @@
 using namespace compiler::utils;
 
 struct ManglingTest : ::testing::Test {
-  void SetUp() override { M = std::make_unique<llvm::Module>("ID", Context); }
+  void SetUp() override {}
 
   std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
     llvm::SMDiagnostic Error;
@@ -47,7 +47,6 @@ struct ManglingTest : ::testing::Test {
   }
 
   llvm::LLVMContext Context;
-  std::unique_ptr<llvm::Module> M;
 };
 
 TEST_F(ManglingTest, MangleBuiltinTypes) {
@@ -61,7 +60,7 @@ TEST_F(ManglingTest, MangleBuiltinTypes) {
 #if LLVM_VERSION_LESS(17, 0)
   GTEST_SKIP();
 #else
-  NameMangler Mangler(&Context, M.get());
+  NameMangler Mangler(&Context);
 
   std::pair<llvm::Type *, const char *> TypesToMangle[] = {
       {tgtext::getEventTy(Context), "9ocl_event"},
@@ -103,7 +102,7 @@ TEST_F(ManglingTest, DemangleImage1DTy) {
   declare void @_Z4test11ocl_image1d(ptr %img)
   )");
 
-  NameMangler Mangler(&Context, M.get());
+  NameMangler Mangler(&Context);
 
   auto *F = M->getFunction("_Z4test11ocl_image1d");
   EXPECT_TRUE(F);

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -66,6 +66,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_wgc_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/scheduling.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/simple_callback_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/target_extension_types.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/unique_opaque_structs_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/vectorization_factor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/verify_reqd_sub_group_size_pass.h

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -115,6 +115,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mux_math_decls_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_wgc_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/scheduling.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/target_extension_types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/unique_opaque_structs_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp)
 

--- a/modules/compiler/utils/include/compiler/utils/mangling.h
+++ b/modules/compiler/utils/include/compiler/utils/mangling.h
@@ -25,6 +25,8 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 
+#include <optional>
+
 namespace llvm {
 class LLVMContext;
 class Module;
@@ -322,12 +324,12 @@ class NameMangler final {
   /// @return Mangled name of the type or nullptr.
   const char *mangleSimpleType(llvm::Type *Ty, TypeQualifier Qual);
   /// @brief Try to mangle the given builtin type name. This only works for
-  /// opencl
+  /// 'spirv' target extension types (LLVM 17+).
   ///
   /// @param[in] Ty type to mangle.
   ///
-  /// @return string if builtin type could be mangled otherwise nullptr.
-  const char *mangleOpenCLBuiltinType(llvm::Type *Ty);
+  /// @return string if builtin type could be mangled otherwise empty string.
+  std::optional<std::string> mangleBuiltinType(llvm::Type *Ty);
   /// @brief Try to demangle the given type name. This only works for simple
   /// types that do not require string manipulation.
   ///

--- a/modules/compiler/utils/include/compiler/utils/mangling.h
+++ b/modules/compiler/utils/include/compiler/utils/mangling.h
@@ -29,7 +29,6 @@
 
 namespace llvm {
 class LLVMContext;
-class Module;
 class Type;
 class raw_ostream;
 }  // namespace llvm
@@ -230,8 +229,7 @@ class NameMangler final {
   /// @brief Create a new name mangler.
   ///
   /// @param[in] context LLVM context to use.
-  /// @param[in] module LLVM module to use.
-  NameMangler(llvm::LLVMContext *context, llvm::Module *module = nullptr);
+  NameMangler(llvm::LLVMContext *context);
 
   /// @brief Determine the mangled name of a function.
   ///
@@ -311,8 +309,6 @@ class NameMangler final {
   ///
   /// @return Demangled name or original name if not mangled.
   llvm::StringRef demangleName(llvm::StringRef Name);
-
-  void setModule(llvm::Module *m) { M = m; };
 
  private:
   /// @brief Try to mangle the given qualified type. This only works for simple
@@ -405,8 +401,6 @@ class NameMangler final {
 
   /// @brief LLVM context used to access LLVM types.
   llvm::LLVMContext *Context;
-  /// @brief LLVM mdoule used to check existing LLVM named struct types.
-  llvm::Module *M;
 };
 }  // namespace utils
 }  // namespace compiler

--- a/modules/compiler/utils/include/compiler/utils/target_extension_types.h
+++ b/modules/compiler/utils/include/compiler/utils/target_extension_types.h
@@ -17,6 +17,11 @@
 #ifndef COMPILER_UTILS_TARGET_EXTENSION_TYPES_H_INCLUDED
 #define COMPILER_UTILS_TARGET_EXTENSION_TYPES_H_INCLUDED
 
+namespace llvm {
+class Type;
+class LLVMContext;
+}  // namespace llvm
+
 namespace compiler {
 namespace utils {
 namespace tgtext {
@@ -79,6 +84,58 @@ enum ImageTyAccessQualParam {
   ImageAccessQualWriteOnly,
   ImageAccessQualReadWrite,
 };
+
+/// @brief Returns the TargetExtType representing an 'event' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getEventTy(llvm::LLVMContext &Ctx);
+
+/// @brief Returns the TargetExtType representing an 'sampler' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getSamplerTy(llvm::LLVMContext &Ctx);
+
+/// @brief Returns the TargetExtType representing an 'image1d_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage1DTy(
+    llvm::LLVMContext &Ctx,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
+
+/// @brief Returns the TargetExtType representing an 'image1d_array_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage1DArrayTy(
+    llvm::LLVMContext &Ctx,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
+
+/// @brief Returns the TargetExtType representing an 'image1d_buffer_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage1DBufferTy(
+    llvm::LLVMContext &Ctx,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
+
+/// @brief Returns the TargetExtType representing an 'image2d_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage2DTy(
+    llvm::LLVMContext &Ctx, bool Depth = false, bool MS = false,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
+
+/// @brief Returns the TargetExtType representing an 'image2d_array_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage2DArrayTy(
+    llvm::LLVMContext &Ctx, bool Depth = false, bool MS = false,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
+
+/// @brief Returns the TargetExtType representing an 'image3d_t' type.
+///
+/// Note: Only intended for use LLVM 17+ - throws 'unreachable' otherwise.
+llvm::Type *getImage3DTy(
+    llvm::LLVMContext &Ctx,
+    ImageTyAccessQualParam AccessQual = ImageAccessQualReadOnly);
 
 }  // namespace tgtext
 }  // namespace utils

--- a/modules/compiler/utils/include/compiler/utils/target_extension_types.h
+++ b/modules/compiler/utils/include/compiler/utils/target_extension_types.h
@@ -1,0 +1,87 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef COMPILER_UTILS_TARGET_EXTENSION_TYPES_H_INCLUDED
+#define COMPILER_UTILS_TARGET_EXTENSION_TYPES_H_INCLUDED
+
+namespace compiler {
+namespace utils {
+namespace tgtext {
+
+/// @brief The indices of the *integer* parameters of a "spirv.Image" type.
+enum ImageTyIntParamIdx {
+  ImageTyDimensionalityIdx = 0,
+  ImageTyDepthIdx,
+  ImageTyArrayedIdx,
+  ImageTyMSIdx,
+  ImageTySampledIdx,
+  ImageTyFormatIdx,
+  ImageTyAccessQualIdx,
+};
+
+/// @brief Values the 'dimensionality' parameter of a "spirv.Image" type may
+/// hold.
+///
+/// Note that not all of these are supported by the compiler.
+enum ImageTyDimensionalityParam {
+  ImageDim1D = 0,
+  ImageDim2D,
+  ImageDim3D,
+  ImageDimCube,
+  ImageDimRect,
+  ImageDimBuffer,
+  ImageDimSubpassData,
+};
+
+/// @brief Values the 'depth' parameter of a "spirv.Image" type may hold.
+enum ImageTyDepthParam {
+  ImageDepthNone = 0,  // Not a depth image
+  ImageDepth,          // A depth image
+  ImageDepthUnknown,   // No indication as to whether this is a depth or
+                       // non-depth image
+};
+
+/// @brief Values the 'arrayed' parameter of a "spirv.Image" type may hold.
+enum ImageTyArrayedParam {
+  ImageNonArrayed = 0,
+  ImageArrayed,
+};
+
+/// @brief Values the 'MS' parameter of a "spirv.Image" type may hold.
+enum ImageTyMSParam {
+  ImageMSSingleSampled = 0,
+  ImageMSMultiSampled,
+};
+
+/// @brief Values the 'Sampled' parameter of a "spirv.Image" type may hold.
+enum ImageTySampledParam {
+  ImageSampledRuntime = 0,      // only known at run time
+  ImageSampledCompat,           // compatible with sampling operations
+  ImageSampledReadWriteCompat,  // compatiable with read/write operations (a
+                                // storage or subpass data image)
+};
+
+enum ImageTyAccessQualParam {
+  ImageAccessQualReadOnly = 0,
+  ImageAccessQualWriteOnly,
+  ImageAccessQualReadWrite,
+};
+
+}  // namespace tgtext
+}  // namespace utils
+}  // namespace compiler
+
+#endif  // COMPILER_UTILS_TARGET_EXTENSION_TYPES_H_INCLUDED

--- a/modules/compiler/utils/source/cl_builtin_info.cpp
+++ b/modules/compiler/utils/source/cl_builtin_info.cpp
@@ -1293,7 +1293,7 @@ Function *CLBuiltinInfo::getVectorEquivalent(Builtin const &B, unsigned Width,
 
   // Builtin functions have mangled names. If it's not mangled, there will be
   // no vector equivalent.
-  NameMangler Mangler(&B.function.getContext(), M);
+  NameMangler Mangler(&B.function.getContext());
   SmallVector<Type *, 4> BuiltinArgTypes, BuiltinPointeeTypes;
   SmallVector<TypeQualifiers, 4> BuiltinArgQuals;
   StringRef BuiltinName =

--- a/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
+++ b/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
@@ -78,7 +78,7 @@ std::string lookupWGBuiltin(StringRef SubgroupBuiltin, LLVMContext *Ctx,
     return compiler::utils::MuxBuiltins::work_group_barrier;
   }
 
-  compiler::utils::NameMangler Mangler(Ctx, M);
+  compiler::utils::NameMangler Mangler(Ctx);
   SmallVector<Type *, 4> ArgumentTypes;
   SmallVector<compiler::utils::TypeQualifiers, 4> Qualifiers;
 

--- a/modules/compiler/utils/source/dma.cpp
+++ b/modules/compiler/utils/source/dma.cpp
@@ -63,8 +63,8 @@ void buildThreadCheck(llvm::BasicBlock *entryBlock, llvm::BasicBlock *trueBlock,
 }
 
 llvm::StructType *getOrCreateMuxDMAEventType(llvm::Module &m) {
-  if (auto *eventType =
-          multi_llvm::getStructTypeByName(m, MuxBuiltins::dma_event_type)) {
+  if (auto *eventType = multi_llvm::getStructTypeByName(
+          m.getContext(), MuxBuiltins::dma_event_type)) {
     return eventType;
   }
 

--- a/modules/compiler/utils/source/group_collective_helpers.cpp
+++ b/modules/compiler/utils/source/group_collective_helpers.cpp
@@ -77,7 +77,7 @@ llvm::Constant *compiler::utils::getIdentityVal(RecurKind Kind, Type *Ty) {
 
 multi_llvm::Optional<compiler::utils::GroupCollective>
 compiler::utils::isGroupCollective(llvm::Function *f) {
-  compiler::utils::NameMangler Mangler(&f->getContext(), f->getParent());
+  compiler::utils::NameMangler Mangler(&f->getContext());
   SmallVector<Type *, 4> ArgumentTypes;
   SmallVector<compiler::utils::TypeQualifiers, 4> Qualifiers;
 

--- a/modules/compiler/utils/source/link_builtins_pass.cpp
+++ b/modules/compiler/utils/source/link_builtins_pass.cpp
@@ -95,7 +95,7 @@ const StringSet<> DeferredBuiltins = {
 };
 
 bool isDeferredBuiltin(Function &F) {
-  compiler::utils::NameMangler Mangler(&F.getContext(), F.getParent());
+  compiler::utils::NameMangler Mangler(&F.getContext());
 
   SmallVector<Type *, 4> Types;
   SmallVector<compiler::utils::TypeQualifiers, 4> Quals;

--- a/modules/compiler/utils/source/mangling.cpp
+++ b/modules/compiler/utils/source/mangling.cpp
@@ -33,8 +33,7 @@ namespace compiler {
 namespace utils {
 using namespace llvm;
 
-NameMangler::NameMangler(LLVMContext *context, Module *module)
-    : Context(context), M(module) {}
+NameMangler::NameMangler(LLVMContext *context) : Context(context) {}
 
 std::string NameMangler::mangleName(StringRef Name, ArrayRef<Type *> Tys,
                                     ArrayRef<TypeQualifiers> Quals) {
@@ -498,10 +497,11 @@ bool NameMangler::demangleOpenCLBuiltinType(Lexer &L, Type *&Ty) {
     return false;
   }
 
-  if (auto *const OpenCLType = multi_llvm::getStructTypeByName(*M, Name)) {
+  if (auto *const OpenCLType =
+          multi_llvm::getStructTypeByName(*Context, Name)) {
     Ty = OpenCLType;
   } else {
-    Ty = llvm::StructType::create(M->getContext(), Name);
+    Ty = llvm::StructType::create(*Context, Name);
   }
 
   return true;

--- a/modules/compiler/utils/source/optimal_builtin_replacement_pass.cpp
+++ b/modules/compiler/utils/source/optimal_builtin_replacement_pass.cpp
@@ -187,8 +187,7 @@ OptimalBuiltinReplacementPass::OptimalBuiltinReplacementPass() {
 Value *OptimalBuiltinReplacementPass::replaceBuiltinWithInlineIR(
     CallBase &CB) const {
   auto *M = CB.getModule();
-  LLVMContext &Ctx = M->getContext();
-  NameMangler mangler(&Ctx, M);
+  NameMangler mangler(&M->getContext());
 
   SmallVector<Type *, 4> Types;
   SmallVector<TypeQualifiers, 4> Quals;

--- a/modules/compiler/utils/source/replace_async_copies_pass.cpp
+++ b/modules/compiler/utils/source/replace_async_copies_pass.cpp
@@ -392,8 +392,7 @@ void defineWaitGroupEvents(Function &WaitGroupEvents) {
 /// @retval True if @p Function is async builtin and is now defined.
 /// @retval False if @p Function was not async builtin.
 bool runOnFunction(Function &Function) {
-  compiler::utils::NameMangler Mangler(&Function.getContext(),
-                                       Function.getParent());
+  compiler::utils::NameMangler Mangler(&Function.getContext());
   // Parse the name part.
   StringRef DemangledName = Mangler.demangleName(Function.getName());
 

--- a/modules/compiler/utils/source/scheduling.cpp
+++ b/modules/compiler/utils/source/scheduling.cpp
@@ -35,7 +35,7 @@ static constexpr const char *WorkGroupParamName = "MuxWorkGroupInfo";
 StructType *getWorkItemInfoStructTy(llvm::Module &M) {
   LLVMContext &ctx = M.getContext();
   // Check whether this struct has previously been defined.
-  if (auto *ty = multi_llvm::getStructTypeByName(M, WorkItemParamName)) {
+  if (auto *ty = multi_llvm::getStructTypeByName(ctx, WorkItemParamName)) {
     return ty;
   }
   auto *uint_type = Type::getInt32Ty(ctx);
@@ -56,7 +56,7 @@ StructType *getWorkItemInfoStructTy(llvm::Module &M) {
 StructType *getWorkGroupInfoStructTy(llvm::Module &M) {
   LLVMContext &ctx = M.getContext();
   // Check whether this struct has previously been defined.
-  if (auto *ty = multi_llvm::getStructTypeByName(M, WorkGroupParamName)) {
+  if (auto *ty = multi_llvm::getStructTypeByName(ctx, WorkGroupParamName)) {
     return ty;
   }
   auto *uint_type = Type::getInt32Ty(ctx);

--- a/modules/compiler/utils/source/target_extension_types.cpp
+++ b/modules/compiler/utils/source/target_extension_types.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/target_extension_types.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Type.h>
+#include <multi_llvm/llvm_version.h>
+
+using namespace compiler::utils;
+using namespace llvm;
+
+namespace compiler {
+namespace utils {
+namespace tgtext {
+
+Type *getEventTy(LLVMContext &Ctx) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return TargetExtType::get(Ctx, "spirv.Event");
+#endif
+}
+
+Type *getSamplerTy(LLVMContext &Ctx) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return TargetExtType::get(Ctx, "spirv.Sampler");
+#endif
+}
+
+[[maybe_unused]] static Type *getImageTyHelper(
+    LLVMContext &Ctx, ImageTyDimensionalityParam Dim, ImageTyDepthParam Depth,
+    ImageTyArrayedParam Arrayed, ImageTyMSParam MS, ImageTySampledParam Sampled,
+    ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)Dim;
+  (void)Depth;
+  (void)Arrayed;
+  (void)MS;
+  (void)Sampled;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  unsigned IntParams[7];
+  IntParams[ImageTyDimensionalityIdx] = Dim;
+  IntParams[ImageTyDepthIdx] = Depth;
+  IntParams[ImageTyArrayedIdx] = Arrayed;
+  IntParams[ImageTyMSIdx] = MS;
+  IntParams[ImageTySampledIdx] = Sampled;
+  IntParams[ImageTyFormatIdx] = /*Unknown*/ 0;
+  IntParams[ImageTyAccessQualIdx] = AccessQual;
+  return TargetExtType::get(Ctx, "spirv.Image", Type::getVoidTy(Ctx),
+                            IntParams);
+#endif
+}
+
+[[maybe_unused]] static Type *getOpenCLImageTyHelper(
+    LLVMContext &Ctx, ImageTyDimensionalityParam Dim,
+    ImageTyArrayedParam Arrayed, ImageTyDepthParam Depth, ImageTyMSParam MS,
+    ImageTyAccessQualParam AccessQual) {
+  return getImageTyHelper(Ctx, Dim, Depth, Arrayed, MS, ImageSampledRuntime,
+                          AccessQual);
+}
+
+[[maybe_unused]] static Type *getOpenCLImageTyHelper(
+    LLVMContext &Ctx, ImageTyDimensionalityParam Dim,
+    ImageTyArrayedParam Arrayed, ImageTyAccessQualParam AccessQual) {
+  return getOpenCLImageTyHelper(Ctx, Dim, Arrayed, ImageDepthNone,
+                                ImageMSSingleSampled, AccessQual);
+}
+
+Type *getImage1DTy(LLVMContext &Ctx, ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(Ctx, ImageDim1D, ImageNonArrayed, AccessQual);
+#endif
+}
+
+Type *getImage1DArrayTy(LLVMContext &Ctx, ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(Ctx, ImageDim1D, ImageArrayed, AccessQual);
+#endif
+}
+
+Type *getImage1DBufferTy(LLVMContext &Ctx, ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(Ctx, ImageDimBuffer, ImageNonArrayed,
+                                AccessQual);
+#endif
+}
+
+Type *getImage2DTy(LLVMContext &Ctx, bool Depth, bool MS,
+                   ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)Depth;
+  (void)MS;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(
+      Ctx, ImageDim2D, ImageNonArrayed, Depth ? ImageDepth : ImageDepthNone,
+      MS ? ImageMSMultiSampled : ImageMSSingleSampled, AccessQual);
+#endif
+}
+
+Type *getImage2DArrayTy(LLVMContext &Ctx, bool Depth, bool MS,
+                        ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)Depth;
+  (void)MS;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(
+      Ctx, ImageDim2D, ImageArrayed, Depth ? ImageDepth : ImageDepthNone,
+      MS ? ImageMSMultiSampled : ImageMSSingleSampled, AccessQual);
+#endif
+}
+
+Type *getImage3DTy(LLVMContext &Ctx, ImageTyAccessQualParam AccessQual) {
+#if LLVM_VERSION_LESS(17, 0)
+  (void)Ctx;
+  (void)AccessQual;
+  llvm_unreachable("Can't use target extension types before LLVM 17");
+#else
+  return getOpenCLImageTyHelper(Ctx, ImageDim3D, ImageNonArrayed, AccessQual);
+#endif
+}
+
+}  // namespace tgtext
+}  // namespace utils
+}  // namespace compiler

--- a/modules/compiler/utils/source/unique_opaque_structs_pass.cpp
+++ b/modules/compiler/utils/source/unique_opaque_structs_pass.cpp
@@ -108,8 +108,8 @@ static compiler::utils::StructMap uniqueOpaqueSuffixedStructs(
 
     // Check whether there is a type in the context with the same name minus a
     // suffix.
-    if (auto *ctxStructTy =
-            multi_llvm::getStructTypeByName(module, structName.rtrim(Suffix))) {
+    if (auto *ctxStructTy = multi_llvm::getStructTypeByName(
+            module.getContext(), structName.rtrim(Suffix))) {
       // Make sure it is also opaque.
       if (!ctxStructTy->isOpaque()) {
         continue;

--- a/modules/compiler/vecz/source/vectorization_context.cpp
+++ b/modules/compiler/vecz/source/vectorization_context.cpp
@@ -143,7 +143,7 @@ VectorizationResult &VectorizationContext::getOrCreateBuiltin(
     return result;
   }
 
-  compiler::utils::NameMangler Mangler(&F.getContext(), &Module);
+  compiler::utils::NameMangler Mangler(&F.getContext());
   auto const BuiltinName = Mangler.demangleName(F.getName()).str();
 
   result.func = VectorCallee;


### PR DESCRIPTION
This starts to teach the compiler about Target Extension Types[1], which we will start to expect and accommodate in LLVM 17.

The reason for this is that clang will now generate `spirv.Event`, `spirv.Sampler` and `spirv.Image` types for the corresponding OpenCL types. The plan is to make `spirv-ll` generate these types too, so that the IR is in a consistent format for each version. The decision about SPIR 1.2 is still undecided.

These types are beneficial for us because they are better defined than the previous solution of pointers to opaque structs with specific names - primarily because opaque pointers make it difficult or impossible to actually determine these types.

The target extension types, however, can not reach the backend unless that backend can actually work with them. Therefore we will be forced to replace them with other types at a certain point in the compiler pipeline. We already do this for images, but we abuse the current pointer-ness of events and samplers in certain scenarios to treat them as integers.

This PR only introduces them to the program/kernel metadata and mangling APIs. The next step will be to update `spirv-ll`, and then the compiler passes.

[1]: https://llvm.org/docs/LangRef.html#target-extension-type