### PR TITLE
[compiler] Add a pass to replace target extension types

### DIFF
--- a/doc/modules/compiler/utils.rst
+++ b/doc/modules/compiler/utils.rst
@@ -1084,6 +1084,34 @@ with a required sub-group size and checks whether the vectorizer was able to
 satisfy that requirement. As such, it should be run after vectorization. A
 compiler diagnostic is raised for each kernel for which this does not hold.
 
+ReplaceTargetExtTysPass
+-----------------------
+
+The ``ReplaceTargetExtTysPass`` pass replaces certain `target extension types
+<https://llvm.org/docs/LangRef.html#target-extension-type>`_ found in the
+initial compiler IR. It replaces them with new types reported by the
+``BuiltinInfo::getRemappedTargetExtTy`` analysis function. This is conceptually
+replacing abstract and target-agnostic opaque types with concrete ones ready
+for the target.
+
+This pass can replace any of the following types:
+
+* ``spirv.Image``
+* ``spirv.Event``
+* ``spirv.Sampler``
+
+It replaces any of the above types across the module, replacing any functions
+with any of these target extension types as function parameters or return types
+*in-place*, i.e., with a new function with the updated function signature.
+
+If the target's compiler backend is able to handle any of the above types
+natively then the target **may** opt out of this process completely. Note
+however that some aspects of the ComputeMux compiler **may** make assumptions
+about some of the above types, such as the type of images passed to any of the
+:doc:`/modules/builtins/libimg` functions. This means that in such a situation,
+it may be required to skip other passes such as the
+``compiler::ImageArgumentSubstitutionPass``.
+
 Metadata Utilities
 ------------------
 

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -61,6 +61,7 @@
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/replace_mem_intrinsics_pass.h>
 #include <compiler/utils/replace_mux_math_decls_pass.h>
+#include <compiler/utils/replace_target_ext_tys_pass.h>
 #include <compiler/utils/replace_wgc_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
 #include <compiler/utils/unique_opaque_structs_pass.h>
@@ -401,6 +402,26 @@ Expected<std::vector<llvm::StringRef>> parseReduceToFunctionPassOptions(
   }
 
   return Names;
