### PR TITLE
Updated documentation to mention 16.0.6 LLVM versions

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -718,11 +718,8 @@ a specialised build of of LLVM for the cross-compilation target. In this guide,
 the following environment variables are assumed.
 
 ```sh
-# name of the release branch according to ca-llvm repository convention, e.g.
-LLVMBranch=release_100
-
-# or equivalent path for upstream LLVM build
-LLVMNativeBuild=/absolute/path/to/ca-llvm/build/${LLVMBranch}
+# path to upstream LLVM build
+LLVMNativeBuild=/absolute/path/to/native_llvm/build
 
 # usually equivalent to ${LLVMNativeBuild}/install
 LLVMNativeInstall=${CMAKE_INSTALL_PREFIX}

--- a/doc/overview/compiler/supported-llvm-versions.rst
+++ b/doc/overview/compiler/supported-llvm-versions.rst
@@ -9,11 +9,11 @@ Host
 .. rubric:: Supported - tested daily
 
 - 15.0.0 (Any released version)
-- 16.0.4+
+- 16.0.6+
 
 RISC-V
 ------
 
 .. rubric:: Supported - tested daily
 
-- 16.0.4+
+- 16.0.6+


### PR DESCRIPTION
# Overview

Updated documentation to mention 16.0.6 LLVM versions and removed out of date references to ca-llvm

# Reason for change

Documentation was out of date on versions used and made an out of date reference.

# Description of change

Updated reference of LLVM versions to use. Also deleted any references to ca-llvm.
