### PR TITLE
[compiler] Make some utilities more flexible

### DIFF
--- a/modules/compiler/test/CMakeLists.txt
+++ b/modules/compiler/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_ca_executable(UnitCompiler
   ${CMAKE_CURRENT_SOURCE_DIR}/mangling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/module.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/target.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
   $<$<PLATFORM_ID:Windows>:${BUILTINS_RC_FILE}>)
 
 target_include_directories(UnitCompiler PRIVATE

--- a/modules/compiler/test/utils.cpp
+++ b/modules/compiler/test/utils.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/attributes.h>
+#include <compiler/utils/pass_functions.h>
+#include <llvm/AsmParser/Parser.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/Support/SourceMgr.h>
+
+#include <cstdint>
+#include <cstring>
+#include <tuple>
+
+#include "common.h"
+#include "compiler/module.h"
+
+using namespace compiler::utils;
+
+struct CompilerUtilsTest : ::testing::Test {
+  void SetUp() override {}
+
+  std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
+    llvm::SMDiagnostic Error;
+    auto M = llvm::parseAssemblyString(Assembly, Error, Context);
+
+    std::string ErrMsg;
+    llvm::raw_string_ostream OS(ErrMsg);
+    Error.print("", OS);
+    EXPECT_TRUE(M) << OS.str();
+
+    return M;
+  }
+
+  llvm::LLVMContext Context;
+};
+
+TEST_F(CompilerUtilsTest, CreateKernelWrapper) {
+  auto M = parseModule(R"(
+  declare void @foo(i8 %a, i16 zeroext %b, i32 %c)
+  declare void @bar(i8 %a, i16 zeroext %b, i32 %c) #0
+
+  attributes #0 = { "mux-base-fn-name"="baz" }
+  )");
+
+  // Check equality of a function with its wrapper function
+  auto CheckFns = [](llvm::Function *F, llvm::Function *WrapperF) {
+    // TODO: We may want to check attributes are correctly copied, but it's
+    // complicated by the wrapper receiving 'nounwind', occasionally
+    // 'alwaysinline', as well as the base name attributes. It's therefore not a
+    // straightforward equality check, and relies on implementation details.
+    auto *const FTy = F->getFunctionType();
+    EXPECT_EQ(FTy, WrapperF->getFunctionType());
+    // Check all parameters are the same
+    auto FAttrs = F->getAttributes();
+    auto WrapperFAttrs = WrapperF->getAttributes();
+    for (unsigned i = 0, e = FTy->getNumParams(); i != e; i++) {
+      EXPECT_EQ(F->getArg(i)->getName(), WrapperF->getArg(i)->getName());
+      EXPECT_EQ(FAttrs.getParamAttrs(i), WrapperFAttrs.getParamAttrs(i));
+    }
+    auto FBaseName = getBaseFnName(*F);
+    auto WrapperFBaseName = getBaseFnName(*WrapperF);
+    // The wrapper should always have a base name set, since it's inhereted the
+    // old function's name.
+    EXPECT_FALSE(WrapperFBaseName.empty());
+    // Any base names should be identical, unless the original function didn't
+    // have one.
+    EXPECT_TRUE((FBaseName == WrapperFBaseName) ||
+                (FBaseName.empty() && WrapperFBaseName == F->getName()));
+  };
+
+  // Check that we can create wrappers, leaving the old functions in place.
+  //   { function name, expected wrapper function name }
+  std::tuple<const char *, const char *> TestData[2] = {
+      {"foo", "foo.new"},
+      {"bar", "baz.new"},
+  };
+
+  for (auto [Name, ExpName] : TestData) {
+    auto *F = M->getFunction(Name);
+    EXPECT_TRUE(F);
+
+    auto *const NewF = createKernelWrapperFunction(*F, ".new");
+    EXPECT_TRUE(NewF);
+    EXPECT_EQ(NewF->getName(), ExpName);
+    CheckFns(F, NewF);
+  }
+
+  // Now check that we can rename the old functions at the same time.
+  //   { function name, expected wrapper function name }
+  std::tuple<const char *, const char *, const char *> RenameOldFnsTestData[2] =
+      {
+          {"foo", "foo.old", "foo.brand_new"},
+          {"bar", "bar.old", "baz.brand_new"},
+      };
+
+  for (auto [Name, ExpOldName, ExpNewName] : RenameOldFnsTestData) {
+    auto *const F = M->getFunction(Name);
+    EXPECT_TRUE(F);
+
+    auto *const NewF = createKernelWrapperFunction(*F, ".brand_new", ".old");
+    EXPECT_TRUE(NewF);
+    EXPECT_EQ(F->getName(), ExpOldName);
+    EXPECT_EQ(NewF->getName(), ExpNewName);
+    CheckFns(F, NewF);
+  }
+}