+}
+
+Expected<compiler::utils::ReplaceTargetExtTysOptions>
+parseReplaceTargetExtTysPassOptions(StringRef Params) {
+  compiler::utils::ReplaceTargetExtTysOptions Opts;
+
+  while (!Params.empty()) {
+    StringRef ParamName;
+    std::tie(ParamName, Params) = Params.split(';');
+
+    if (ParamName == "no-images") {
+      Opts.ReplaceImages = false;
+    } else if (ParamName == "no-samplers") {
+      Opts.ReplaceSamplers = false;
+    } else if (ParamName == "no-events") {
+      Opts.ReplaceEvents = false;
+    }
+  }
+
+  return Opts;
 }
 
 void BaseModulePassMachinery::registerPasses() {

--- a/modules/compiler/source/base/source/base_pass_registry.def
+++ b/modules/compiler/source/base/source/base_pass_registry.def
@@ -111,6 +111,14 @@ MODULE_PASS_WITH_PARAMS(
     parseReplaceMuxMathDeclsPassOptions, "fast")
 
 MODULE_PASS_WITH_PARAMS(
+    "replace-target-ext-tys", "compiler::utils::ReplaceTargetExtTysPass",
+    [](compiler::utils::ReplaceTargetExtTysOptions Options) {
+      return compiler::utils::ReplaceTargetExtTysPass(Options);
+    },
+    parseReplaceTargetExtTysPassOptions,
+    "no-images;no-samplers;no-events")
+
+MODULE_PASS_WITH_PARAMS(
     "fixup-calling-conv", "compiler::utils::FixupCallingConventionPass",
     [](llvm::CallingConv::ID Option) {
       return compiler::utils::FixupCallingConventionPass(Option);

--- a/modules/compiler/test/lit/passes/replace-image-tys.ll
+++ b/modules/compiler/test/lit/passes/replace-image-tys.ll
@@ -1,0 +1,131 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; Test the pass in various configurations: replacing all target types, only
+; replacing samplers and only replacing images.
+; RUN: muxc --passes replace-target-ext-tys,verify %s \
+; RUN:   | FileCheck %s --check-prefixes CHECK,CHECK-IMG,CHECK-SAMP
+; RUN: muxc --passes "replace-target-ext-tys<no-images>",verify %s \
+; RUN:   | FileCheck %s --check-prefixes CHECK,CHECK-NOIMG,CHECK-SAMP
+; RUN: muxc --passes "replace-target-ext-tys<no-samplers>",verify %s \
+; RUN:   | FileCheck %s --check-prefixes CHECK,CHECK-IMG,CHECK-NOSAMP
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0,
+; CHECK-IMG-SAME: ptr %img,
+; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img,
+; CHECK-SAMP-SAME: i32 %sampler1, i32 %sampler2
+; CHECK-NOSAMP-SAME: target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2
+; CHECK-SAME: ) #0 !custom_metadata [[MD:\![0-9]+]] {
+define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 !custom_metadata !9 {
+; Check that a sampler stored to and loaded from a stack slot is also remapped
+; CHECK-SAMP: alloca i32, align 8
+  %v4 = alloca target("spirv.Sampler"), align 8
+; CHECK-SAMP: store i32 %sampler2, ptr %v4, align 8
+  store target("spirv.Sampler") %sampler2, ptr %v4, align 8
+  %v5 = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %v6 = trunc i64 %v5 to i32
+  %v7 = tail call spir_func float @_Z13convert_floati(i32 %v6)
+  %v8 = tail call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %v9 = tail call spir_func float @_Z13convert_floatm(i64 %v8)
+  %v10 = fmul float %v9, 5.000000e-01
+  %v11 = fdiv float %v7, %v10
+  %v12 = fadd float %v11, 0x3FA99999A0000000
+; CHECK:  %v13 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(
+; CHECK-IMG-SAME: ptr %img,
+; CHECK-SAMP-SAME: i32 %sampler1,
+; CHECK-SAME: float %v12)
+  %v13 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, float %v12)
+; CHECK-SAMP: %sampler2_reload = load i32, ptr %v4, align 8
+  %sampler2_reload = load target("spirv.Sampler"), ptr %v4, align 8
+; CHECK: %v14 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(
+; CHECK-IMG-SAME: ptr %img,
+; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img,
+; CHECK-SAMP-SAME: i32 %sampler2_reload,
+; CHECK-NOSAMP-SAME: target("spirv.Sampler") %sampler2_reload,
+; CHECK-SAME: float %v12)
+  %v14 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler2_reload, float %v12)
+; Check that a sampler introduced to the program by a function is also remapped
+; CHECK-SAMP: %sampler3 = call i32 @__translate_sampler_initializer(i32 42)
+  %sampler3 = call target("spirv.Sampler") @__translate_sampler_initializer(i32 42)
+; CHECK: %v23 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(
+; CHECK-IMG-SAME: ptr %img,
+; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img,
+; CHECK-SAMP-SAME: i32 %sampler3,
+; CHECK-NOSAMP-SAME: target("spirv.Sampler") %sampler3,
+; CHECK-SAME: float %v12)
+  %v23 = tail call spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler3, float %v12)
+  %v15 = extractelement <4 x i32> %v13, i64 0
+  %v16 = shl nsw i32 %v6, 1
+  %v17 = sext i32 %v16 to i64
+  %v18 = getelementptr inbounds i32, ptr addrspace(1) %v0, i64 %v17
+  store i32 %v15, ptr addrspace(1) %v18, align 4
+  %v19 = extractelement <4 x i32> %v14, i64 0
+  %v20 = or i32 %v16, 1
+  %v21 = sext i32 %v20 to i64
+  %v22 = getelementptr inbounds i32, ptr addrspace(1) %v0, i64 %v21
+  store i32 %v19, ptr addrspace(1) %v22, align 4
+  %v24 = extractelement <4 x i32> %v23, i64 0
+  %v25 = shl nsw i32 %v6, 2
+  %v26 = sext i32 %v25 to i64
+  %v27 = getelementptr inbounds i32, ptr addrspace(1) %v0, i64 %v26
+  store i32 %v24, ptr addrspace(1) %v27, align 4
+  ret void
+}
+
+declare spir_func float @_Z13convert_floati(i32) #0
+
+declare spir_func float @_Z13convert_floatm(i64) #0
+
+; CHECK-SAMP: declare i32 @__translate_sampler_initializer(i32) #0
+declare target("spirv.Sampler") @__translate_sampler_initializer(i32) #0
+
+; CHECK: declare spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(
+; CHECK-IMG-SAME: ptr,
+; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0),
+; CHECK-SAMP-SAME: i32,
+; CHECK-NOSAMP-SAME: target("spirv.Sampler"),
+; CHECK-SAME: float) #0
+declare spir_func <4 x i32> @_Z12read_imageui11ocl_image1d11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), target("spirv.Sampler"), float) #0
+
+declare spir_func i64 @_Z13get_global_idj(i32) #1
+
+declare spir_func i64 @_Z15get_global_sizej(i32) #1
+
+attributes #0 = { convergent nounwind }
+attributes #1 = { nofree nounwind memory(read) }
+
+!llvm.ident = !{!0}
+!opencl.kernels = !{!1}
+!opencl.ocl.version = !{!8}
+
+; Check that the new functions have replaced the old ones in metadata
+; CHECK-DAG:        = !{ptr @image_sampler,
+; Check that the global metadata has been updated with the new types
+; CHECK-SAMP-DAG: [[MD]] = !{!"custom_metadata", i32 0}
+!0 = !{!"Source language: OpenCL C, Version: 102000"}
+!1 = !{ptr @image_sampler, !2, !3, !4, !5, !6, !7}
+!2 = !{!"kernel_arg_addr_space", i32 1, i32 0, i32 0, i32 0}
+!3 = !{!"kernel_arg_access_qual", !"none", !"read_only", !"none", !"none"}
+!4 = !{!"kernel_arg_type", !"uint*", !"image1d_t", !"sampler_t", !"sampler_t"}
+!5 = !{!"kernel_arg_base_type", !"uint*", !"image1d_t", !"sampler_t", !"sampler_t"}
+!6 = !{!"kernel_arg_type_qual", !"", !"", !"", !""}
+!7 = !{!"kernel_arg_name", !"", !"", !"", !""}
+!8 = !{i32 3, i32 0}
+!9 = !{!"custom_metadata", target("spirv.Sampler") zeroinitializer}

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -63,6 +63,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_local_module_scope_variables_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_mem_intrinsics_pass.h  
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_mux_math_decls_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_target_ext_tys_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_wgc_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/scheduling.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/simple_callback_pass.h
@@ -113,6 +114,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_local_module_scope_variables_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mem_intrinsics_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mux_math_decls_pass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_target_ext_tys_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_wgc_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/scheduling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/target_extension_types.cpp

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -629,6 +629,22 @@ class BuiltinInfo {
   /// the AddSchedulingParametersPass.
   bool requiresSchedulingParameters(BuiltinID ID);
 
+  /// @brief Returns the remapped type for a target extension type
+  ///
+  /// This method is intended for target implementations to be able signal to
+  /// the DefineTargetExtTysPass how LLVM's target extension types should be
+  /// remapped across the module. There is a default implementation: see
+  /// BIMuxInfoConcept::getRemappedTargetExtTy
+  ///
+  /// This method is safe to call before LLVM 17 but will do nothing (there are
+  /// no target extension types before LLVM 17). Otherwise this method asserts
+  /// that the type is a target extension type.
+  ///
+  /// @param Ty The target extension type to remap
+  /// @return The remapped type, or nullptr if the type does not require
+  /// remapping
+  llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty);
+
   /// Handle the invalidation of this information.
   ///
   /// When used as a result of BuiltinInfoAnalysis this method will be called
@@ -691,6 +707,15 @@ class BIMuxInfoConcept {
   /// @brief Returns true if the mux builtin requires scheduling parameters to
   /// function.
   virtual bool requiresSchedulingParameters(BuiltinID);
+
+  /// @brief See BuiltinInfo::getRemappedTargetExtTy
+  ///
+  /// This method is overridable but the default implementation provides the
+  /// following mappings:
+  ///   * spirv.Event -> i32
+  ///   * spirv.Sampler -> i32
+  ///   * spirv.Image -> MuxImage* (regardless of image parameters)
+  virtual llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty);
 
   enum MemScope : uint32_t {
     MemScopeCrossDevice = 0,

--- a/modules/compiler/utils/include/compiler/utils/replace_target_ext_tys_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/replace_target_ext_tys_pass.h
@@ -1,0 +1,65 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef COMPILER_UTILS_REPLACE_TARGET_EXT_TYS_PASS_H_INCLUDED
+#define COMPILER_UTILS_REPLACE_TARGET_EXT_TYS_PASS_H_INCLUDED
+
+#include <llvm/IR/PassManager.h>
+
+namespace compiler {
+namespace utils {
+
+struct ReplaceTargetExtTysOptions {
+  /// @brief Set to true if the pass should replace "spirv.Image" types.
+  bool ReplaceImages = true;
+  /// @brief Set to true if the pass should replace "spirv.Sampler" types.
+  bool ReplaceSamplers = true;
+  /// @brief Set to true if the pass should replace "spirv.Event" types.
+  bool ReplaceEvents = true;
+};
+
+/// @brief This pass replaces LLVM target extension types with types appropriate
+/// for the ComputeMux target.
+///
+/// It can replace any subset of the following target extension types,
+/// module-wide:
+/// * "spirv.Image"
+/// * "spirv.Event"
+/// * "spirv.Sampler"
+///
+/// The ComputeMux target's implementation of BuiltinInfo is ultimately
+/// responsible for the precise mapping of types - there is nothing to say that
+/// the target can't introduce further target extension types if it wishes.
+class ReplaceTargetExtTysPass final
+    : public llvm::PassInfoMixin<ReplaceTargetExtTysPass> {
+ public:
+  ReplaceTargetExtTysPass(const ReplaceTargetExtTysOptions &Options)
+      : ReplaceImages(Options.ReplaceImages),
+        ReplaceSamplers(Options.ReplaceSamplers),
+        ReplaceEvents(Options.ReplaceEvents) {}
+
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
+
+ private:
+  bool ReplaceImages;
+  bool ReplaceSamplers;
+  bool ReplaceEvents;
+};
+
+}  // namespace utils
+}  // namespace compiler
+
+#endif  // COMPILER_UTILS_REPLACE_TARGET_EXT_TYS_PASS_H_INCLUDED

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -405,6 +405,11 @@ bool BuiltinInfo::requiresSchedulingParameters(BuiltinID ID) {
   return MuxImpl->requiresSchedulingParameters(ID);
 }
 
+Type *BuiltinInfo::getRemappedTargetExtTy(Type *Ty) {
+  // Defer to mux for the scheduling parameters.
+  return MuxImpl->getRemappedTargetExtTy(Ty);
+}
+
 SmallVector<BuiltinInfo::SchedParamInfo, 4>
 BuiltinInfo::getMuxSchedulingParameters(Module &M) {
   // Defer to mux for the scheduling parameters.

--- a/modules/compiler/utils/source/replace_target_ext_tys_pass.cpp
+++ b/modules/compiler/utils/source/replace_target_ext_tys_pass.cpp
@@ -1,0 +1,173 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/builtin_info.h>
+#include <compiler/utils/metadata.h>
+#include <compiler/utils/replace_target_ext_tys_pass.h>
+#include <compiler/utils/target_extension_types.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
+#include <multi_llvm/llvm_version.h>
+
+using namespace llvm;
+
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+
+class TargetExtTypeRemapper : public ValueMapTypeRemapper {
+ public:
+  TargetExtTypeRemapper(compiler::utils::BuiltinInfo &BI, bool ReplaceImages,
+                        bool ReplaceSamplers, bool ReplaceEvents)
+      : BI(BI),
+        ReplaceImages(ReplaceImages),
+        ReplaceSamplers(ReplaceSamplers),
+        ReplaceEvents(ReplaceEvents) {}
+
+  Type *remapType(Type *Ty) {
+    // Don't replace this type if it's:
+    // * not a TargetExtType
+    // * an image and we don't want to replace images
+    // * a sampler we don't want to replace samplers
+    // * an event and we don't want to replace events
+    if (auto *const TgtExtTy = dyn_cast<TargetExtType>(Ty);
+        !TgtExtTy || (!ReplaceImages && TgtExtTy->getName() == "spirv.Image") ||
+        (!ReplaceSamplers && TgtExtTy->getName() == "spirv.Sampler") ||
+        (!ReplaceEvents && TgtExtTy->getName() == "spirv.Event")) {
+      return Ty;
+    }
+    // Now look up the cache in case we've seen this type before.
+    if (auto I = TyReplacementCache.find(Ty); I != TyReplacementCache.end()) {
+      return I->getSecond();
+    }
+    // Check if the target wants to remap this type.
+    if (auto *NewTy = BI.getRemappedTargetExtTy(Ty)) {
+      // Cache this type for next time.
+      TyReplacementCache[Ty] = NewTy;
+      return NewTy;
+    }
+    return Ty;
+  }
+
+ private:
+  compiler::utils::BuiltinInfo &BI;
+  bool ReplaceImages = true;
+  bool ReplaceSamplers = true;
+  bool ReplaceEvents = true;
+  DenseMap<Type *, Type *> TyReplacementCache;
+};
+
+PreservedAnalyses compiler::utils::ReplaceTargetExtTysPass::run(
+    Module &M, ModuleAnalysisManager &AM) {
+  auto &BI = AM.getResult<compiler::utils::BuiltinInfoAnalysis>(M);
+
+  ValueToValueMapTy VM;
+  TargetExtTypeRemapper TyMapper(BI, ReplaceImages, ReplaceSamplers,
+                                 ReplaceEvents);
+
+  SmallPtrSet<Function *, 4> ToDelete;
+  // Note that despite us using a ValueMapper to remap functions, below, we're
+  // still safest creating new IR values and replacing the old ones with them.
+  // The ValueMapper ostensibly can mutate function arguments in-place. However,
+  // in practice I've observed the functions looking like they've been remapped,
+  // even dumping this to the console after the pass has run, but LLVM's
+  // verifier can still pick up on the old module state and throw an error due
+  // to mismatched function arguments.
+  for (auto &F : M) {
+    auto *FTy = F.getFunctionType();
+    auto *const NewFRetTy = TyMapper.remapType(FTy->getReturnType());
+
+    // Transform old parameter types to new types.
+    SmallVector<Type *> NewFParams(FTy->getNumParams());
+    transform(FTy->params(), NewFParams.begin(),
+              [&TyMapper](Type *Ty) { return TyMapper.remapType(Ty); });
+
+    // Skip this function if its prototype doesn't need replaced.
+    if (FTy->getReturnType() == NewFRetTy && equal(FTy->params(), NewFParams)) {
+      continue;
+    }
+
+    auto *const NewFTy = FunctionType::get(NewFRetTy, NewFParams, F.isVarArg());
+
+    auto *NewF = Function::Create(NewFTy, F.getLinkage(), "", &M);
+
+    // Set up a mapping from the old function to the new one
+    VM[&F] = NewF;
+
+    // Steal the old function's name
+    NewF->takeName(&F);
+
+    // Set the correct calling convention
+    NewF->setCallingConv(F.getCallingConv());
+
+    // Steal all the old parameters' names
+    for (auto [Old, New] : zip(F.args(), NewF->args())) {
+      New.takeName(&Old);
+    }
+
+    if (F.isDeclaration()) {
+      // Copy debug info for function over; CloneFunctionInto takes care of this
+      // if this function has a body
+      NewF->setSubprogram(F.getSubprogram());
+      // Copy the attributes over to the new function
+      NewF->setAttributes(F.getAttributes());
+      // Copy the metadata over to the new function, ignoring any debug info.
+      compiler::utils::copyFunctionMetadata(F, *NewF);
+    } else {
+      // Map all original function arguments to the new ones
+      for (auto [Old, New] : zip(F.args(), NewF->args())) {
+        VM[&Old] = &New;
+      }
+      SmallVector<ReturnInst *, 4> Returns;
+      CloneFunctionInto(NewF, &F, VM, CloneFunctionChangeType::LocalChangesOnly,
+                        Returns, /*NameSuffix*/ "", /*CodeInfo*/ nullptr,
+                        &TyMapper);
+    }
+
+    ToDelete.insert(&F);
+  }
+
+  ValueMapper Mapper(VM, RF_IgnoreMissingLocals, &TyMapper);
+
+  // Keep the dead functions around for a bit longer so that we can auto-remap
+  // their uses to their replacements.
+  for (auto &F : M) {
+    if (!ToDelete.contains(&F)) {
+      Mapper.remapFunction(F);
+    }
+  }
+
+  for (auto *F : ToDelete) {
+    // There might be remaining uses of the old function, outside of other
+    // functions, e.g., in metadata. Clear those up now before deleting the old
+    // function.
+    F->replaceAllUsesWith(VM[F]);
+    F->eraseFromParent();
+  }
+
+  return PreservedAnalyses::none();
+}
+
+#else
+
+PreservedAnalyses compiler::utils::ReplaceTargetExtTysPass::run(
+    Module &, ModuleAnalysisManager &) {
+  // There's no target extension types to remap before LLVM 17.
+  (void)ReplaceEvents;
+  (void)ReplaceImages;
+  (void)ReplaceSamplers;
+  return PreservedAnalyses::all();
+}
+
+#endif


### PR DESCRIPTION
The target extension types introduced in LLVM 17 pose a problem for us because no upstream backend supports the "spirv" types and will crash when lowering them. This means we must replace them across the module with "real" types.

This commit introduces a new pass and extension to the BuiltinInfo to provide the target with a way to customize how target extension types are removed from the module by replacing them with other types.

Events and samplers are replaced with `i32` types, and images are replaced with a pointer to `MuxImage` (which is just a mux-friendly rename of the undocumented `struct.Image` structure the ImageArgumentSubstitutionPass currently uses).

Note that functions are replaced in-place (i.e., without wrappers) as a wrapper would still keep the types lingering around in the module.

The replacement of each of three different types can be opted out, as in reality we will want to replace images & samplers at a different time to events.

This pass only does something in LLVM 17+, since before that point there will never be any target extension types to replace. The pass is also not yet scheduled in the pipeline as it's not officially ready to use - subsequent passes still need work to provide a more stable experience.