### PR TITLE
Don't propagate alignment decorations down access chains

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1647,13 +1647,6 @@ cargo::optional<Error> Builder::create<OpSpecConstantOp>(
         indexes.push_back(index);
       }
 
-      // Check if we have an alignment decoration to propagate to the new
-      // pointer.
-      if (auto align = module.getFirstDecoration(
-              op->getValueAtOffset(firstArgIndex), spv::DecorationAlignment)) {
-        module.addDecoration(op->IdResult(), align);
-      }
-
       auto elementType = module.getType(pointerTy->getTypePointer()->Type());
       SPIRV_LL_ASSERT_PTR(elementType);
       if (elementType->isStructTy()) {
@@ -2970,12 +2963,6 @@ cargo::optional<Error> Builder::create<OpAccessChain>(const OpAccessChain *op) {
                                               module.getName(op->IdResult()),
                                               IRBuilder.GetInsertBlock());
 
-  // check if we have an alignment decoration to propagate to the new pointer
-  if (auto align =
-          module.getFirstDecoration(op->Base(), spv::DecorationAlignment)) {
-    module.addDecoration(op->IdResult(), align);
-  }
-
   if (basePointeeTy->isStructTy()) {
     checkMemberDecorations(basePointeeTy, indexes, op->IdResult());
   }
@@ -3006,11 +2993,6 @@ cargo::optional<Error> Builder::create<OpInBoundsAccessChain>(
       IRBuilder.GetInsertBlock());
   inst->setIsInBounds();
 
-  // check if we have an alignment decoration to propagate to the new pointer
-  if (auto align =
-          module.getFirstDecoration(op->Base(), spv::DecorationAlignment)) {
-    module.addDecoration(op->IdResult(), align);
-  }
 
   if (basePointeeTy->isStructTy()) {
     checkMemberDecorations(basePointeeTy, indexes, op->IdResult());
@@ -3043,12 +3025,6 @@ cargo::optional<Error> Builder::create<OpPtrAccessChain>(
   llvm::GetElementPtrInst *inst = llvm::GetElementPtrInst::Create(
       basePointeeTy, base, indexes, module.getName(op->IdResult()),
       IRBuilder.GetInsertBlock());
-
-  // check if we have an alignment decoration to propagate to the new pointer
-  if (auto align =
-          module.getFirstDecoration(op->Base(), spv::DecorationAlignment)) {
-    module.addDecoration(op->IdResult(), align);
-  }
 
   if (basePointeeTy->isStructTy()) {
     checkMemberDecorations(basePointeeTy, indexes, op->IdResult());
@@ -3167,12 +3143,6 @@ cargo::optional<Error> Builder::create<OpInBoundsPtrAccessChain>(
       basePointeeTy, base, indexes, module.getName(op->IdResult()),
       IRBuilder.GetInsertBlock());
   inst->setIsInBounds();
-
-  // check if we have an alignment decoration to propagate to the new pointer
-  if (auto align =
-          module.getFirstDecoration(op->Base(), spv::DecorationAlignment)) {
-    module.addDecoration(op->IdResult(), align);
-  }
 
   module.addID(op->IdResult(), op, inst);
   return cargo::nullopt;


### PR DESCRIPTION
# Overview

The SPIR-V builder (`spirv_ll::builder`) no longer propagates Alignment Decorators down Access Chains.

# Reason for change

SYCL-CTS tests were failing on RiscV because of unaligned memory access errors.

Applying the same alignment to the result of a GEP as the alignment of the base pointer doesn't make any sense in general, since there is no reason that an individual element needs to have the same alignment, especially when it is access to a member of a struct. A struct is likely to be aligned according to its largest member, but may contain smaller members that are not so aligned.

# Description of change

When processing the SPIR-V IR opcodes `OpAccessChain`, `OpPtrAccessChain`, `OpInBoundsAccessChain` and `OpInBoundsPtrAccessChain`, any alignment decorators (`OpDecorate`) that were applied to the base pointer would also be applied to the result of the access operation. This functionality has been removed.
