### PR TITLE
[cmake] Continue to disable -Wmaybe-uninitialized

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -204,12 +204,11 @@ set(CA_COMPILE_OPTIONS
         -Wno-redundant-move
         -Wno-pessimizing-move
       >
-      $<$<AND:$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,10>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,12.3>>:
+      $<$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,10>:
         # GCC has become awful complainy about passing the address of an
         # uninitialized variable to another function which performs the
-        # initialization itself
-        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96564 is targeted for 11.4.
-        # If this update proves inadequate, update the above version
+        # initialization itself, reconsider disabling this warning if
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96564 is addressed.
         -Wno-maybe-uninitialized
       >
     >


### PR DESCRIPTION
# Overview

Always set `-Wno-maybe-uninitialized` for GCC above version 10.

# Reason for change

Silence a wall of warnings which keep coming back every time a new GCC version is releases without this [bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96564) being fixed. This was supposed to be fixed in 11.4, then moved to 11.5, after which the ticekt has not been updated again. GCC 13 is now available.

# Description of change

Remove the upper bound on the version check to set the `-Wno-maybe-uninitialized` flag to disable warnings previously determined to be of dubious value.