### PR TITLE
[spirv-ll] Update to generate Target Extension Types in LLVM 17

### DIFF
--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(spirv-ll PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source)
 target_include_directories(spirv-ll SYSTEM PUBLIC
   ${spirv-headers_SOURCE_DIR}/include ${LLVM_INCLUDE_DIR})
-target_link_libraries(spirv-ll PUBLIC cargo multi_llvm LLVMCore LLVMBitWriter)
+target_link_libraries(spirv-ll PUBLIC cargo multi_llvm compiler-utils LLVMCore LLVMBitWriter)
 
 add_subdirectory(tools)
 if(CA_ENABLE_TESTS)

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -318,6 +318,7 @@ class Module : public ModuleHeader {
   const OpExecutionMode *getExecutionMode(spv::Id entryPoint,
                                           spv::ExecutionMode mode) const;
 
+#if LLVM_VERSION_LESS(17, 0)
   /// @brief Register an ID as corresponding to an internal struct type. These
   /// are opaque types such as image and events for which we pass pointers
   /// to structs around. We need to log the underlying struct type separately
@@ -334,6 +335,7 @@ class Module : public ModuleHeader {
   ///
   /// @return Returns a pointer to the type if found, `nullptr` otherwise.
   llvm::StructType *getInternalStructType(spv::Id ty) const;
+#endif
 
   /// @brief Sets the internally stored source language enum.
   void setSourceLanguage(const spv::SourceLanguage sourceLang);
@@ -1017,9 +1019,11 @@ class Module : public ModuleHeader {
   llvm::DenseMap<spv::Id, llvm::SmallVector<const OpExecutionMode *, 2>>
       ExecutionModes;
 
+#if LLVM_VERSION_LESS(17, 0)
   /// @brief A map of ID's to internal opaque struct types. Currently only used
   /// for images and events.
   llvm::DenseMap<spv::Id, llvm::StructType *> InternalStructureTypes;
+#endif
 
   /// @brief Source language enum reported by OpSource.
   spv::SourceLanguage sourceLanguage;

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -27,6 +27,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
+#include <multi_llvm/llvm_version.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/opcodes.h>
 #include <spirv/unified1/spirv.hpp>

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -759,18 +759,6 @@ class Module : public ModuleHeader {
   /// @param type_id ID of the type that was defined.
   void updateIncompletePointer(spv::Id type_id);
 
-  /// @brief Store the ID of the declared sampler type.
-  ///
-  /// We don't need to worry about multiple sampler types being declared as
-  /// OpTypeSampler doens't take any arguments and duplicate type declarations
-  /// are illegal.
-  void setSampler(spv::Id sampler);
-
-  /// @brief Get the stored sampler type ID.
-  ///
-  /// @return ID of the stored sampler type.
-  spv::Id getSampler() const;
-
   /// @brief Add id, image and sampler to the module.
   ///
   /// @param[in] id The ID to add.
@@ -1103,8 +1091,6 @@ class Module : public ModuleHeader {
       IncompleteStructs;
   /// @brief Map incomplete pointers and pointed to types.
   llvm::DenseMap<const OpTypePointer *, spv::Id> IncompletePointers;
-  /// @brief ID of the declared sampler type.
-  spv::Id SamplerID;
   /// @brief Map of IDs that correspond to sampled image structs.
   llvm::DenseMap<spv::Id, SampledImage> SampledImagesMap;
 

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <compiler/utils/target_extension_types.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/Support/type_traits.h>
 #include <multi_llvm/optional_helper.h>
@@ -1250,6 +1251,25 @@ std::string spirv_ll::Builder::getMangledTypeName(
     }
     if (tyName == "spirv.Sampler") {
       return "11ocl_sampler";
+    }
+    if (tyName == "spirv.Image") {
+      // TODO: This only covers the small range of images we support.
+      auto dim = tgtExtTy->getIntParameter(
+          compiler::utils::tgtext::ImageTyDimensionalityIdx);
+      auto arrayed =
+          tgtExtTy->getIntParameter(compiler::utils::tgtext::ImageTyArrayedIdx);
+      switch (dim) {
+        default:
+          break;
+        case compiler::utils::tgtext::ImageDim1D:
+          return arrayed ? "16ocl_image1darray" : "11ocl_image1d";
+        case compiler::utils::tgtext::ImageDim2D:
+          return arrayed ? "16ocl_image2darray" : "11ocl_image2d";
+        case compiler::utils::tgtext::ImageDim3D:
+          return "11ocl_image3d";
+        case compiler::utils::tgtext::ImageDimBuffer:
+          return "17ocl_image1dbuffer";
+      }
     }
 #endif
   }

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1242,6 +1242,13 @@ std::string spirv_ll::Builder::getMangledTypeName(
     }
     return "P" +
            getMangledTypeName(ty->getArrayElementType(), eltMangleInfo, subTys);
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+  } else if (auto *tgtExtTy = llvm::dyn_cast<llvm::TargetExtType>(ty)) {
+    auto tyName = tgtExtTy->getName();
+    if (tyName == "spirv.Sampler") {
+      return "11ocl_sampler";
+    }
+#endif
   }
   llvm_unreachable("mangler: unsupported argument type");
 }

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1245,6 +1245,9 @@ std::string spirv_ll::Builder::getMangledTypeName(
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
   } else if (auto *tgtExtTy = llvm::dyn_cast<llvm::TargetExtType>(ty)) {
     auto tyName = tgtExtTy->getName();
+    if (tyName == "spirv.Event") {
+      return "9ocl_event";
+    }
     if (tyName == "spirv.Sampler") {
       return "11ocl_sampler";
     }

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -162,6 +162,7 @@ const spirv_ll::OpExecutionMode *spirv_ll::Module::getExecutionMode(
   return nullptr;
 }
 
+#if LLVM_VERSION_LESS(17, 0)
 void spirv_ll::Module::addInternalStructType(spv::Id ty,
                                              llvm::StructType *structTy) {
   InternalStructureTypes[ty] = structTy;
@@ -174,6 +175,7 @@ llvm::StructType *spirv_ll::Module::getInternalStructType(spv::Id ty) const {
   }
   return nullptr;
 }
+#endif
 
 void spirv_ll::Module::setSourceLanguage(spv::SourceLanguage sourceLang) {
   sourceLanguage = sourceLang;

--- a/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
@@ -87,7 +87,14 @@
 ;      point to those for the variable `a`, adding an OpLine before `main`'s
 ;      OpFunction has no effect.
 ; CHECK: [[mainLexicalBlock]] = distinct !DILexicalBlock(scope: [[mainSubprogram:![0-9]+]], file: [[File]], line: 6, column: 3)
-; CHECK: [[mainSubprogram]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: [[File]], line: 6, type: [[mainSubroutineType:![0-9]+]], {{(isLocal: true, isDefinition: true, )?}}scopeLine: 1, {{(isOptimized: false|spFlags: DISPFlagDefinition)}}, {{(unit: ![0-9], )?}}{{(variables|retainedNodes)}}: !{{[0-9]+}})
+; CHECK: [[mainSubprogram]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: [[File]],
+; CHECK-SAME: line: 6, type: [[mainSubroutineType:![0-9]+]]
+; CHECK-SAME: {{(, isLocal: true, isDefinition: true)?}}, scopeLine: 1
+; CHECK-SAME: {{(, isOptimized: false)?}}
+; CHECK-SAME: {{(, spFlags: DISPFlagDefinition)?}}
+; CHECK-SAME: {{(, unit: ![0-9]+)?}}
+; CHECK-SAME: {{(, (variables|retainedNodes): ![0-9]+)?}}
+; CHECK-SAME: )
 ; CHECK: [[mainSubroutineType]] = !DISubroutineType(types: !{{[0-9]+}})
 ; CHECK: [[bLocation]] = !DILocation(line: 7, column: 3, scope: [[mainLexicalBlock]])
 ; CHECK: [[ifConditionLocation]] = !DILocation(line: 8, column: 3, scope: [[mainLexicalBlock]])

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel
                         OpCapability Addresses
@@ -42,15 +43,16 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                    %1 = OpLabel
        %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
+; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
+; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                    %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr [[SAMPLER]], float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
                    %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr [[SAMPLER]], i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
                    %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr [[SAMPLER]], float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
                    %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr [[SAMPLER]], i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -17,7 +17,6 @@
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
-; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -40,19 +39,20 @@
        %const_sampler = OpConstantSampler %sampler_t None 0 Nearest
     %constant_sampler = OpFunction %void_t None %sampler_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
        %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
 ; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                    %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
                    %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
                    %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
                    %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], i32 1)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -47,15 +48,16 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
+; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
+; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -45,19 +45,20 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image1d_array_ro_t
-; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
 ; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2uint_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -48,15 +49,16 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
+; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
+; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -46,19 +46,20 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_ro_t
-; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
 ; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -45,15 +46,16 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
+; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
+; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -43,19 +43,20 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_array_ro_t
-; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
 ; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -45,15 +46,16 @@
 ; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK: [[SAMPLER:%.*]] = call ptr @__translate_sampler_initializer(i32 16)
+; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
+; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -43,19 +43,20 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image3d_ro_t
-; CHECK: define spir_kernel void @constant_sampler(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
 ; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -53,10 +54,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]] 
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]] 
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -53,10 +54,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]]
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -52,10 +53,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]]
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -52,10 +53,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]]
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -54,10 +55,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]]
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -53,10 +54,12 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
-; CHECK: [[EVENT_VAR:%[a-zA-Z0-9_]+]] = alloca ptr
-; CHECK: [[EVENT:%[a-zA-Z0-9_]+]] = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, ptr null)
-; CHECK: store ptr [[EVENT]], ptr [[EVENT_VAR]]
+; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
+; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
+; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void
-; CHECK: declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, ptr)
+; CHECK: declare spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1), ptr addrspace(3), i64, i64, [[EVENT_TY]])
 ; CHECK: declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -44,7 +45,8 @@
            %4 = OpImageRead %float4_t %get_image %int_0
                 OpReturn
                 OpFunctionEnd
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %image, ptr{{( %0)?}})
+; CHECK-GE17: define spir_kernel void @image1d(ptr addrspace(1) %image, target("spirv.Sampler"){{( %0)?}})
+; CHECK-LT17: define spir_kernel void @image1d(ptr addrspace(1) %image, ptr{{( %0)?}})
 ; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di(ptr addrspace(1) %image, i32 0)
 ; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di(ptr addrspace(1) %image, i32 0)
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -45,9 +45,9 @@
            %4 = OpImageRead %float4_t %get_image %int_0
                 OpReturn
                 OpFunctionEnd
