### PR TITLE
Fixed upper version of LLVM to be 16.0.6 and fixed version checking

### DIFF
--- a/cmake/ImportLLVM.cmake
+++ b/cmake/ImportLLVM.cmake
@@ -76,7 +76,7 @@ include(DetectLLVMMSVCCRT)
   a supported version.
 #]=======================================================================]
 set(CA_LLVM_MINIMUM_VERSION 14.0.0)
-set(CA_LLVM_MAXIMUM_VERSION 16.0.4)
+set(CA_LLVM_MAXIMUM_VERSION 16.0.6)
 string(REPLACE ";" "', '" CA_LLVM_VERSIONS_PRETTY "${CA_LLVM_VERSIONS}")
 if("${LLVM_PACKAGE_VERSION}" VERSION_LESS "${CA_LLVM_MINIMUM_VERSION}")
   message(FATAL_ERROR

--- a/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
+++ b/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
@@ -119,12 +119,12 @@ function(find_builtins_tools tools_dir)
     string(REPLACE "svn" "" llvm_version ${LLVM_PACKAGE_VERSION})
     string(REGEX MATCH "clang version [0-9]+\\.[0-9]+\\.[0-9]"
       version_string ${version_string})
-    string(REPLACE "clang version" "" version_string ${version_string})
+    string(REPLACE "clang version " "" version_string ${version_string})
     if(NOT llvm_version VERSION_EQUAL version_string)
       message(FATAL_ERROR
               "Builtins: LLVM tool versions do not match\n"
-              "LLVM_PACKAGE_VERSION: ${llvm_version}\n"
-              "BUILTINS_COMPILER version: ${version_string}")
+              "LLVM_PACKAGE_VERSION: '${llvm_version}'\n"
+              "BUILTINS_COMPILER version: '${version_string}'")
     else()
       message(STATUS "Builtins: LLVM tool versions match")
     endif()


### PR DESCRIPTION
# Overview

Fix warning that max version is 16.0.4 for LLVM and version checking strings

# Reason for change

We are promoting llvm version 16.0.6 as the one to use for LLVM 16. Also the builtins compiler version was including spacing causing errors.

# Description of change

Changed version in CMakeLists.txt. Also added quotes around llvm tool version error report checking to help assist debugging issues in this area and fixed the tool version checking to not include spaces.