--- a/modules/compiler/utils/include/compiler/utils/metadata.h
+++ b/modules/compiler/utils/include/compiler/utils/metadata.h
@@ -269,6 +269,14 @@ struct KernelInfo {
 void populateKernelList(llvm::Module &m,
                         llvm::SmallVectorImpl<KernelInfo> &results);
 
+/// @brief Replaces instances of kernel fromF with toF in module-level
+/// !opencl.kernels metadata.
+/// @param fromF Function to replace with toF in metadata
+/// @param toF Function with which to replace references to fromF
+/// @param M Module in which to find the metadata
+void replaceKernelInOpenCLKernelsMetadata(llvm::Function &fromF,
+                                          llvm::Function &toF, llvm::Module &M);
+
 /// @brief Encodes information about a function's local work group size as
 /// metadata.
 ///

--- a/modules/compiler/utils/include/compiler/utils/pass_functions.h
+++ b/modules/compiler/utils/include/compiler/utils/pass_functions.h
@@ -237,7 +237,8 @@ llvm::IntegerType *getSizeType(const llvm::Module &m);
 /// @param M Containing module
 /// @param F Kernel function which is being replaced
 /// @param ArgTypes List of types to be used for the new function
-/// @param Suffix Non-empty string to which to append to the new function
+/// @param Suffix String to which to append to the new function
+/// @param OldSuffix String to which to append to the old function
 /// @note This takes the metadata and debug from the original function.
 ///       This is intended to be used for creating a function which replaces
 ///       the original function but calls the original.
@@ -255,19 +256,29 @@ llvm::IntegerType *getSizeType(const llvm::Module &m);
 ///         declare void @foo.wrapper()
 ///         declare void @baz.wrapper()
 ///
+///       With suffix '.new' and old suffix '.old', this function will produce:
+///
+///         declare void @foo.old()
+///         ; Function attrs "mux-base-fn-name"="baz"
+///         declare void @bar.old()
+///
+///         declare void @foo.new()
+///         declare void @baz.new()
+///
 ///       It is advised that the suffix begins with a character that may not
 ///       occur in the original source language, to avoid clashes with user
 ///       functions.
 llvm::Function *createKernelWrapperFunction(
     llvm::Module &M, llvm::Function &F, llvm::ArrayRef<llvm::Type *> ArgTypes,
-    llvm::StringRef Suffix);
+    llvm::StringRef Suffix, llvm::StringRef OldSuffix = "");
 
 /// @brief As above, but creating a wrapper with the exact function signature
 /// of @p F.
 ///
 /// Copies over all parameter names and attributes.
 llvm::Function *createKernelWrapperFunction(llvm::Function &F,
-                                            llvm::StringRef Suffix);
+                                            llvm::StringRef Suffix,
+                                            llvm::StringRef OldSuffix = "");
 
 /// @}
 }  // namespace utils

--- a/modules/compiler/utils/source/align_module_structs_pass.cpp
+++ b/modules/compiler/utils/source/align_module_structs_pass.cpp
@@ -16,6 +16,7 @@
 
 #include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/attributes.h>
+#include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/DIBuilder.h>
@@ -311,14 +312,8 @@ Function *cloneFunctionUpdatingTypes(Function &func,
                     &structMapper);
 
   // update the kernel metadata
-  if (auto *namedMetaData =
-          func.getParent()->getNamedMetadata("opencl.kernels")) {
-    for (auto *md : namedMetaData->operands()) {
-      if (md && (md->getOperand(0) == ValueAsMetadata::get(&func))) {
-        md->replaceOperandWith(0, ValueAsMetadata::get(newFunc));
-      }
-    }
-  }
+  compiler::utils::replaceKernelInOpenCLKernelsMetadata(func, *newFunc,
+                                                        *func.getParent());
 
   // take kernel-specific data from the old function.
   compiler::utils::takeIsKernel(*newFunc, func);

--- a/modules/compiler/utils/source/metadata.cpp
+++ b/modules/compiler/utils/source/metadata.cpp
@@ -371,6 +371,18 @@ void populateKernelList(Module &m, SmallVectorImpl<KernelInfo> &results) {
   }
 }
 
+void replaceKernelInOpenCLKernelsMetadata(Function &fromF, Function &toF,
+                                          Module &M) {
+  // update the kernel metadata
+  if (auto *const namedMD = M.getNamedMetadata("opencl.kernels")) {
+    for (auto *md : namedMD->operands()) {
+      if (md && md->getOperand(0) == ValueAsMetadata::get(&fromF)) {
+        md->replaceOperandWith(0, ValueAsMetadata::get(&toF));
+      }
+    }
+  }
+}
+
 static constexpr const char *ReqdSGSizeMD = "intel_reqd_sub_group_size";
 
 void encodeReqdSubgroupSizeMetadata(Function &f, uint32_t size) {


### PR DESCRIPTION
This provides some groundwork for an upcoming change to the kernel ABI with regards to samplers. I've split this prep work away from that main change, in case we want to land it later, or revert it later on.

Each change is tested with UnitCompiler, so should be safe to land with a pass to make use of them.