-; CHECK-GE17: define spir_kernel void @image1d(ptr addrspace(1) %image, target("spirv.Sampler"){{( %0)?}})
-; CHECK-LT17: define spir_kernel void @image1d(ptr addrspace(1) %image, ptr{{( %0)?}})
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di(ptr addrspace(1) %image, i32 0)
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di(ptr addrspace(1) %image, i32 0)
+; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image, target("spirv.Sampler"){{( %0)?}})
+; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] %image, ptr{{( %0)?}})
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[IMG_TY]] %image, i32 0)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di([[IMG_TY]] %image, i32 0)
 ; CHECK: ret void
 ; CHECK: }

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image1d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image1d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image1darray(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image1darray([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK: define spir_kernel void @image1d_buffer(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type17ocl_image1dbuffer(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type17ocl_image1dbuffer([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image2darray(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image2darray([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image3d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image3d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image1d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image1d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order16ocl_image1darray(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order16ocl_image1darray([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK: define spir_kernel void @image1d_buffer(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order17ocl_image1dbuffer(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order17ocl_image1dbuffer([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image2d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image2d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order16ocl_image2darray(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order16ocl_image2darray([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -33,10 +34,11 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image3d(ptr addrspace(1) %in_image)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z23get_image_channel_order11ocl_image3d([[TY]] %in_image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -34,10 +35,11 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %int_t %image %int_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func i32 @_Z15get_image_width11ocl_image1d(ptr addrspace(1) %image)
+; CHECK: {{%.*}} = call spir_func i32 @_Z15get_image_width11ocl_image1d([[IMG_TY]] %image)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,14 +36,15 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
-; CHECK: [[size_result:%[a-zA-Z0-9]+]] = call spir_func [[bitness:[a-zA-Z0-9]+]] @_Z20get_image_array_size16ocl_image1darray(ptr addrspace(1) %image)
-; CHECK: [[size_result_trunc:%[a-zA-Z0-9]+]] = trunc [[bitness]] [[size_result]] to i32
-; CHECK: [[v2int_idx_1:%[a-zA-Z0-9]+]] = insertelement <2 x i32> undef, i32 [[size_result_trunc]], i32 1
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width16ocl_image1darray(ptr addrspace(1) %image)
-; CHECK: {{%[a-zA-Z0-9_]+}} = insertelement <2 x i32> [[v2int_idx_1]], i32 [[width_result]], i32 0
+; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)
+; CHECK: [[size_result_trunc:%.*]] = trunc [[bitness]] [[size_result]] to i32
+; CHECK: [[v2int_idx_1:%.*]] = insertelement <2 x i32> undef, i32 [[size_result_trunc]], i32 1
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width16ocl_image1darray([[IMG_TY]] %image)
+; CHECK: {{%.*}} = insertelement <2 x i32> [[v2int_idx_1]], i32 [[width_result]], i32 0
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 32 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 32 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,13 +36,14 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
-; CHECK: [[size_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z20get_image_array_size16ocl_image1darray(ptr addrspace(1) %image)
-; CHECK: [[v2int_idx_1:%[a-zA-Z0-9]+]] = insertelement <2 x i32> undef, i32 [[size_result]], i32 1
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width16ocl_image1darray(ptr addrspace(1) %image)
-; CHECK: {{%[a-zA-Z0-9_]+}} = insertelement <2 x i32> [[v2int_idx_1]], i32 [[width_result]], i32 0
+; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)
+; CHECK: [[v2int_idx_1:%.*]] = insertelement <2 x i32> undef, i32 [[size_result]], i32 1
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width16ocl_image1darray([[IMG_TY]] %image)
+; CHECK: {{%.*}} = insertelement <2 x i32> [[v2int_idx_1]], i32 [[width_result]], i32 0
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -35,13 +36,14 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width11ocl_image2d(ptr addrspace(1) %image)
-; CHECK: [[v2int_idx_0:%[a-zA-Z0-9]+]] = insertelement <2 x i32> undef, i32 [[width_result]], i32 0
-; CHECK: [[height_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z16get_image_height11ocl_image2d(ptr addrspace(1) %image)
-; CHECK: [[v2int_idx_1:%[a-zA-Z0-9]+]] = insertelement <2 x i32> [[v2int_idx_0]], i32 [[height_result]], i32 1
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image2d([[IMG_TY]] %image)
+; CHECK: [[v2int_idx_0:%.*]] = insertelement <2 x i32> undef, i32 [[width_result]], i32 0
+; CHECK: [[height_result:%.*]] = call spir_func i32 @_Z16get_image_height11ocl_image2d([[IMG_TY]] %image)
+; CHECK: [[v2int_idx_1:%.*]] = insertelement <2 x i32> [[v2int_idx_0]], i32 [[height_result]], i32 1
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -35,16 +36,17 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
-; CHECK: [[size_result:%[a-zA-Z0-9]+]] = call spir_func [[bitness:[a-zA-Z0-9]+]] @_Z20get_image_array_size16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: [[size_result_trunc:%[a-zA-Z0-9]+]] = trunc [[bitness]] [[size_result]] to i32
-; CHECK: [[v3int_idx_2:%[a-zA-Z0-9]+]] = insertelement <3 x i32> undef, i32 [[size_result_trunc]], i32 2
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: [[v3int_idx_0:%[a-zA-Z0-9]+]] = insertelement <3 x i32> [[v3int_idx_2]], i32 [[width_result]], i32 0
-; CHECK: [[height_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z16get_image_height16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: {{%[a-zA-Z0-9_]+}} = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
+; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: [[size_result_trunc:%.*]] = trunc [[bitness]] [[size_result]] to i32
+; CHECK: [[v3int_idx_2:%.*]] = insertelement <3 x i32> undef, i32 [[size_result_trunc]], i32 2
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: [[v3int_idx_0:%.*]] = insertelement <3 x i32> [[v3int_idx_2]], i32 [[width_result]], i32 0
+; CHECK: [[height_result:%.*]] = call spir_func i32 @_Z16get_image_height16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: {{%.*}} = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 32 -c SampledBuffer %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 32 -c SampledBuffer %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -35,15 +36,16 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
-; CHECK: [[size_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z20get_image_array_size16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: [[v3int_idx_2:%[a-zA-Z0-9]+]] = insertelement <3 x i32> undef, i32 [[size_result]], i32 2
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: [[v3int_idx_0:%[a-zA-Z0-9]+]] = insertelement <3 x i32> [[v3int_idx_2]], i32 [[width_result]], i32 0
-; CHECK: [[height_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z16get_image_height16ocl_image2darray(ptr addrspace(1) %image)
-; CHECK: {{%[a-zA-Z0-9_]+}} = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
+; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: [[v3int_idx_2:%.*]] = insertelement <3 x i32> undef, i32 [[size_result]], i32 2
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: [[v3int_idx_0:%.*]] = insertelement <3 x i32> [[v3int_idx_2]], i32 [[width_result]], i32 0
+; CHECK: [[height_result:%.*]] = call spir_func i32 @_Z16get_image_height16ocl_image2darray([[IMG_TY]] %image)
+; CHECK: {{%.*}} = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,15 +36,16 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image3d([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image3d([[IMG_TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
-; CHECK: [[width_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_width11ocl_image3d(ptr addrspace(1) %image)
-; CHECK: [[v3int_idx_0:%[a-zA-Z0-9]+]] = insertelement <3 x i32> undef, i32 [[width_result]], i32 0
-; CHECK: [[height_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z16get_image_height11ocl_image3d(ptr addrspace(1) %image)
-; CHECK: [[v3int_idx_1:%[a-zA-Z0-9]+]] = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
-; CHECK: [[depth_result:%[a-zA-Z0-9]+]] = call spir_func i32 @_Z15get_image_depth11ocl_image3d(ptr addrspace(1) %image)
-; CHECK: [[v3int_ptr_idx_2:%[a-zA-Z0-9]+]] = insertelement <3 x i32> [[v3int_idx_1]], i32 [[depth_result]], i32 2
+; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image3d([[IMG_TY]] %image)
+; CHECK: [[v3int_idx_0:%.*]] = insertelement <3 x i32> undef, i32 [[width_result]], i32 0
+; CHECK: [[height_result:%.*]] = call spir_func i32 @_Z16get_image_height11ocl_image3d([[IMG_TY]] %image)
+; CHECK: [[v3int_idx_1:%.*]] = insertelement <3 x i32> [[v3int_idx_0]], i32 [[height_result]], i32 1
+; CHECK: [[depth_result:%.*]] = call spir_func i32 @_Z15get_image_depth11ocl_image3d([[IMG_TY]] %image)
+; CHECK: [[v3int_ptr_idx_2:%.*]] = insertelement <3 x i32> [[v3int_idx_1]], i32 [[depth_result]], i32 2
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -34,12 +35,13 @@
       %uint_0 = OpConstant %uint_t 0
      %image1d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %uint_0
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di(ptr addrspace(1) %image, i32 0)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[TY]] %image, i32 0)
            %4 = OpImageRead %float4_t %image %uint_0
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di(ptr addrspace(1) %image, i32 0)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di([[TY]] %image, i32 0)
                 OpReturn
 ; CHECK: ret void
                 OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -36,12 +37,13 @@
             %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
    %image1d_array = OpFunction %void_t None %foo_t
            %image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %image)
                %1 = OpLabel
                %3 = OpImageRead %uint4_t %image %int2_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darrayDv2_i(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darrayDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)
                %4 = OpImageRead %float4_t %image %int2_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darrayDv2_i(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darrayDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)
                     OpReturn
 ; CHECK: ret void
                     OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability ImageBasic
@@ -34,12 +35,13 @@
                %int_0 = OpConstant %uint_t 0
       %image1d_buffer = OpFunction %void_t None %foo_t
                %image = OpFunctionParameter %image1d_buffer_t
-; CHECK: define spir_kernel void @image1d_buffer(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %image)
                    %1 = OpLabel
                    %3 = OpImageRead %uint4_t %image %int_0
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui17ocl_image1dbufferi(ptr addrspace(1) %image, i32 0)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui17ocl_image1dbufferi([[TY]] %image, i32 0)
                    %4 = OpImageRead %float4_t %image %int_0
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef17ocl_image1dbufferi(ptr addrspace(1) %image, i32 0)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef17ocl_image1dbufferi([[TY]] %image, i32 0)
                         OpReturn
 ; CHECK: ret void
                         OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %t
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability Sampled1D
@@ -36,12 +37,13 @@
       %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
      %image2d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int2_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2dDv2_i(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2dDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)
            %4 = OpImageRead %float4_t %image %int2_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2dDv2_i(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2dDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)
                 OpReturn
 ; CHECK: ret void
                 OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability ImageBasic
@@ -35,12 +36,13 @@
             %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image2d_array = OpFunction %void_t None %foo_t
              %image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %image)
                  %1 = OpLabel
                  %3 = OpImageRead %uint4_t %image %int4_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darrayDv4_i(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darrayDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %4 = OpImageRead %float4_t %image %int4_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darrayDv4_i(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darrayDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -35,12 +36,13 @@
       %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image3d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int4_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3dDv4_i(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3dDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
            %4 = OpImageRead %float4_t %image %int4_1
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3dDv4_i(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3dDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                 OpReturn
 ; CHECK: ret void
                 OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -43,18 +43,20 @@
            %image1d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
                 %10 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                 %11 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
                 %12 = OpImageSampleExplicitLod %v4float_t %sampled_image %int_1 None 
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
                 %15 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
                 %16 = OpImageSampleExplicitLod %v4uint_t %sampled_image %int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -42,17 +43,18 @@
            %image1d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @image1d(ptr %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
                 %10 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                 %11 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
                 %12 = OpImageSampleExplicitLod %v4float_t %sampled_image %int_1 None 
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
                 %15 = OpImageSampleExplicitLod %v4uint_t %sampled_image %float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, ptr %in_sampler, float 1.000000e+00)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, float 1.000000e+00)
                 %16 = OpImageSampleExplicitLod %v4uint_t %sampled_image %int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, ptr %in_sampler, i32 1)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_sampleri(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, i32 1)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -46,17 +47,18 @@
      %image1d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -47,18 +47,20 @@
      %image1d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darray11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -46,17 +47,18 @@
            %image2d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, ptr %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -47,18 +47,20 @@
            %image2d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v2int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2d11ocl_samplerDv2_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <2 x i32> <i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -45,18 +45,20 @@
      %image2d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
         %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -44,17 +45,18 @@
      %image2d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
         %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darray11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -45,17 +46,18 @@
            %image3d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, ptr %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -46,18 +46,20 @@
            %image3d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler, ptr addrspace(1) %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] %in_sampler, ptr addrspace(1) %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                  %6 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4float_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                  %7 = OpImageSampleExplicitLod %v4uint_t %sampled_image %v4int_1 None
-; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i(ptr addrspace(1) %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: {{%.*}} = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3d11ocl_samplerDv4_i([[IMG_TY]] %in_image, [[SAMPLER_TY]] %in_sampler, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                       OpReturn
 ; CHECK: ret void                         
                       OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -45,12 +45,13 @@
 ; All functions              
                     %test = OpFunction %void_t None %test
                    %image = OpFunctionParameter %image1d_t
-; CHECK: define spir_kernel void @test(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @test([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @test([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %int_0 %float4_color
-; CHECK: call spir_func void @_Z12write_imagef11ocl_image1diDv4_f(ptr addrspace(1) %image, i32 0, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef11ocl_image1diDv4_f([[TY]] %image, i32 0, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %int_0 %uint4_color
-; CHECK: call spir_func void @_Z13write_imageui11ocl_image1diDv4_j(ptr addrspace(1) %image, i32 0, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui11ocl_image1diDv4_j([[TY]] %image, i32 0, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -43,12 +43,13 @@
 ; All functions
            %image1d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_array_t
-; CHECK: define spir_kernel void @image1d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
-; CHECK: call spir_func void @_Z12write_imagef16ocl_image1darrayDv2_iDv4_f(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef16ocl_image1darrayDv2_iDv4_f([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %v2int_1 %v4uint_1
-; CHECK: call spir_func void @_Z13write_imageui16ocl_image1darrayDv2_iDv4_j(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui16ocl_image1darrayDv2_iDv4_j([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -41,12 +41,13 @@
 ; All functions
           %image1d_buffer = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_buffer_t
-; CHECK: define spir_kernel void @image1d_buffer(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %uint_1 %v4float_1
-; CHECK: call spir_func void @_Z12write_imagef17ocl_image1dbufferiDv4_f(ptr addrspace(1) %image, i32 1, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef17ocl_image1dbufferiDv4_f([[TY]] %image, i32 1, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %uint_1 %v4uint_1
-; CHECK: call spir_func void @_Z13write_imageui17ocl_image1dbufferiDv4_j(ptr addrspace(1) %image, i32 1, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui17ocl_image1dbufferiDv4_j([[TY]] %image, i32 1, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -44,12 +44,13 @@
 ; All functions
                  %image2d = OpFunction %void_t None %image_write_fn_t                            
                    %image = OpFunctionParameter %image2d_t
-; CHECK: define spir_kernel void @image2d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
-; CHECK: call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %v2int_1 %v4uint_1
-; CHECK: call spir_func void @_Z13write_imageui11ocl_image2dDv2_iDv4_j(ptr addrspace(1) %image, <2 x i32> <i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui11ocl_image2dDv2_iDv4_j([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability StorageImageWriteWithoutFormat
@@ -41,12 +41,13 @@
 ; All functions
            %image2d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image2d_array_t
-; CHECK: define spir_kernel void @image2d_array(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4int_1 %v4float_1
-; CHECK: call spir_func void @_Z12write_imagef16ocl_image2darrayDv4_iDv4_f(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef16ocl_image2darrayDv4_iDv4_f([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %v4int_1 %v4int_1
-; CHECK: call spir_func void @_Z13write_imageui16ocl_image2darrayDv4_iDv4_j(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui16ocl_image2darrayDv4_iDv4_j([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
@@ -15,8 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
-; CHECK: ; ModuleID = '{{.*}}'
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -41,12 +41,13 @@
 ; All functions
                  %image3d = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image3d_t
-; CHECK: define spir_kernel void @image3d(ptr addrspace(1) %image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4uint_1 %v4float_1
-; CHECK: call spir_func void @_Z12write_imagef11ocl_image3dDv4_iDv4_f(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; CHECK: call spir_func void @_Z12write_imagef11ocl_image3dDv4_iDv4_f([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
                             OpImageWrite %image %v4uint_1 %v4uint_1
-; CHECK: call spir_func void @_Z13write_imageui11ocl_image3dDv4_iDv4_j(ptr addrspace(1) %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
+; CHECK: call spir_func void @_Z13write_imageui11ocl_image3dDv4_iDv4_j([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)
                             OpReturn
 ; CHECK: ret void
                             OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
 
                         OpCapability Kernel
                         OpCapability Addresses
@@ -57,11 +58,14 @@
 
 ; CHECK: define spir_kernel void @my_kernel(ptr addrspace(1) %a,
 ; CHECK-SAME:                              [3 x ptr addrspace(1)] %b, ptr addrspace(3) %c,
-; CHECK-SAME:                              ptr addrspace(1) %d, ptr addrspace(1) %e)
+; CHECK-GE17-SAME:                         target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %d
+; CHECK-LT17-SAME:                         ptr addrspace(1) %d
+; CHECK-SAME:                              ptr addrspace(1) %e)
 
 ; CHECK-SAME: !kernel_arg_addr_space !0 !kernel_arg_access_qual !1 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !3 !kernel_arg_name !4 {
 
-; CHECK: !0 = !{i32 1, i32 0, i32 3, i32 1, i32 1}
+; CHECK-GE17: !0 = !{i32 1, i32 0, i32 3, i32 0, i32 1}
+; CHECK-LT17: !0 = !{i32 1, i32 0, i32 3, i32 1, i32 1}
 ; CHECK: !1 = !{!"none", !"none", !"none", !"read_only", !"none"}
 ; CHECK: !2 = !{!"array*", !"array", !"sampler_t*", !"image2d_t", !"image2d_t*"}
 ; CHECK: !3 = !{!"", !"", !"", !"", !""}

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
@@ -15,7 +15,8 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel
                         OpCapability Addresses
@@ -27,7 +28,8 @@
           %sampler2_t = OpTypeSampler
         %sampler_fn_t = OpTypeFunction %void %sampler1_t %sampler2_t
         %sampler_type = OpFunction %void None %sampler_fn_t
-; CHECK: define spir_kernel void @sampler_type(ptr{{( %0)?}}, ptr{{( %1)?}}){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
+; CHECK-GE17: define spir_kernel void @sampler_type(target("spirv.Sampler") %0, target("spirv.Sampler") %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
+; CHECK-LT17: define spir_kernel void @sampler_type(ptr %0, ptr %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
   %sampler_type_enter = OpLabel
                         OpReturn
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
@@ -16,7 +16,8 @@
 
 ; REQUIRES: spirv-as-v2020+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
 
                         OpCapability Addresses
                         OpCapability Linkage
@@ -56,11 +57,13 @@
                %entry = OpLabel
 
 
-; CHECK: [[inEvent:%[a-zA-Z0-9]+]] = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr null)
+; CHECK-GE17: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") zeroinitializer)
+; CHECK-LT17: [[inEvent:%.*]] = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr null)
              %inEvent = OpExtInst %eventT %groupAsyncCopies 1 %scratch %int64Zero %in %int64Zero %sizeofInt32T %numBytesPerLine %numLines %lineLength %lineLength %nullEvent
 
 
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr [[inEvent]])
+; CHECK-GE17: {{%.*}} = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") [[inEvent]])
+; CHECK-LT17: {{%.*}} = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr [[inEvent]])
             %outEvent = OpExtInst %eventT %groupAsyncCopies 1 %out %int64Zero %scratch %int64Zero %sizeofInt32T %numBytesPerLine %numLines %lineLength %lineLength %inEvent
 
                         OpReturn

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
@@ -16,7 +16,8 @@
 
 ; REQUIRES: spirv-as-v2020+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
 
                         OpCapability Addresses
                         OpCapability Linkage
@@ -58,11 +59,13 @@
                %entry = OpLabel
 
 
-; CHECK: [[inEvent:%[a-zA-Z0-9]+]] = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr null)
+; CHECK-GE17: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") zeroinitializer)
+; CHECK-LT17: [[inEvent:%.*]] = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr null)
              %inEvent = OpExtInst %eventT %groupAsyncCopies 2 %scratch %int64Zero %in %int64Zero %sizeofInt32T %numBytesPerLine %numLines %numPlanes %lineLength %planeArea %lineLength %planeArea %nullEvent
 
 
-; CHECK: {{%[a-zA-Z0-9]+}} = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr [[inEvent]])
+; CHECK-GE17: {{%.*}} = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") [[inEvent]])
+; CHECK-LT17: {{%.*}} = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr [[inEvent]])
             %outEvent = OpExtInst %eventT %groupAsyncCopies 2 %out %int64Zero %scratch %int64Zero %sizeofInt32T %numBytesPerLine %numLines %numPlanes %lineLength %planeArea %lineLength %planeArea %inEvent
 
                         OpReturn


### PR DESCRIPTION
To match the IR generated by clang, this PR updates `spirv-ll` to generate target extension types:

* `target("spirv.Sampler")` for `OpTypeSampler`
* `target("spirv.Event")` for `OpTypeEvent`
* `target("spirv.Image", ...)` for `OpTypeImage`

This is fairly straightforward, given SPIR-V is a natural fit for these types (the clue's in the name). It allows us to simplify and deprecate some of the old code.