### PR TITLE
[ci] Fix typo causing some PR workflows not to trigger

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - 'source/**'
-      - 'module/**'
+      - 'modules/**'
       - 'examples/**'
       - 'cmake/**'
       - 'hal/**'


### PR DESCRIPTION
If a PR only touched modules/, as #55 does, the PR actions weren't triggering due to this typo.