### PR TITLE
Add basic pass through for OpCapability MemoryAccessAliasingINTEL 

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2376,6 +2376,11 @@ if (SpirvAsVersionYear GREATER_EQUAL 2022)
     intel_opt_none.spvasm)
 endif()
 
+if (SpirvAsVersionYear GREATER 2022)
+  list(APPEND SPVASM_FILES
+    intel_memory_access_aliasing.spvasm)
+endif()
+
 # Test files that require SPIR-V v1.1
 # TODO: It might be more convenient to support a system like UnitCL where test
 # files declare their own requirements.

--- a/modules/compiler/spirv-ll/test/spvasm/intel_memory_access_aliasing.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_memory_access_aliasing.spvasm
@@ -1,0 +1,36 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; REQUIRES: spirv-as-v2023+
+; RUN: spirv-as --version
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -e SPV_INTEL_memory_access_aliasing %spv_file_s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability MemoryAccessAliasingINTEL
+               OpExtension "SPV_INTEL_memory_access_aliasing"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %4 "foo"
+               OpExecutionMode %4 VecTypeHint 0
+          %6 = OpString "kernel_arg_type.foo."
+               OpSource OpenCL_C 102000
+               OpName %entry "entry"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void DontInline %3
+      %entry = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -287,6 +287,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
         spv::CapabilityKernelAttributesINTEL,
         spv::CapabilityExpectAssumeKHR,
         spv::CapabilityOptNoneINTEL,
+        spv::CapabilityMemoryAccessAliasingINTEL,
     });
     if (enableAll) {
       // Add the optional OpenCL capabilities if this flag was set.
@@ -444,7 +445,8 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
           spv::CapabilityAtomicFloat32MinMaxEXT,
           spv::CapabilityAtomicFloat64MinMaxEXT,
           spv::CapabilityArbitraryPrecisionIntegersINTEL,
-          spv::CapabilityOptNoneINTEL};
+          spv::CapabilityOptNoneINTEL,
+          spv::CapabilityMemoryAccessAliasingINTEL};
 
       // SPIR-V 1.1 list of capabilities.
       static std::unordered_set<spv::Capability> supported_v1_1_capabilities = {
@@ -477,6 +479,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
         "SPV_KHR_linkonce_odr",
         "SPV_KHR_uniform_group_instructions",
         "SPV_INTEL_optnone",
+        "SPV_INTEL_memory_access_aliasing",
     });
   } else {
     for (auto extension : extensions) {

--- a/source/cl/source/binary/source/spirv.cpp
+++ b/source/cl/source/binary/source/spirv.cpp
@@ -28,7 +28,7 @@ namespace binary {
 // TODO: add a proper mechanism for extending spirv-ll and reporting extension
 // support. We don't actually support the generic storage class extension on
 // all core targets. See CA-3067.
-const std::array<const std::string, 9> supported_extensions = {
+const std::array<const std::string, 10> supported_extensions = {
     {
         "SPV_KHR_no_integer_wrap_decoration",
         "SPV_INTEL_kernel_attributes",
@@ -39,6 +39,7 @@ const std::array<const std::string, 9> supported_extensions = {
         "SPV_KHR_uniform_group_instructions",
         "SPV_INTEL_arbitrary_precision_integers",
         "SPV_INTEL_optnone",
+        "SPV_INTEL_memory_access_aliasing",
     },
 };
 
@@ -50,7 +51,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
   auto &spvCapabilities = spvDeviceInfo.capabilities;
 
   // A set of capabilities shared between the OpenCL profiles we support.
-  static std::array<spv::Capability, 13> sharedCapabilities = {
+  static std::array<spv::Capability, 14> sharedCapabilities = {
       spv::CapabilityAddresses,
       spv::CapabilityFloat16Buffer,
       spv::CapabilityGroups,
@@ -64,6 +65,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
       spv::CapabilityGroupUniformArithmeticKHR,
       spv::CapabilityArbitraryPrecisionIntegersINTEL,
       spv::CapabilityOptNoneINTEL,
+      spv::CapabilityMemoryAccessAliasingINTEL,
   };
 
   if (profile == "FULL_PROFILE") {


### PR DESCRIPTION
# Overview

To get sycl-nbody runwith oneapi-construction-kit and dpc++, `OpCapability MemoryAccessAliasingINTEL` support is needed.

# Reason for change

While trying to run sycl-nbody with oneapi-cnstruction-kit, we get the error:
`error: OpCapability MemoryAccessAliasingINTEL (#5910) not supported by device`.

# Description of change

As for now just the basic pass through is added. A proper fix may be added later.


# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
