### PR TITLE
Fix clang-format CI job

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -105,8 +105,8 @@ jobs:
         run: |
           # we've installed clang-format-16 in the docker via pip, which just installs it as clang-format,
           # so just use clang-format-diff and -b clang-format directly
-          git fetch origin
-          git diff -U0 --no-color HEAD..origin/${{ github.base_ref }} | \
+          git fetch origin ${{ github.base_ref }}
+          git diff -U0 --no-color origin/${{ github.base_ref }} | \
             clang-format-diff.py -p1 -regex \
             "^(?!(.+\\/)*(external|cookie)\\/).*\\.(c|cc|cxx|cpp|h|hh|hxx|hpp)$" -b clang-format \
             > clang-format.diff


### PR DESCRIPTION
The diff was mistakenly reversed so we weren't actually checking the PR branch's commits: we were effectively checking 'main' for formatting errors.