### PR TITLE
[compiler] Fix a use-after-free

### DIFF
--- a/modules/compiler/utils/source/pass_functions.cpp
+++ b/modules/compiler/utils/source/pass_functions.cpp
@@ -628,7 +628,9 @@ llvm::IntegerType *getSizeType(const llvm::Module &m) {
 static llvm::Function *createKernelWrapperFunctionImpl(
     llvm::Function &F, llvm::Function &NewFunction, llvm::StringRef Suffix,
     llvm::StringRef OldSuffix) {
-  auto baseName = getOrSetBaseFnName(NewFunction, F);
+  // Make sure we take a copy of the basename as we're going to change the
+  // original function's name from underneath the StringRef.
+  std::string baseName = getOrSetBaseFnName(NewFunction, F).str();
 
   if (!OldSuffix.empty()) {
     if (getBaseFnName(F).empty()) {


### PR DESCRIPTION
We were taking a reference to a function's base name (or just plain name) and then change that name afterwards, leaving the StringRef in an invalid state.