### PR TITLE
[compiler] Remove need to run the SpirFixupPass on SPIR-V

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -44,6 +44,9 @@ namespace spirv_ll {
 /// @brief Type used to pass around the list of builtin IDs used by a function
 using BuiltinIDList = llvm::SmallVector<spv::Id, 2>;
 
+static constexpr const char SAMPLER_INIT_FN[] =
+    "__translate_sampler_initializer";
+
 class Builder;
 
 class OpenCLBuilder {

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -159,47 +159,35 @@ void spirv_ll::Builder::addDebugInfoToModule() {
 }
 
 namespace {
+
+static llvm::DenseMap<uint32_t, llvm::StringRef> BuiltinFnNames = {
+    {spv::BuiltInNumWorkgroups, "_Z14get_num_groupsj"},
+    {spv::BuiltInWorkDim, "_Z12get_work_dimv"},
+    {spv::BuiltInWorkgroupSize, "_Z14get_local_sizej"},
+    {spv::BuiltInWorkgroupId, "_Z12get_group_idj"},
+    {spv::BuiltInLocalInvocationId, "_Z12get_local_idj"},
+    {spv::BuiltInGlobalInvocationId, "_Z13get_global_idj"},
+    {spv::BuiltInGlobalSize, "_Z15get_global_sizej"},
+    {spv::BuiltInGlobalOffset, "_Z17get_global_offsetj"},
+    {spv::BuiltInSubgroupId, "_Z16get_sub_group_idv"},
+    {spv::BuiltInSubgroupSize, "_Z18get_sub_group_sizev"},
+    {spv::BuiltInSubgroupMaxSize, "_Z22get_max_sub_group_sizev"},
+    {spv::BuiltInNumSubgroups, "_Z18get_num_sub_groupsv"},
+    {spv::BuiltInNumEnqueuedSubgroups, "_Z27get_enqueued_num_sub_groupsv"},
+    {spv::BuiltInSubgroupLocalInvocationId, "_Z22get_sub_group_local_idv"},
+    {spv::BuiltInGlobalLinearId, "_Z20get_global_linear_idv"},
+    {spv::BuiltInLocalInvocationIndex, "_Z19get_local_linear_idv"},
+    {spv::BuiltInEnqueuedWorkgroupSize, "_Z23get_enqueued_local_sizej"},
+};
+
 llvm::StringRef getBuiltinName(uint32_t builtin) {
   // Return the mangled names here as there will be no OpCode's to pass to
   // createMangledBuiltinCall for use in name mangling.
-  switch (builtin) {
-    case spv::BuiltInNumWorkgroups:
-      return "_Z14get_num_groupsj";
-    case spv::BuiltInWorkDim:
-      return "_Z12get_work_dimv";
-    case spv::BuiltInWorkgroupSize:
-      return "_Z14get_local_sizej";
-    case spv::BuiltInWorkgroupId:
-      return "_Z12get_group_idj";
-    case spv::BuiltInLocalInvocationId:
-      return "_Z12get_local_idj";
-    case spv::BuiltInGlobalInvocationId:
-      return "_Z13get_global_idj";
-    case spv::BuiltInGlobalSize:
-      return "_Z15get_global_sizej";
-    case spv::BuiltInGlobalOffset:
-      return "_Z17get_global_offsetj";
-    case spv::BuiltInSubgroupId:
-      return "_Z16get_sub_group_idv";
-    case spv::BuiltInSubgroupSize:
-      return "_Z18get_sub_group_sizev";
-    case spv::BuiltInSubgroupMaxSize:
-      return "_Z22get_max_sub_group_sizev";
-    case spv::BuiltInNumSubgroups:
-      return "_Z18get_num_sub_groupsv";
-    case spv::BuiltInNumEnqueuedSubgroups:
-      return "_Z27get_enqueued_num_sub_groupsv";
-    case spv::BuiltInSubgroupLocalInvocationId:
-      return "_Z22get_sub_group_local_idv";
-    case spv::BuiltInGlobalLinearId:
-      return "_Z20get_global_linear_idv";
-    case spv::BuiltInLocalInvocationIndex:
-      return "_Z19get_local_linear_idv";
-    case spv::BuiltInEnqueuedWorkgroupSize:
-      return "_Z23get_enqueued_local_sizej";
-    default:
-      llvm_unreachable("invalid work item builtin");
+  auto It = BuiltinFnNames.find(builtin);
+  if (It == BuiltinFnNames.end()) {
+    llvm_unreachable("invalid work item builtin");
   }
+  return It->getSecond();
 }
 }  // namespace
 
@@ -611,7 +599,13 @@ llvm::CallInst *spirv_ll::Builder::createBuiltinCall(
     function = declareBuiltinFunction(
         name.str(), llvm::FunctionType::get(retTy, argTys, false), convergent);
   }
-  auto call = IRBuilder.CreateCall(function, args);
+  // Builtin functions also only read memory - set that attribute
+  if (llvm::find_if(BuiltinFnNames, [name](const auto &pair) {
+        return pair.getSecond() == name;
+      }) != BuiltinFnNames.end()) {
+    function->setOnlyReadsMemory();
+  }
+  auto *const call = IRBuilder.CreateCall(function, args);
   if (!name.equals(SAMPLER_INIT_FN)) {
     call->setCallingConv(llvm::CallingConv::SPIR_FUNC);
   }

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -587,7 +587,7 @@ llvm::Function *spirv_ll::Builder::declareBuiltinFunction(
   llvm::Function *func = llvm::Function::Create(
       ty, llvm::GlobalValue::LinkageTypes::ExternalLinkage, func_name,
       module.llvmModule.get());
-  if (func_name != "__translate_sampler_initializer") {
+  if (func_name != SAMPLER_INIT_FN) {
     func->setCallingConv(llvm::CallingConv::SPIR_FUNC);
   }
   if (convergent) {
@@ -612,7 +612,7 @@ llvm::CallInst *spirv_ll::Builder::createBuiltinCall(
         name.str(), llvm::FunctionType::get(retTy, argTys, false), convergent);
   }
   auto call = IRBuilder.CreateCall(function, args);
-  if (!name.equals("__translate_sampler_initializer")) {
+  if (!name.equals(SAMPLER_INIT_FN)) {
     call->setCallingConv(llvm::CallingConv::SPIR_FUNC);
   }
   return call;
@@ -1106,7 +1106,8 @@ std::string spirv_ll::Builder::getMangledFunctionName(
         auto *const spvPtrTy = module.get<OpType>(mangleInfo->id);
         if (spvPtrTy->isPointerType()) {
           pointeeTy = module.getType(spvPtrTy->getTypePointer()->Type());
-        } else if (spvPtrTy->isImageType() || spvPtrTy->isEventType()) {
+        } else if (spvPtrTy->isImageType() || spvPtrTy->isEventType() ||
+                   spvPtrTy->isSamplerType()) {
           pointeeTy = module.getInternalStructType(spvPtrTy->IdResult());
         }
         SPIRV_LL_ASSERT_PTR(pointeeTy);

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -1124,6 +1124,9 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
     }
   }
 
+  // replace all global builtin vars with function local versions
+  builder.replaceBuiltinGlobals();
+
   // Check non-entry-point functions with empty names and re-set the name if it
   // exists in the Module's Value map. See function creation in
   // Builder::create<OpFunction>(const OpFunction *op) in builder_core.cpp
@@ -1139,9 +1142,6 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
       }
     }
   }
-
-  // replace all global builtin vars with function local versions
-  builder.replaceBuiltinGlobals();
 
   // add any remaining metadata to llvm module
   builder.finalizeMetadata();

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -1128,6 +1128,10 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
   // exists in the Module's Value map. See function creation in
   // Builder::create<OpFunction>(const OpFunction *op) in builder_core.cpp
   for (auto &function : module.llvmModule->functions()) {
+    // We don't use exceptions
+    if (!function.hasFnAttribute(llvm::Attribute::NoUnwind)) {
+      function.addFnAttr(llvm::Attribute::NoUnwind);
+    }
     if (function.getCallingConv() == llvm::CallingConv::SPIR_FUNC) {
       const std::string name = module.getName(&function);
       if (!name.empty()) {

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -64,7 +64,6 @@ spirv_ll::Module::Module(
       File(nullptr),
       CurrentOpLineRange(nullptr, llvm::BasicBlock::iterator()),
       LoopControl(),
-      SamplerID(0),
       specInfo(specInfo),
       PushConstantStructVariable(nullptr),
       PushConstantStructID{},
@@ -90,7 +89,6 @@ spirv_ll::Module::Module(spirv_ll::Context &context,
       File(nullptr),
       CurrentOpLineRange(nullptr, llvm::BasicBlock::iterator()),
       LoopControl(),
-      SamplerID(0),
       specInfo(),
       PushConstantStructVariable(nullptr),
       PushConstantStructID{},
@@ -647,10 +645,6 @@ void spirv_ll::Module::updateIncompletePointer(spv::Id type_id) {
     }
   }
 }
-
-void spirv_ll::Module::setSampler(spv::Id sampler) { SamplerID = sampler; }
-
-spv::Id spirv_ll::Module::getSampler() const { return SamplerID; }
 
 void spirv_ll::Module::addSampledImage(spv::Id id, llvm::Value *image,
                                        llvm::Value *sampler) {

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_GlobalInvocationID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_GlobalInvocationID.comp
@@ -24,7 +24,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func {{i[0-9]+}} @_Z13get_global_idj(i32 0)
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationID.comp
@@ -23,7 +23,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func {{i[0-9]+}} @_Z12get_local_idj(i32 0)
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationIndex.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_LocalInvocationIndex.comp
@@ -23,7 +23,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func {{i[0-9]+}} @_Z19get_local_linear_idv()
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_NumWorkGroups.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_NumWorkGroups.comp
@@ -23,7 +23,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func {{i[0-9]+}} @_Z14get_num_groupsj(i32 0)
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_WorkGroupID.comp
+++ b/modules/compiler/spirv-ll/test/glsl/builtin_var_gl_WorkGroupID.comp
@@ -23,7 +23,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func {{i[0-9]+}} @_Z12get_group_idj(i32 0)
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_bool.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func i1  @{{("func_ret_bool.+")}}()
 // CHECK: store i1 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_double.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func double  @{{("func_ret_double.+")}}()
 // CHECK: store double {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_float.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func float  @{{("func_ret_float.+")}}()
 // CHECK: store float {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_int.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func i32  @{{("func_ret_int.+")}}()
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_scalar_uint.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func i32  @{{("func_ret_uint.+")}}()
 // CHECK: store i32 {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_bool.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <2 x i1> @{{("func_call_ret_vec2_bool.+")}}()
 // CHECK: store <2 x i1> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_double.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <2 x double> @{{("func_call_ret_vec2_double.+")}}()
 // CHECK: store <2 x double> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_float.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <2 x float> @{{("func_call_ret_vec2_float.+")}}()
 // CHECK: store <2 x float> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_int.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <2 x i32> @{{("func_call_ret_vec2_int.+")}}()
 // CHECK: store <2 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec2_uint.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <2 x i32> @{{("func_call_ret_vec2_uint.+")}}()
 // CHECK: store <2 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_bool.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <3 x i1> @{{("func_call_ret_vec3_bool.+")}}()
 // CHECK: store <3 x i1> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_double.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <3 x double> @{{("func_call_ret_vec3_double.+")}}()
 // CHECK: store <3 x double> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_float.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <3 x float> @{{("func_call_ret_vec3_float.+")}}()
 // CHECK: store <3 x float> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_int.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <3 x i32> @{{("func_call_ret_vec3_int.+")}}()
 // CHECK: store <3 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec3_uint.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <3 x i32> @{{("func_call_ret_vec3_uint.+")}}()
 // CHECK: store <3 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_bool.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <4 x i1> @{{("func_call_ret_vec4_bool.+")}}()
 // CHECK: store <4 x i1> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_double.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <4 x double> @{{("func_call_ret_vec4_double.+")}}()
 // CHECK: store <4 x double> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_float.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <4 x float> @{{("func_call_ret_vec4_float.+")}}()
 // CHECK: store <4 x float> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_int.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <4 x i32> @{{("func_call_ret_vec4_int.+")}}()
 // CHECK: store <4 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/func_call_ret_vec4_uint.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = call spir_func <4 x i32> @{{("func_call_ret_vec4_uint.+")}}()
 // CHECK: store <4 x i32> {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_double.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: store double {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_float.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: store float {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_int.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/negate_op_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/negate_op_uint.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i1]
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_double.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x double]
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_float.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x float]
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i32]
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_access_array_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_access_array_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i32]
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_add_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_add_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec2.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store <2 x i1> <i1 true, i1 true>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store <3 x i1> <i1 true, i1 true, i1 true>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_all_bvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_all_bvec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store <4 x i1> <i1 true, i1 true, i1 true, i1 true>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_bool_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_and_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_and_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec2.comp
@@ -26,7 +26,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: %vec = alloca <2 x i1>
 // CHECK: %result = alloca i1
 // CHECK: store <2 x i1> <i1 true, i1 true>, ptr %vec

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store <3 x i1> <i1 true, i1 true, i1 true>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_any_bvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_any_bvec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i1>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store <4 x i1> <i1 true, i1 true, i1 true, i1 true>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_bool.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 // CHECK: [[result:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[result_a_ptr:%[a-zA-Z0-9]+]] = getelementptr i32, ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0
 // CHECK: [[result_a:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) %3

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_double.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 // CHECK: [[result:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[result_a_ptr:%[a-zA-Z0-9]+]] = getelementptr i32, ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0
 // CHECK: [[result_a:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) %3

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_float.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 // CHECK: [[result:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[result_a_ptr:%[a-zA-Z0-9]+]] = getelementptr i32, ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0
 // CHECK: [[result_a:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[result_a_ptr]]

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_int.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 // CHECK: [[result:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[result_a_ptr:%[a-zA-Z0-9]+]] = getelementptr i32, ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0
 // CHECK: [[result_a:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[result_a_ptr]]

--- a/modules/compiler/spirv-ll/test/glsl/op_array_length_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_array_length_uint.comp
@@ -29,7 +29,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 // CHECK: [[result:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[result_a_ptr:%[a-zA-Z0-9]+]] = getelementptr i32, ptr addrspace({{[0-9]}}) {{%[a-zA-Z0-9]+}}, i32 0
 // CHECK: [[result_a:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[result_a_ptr]]

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_ashr_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitcount_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitcount_int.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_int.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec2.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: store <2 x i32> <i32 -42, i32 -42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: store <3 x i32> <i32 -42, i32 -42, i32 -42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_ivec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: store <4 x i32> <i32 -42, i32 -42, i32 -42, i32 -42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uint.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec2.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: store <2 x i32> <i32 42, i32 42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: store <3 x i32> <i32 42, i32 42, i32 42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_extract_uvec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: store <4 x i32> <i32 42, i32 42, i32 42, i32 42>, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec2.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec3.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_ivec4.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec2.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec3.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_bitfield_insert_uvec4.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_cmp_eq_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_cmp_eq_two_bool_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_float.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: store double {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_int.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store double {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_double_to_uint.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store double {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec2_to_ivec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec2_to_ivec2.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <2 x double>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <2 x i32>
 // CHECK: store <2 x double> <double -4.242000e+01, double -4.242000e+01>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec3_to_ivec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec3_to_ivec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <3 x double>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <3 x i32>
 // CHECK: store <3 x double> <double -4.242000e+01, double -4.242000e+01, double -4.242000e+01>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_dvec4_to_ivec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_dvec4_to_ivec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <4 x double>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <4 x i32>
 // CHECK: store <4 x double> <double -4.242000e+01, double -4.242000e+01, double -4.242000e+01, double -4.242000e+01>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_double.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: store float {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_int.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store float {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_float_to_uint.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store float {{(-?[0-9]+\.[0-9]+e\+[0-9]+|0x[0-9A-F]+)}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_double.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_int_to_float.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec2_to_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec2_to_vec2.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <2 x i32>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <2 x float>
 // CHECK: store <2 x i32> <i32 -42, i32 -42>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec3_to_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec3_to_vec3.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <3 x i32>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <3 x float>
 // CHECK: store <3 x i32> <i32 -42, i32 -42, i32 -42>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_ivec4_to_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_ivec4_to_vec4.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[FROM:%[a-zA-Z0-9_]+]] = alloca <4 x i32>
 // CHECK: [[TO:%[a-zA-Z0-9_]+]] = alloca <4 x float>
 // CHECK: store <4 x i32> <i32 -42, i32 -42, i32 -42, i32 -42>, ptr [[FROM]]

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_double.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: store i32 42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_convert_uint_to_float.comp
@@ -25,7 +25,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: store i32 42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec2_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec3_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_dvec4_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec2_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec3_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_dvec4_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec2_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec3_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_two_vec4_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec2_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec3_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fadd_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fadd_vec4_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oeq_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_oge_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ogt_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_ole_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fcmp_olt_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec2_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec3_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_dvec4_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec2_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec3_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_dvec4_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec2_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec3_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_two_vec4_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec2_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec3_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fdiv_vec4_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_double.comp
@@ -27,7 +27,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_double_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_double_arm.comp
@@ -27,7 +27,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec2_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec3_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_dvec4_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_float.comp
@@ -27,7 +27,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_float_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_float_arm.comp
@@ -27,7 +27,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float
 // CHECK: {{%[a-zA-Z0-9_]+}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec2_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec3_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4_arm.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmod_vec4_arm.comp
@@ -22,7 +22,7 @@
 #version 450
 
 void main() {
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>
 // CHECK:  {{%[a-zA-Z0-9_]+}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec2_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec3_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_dvec4_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec2_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec3_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_dvec4_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec2_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec3_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_two_vec4_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec2_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec3_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fmul_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fmul_vec4_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec2_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec2_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec3_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec3_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec4_scalar_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_dvec4_scalar_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec2_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec2_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec3_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec3_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec4_double_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_dvec4_double_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x double>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec2_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec2_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec3_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec3_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec4_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_two_vec4_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec2_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec2_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec3_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec3_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_fsub_vec4_scalar_float_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_fsub_vec4_scalar_float_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x float>

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_bool.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[res:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param1:%[a-zA-Z0-9]+]] = alloca i1
@@ -40,7 +40,7 @@ void main() {
 // CHECK: ret void
 // CHECK: }
 
-// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) {
+// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) #0 {
 // CHECK: [[a:%[a-zA-Z0-9]+]] = load i1, ptr %a
 // CHECK: [[b:%[a-zA-Z0-9]+]] = load i1, ptr %b
 // CHECK: [[ret:%[a-zA-Z0-9]+]] = icmp eq i1 [[a]], [[b]]

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_double.comp
@@ -28,7 +28,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[res:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param:%[a-zA-Z0-9]+]] = alloca double
 // CHECK: [[param1:%[a-zA-Z0-9]+]] = alloca double
@@ -39,7 +39,7 @@ void main() {
 // CHECK: ret void
 // CHECK: }
 
-// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) {
+// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) #0 {
 // CHECK: [[a:%[a-zA-Z0-9]+]] = load double, ptr %a
 // CHECK: [[b:%[a-zA-Z0-9]+]] = load double, ptr %b
 // CHECK: [[ret:%[a-zA-Z0-9]+]] = fcmp oeq double [[a]], [[b]]

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_float.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[res:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param:%[a-zA-Z0-9]+]] = alloca float
 // CHECK: [[param1:%[a-zA-Z0-9]+]] = alloca float
@@ -40,7 +40,7 @@ void main() {
 // CHECK: ret void
 // CHECK: }
 
-// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) {
+// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) #0 {
 // CHECK: [[a:%[a-zA-Z0-9]+]] = load float, ptr %a
 // CHECK: [[b:%[a-zA-Z0-9]+]] = load float, ptr %b
 // CHECK: [[ret:%[a-zA-Z0-9]+]] = fcmp oeq float [[a]], [[b]]

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_int.comp
@@ -28,7 +28,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[res:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[param1:%[a-zA-Z0-9]+]] = alloca i32
@@ -39,7 +39,7 @@ void main() {
 // CHECK: ret void
 // CHECK: }
 
-// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) {
+// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) #0 {
 // CHECK: [[a:%[a-zA-Z0-9]+]] = load i32, ptr %a
 // CHECK: [[b:%[a-zA-Z0-9]+]] = load i32, ptr %b
 // CHECK: [[ret:%[a-zA-Z0-9]+]] = icmp eq i32 [[a]], [[b]]

--- a/modules/compiler/spirv-ll/test/glsl/op_function_parameter_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_function_parameter_uint.comp
@@ -28,7 +28,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: [[res:%[a-zA-Z0-9]+]] = alloca i1
 // CHECK: [[param:%[a-zA-Z0-9]+]] = alloca i32
 // CHECK: [[param1:%[a-zA-Z0-9]+]] = alloca i32
@@ -39,7 +39,7 @@ void main() {
 // CHECK: ret void
 // CHECK: }
 
-// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) {
+// CHECK: define private spir_func i1 @{{(foo|"foo\(.+")}}(ptr %a, ptr %b) #0 {
 // CHECK: [[a:%[a-zA-Z0-9]+]] = load i32, ptr %a
 // CHECK: [[b:%[a-zA-Z0-9]+]] = load i32, ptr %b
 // CHECK: [[ret:%[a-zA-Z0-9]+]] = icmp eq i32 [[a]], [[b]]

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackHalf2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackHalf2x16_vec2.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load <2 x float>, ptr addrspace(1) [[arg0]]
   res = packHalf2x16(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm2x16_vec2.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg9value:%[a-zA-Z0-9]+]] = load <2 x float>, ptr addrspace(1) [[arg0]]
   res = packSnorm2x16(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm4x8_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackSnorm4x8_vec4.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load <4 x float>, ptr addrspace(1) [[arg0]]
   res = packSnorm4x8(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm2x16_vec2.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm2x16_vec2.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load <2 x float>, ptr addrspace(1) [[arg0]]
   res = packUnorm2x16(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm4x8_vec4.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_PackUnorm4x8_vec4.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load <4 x float>, ptr addrspace(1) [[arg0]]
   res = packUnorm4x8(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackDouble2x32_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackDouble2x32_double.comp
@@ -33,7 +33,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[bufferArg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = load double, ptr addrspace(1) [[bufferArg0]]
 // CHECK:   [[cast:%[a-zA-Z0-9]+]] = bitcast double [[arg0]] to <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackHalf2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackHalf2x16_uint.comp
@@ -33,7 +33,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK: [[bufferArg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) %0, i32 0, i32 0
 // CHECK: [[arg0:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[bufferArg0]]
 // CHECK: [[call:%[a-zA-Z0-9]+]] = call spir_func <2 x float> @_Z14unpackHalf2x16j(i32 [[arg0]])

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm2x16_uint.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[arg0]]
   res = unpackSnorm2x16(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm4x8_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackSnorm4x8_uint.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[arg0]]
   res = unpackSnorm4x8(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm2x16_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_glsl_UnpackUnorm2x16_uint.comp
@@ -29,7 +29,7 @@ layout (std430, set=0, binding=1) buffer outR {
 };
 
 void main() {
-// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}) #0 {
 // CHECK:   [[arg0:%[a-zA-Z0-9]+]] = getelementptr [[inA:%.*]], ptr addrspace(1) {{%[a-zA-Z0-9]+}}, i32 0, i32 0
 // CHECK:   [[arg0value:%[a-zA-Z0-9]+]] = load i32, ptr addrspace(1) [[arg0]]
   res = unpackUnorm2x16(arg0);

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_eq_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ne_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sge_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sge_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sgt_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sgt_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_sle_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_sle_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_slt_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_slt_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_uge_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_uge_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ugt_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ugt_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ule_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ule_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_icmp_ult_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_icmp_ult_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i1]
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_double.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x double]
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_float.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x float]
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i32]
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_insert_array_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_insert_array_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca [4 x i32]
 // CHECK: store i32 -42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_lshr_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_mul_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_mul_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_bool_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_or_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_or_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sdiv_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_shl_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_shl_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_smod_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_add_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_and_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_ashr_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_ashr_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_cmp_eq_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_cmp_eq_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_eq_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ne_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sge_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sge_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sgt_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sgt_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sle_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_sle_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_slt_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_slt_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_uge_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_uge_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ugt_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ugt_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ule_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ule_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ult_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_icmp_ult_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_lshr_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_lshr_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_mul_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_or_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sdiv_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sdiv_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_shl_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_smod_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_smod_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_sub_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_udiv_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_udiv_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_umod_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_umod_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_bool.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: store i1 {{true|false}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_int.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{-?[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_spec_constant_op_xor_uint.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 {{[0-9]+}}, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}
 // CHECK: ret void

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_sub_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_sub_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_switch.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_switch.comp
@@ -33,7 +33,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 42, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_switch_default.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_switch_default.comp
@@ -33,7 +33,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: store i32 0, ptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_udiv_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_umod_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_umod_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec2_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec2_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec3_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec3_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_ivec4_scalar_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_ivec4_scalar_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_bool_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_bool_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec2_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec2_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec3_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec3_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec4_int_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_ivec4_int_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec2_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec2_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec3_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec3_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec4_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_two_uvec4_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec2_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec2_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <2 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec3_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec3_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <3 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/op_xor_uvec4_scalar_uint_operands.comp
+++ b/modules/compiler/spirv-ll/test/glsl/op_xor_uvec4_scalar_uint_operands.comp
@@ -26,7 +26,7 @@ void main() {
 }
 
 // CHECK: ; ModuleID = '{{.*}}'
-// CHECK: define spir_kernel void @main() {
+// CHECK: define spir_kernel void @main() #0 {
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca <4 x i32>

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_bool.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_bool.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = type { i32 }
-// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) #0 {
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = getelementptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, i32 0, i32 0
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = load i32, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_double.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_double.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = type { double }
-// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) #0 {
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = getelementptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, i32 0, i32 0
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = load double, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_float.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_float.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = type { float }
-// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) #0 {
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = getelementptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, i32 0, i32 0
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = load float, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_int.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_int.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = type { i32 }
-// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) #0 {
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = getelementptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, i32 0, i32 0
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = load i32, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/glsl/push_constant_uint.comp
+++ b/modules/compiler/spirv-ll/test/glsl/push_constant_uint.comp
@@ -29,7 +29,7 @@ void main() {
 
 // CHECK: ; ModuleID = '{{.*}}'
 // CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = type { i32 }
-// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) {
+// CHECK: define spir_kernel void @main(ptr addrspace(2){{( %0)?}}) #0 {
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = getelementptr {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}, i32 0, i32 0
 // CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = load i32, ptr addrspace({{[0-9]}}) {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}}

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -151,6 +151,7 @@ set(SPVASM_FILES
   op_forward_pointer_long.spvasm
   op_forward_pointer_uint.spvasm
   op_function_call_import.spvasm
+  op_global_invocation_id.spvasm
   op_glsl_Barrier.spvasm
   op_glsl_FrexpStruct_double.spvasm
   op_glsl_FrexpStruct_dvec2.spvasm

--- a/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
@@ -32,6 +32,5 @@
       %entry = OpLabel
                OpReturn
                OpFunctionEnd
-; CHECK: Function Attrs: noinline optnone
 ; CHECK: define spir_kernel void @foo() [[ATTRS:#[0-9]]]
-; CHECK: attributes [[ATTRS]] = { noinline optnone }
+; CHECK: attributes [[ATTRS]] = { noinline nounwind optnone }

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_global.spvasm
@@ -36,7 +36,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_decPU3AS1Vi(ptr addrspace(1) {{%[a-zA-Z0-9_]+}})
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_decPU3AS1Vi(ptr addrspace(1))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_signed_local.spvasm
@@ -35,7 +35,7 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: @0 = internal addrspace(3) global i32 0
-; CHECK: define spir_kernel void @test() {
+; CHECK: define spir_kernel void @test() #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_decPU3AS3Vi(ptr addrspace(3) @0)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_decPU3AS3Vi(ptr addrspace(3))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_global.spvasm
@@ -35,7 +35,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_decPU3AS1Vj(ptr addrspace(1) {{%[a-zA-Z0-9_]+}})
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_decPU3AS1Vj(ptr addrspace(1))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_decrement_unsigned_local.spvasm
@@ -34,7 +34,7 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: @0 = internal addrspace(3) global i32 0
-; CHECK: define spir_kernel void @test() {
+; CHECK: define spir_kernel void @test() #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_decPU3AS3Vj(ptr addrspace(3) @0)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_decPU3AS3Vj(ptr addrspace(3))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_global.spvasm
@@ -36,7 +36,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_incPU3AS1Vi(ptr addrspace(1) {{%[a-zA-Z0-9_]+}})
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_incPU3AS1Vi(ptr addrspace(1))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_signed_local.spvasm
@@ -35,7 +35,7 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: @0 = internal addrspace(3) global i32 0
-; CHECK: define spir_kernel void @test() {
+; CHECK: define spir_kernel void @test() #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_incPU3AS3Vi(ptr addrspace(3) @0)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_incPU3AS3Vi(ptr addrspace(3))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_global.spvasm
@@ -35,7 +35,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+; CHECK: define spir_kernel void @test(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_incPU3AS1Vj(ptr addrspace(1) {{%[a-zA-Z0-9_]+}})
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_incPU3AS1Vj(ptr addrspace(1))

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_increment_unsigned_local.spvasm
@@ -34,7 +34,7 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: @0 = internal addrspace(3) global i32 0
-; CHECK: define spir_kernel void @test() {
+; CHECK: define spir_kernel void @test() #0 {
 ; CHECK: {{%[a-zA-Z0-9_]+}} = call spir_func i32 @_Z10atomic_incPU3AS3Vj(ptr addrspace(3) @0)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_incPU3AS3Vj(ptr addrspace(3))

--- a/modules/compiler/spirv-ll/test/spvasm/op_composite_construct.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_composite_construct.spvasm
@@ -44,7 +44,7 @@
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: [[STRUCT:%[a-zA-Z0-9_]+]] = type { <2 x i32>, i32, i32 }
-; CHECK: define spir_kernel void @main() {
+; CHECK: define spir_kernel void @main() #0 {
 ; CHECK: [[VAR:%[a-zA-Z0-9_]+]] = alloca [[STRUCT]]
 ; CHECK: store [[STRUCT]] { <2 x i32> <i32 42, i32 3>, i32 3, i32 42 }, ptr [[VAR]]
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -42,14 +42,15 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                    %1 = OpLabel
        %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
+; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
                    %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, i32 16, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr [[SAMPLER]], float 1.000000e+00)
                    %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %uint_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, i32 16, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr [[SAMPLER]], i32 1)
                    %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, i32 16, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr [[SAMPLER]], float 1.000000e+00)
                    %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %uint_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, i32 16, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr [[SAMPLER]], i32 1)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -47,14 +47,15 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
+; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 16, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2uint_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 16, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 16, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2uint_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 16, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -48,14 +48,15 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
+; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 16, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 16, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 16, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 16, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -45,14 +45,15 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
+; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 16, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 16, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 16, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 16, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -45,14 +45,15 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
+; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 16, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 16, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 16, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 16, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_double_operands.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_double_operands.spvasm
@@ -50,7 +50,7 @@
                OpFunctionEnd
 
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @main() {
+; CHECK: define spir_kernel void @main() #0 {
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca double
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_float_operands.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_fcmp_one_two_float_operands.spvasm
@@ -49,7 +49,7 @@
                OpFunctionEnd
 
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @main() {
+; CHECK: define spir_kernel void @main() #0 {
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca float
 ; CHECK: {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i1

--- a/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
@@ -60,7 +60,7 @@
                OpFunctionEnd
 
 
-; CHECK: define private spir_func void @foo(i64 {{%.*}}, {{(ptr|i64\*)}} byval(i64) {{%.*}}) {
+; CHECK: define private spir_func void @foo(i64 {{%.*}}, {{(ptr|i64\*)}} byval(i64) {{%.*}}) #0 {
 %foo = OpFunction %void None %foo_fn_ty
   %0 = OpFunctionParameter %ulong
 %ptr = OpFunctionParameter %ptr_ty

--- a/modules/compiler/spirv-ll/test/spvasm/op_global_invocation_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_global_invocation_id.spvasm
@@ -1,0 +1,52 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
+               OpCapability Kernel
+               OpCapability Addresses
+               OpCapability Int64
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %main "main" %global_id
+
+               OpDecorate %global_id BuiltIn GlobalInvocationId
+
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint_t = OpTypeInt 32 0
+       %size_t = OpTypeInt 64 0
+    %v3uint = OpTypeVector %size_t 3
+ %_ptr_Function_uint = OpTypePointer Function %size_t
+  %_ptr_Input_v3uint = OpTypePointer Input %v3uint
+    %_ptr_Input_uint = OpTypePointer Input %size_t
+%global_id = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint_t 0
+     %size_t_4 = OpConstant %size_t 4
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %id = OpLoad %v3uint %global_id
+; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+         %45 = OpVectorExtractDynamic %size_t %id %uint_0
+         %14 = OpIAdd %size_t %45 %size_t_4
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: declare spir_func i64 @_Z13get_global_idj(i32) [[ATTRS:#[0-9]+]]
+
+; CHECK-GE16: attributes [[ATTRS]] = { nounwind memory(read) }
+; CHECK-LT16: attributes [[ATTRS]] = { nounwind readonly }

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_decorate.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_decorate.spvasm
@@ -86,7 +86,7 @@
      %uint_0 = OpConstant %uint 0
       %int_0 = OpConstant %int 0
        %main = OpFunction %void None %3
-; CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}, ptr addrspace(1){{( %3)?}}, ptr addrspace(1){{( %4)?}}) {
+; CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}, ptr addrspace(1){{( %2)?}}, ptr addrspace(1){{( %3)?}}, ptr addrspace(1){{( %4)?}}) #0 {
           %5 = OpLabel
          %id = OpVariable %_ptr_Function_uint Function
 ; CHECK:   {{[%@][-a-zA-Z$._0-9][-a-zA-Z$._0-9]*}} = alloca i32

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_member_decorate.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_member_decorate.spvasm
@@ -61,7 +61,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: [[STRUCT:%[a-zA-Z0-9_]+]] = type { i32, i32 }
-; CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) {
+; CHECK: define spir_kernel void @main(ptr addrspace(1){{( %0)?}}, ptr addrspace(1){{( %1)?}}) #0 {
 ; CHECK: [[IN_GEP:%[a-zA-Z0-9_]+]] = getelementptr [[STRUCT]], ptr addrspace(1) %0, i32 0, i32 0
 ; Check that the volatile decoration was correctly propagated to the result of the GEP
 ; CHECK: {{%[a-zA-Z0-9_]+}} = load volatile i32, ptr addrspace(1) [[IN_GEP]]

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -44,7 +44,7 @@
            %4 = OpImageRead %float4_t %get_image %int_0
                 OpReturn
                 OpFunctionEnd
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %image, i32{{( %0)?}})
+; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %image, ptr{{( %0)?}})
 ; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di(ptr addrspace(1) %image, i32 0)
 ; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di(ptr addrspace(1) %image, i32 0)
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -42,17 +42,17 @@
            %image1d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(i32 %in_sampler, ptr addrspace(1) %in_image)
+; CHECK: define spir_kernel void @image1d(ptr %in_sampler, ptr addrspace(1) %in_image)
                 %10 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                 %11 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, i32 %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr %in_sampler, float 1.000000e+00)
                 %12 = OpImageSampleExplicitLod %v4float_t %sampled_image %int_1 None 
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, i32 %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr %in_sampler, i32 1)
                 %15 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, i32 %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr %in_sampler, float 1.000000e+00)
                 %16 = OpImageSampleExplicitLod %v4uint_t %sampled_image %int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, i32 %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr %in_sampler, i32 1)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -46,17 +46,17 @@
      %image1d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(i32 %in_sampler, ptr addrspace(1) %in_image)
+; CHECK: define spir_kernel void @image1d_array(ptr %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -46,17 +46,17 @@
            %image2d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(i32 %in_sampler, ptr addrspace(1) %in_image)
+; CHECK: define spir_kernel void @image2d(ptr %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, i32 %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -44,17 +44,17 @@
      %image2d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(i32 %in_sampler, ptr addrspace(1) %in_image)
+; CHECK: define spir_kernel void @image2d_array(ptr %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
         %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -45,17 +45,17 @@
            %image3d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(i32 %in_sampler, ptr addrspace(1) %in_image)
+; CHECK: define spir_kernel void @image3d(ptr %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, i32 %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_spec_constant_op_fmod_double.spvasm
@@ -43,7 +43,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @main() {
+; CHECK: define spir_kernel void @main() #0 {
 ; CHECK: [[MOD:%[a-zA-Z0-9_]+]] = call spir_func double @_Z4fmoddd(double -4.242000e+01, double -4.242000e+01)
 ; CHECK: [[SPEC:%[a-zA-Z0-9_]+]] = call spir_func double @_Z8copysigndd(double [[MOD]], double -4.242000e+01)
 ; CHECK: br label {{%[a-zA-Z0-9_]+}}

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
@@ -23,12 +23,16 @@
                         OpEntryPoint Kernel %sampler_type "sampler_type"
                         OpSource OpenCL_C 120
                 %void = OpTypeVoid
-           %sampler_t = OpTypeSampler
-        %sampler_fn_t = OpTypeFunction %void %sampler_t             
+          %sampler1_t = OpTypeSampler
+          %sampler2_t = OpTypeSampler
+        %sampler_fn_t = OpTypeFunction %void %sampler1_t %sampler2_t
         %sampler_type = OpFunction %void None %sampler_fn_t
-; CHECK: define spir_kernel void @sampler_type(i32{{( %0)?}})
+; CHECK: define spir_kernel void @sampler_type(ptr{{( %0)?}}, ptr{{( %1)?}}){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
   %sampler_type_enter = OpLabel
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd
 ; CHECK: }
+
+; Check that both sampler types are made identical
+; CHECK: [[MD]] = !{!"sampler_t", !"sampler_t"}


### PR DESCRIPTION
Running the `SpirFixupPass` on `SPIR-V` inputs has always been awkward, given the two IRs aren't strictly related, and we're in full control of the SPIR-V to IR translation layer (i.e., `spirv-ll`).

The idea of `spirv-ll` is to generate correct spec-conformant IR out of the gate, so relying on fixups is bad form.

This was a long-standing backlog task but was spurred on by the work to update the compiler for LLVM 17, where we need to perform different fixups for SPIR 1.2 and SPIR-V, meaning the single fixup pass was going to become burdensome. It's also unclear whether we want to support SPIR 1.2 for much longer, and so this PR will allow us to remove the eponymous fixup pass alongside the IR.