### PR TITLE
[compiler] Introduce mux builtins for 'group operations'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Upgrade guidance:
 * The mux spec has been bumped:
   * 0.77.0: to loosen the requirements on the mux `event` type used by
     DMA builtins.
+  * 0.78.0: to introduce mux builtins for sub-group, work-group, and
+    vector-group operations.
 * The `compiler::ImageArgumentSubstitutionPass` now replaces sampler typed
   parameters in kernel functions with i32 parameters via a wrapper function.
   The `host` target as a consequence now passes samplers to kernels as 32-bit

--- a/doc/modules/mux/changes.rst
+++ b/doc/modules/mux/changes.rst
@@ -11,6 +11,11 @@ version increases mean backward compatible bug fixes have been applied.
    Versions prior to 1.0.0 may contain breaking changes in minor
    versions as the API is still under development.
 
+0.78.0
+------
+
+* Added sub-group, work-group, and vector-group operation builtins.
+
 0.77.0
 ------
 

--- a/doc/specifications/mux-runtime-spec.rst
+++ b/doc/specifications/mux-runtime-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Runtime Specification
 ================================
 
-   This is version 0.77.0 of the specification.
+   This is version 0.78.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,

--- a/doc/tutorials/custom-lowering-work-item-builtins.rst
+++ b/doc/tutorials/custom-lowering-work-item-builtins.rst
@@ -123,10 +123,11 @@ The code for this example is as follows:
 .. code:: cpp
 
   class MyMuxImpl : public utils::BIMuxInfoConcept {
-    virtual llvm::Function *defineMuxBuiltin(utils::BuiltinID ID,
-                                             llvm::Module &M) override {
+    virtual llvm::Function *defineMuxBuiltin(
+        utils::BuiltinID ID, llvm::Module &M,
+        llvm::ArrayRef<llvm::Type *> OverloadInfo = {}) override {
       if (ID != utils::eMuxBuiltinGetLocalId) {
-        return BIMuxInfoConcept::defineMuxBuiltin(ID, M);
+        return BIMuxInfoConcept::defineMuxBuiltin(ID, M, OverloadInfo);
       }
       llvm::Function *F =
           M.getFunction(utils::BuiltinInfo::getMuxBuiltinName(ID));
@@ -390,8 +391,9 @@ data beyond the view of ComputeMux, e.g., in the driver or the HAL.
       return List;
     }
 
-    virtual llvm::Function *defineMuxBuiltin(utils::BuiltinID ID,
-                                             llvm::Module &M) override {
+    virtual llvm::Function *defineMuxBuiltin(
+        utils::BuiltinID ID, llvm::Module &M,
+        llvm::ArrayRef<llvm::Type *> OverloadInfo = {}) override {
       if (ID == utils::eMuxBuiltinGetLocalId) {
         llvm::Function *F =
             M.getFunction(utils::BuiltinInfo::getMuxBuiltinName(ID));
@@ -407,7 +409,7 @@ data beyond the view of ComputeMux, e.g., in the driver or the HAL.
         B.CreateRet(std::prev(F->arg_end()));
         return F;
       }
-      return BIMuxInfoConcept::defineMuxBuiltin(ID, M);
+      return BIMuxInfoConcept::defineMuxBuiltin(ID, M, OverloadInfo);
     }
   };
 

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_mux_builtin_info.h
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/refsi_mux_builtin_info.h
@@ -42,11 +42,13 @@ class RefSiG1BIMuxInfo : public compiler::utils::BIMuxInfoConcept {
  public:
   static llvm::StructType *getExecStateStruct(llvm::Module &M);
 
-  llvm::Function *getOrDeclareMuxBuiltin(compiler::utils::BuiltinID ID,
-                                         llvm::Module &M) override;
+  llvm::Function *getOrDeclareMuxBuiltin(
+      compiler::utils::BuiltinID ID, llvm::Module &M,
+      llvm::ArrayRef<llvm::Type *> OverloadInfo = {}) override;
 
-  llvm::Function *defineMuxBuiltin(compiler::utils::BuiltinID ID,
-                                   llvm::Module &M) override;
+  llvm::Function *defineMuxBuiltin(
+      compiler::utils::BuiltinID ID, llvm::Module &M,
+      llvm::ArrayRef<llvm::Type *> OverloadInfo = {}) override;
 };
 
 }  // namespace refsi_g1_wi

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
@@ -57,8 +57,10 @@ StructType *RefSiG1BIMuxInfo::getExecStateStruct(Module &M) {
 }
 
 Function *RefSiG1BIMuxInfo::getOrDeclareMuxBuiltin(
-    compiler::utils::BuiltinID ID, Module &M) {
-  auto *F = compiler::utils::BIMuxInfoConcept::getOrDeclareMuxBuiltin(ID, M);
+    compiler::utils::BuiltinID ID, Module &M,
+    llvm::ArrayRef<llvm::Type *> OverloadInfo) {
+  auto *F = compiler::utils::BIMuxInfoConcept::getOrDeclareMuxBuiltin(
+      ID, M, OverloadInfo);
   if (!F) {
     return F;
   }
@@ -78,7 +80,8 @@ Function *RefSiG1BIMuxInfo::getOrDeclareMuxBuiltin(
 }
 
 Function *RefSiG1BIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
-                                             Module &M) {
+                                             Module &M,
+                                             ArrayRef<Type *> OverloadInfo) {
   assert(compiler::utils::BuiltinInfo::isMuxBuiltinID(ID) &&
          "Only handling mux builtins");
   Function *F =
@@ -213,7 +216,8 @@ Function *RefSiG1BIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
   }
 
   if (ID != compiler::utils::eMuxBuiltinGetLocalId) {
-    return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M);
+    return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M,
+                                                               OverloadInfo);
   }
 
   Optional<unsigned> ParamIdx;

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
@@ -375,7 +375,8 @@ void defineRefSiDmaWait(Function &F) {
 }
 
 Function *RefSiM1BIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
-                                             Module &M) {
+                                             Module &M,
+                                             ArrayRef<Type *> OverloadInfo) {
   assert(compiler::utils::BuiltinInfo::isMuxBuiltinID(ID) &&
          "Only handling mux builtins");
   auto FnName = compiler::utils::BuiltinInfo::getMuxBuiltinName(ID);
@@ -390,7 +391,8 @@ Function *RefSiM1BIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
 
   switch (ID) {
     default:
-      return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M);
+      return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M,
+                                                                 OverloadInfo);
     case compiler::utils::eMuxBuiltinDMARead1D:
     case compiler::utils::eMuxBuiltinDMAWrite1D:
       defineRefSiDma1D(*F, *this);

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -57,6 +57,7 @@
 #include <compiler/utils/replace_atomic_funcs_pass.h>
 #include <compiler/utils/replace_barriers_pass.h>
 #include <compiler/utils/replace_c11_atomic_funcs_pass.h>
+#include <compiler/utils/replace_group_funcs_pass.h>
 #include <compiler/utils/replace_local_module_scope_variables_pass.h>
 #include <compiler/utils/replace_mem_intrinsics_pass.h>
 #include <compiler/utils/replace_mux_math_decls_pass.h>

--- a/modules/compiler/source/base/source/base_pass_registry.def
+++ b/modules/compiler/source/base/source/base_pass_registry.def
@@ -43,6 +43,7 @@ MODULE_PASS("replace-atomic-funcs", compiler::utils::ReplaceAtomicFuncsPass())
 MODULE_PASS("replace-barriers", compiler::utils::ReplaceBarriersPass())
 MODULE_PASS("replace-c11-atomic-funcs",
             compiler::utils::ReplaceC11AtomicFuncsPass())
+MODULE_PASS("replace-group-funcs", compiler::utils::ReplaceGroupFuncsPass())
 MODULE_PASS("replace-wgc", compiler::utils::ReplaceWGCPass())
 
 MODULE_PASS("replace-module-scope-vars",

--- a/modules/compiler/targets/host/include/host/host_mux_builtin_info.h
+++ b/modules/compiler/targets/host/include/host/host_mux_builtin_info.h
@@ -46,8 +46,9 @@ class HostBIMuxInfo : public compiler::utils::BIMuxInfoConcept {
   llvm::SmallVector<compiler::utils::BuiltinInfo::SchedParamInfo, 4>
   getMuxSchedulingParameters(llvm::Module &M) override;
 
-  llvm::Function *defineMuxBuiltin(compiler::utils::BuiltinID ID,
-                                   llvm::Module &M) override;
+  llvm::Function *defineMuxBuiltin(
+      compiler::utils::BuiltinID ID, llvm::Module &M,
+      llvm::ArrayRef<llvm::Type *> OverloadInfo) override;
 
   llvm::Value *initializeSchedulingParamForWrappedKernel(
       const compiler::utils::BuiltinInfo::SchedParamInfo &Info,

--- a/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
+++ b/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
@@ -138,7 +138,8 @@ HostBIMuxInfo::getMuxSchedulingParameters(Module &M) {
 }
 
 Function *HostBIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
-                                          Module &M) {
+                                          Module &M,
+                                          ArrayRef<Type *> OverloadInfo) {
   assert(compiler::utils::BuiltinInfo::isMuxBuiltinID(ID) &&
          "Only handling mux builtins");
   Function *F =
@@ -157,7 +158,8 @@ Function *HostBIMuxInfo::defineMuxBuiltin(compiler::utils::BuiltinID ID,
 
   switch (ID) {
     default:
-      return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M);
+      return compiler::utils::BIMuxInfoConcept::defineMuxBuiltin(ID, M,
+                                                                 OverloadInfo);
     case compiler::utils::eMuxBuiltinGetLocalSize:
       ParamIdx = SchedParamIndices::SCHED;
       DefaultVal = 1;

--- a/modules/compiler/test/CMakeLists.txt
+++ b/modules/compiler/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 add_ca_executable(UnitCompiler
   ${CMAKE_CURRENT_SOURCE_DIR}/common.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/group_ops.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/info.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/kernel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/library.cpp
@@ -30,7 +31,7 @@ target_include_directories(UnitCompiler PRIVATE
   ${PROJECT_SOURCE_DIR}/modules/compiler/include)
 
 target_link_libraries(UnitCompiler PRIVATE cargo
-  compiler-static mux ca_gtest_main compiler-utils)
+  compiler-static mux ca_gtest_main compiler-base compiler-utils)
 
 target_resources(UnitCompiler NAMESPACES ${BUILTINS_NAMESPACES})
 

--- a/modules/compiler/test/common.h
+++ b/modules/compiler/test/common.h
@@ -28,6 +28,9 @@
 #include <compiler/module.h>
 #include <compiler/target.h>
 #include <gtest/gtest.h>
+#include <llvm/AsmParser/Parser.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/SourceMgr.h>
 #include <mux/mux.h>
 #include <mux/utils/helpers.h>
 
@@ -322,6 +325,28 @@ static inline std::vector<const compiler::Info *> deferrableCompilers() {
   }
   return deferrable_compilers;
 }
+
+/// @brief Fixture for testing behavior of the compiler with LLVM modules.
+///
+/// Tests based on this fixture should test the behavior of
+/// LLVM-based APIs and transforms.
+struct CompilerLLVMModuleTest : ::testing::Test {
+  void SetUp() override {}
+
+  std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
+    llvm::SMDiagnostic Error;
+    auto M = llvm::parseAssemblyString(Assembly, Error, Context);
+
+    std::string ErrMsg;
+    llvm::raw_string_ostream OS(ErrMsg);
+    Error.print("", OS);
+    EXPECT_TRUE(M) << OS.str();
+
+    return M;
+  }
+
+  llvm::LLVMContext Context;
+};
 
 /// @brief Macro for instantiating test fixture parameterized over all
 /// compiler targets available on the platform.

--- a/modules/compiler/test/group_ops.cpp
+++ b/modules/compiler/test/group_ops.cpp
@@ -1,0 +1,442 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <base/base_pass_machinery.h>
+#include <compiler/utils/builtin_info.h>
+#include <compiler/utils/cl_builtin_info.h>
+#include <compiler/utils/mangling.h>
+#include <compiler/utils/replace_group_funcs_pass.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/Support/Debug.h>
+#include <multi_llvm/llvm_version.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "common.h"
+#include "compiler/module.h"
+
+using namespace llvm;
+using namespace compiler::utils;
+
+class GroupOpsTest : public CompilerLLVMModuleTest {
+ public:
+  std::unique_ptr<PassMachinery> PassMach;
+
+  void SetUp() override {
+    CompilerLLVMModuleTest::SetUp();
+
+    auto Callback = [](const llvm::Module &) {
+      return compiler::utils::BuiltinInfo(
+          compiler::utils::createCLBuiltinInfo(/*builtins*/ nullptr));
+    };
+
+    PassMach = std::make_unique<compiler::BaseModulePassMachinery>(
+        Context, /*TM*/ nullptr, /*Info*/ multi_llvm::None, Callback,
+        /*verify*/ false, /*logging level*/ DebugLogging::None,
+        /*time passes*/ false);
+    PassMach->initializeStart();
+    PassMach->initializeFinish();
+  }
+
+  struct GroupOp {
+    GroupOp(StringRef FnName, StringRef LLVMTy, GroupCollective C)
+        : MangledFnName(FnName), LLVMTy(LLVMTy), Collective(C) {}
+
+    std::string getLLVMFnString(StringRef ParamName = "%x") const {
+      std::string FnStr =
+          LLVMTy + " @" + MangledFnName + "(" + LLVMTy + " " + ParamName.str();
+      if (Collective.Op == GroupCollective::OpKind::Broadcast) {
+        if (Collective.Scope == GroupCollective::ScopeKind::SubGroup) {
+          FnStr += ", i32 %sg_lid";
+        } else {
+          FnStr += ", i64 %lid_x, i64 %lid_y, i64 %lid_z";
+        }
+      }
+      FnStr += ")";
+      return FnStr;
+    }
+
+    std::string MangledFnName;
+    std::string LLVMTy;
+    GroupCollective Collective;
+  };
+
+  static std::string getGroupBuiltinBaseName(GroupCollective::ScopeKind Scope) {
+    return std::string(Scope == GroupCollective::ScopeKind::SubGroup ? "sub"
+                       : Scope == GroupCollective::ScopeKind::VectorGroup
+                           ? "vec"
+                           : "work") +
+           "_group_";
+  }
+
+  std::vector<GroupOp> getGroupBroadcasts(GroupCollective::ScopeKind Scope) {
+    std::vector<GroupOp> GroupOps;
+    std::string BaseName = getGroupBuiltinBaseName(Scope);
+
+    NameMangler Mangler(&Context);
+    Type *const I32Ty = IntegerType::getInt32Ty(Context);
+    Type *const I64Ty = IntegerType::getInt64Ty(Context);
+    Type *const FloatTy = IntegerType::getFloatTy(Context);
+
+    GroupCollective Collective;
+    Collective.IsLogical = false;
+    Collective.Scope = Scope;
+    // Broadcasts don't expect a recursion kind.
+    Collective.Recurrence = RecurKind::None;
+    Collective.Op = GroupCollective::OpKind::Broadcast;
+
+    if (Scope == GroupCollective::ScopeKind::SubGroup ||
+        Scope == GroupCollective::ScopeKind::VectorGroup) {
+      std::string BuiltinName = BaseName + "broadcast";
+      SmallVector<TypeQualifiers, 4> QualsVec;
+      QualsVec.push_back(eTypeQualNone);
+      // And another for the index
+      QualsVec.push_back(eTypeQualNone);
+      // float version
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, {FloatTy, I32Ty}, QualsVec),
+                  "float", Collective));
+      // unsigned version
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, {I32Ty, I32Ty}, QualsVec),
+                  "i32", Collective));
+      // signed version
+      QualsVec[0] = eTypeQualSignedInt;
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, {I32Ty, I32Ty}, QualsVec),
+                  "i32", Collective));
+    } else {
+      SmallVector<Type *, 4> Args;
+      SmallVector<TypeQualifiers, 4> QualsVec;
+      std::string BuiltinName = BaseName + "broadcast";
+
+      // Qualifiers for the argument
+      Args.push_back(nullptr);
+      QualsVec.push_back(eTypeQualNone);
+      // Qualifiers for the indices
+      Args.push_back(I64Ty);
+      QualsVec.push_back(eTypeQualNone);
+      Args.push_back(I64Ty);
+      QualsVec.push_back(eTypeQualNone);
+      Args.push_back(I64Ty);
+      QualsVec.push_back(eTypeQualNone);
+      // float version
+      Args[0] = FloatTy;
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, Args, QualsVec), "float",
+                  Collective));
+      // unsigned version
+      Args[0] = I32Ty;
+      GroupOps.emplace_back(GroupOp(
+          Mangler.mangleName(BuiltinName, Args, QualsVec), "i32", Collective));
+
+      // signed version
+      Args[0] = I32Ty;
+      QualsVec[0] = eTypeQualSignedInt;
+      GroupOps.emplace_back(GroupOp(
+          Mangler.mangleName(BuiltinName, Args, QualsVec), "i32", Collective));
+    }
+
+    return GroupOps;
+  }
+
+  // GroupOpKind = "" for reductions, "exclusive" for exclusive scans and
+  // "inclusive" for inclusive scans.
+  std::vector<GroupOp> getGroupScandAndReductions(
+      GroupCollective::ScopeKind Scope, std::string GroupOpKind) {
+    const std::string BaseName = getGroupBuiltinBaseName(Scope);
+
+    NameMangler Mangler(&Context);
+    Type *const I32Ty = IntegerType::getInt32Ty(Context);
+    Type *const FloatTy = IntegerType::getFloatTy(Context);
+
+    std::vector<GroupOp> GroupOps;
+
+    // All sorts of reductions and scans
+    for (StringRef OpKind : {"add", "mul", "max", "min", "and", "or", "xor",
+                             "logical_and", "logical_or", "logical_xor"}) {
+      GroupCollective Collective;
+      Collective.IsLogical = false;
+      Collective.Scope = Scope;
+
+      std::string BuiltinName = BaseName;
+      if (GroupOpKind.empty()) {
+        BuiltinName += "reduce";
+        Collective.Op = GroupCollective::OpKind::Reduction;
+      } else {
+        BuiltinName += "scan_";
+        Collective.Op = GroupOpKind == "inclusive"
+                            ? GroupCollective::OpKind::ScanInclusive
+                            : GroupCollective::OpKind::ScanExclusive;
+      }
+
+      if (OpKind == "add") {
+        Collective.Recurrence = RecurKind::Add;
+      } else if (OpKind == "mul") {
+        Collective.Recurrence = RecurKind::Mul;
+      } else if (OpKind == "max") {
+        Collective.Recurrence = RecurKind::UMax;
+      } else if (OpKind == "min") {
+        Collective.Recurrence = RecurKind::UMin;
+      } else if (OpKind == "and") {
+        Collective.Recurrence = RecurKind::And;
+      } else if (OpKind == "or") {
+        Collective.Recurrence = RecurKind::Or;
+      } else if (OpKind == "xor") {
+        Collective.Recurrence = RecurKind::Xor;
+      } else if (OpKind == "logical_and") {
+        Collective.IsLogical = true;
+        Collective.Recurrence = RecurKind::And;
+      } else if (OpKind == "logical_or") {
+        Collective.IsLogical = true;
+        Collective.Recurrence = RecurKind::Or;
+      } else if (OpKind == "logical_xor") {
+        Collective.IsLogical = true;
+        Collective.Recurrence = RecurKind::Xor;
+      } else {
+        llvm_unreachable("unhandled op kind");
+      }
+
+      BuiltinName += GroupOpKind + "_" + OpKind.str();
+
+      TypeQualifiers DefaultQuals;
+      DefaultQuals.push_back(eTypeQualNone);
+
+      TypeQualifiers SignedIntQuals;
+      SignedIntQuals.push_back(eTypeQualSignedInt);
+
+      if (OpKind == "add" || OpKind == "mul" || OpKind == "max" ||
+          OpKind == "min") {
+        // float version
+        if (OpKind == "add") {
+          Collective.Recurrence = RecurKind::FAdd;
+        } else if (OpKind == "mul") {
+          Collective.Recurrence = RecurKind::FMul;
+        } else if (OpKind == "max") {
+          Collective.Recurrence = RecurKind::FMax;
+        } else if (OpKind == "min") {
+          Collective.Recurrence = RecurKind::FMin;
+        } else {
+          llvm_unreachable("unhandled op kind");
+        }
+        GroupOps.emplace_back(
+            GroupOp(Mangler.mangleName(BuiltinName, FloatTy, DefaultQuals),
+                    "float", Collective));
+      }
+
+      // unsigned version
+      if (OpKind == "add") {
+        Collective.Recurrence = RecurKind::Add;
+      } else if (OpKind == "mul") {
+        Collective.Recurrence = RecurKind::Mul;
+      } else if (OpKind == "max") {
+        Collective.Recurrence = RecurKind::UMax;
+      } else if (OpKind == "min") {
+        Collective.Recurrence = RecurKind::UMin;
+      }
+
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, I32Ty, DefaultQuals), "i32",
+                  Collective));
+
+      // signed version
+      if (OpKind == "max") {
+        Collective.Recurrence = RecurKind::SMax;
+      } else if (OpKind == "min") {
+        Collective.Recurrence = RecurKind::SMin;
+      }
+      GroupOps.emplace_back(
+          GroupOp(Mangler.mangleName(BuiltinName, I32Ty, SignedIntQuals), "i32",
+                  Collective));
+    }
+
+    return GroupOps;
+  }
+
+  std::vector<GroupOp> getGroupBuiltins(GroupCollective::ScopeKind Scope,
+                                        bool IncludeAnyAll = true,
+                                        bool IncludeBroadcasts = true,
+                                        bool IncludeReductions = true,
+                                        bool IncludeScans = true) {
+    std::vector<GroupOp> GroupOps;
+    std::string BaseName = getGroupBuiltinBaseName(Scope);
+
+    if (IncludeAnyAll) {
+      GroupCollective Collective;
+      Collective.Op = GroupCollective::OpKind::Any;
+      Collective.Recurrence = RecurKind::Or;
+      Collective.IsLogical = false;
+      Collective.Scope = Scope;
+
+      NameMangler Mangler(&Context);
+      Type *const I32Ty = IntegerType::getInt32Ty(Context);
+
+      GroupOps.emplace_back(GroupOp(
+          Mangler.mangleName(BaseName + "any", I32Ty, {eTypeQualSignedInt}),
+          "i32", Collective));
+
+      Collective.Op = GroupCollective::OpKind::All;
+      Collective.Recurrence = RecurKind::And;
+      GroupOps.emplace_back(GroupOp(
+          Mangler.mangleName(BaseName + "all", I32Ty, {eTypeQualSignedInt}),
+          "i32", Collective));
+    }
+
+    if (IncludeBroadcasts) {
+      auto Broadcasts = getGroupBroadcasts(Scope);
+      GroupOps.insert(GroupOps.end(), Broadcasts.begin(), Broadcasts.end());
+    }
+
+    if (IncludeReductions) {
+      auto Reductions = getGroupScandAndReductions(Scope, "");
+      GroupOps.insert(GroupOps.end(), Reductions.begin(), Reductions.end());
+    }
+
+    if (IncludeScans) {
+      auto InclusiveScans = getGroupScandAndReductions(Scope, "inclusive");
+      GroupOps.insert(GroupOps.end(), InclusiveScans.begin(),
+                      InclusiveScans.end());
+
+      auto ExclusiveScans = getGroupScandAndReductions(Scope, "exclusive");
+      GroupOps.insert(GroupOps.end(), ExclusiveScans.begin(),
+                      ExclusiveScans.end());
+    }
+
+    return GroupOps;
+  }
+
+  std::string getTestModuleStr(const std::vector<std::string> &BuiltinCalls,
+                               const std::vector<std::string> &BuiltinDecls) {
+    std::string ModuleStr = R"(
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+)";
+
+    ModuleStr += R"(
+define void @test_wrapper(i32 %i, float %f, i32 %sg_lid, i64 %lid_x, i64 %lid_y, i64 %lid_z) {
+)";
+
+    for (const auto &Call : BuiltinCalls) {
+      ModuleStr += "  " + Call + "\n";
+    }
+
+    ModuleStr += "  ret void\n}\n\n";
+
+    for (const auto &Decl : BuiltinDecls) {
+      ModuleStr += Decl + "\n";
+    }
+
+    ModuleStr += R"(
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+)";
+
+    return ModuleStr;
+  }
+
+  // This tests:
+  // * auto-generates all possible OpenCL group builtins and calls them in a
+  // single test function
+  // * runs the ReplaceGroupFuncsPass to replace calls to the mux builtins
+  // * tests a round-trip between identifying and declaring those mux builtins
+  template <GroupCollective::ScopeKind GroupScope>
+  void doTestBody() {
+    auto GroupOps = getGroupBuiltins(GroupScope);
+
+    std::vector<std::string> BuiltinDecls;
+    std::vector<std::string> BuiltinCalls;
+    unsigned Idx = 0;
+    for (const auto &Op : GroupOps) {
+      BuiltinDecls.push_back("declare " + Op.getLLVMFnString());
+
+      StringRef ParamName =
+          Op.LLVMTy == "float" ? "%f" : (Op.LLVMTy == "i32" ? "%i" : "<err>");
+      BuiltinCalls.push_back("%call" + std::to_string(Idx) + " = call " +
+                             Op.getLLVMFnString(ParamName));
+      ++Idx;
+    }
+
+    std::string ModuleStr = getTestModuleStr(BuiltinCalls, BuiltinDecls);
+
+    auto M = parseModule(ModuleStr);
+
+    ModulePassManager PM;
+    PM.addPass(ReplaceGroupFuncsPass());
+
+    PM.run(*M, PassMach->getMAM());
+
+    auto &BI = PassMach->getMAM().getResult<BuiltinInfoAnalysis>(*M);
+
+    auto *TestFn = M->getFunction("test_wrapper");
+    ASSERT_TRUE(TestFn && !TestFn->empty());
+
+    auto &BB = TestFn->front();
+
+    DenseSet<Function *> MuxBuiltins;
+    DenseSet<BuiltinID> MuxBuiltinIDs;
+    // Note we expect the called functions in the basic block to be in the same
+    // order as the group operations we generated earlier.
+    unsigned GroupOpIdx = 0;
+    for (auto &I : BB) {
+      auto const *CI = dyn_cast<CallInst>(&I);
+      if (!CI) {
+        continue;
+      }
+      auto *const CalledFn = CI->getCalledFunction();
+      EXPECT_TRUE(CalledFn);
+      MuxBuiltins.insert(CalledFn);
+
+      auto Builtin = BI.analyzeBuiltin(*CalledFn);
+      std::string InfoStr = " for function " + CalledFn->getName().str() +
+                            " identified as ID " + std::to_string(Builtin.ID);
+      EXPECT_NE(Builtin.ID, eBuiltinInvalid) << InfoStr;
+      EXPECT_TRUE(BI.isMuxBuiltinID(Builtin.ID)) << InfoStr;
+
+      // Do a get-or-declare, and make sure we're getting back the exact same
+      // function.
+      auto *const BuiltinDecl =
+          BI.getOrDeclareMuxBuiltin(Builtin.ID, *M, Builtin.mux_overload_info);
+      EXPECT_TRUE(BuiltinDecl && BuiltinDecl == CalledFn) << InfoStr;
+
+      auto Info = BI.isMuxGroupCollective(Builtin.ID);
+      ASSERT_TRUE(Info) << InfoStr;
+
+      // Now check that the returned values are what we expect. We don't
+      // check 'type' or 'function' here as it's not set by either party.
+      assert(Info && "Asserting the optional to silence a compiler warning");
+      EXPECT_EQ(Info->Op, GroupOps[GroupOpIdx].Collective.Op) << InfoStr;
+      EXPECT_EQ(Info->Scope, GroupOps[GroupOpIdx].Collective.Scope) << InfoStr;
+      EXPECT_EQ(Info->IsLogical, GroupOps[GroupOpIdx].Collective.IsLogical)
+          << InfoStr;
+      EXPECT_EQ(Info->Recurrence, GroupOps[GroupOpIdx].Collective.Recurrence)
+          << InfoStr;
+
+      ++GroupOpIdx;
+    }
+  }
+};
+
+TEST_F(GroupOpsTest, OpenCLSubgroupOps) {
+  doTestBody<GroupCollective::ScopeKind::SubGroup>();
+}
+
+TEST_F(GroupOpsTest, OpenCLWorkgroupOps) {
+  doTestBody<GroupCollective::ScopeKind::WorkGroup>();
+}

--- a/modules/compiler/test/lit/passes/degenerate-sub-group-broadcast-32bit.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-group-broadcast-32bit.ll
@@ -44,7 +44,11 @@ entry:
 }
 
 attributes #0 = { "mux-kernel"="entry-point" }
+
+!opencl.ocl.version = !{!1}
+
 !0 = !{i32 13, i32 64, i32 64}
+!1 = !{i32 3, i32 0}
 
 ; CHECK: declare spir_func i32 @_Z20work_group_broadcastijjj(i32, i32, i32, i32)
 declare spir_func i32 @_Z19sub_group_broadcastij(i32, i32)

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
@@ -32,6 +32,10 @@ declare spir_func i32 @_Z20sub_group_reduce_addi(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" }
 
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+
 ; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test.degenerate-subgroups
 ; CHECK: (i32 [[Y:%.*]]) #[[ATTR0:[0-9]+]]
 ; CHECK: entry:

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
@@ -57,6 +57,10 @@ entry:
 
 declare spir_func i32 @_Z20sub_group_reduce_addi(i32)
 
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+
 attributes #0 = { "mux-kernel"="entry-point" }
 
 ; CHECK: define spir_func i32 @clone_this.degenerate-subgroups(i32 [[X1:%.+]]) {

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups.ll
@@ -273,3 +273,7 @@ declare spir_func void @__mux_sub_group_barrier(i32, i32, i32)
 attributes #0 = { "mux-kernel"="entry-point" }
 !0 = !{i32 13, i32 64, i32 64}
 ; CHECK: attributes #0 = { "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
+
+!opencl.ocl.version = !{!1}
+
+!1 = !{i32 3, i32 0}

--- a/modules/compiler/test/lit/passes/replace-sub-group-ops.ll
+++ b/modules/compiler/test/lit/passes/replace-sub-group-ops.ll
@@ -1,0 +1,284 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; RUN: muxc --passes replace-group-funcs,verify %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define spir_func i32 @sub_group_size_test() {
+; CHECK: %call1 = call i32 @__mux_get_sub_group_size()
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z18get_sub_group_sizev()
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_local_id_test() {
+; CHECK: %call1 = call i32 @__mux_get_sub_group_local_id()
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z22get_sub_group_local_idv()
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_all_test(i32 %x) {
+; CHECK: [[T0:%.*]] = icmp ne i32 %x, 0
+; CHECK: %call1 = call i1 @__mux_sub_group_all_i1(i1 [[T0]])
+; CHECK: [[T1:%.*]] = sext i1 %call1 to i32
+; CHECK: ret i32 [[T1]]
+  %call = call spir_func i32 @_Z13sub_group_alli(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_any_test(i32 %x) {
+; CHECK: [[T0:%.*]] = icmp ne i32 %x, 0
+; CHECK: %call1 = call i1 @__mux_sub_group_any_i1(i1 [[T0]])
+; CHECK: [[T1:%.*]] = sext i1 %call1 to i32
+; CHECK: ret i32 [[T1]]
+  %call = call spir_func i32 @_Z13sub_group_anyi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_broadcasti_test(i32 %x, i32 %lid) {
+; CHECK: %call1 = call i32 @__mux_sub_group_broadcast_i32(i32 %x, i32 %lid)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z19sub_group_broadcastij(i32 %x, i32 %lid)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_broadcastf_test(float %x, i32 %lid) {
+; CHECK: %call1 = call float @__mux_sub_group_broadcast_f32(float %x, i32 %lid)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z19sub_group_broadcastfj(float %x, i32 %lid)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_reduce_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_reduce_add_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20sub_group_reduce_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_reduce_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_reduce_fadd_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20sub_group_reduce_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_reduce_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_reduce_smin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20sub_group_reduce_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_reduce_minu_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_reduce_umin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20sub_group_reduce_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_reduce_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_reduce_fmin_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20sub_group_reduce_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_reduce_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_reduce_smax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20sub_group_reduce_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_reduce_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_reduce_umax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20sub_group_reduce_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_reduce_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_reduce_fmax_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20sub_group_reduce_maxf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_add_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_addj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_add_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_addj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_exclusive_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_exclusive_fadd_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_exclusive_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_smin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_minj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_umin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_exclusive_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_exclusive_fmin_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_exclusive_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_smax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_exclusive_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_exclusive_umax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_exclusive_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_exclusive_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_exclusive_fmax_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_exclusive_maxf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_add_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_addj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_add_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_addj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_inclusive_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_inclusive_fadd_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_inclusive_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_smin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_minj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_umin_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_inclusive_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_inclusive_fmin_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_inclusive_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_smax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @sub_group_scan_inclusive_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_sub_group_scan_inclusive_umax_i32(i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z28sub_group_scan_inclusive_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @sub_group_scan_inclusive_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_sub_group_scan_inclusive_fmax_f32(float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z28sub_group_scan_inclusive_maxf(float %x)
+  ret float %call
+}
+
+declare spir_func i32 @_Z18get_sub_group_sizev()
+declare spir_func i32 @_Z22get_sub_group_local_idv()
+declare spir_func i32 @_Z13sub_group_alli(i32)
+declare spir_func i32 @_Z13sub_group_anyi(i32)
+declare spir_func i32 @_Z19sub_group_broadcastij(i32, i32)
+declare spir_func float @_Z19sub_group_broadcastfj(float, i32)
+declare spir_func i32 @_Z20sub_group_reduce_addi(i32)
+declare spir_func float @_Z20sub_group_reduce_addf(float)
+declare spir_func i32 @_Z20sub_group_reduce_mini(i32)
+declare spir_func i32 @_Z20sub_group_reduce_minj(i32)
+declare spir_func float @_Z20sub_group_reduce_minf(float)
+declare spir_func i32 @_Z20sub_group_reduce_maxi(i32)
+declare spir_func i32 @_Z20sub_group_reduce_maxj(i32)
+declare spir_func float @_Z20sub_group_reduce_maxf(float)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_addi(i32)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_addj(i32)
+declare spir_func float @_Z28sub_group_scan_exclusive_addf(float)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_mini(i32)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_minj(i32)
+declare spir_func float @_Z28sub_group_scan_exclusive_minf(float)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_maxi(i32)
+declare spir_func i32 @_Z28sub_group_scan_exclusive_maxj(i32)
+declare spir_func float @_Z28sub_group_scan_exclusive_maxf(float)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_addi(i32)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_addj(i32)
+declare spir_func float @_Z28sub_group_scan_inclusive_addf(float)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_mini(i32)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_minj(i32)
+declare spir_func float @_Z28sub_group_scan_inclusive_minf(float)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_maxi(i32)
+declare spir_func i32 @_Z28sub_group_scan_inclusive_maxj(i32)
+declare spir_func float @_Z28sub_group_scan_inclusive_maxf(float)
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}

--- a/modules/compiler/test/lit/passes/replace-work-group-ops.ll
+++ b/modules/compiler/test/lit/passes/replace-work-group-ops.ll
@@ -1,0 +1,300 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; RUN: muxc --passes replace-group-funcs,verify %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define spir_func i32 @work_group_all_test(i32 %x) {
+; CHECK: [[T0:%.*]] = icmp ne i32 %x, 0
+; CHECK: %call1 = call i1 @__mux_work_group_all_i1(i32 0, i1 [[T0]])
+; CHECK: [[T1:%.*]] = sext i1 %call1 to i32
+; CHECK: ret i32 [[T1]]
+  %call = call spir_func i32 @_Z14work_group_alli(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_any_test(i32 %x) {
+; CHECK: [[T0:%.*]] = icmp ne i32 %x, 0
+; CHECK: %call1 = call i1 @__mux_work_group_any_i1(i32 0, i1 [[T0]])
+; CHECK: [[T1:%.*]] = sext i1 %call1 to i32
+; CHECK: ret i32 [[T1]]
+  %call = call spir_func i32 @_Z14work_group_anyi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_broadcastxi_test(i32 %x, i64 %lid) {
+; CHECK: %call1 = call i32 @__mux_work_group_broadcast_i32(i32 0, i32 %x, i64 %lid, i64 0, i64 0)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20work_group_broadcastim(i32 %x, i64 %lid)
+  ret i32 %call
+}
+
+define spir_func float @work_group_broadcastxf_test(float %x, i64 %lid) {
+; CHECK: %call1 = call float @__mux_work_group_broadcast_f32(i32 0, float %x, i64 %lid, i64 0, i64 0)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20work_group_broadcastfm(float %x, i64 %lid)
+  ret float %call
+}
+
+define spir_func i32 @work_group_broadcastxyi_test(i32 %x, i64 %lidx, i64 %lidy) {
+; CHECK: %call1 = call i32 @__mux_work_group_broadcast_i32(i32 0, i32 %x, i64 %lidx, i64 %lidy, i64 0)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20work_group_broadcastimm(i32 %x, i64 %lidx, i64 %lidy)
+  ret i32 %call
+}
+
+define spir_func float @work_group_broadcastxyf_test(float %x, i64 %lidx, i64 %lidy) {
+; CHECK: %call1 = call float @__mux_work_group_broadcast_f32(i32 0, float %x, i64 %lidx, i64 %lidy, i64 0)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20work_group_broadcastfmm(float %x, i64 %lidx, i64 %lidy)
+  ret float %call
+}
+
+define spir_func i32 @work_group_broadcastxyzi_test(i32 %x, i64 %lidx, i64 %lidy, i64 %lidz) {
+; CHECK: %call1 = call i32 @__mux_work_group_broadcast_i32(i32 0, i32 %x, i64 %lidx, i64 %lidy, i64 %lidz)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z20work_group_broadcastimmm(i32 %x, i64 %lidx, i64 %lidy, i64 %lidz)
+  ret i32 %call
+}
+
+define spir_func float @work_group_broadcastxyzf_test(float %x, i64 %lidx, i64 %lidy, i64 %lidz) {
+; CHECK: %call1 = call float @__mux_work_group_broadcast_f32(i32 0, float %x, i64 %lidx, i64 %lidy, i64 %lidz)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z20work_group_broadcastfmmm(float %x, i64 %lidx, i64 %lidy, i64 %lidz)
+  ret float %call
+}
+
+define spir_func i32 @work_group_reduce_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_reduce_add_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z21work_group_reduce_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_reduce_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_reduce_fadd_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z21work_group_reduce_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_reduce_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_reduce_smin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z21work_group_reduce_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_reduce_minu_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_reduce_umin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z21work_group_reduce_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_reduce_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_reduce_fmin_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z21work_group_reduce_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_reduce_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_reduce_smax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z21work_group_reduce_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_reduce_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_reduce_umax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z21work_group_reduce_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_reduce_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_reduce_fmax_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z21work_group_reduce_maxf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_add_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_addj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_add_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_addj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_exclusive_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_exclusive_fadd_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_exclusive_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_smin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_minj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_umin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_exclusive_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_exclusive_fmin_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_exclusive_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_smax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_exclusive_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_exclusive_umax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_exclusive_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_exclusive_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_exclusive_fmax_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_exclusive_maxf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_addi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_add_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_addi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_addj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_add_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_addj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_inclusive_addf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_inclusive_fadd_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_inclusive_addf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_mini_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_smin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_mini(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_minj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_umin_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_minj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_inclusive_minf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_inclusive_fmin_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_inclusive_minf(float %x)
+  ret float %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_maxi_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_smax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_maxi(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @work_group_scan_inclusive_maxj_test(i32 %x) {
+; CHECK: %call1 = call i32 @__mux_work_group_scan_inclusive_umax_i32(i32 0, i32 %x)
+; CHECK: ret i32 %call1
+  %call = call spir_func i32 @_Z29work_group_scan_inclusive_maxj(i32 %x)
+  ret i32 %call
+}
+
+define spir_func float @work_group_scan_inclusive_maxf_test(float %x) {
+; CHECK: %call1 = call float @__mux_work_group_scan_inclusive_fmax_f32(i32 0, float %x)
+; CHECK: ret float %call1
+  %call = call spir_func float @_Z29work_group_scan_inclusive_maxf(float %x)
+  ret float %call
+}
+
+declare spir_func i32 @_Z14work_group_alli(i32)
+declare spir_func i32 @_Z14work_group_anyi(i32)
+declare spir_func i32 @_Z20work_group_broadcastim(i32, i64)
+declare spir_func float @_Z20work_group_broadcastfm(float, i64)
+declare spir_func i32 @_Z20work_group_broadcastimm(i32, i64, i64)
+declare spir_func float @_Z20work_group_broadcastfmm(float, i64, i64)
+declare spir_func i32 @_Z20work_group_broadcastimmm(i32, i64, i64, i64)
+declare spir_func float @_Z20work_group_broadcastfmmm(float, i64, i64, i64)
+declare spir_func i32 @_Z21work_group_reduce_addi(i32)
+declare spir_func float @_Z21work_group_reduce_addf(float)
+declare spir_func i32 @_Z21work_group_reduce_mini(i32)
+declare spir_func i32 @_Z21work_group_reduce_minj(i32)
+declare spir_func float @_Z21work_group_reduce_minf(float)
+declare spir_func i32 @_Z21work_group_reduce_maxi(i32)
+declare spir_func i32 @_Z21work_group_reduce_maxj(i32)
+declare spir_func float @_Z21work_group_reduce_maxf(float)
+declare spir_func i32 @_Z29work_group_scan_exclusive_addi(i32)
+declare spir_func i32 @_Z29work_group_scan_exclusive_addj(i32)
+declare spir_func float @_Z29work_group_scan_exclusive_addf(float)
+declare spir_func i32 @_Z29work_group_scan_exclusive_mini(i32)
+declare spir_func i32 @_Z29work_group_scan_exclusive_minj(i32)
+declare spir_func float @_Z29work_group_scan_exclusive_minf(float)
+declare spir_func i32 @_Z29work_group_scan_exclusive_maxi(i32)
+declare spir_func i32 @_Z29work_group_scan_exclusive_maxj(i32)
+declare spir_func float @_Z29work_group_scan_exclusive_maxf(float)
+declare spir_func i32 @_Z29work_group_scan_inclusive_addi(i32)
+declare spir_func i32 @_Z29work_group_scan_inclusive_addj(i32)
+declare spir_func float @_Z29work_group_scan_inclusive_addf(float)
+declare spir_func i32 @_Z29work_group_scan_inclusive_mini(i32)
+declare spir_func i32 @_Z29work_group_scan_inclusive_minj(i32)
+declare spir_func float @_Z29work_group_scan_inclusive_minf(float)
+declare spir_func i32 @_Z29work_group_scan_inclusive_maxi(i32)
+declare spir_func i32 @_Z29work_group_scan_inclusive_maxj(i32)
+declare spir_func float @_Z29work_group_scan_inclusive_maxf(float)
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}

--- a/modules/compiler/test/mangling.cpp
+++ b/modules/compiler/test/mangling.cpp
@@ -16,11 +16,6 @@
 
 #include <compiler/utils/mangling.h>
 #include <compiler/utils/target_extension_types.h>
-#include <llvm/AsmParser/Parser.h>
-#include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Module.h>
-#include <llvm/IR/Type.h>
-#include <llvm/Support/SourceMgr.h>
 #include <multi_llvm/llvm_version.h>
 
 #include <cstdint>
@@ -31,23 +26,7 @@
 
 using namespace compiler::utils;
 
-struct ManglingTest : ::testing::Test {
-  void SetUp() override {}
-
-  std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
-    llvm::SMDiagnostic Error;
-    auto M = llvm::parseAssemblyString(Assembly, Error, Context);
-
-    std::string ErrMsg;
-    llvm::raw_string_ostream OS(ErrMsg);
-    Error.print("", OS);
-    EXPECT_TRUE(M) << OS.str();
-
-    return M;
-  }
-
-  llvm::LLVMContext Context;
-};
+using ManglingTest = CompilerLLVMModuleTest;
 
 TEST_F(ManglingTest, MangleBuiltinTypes) {
   // With opaque pointers, before LLVM 17 we can't actually mangle OpenCL

--- a/modules/compiler/test/utils.cpp
+++ b/modules/compiler/test/utils.cpp
@@ -17,11 +17,6 @@
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
-#include <llvm/AsmParser/Parser.h>
-#include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Module.h>
-#include <llvm/IR/Type.h>
-#include <llvm/Support/SourceMgr.h>
 
 #include <cstdint>
 #include <cstring>
@@ -32,23 +27,7 @@
 
 using namespace compiler::utils;
 
-struct CompilerUtilsTest : ::testing::Test {
-  void SetUp() override {}
-
-  std::unique_ptr<llvm::Module> parseModule(llvm::StringRef Assembly) {
-    llvm::SMDiagnostic Error;
-    auto M = llvm::parseAssemblyString(Assembly, Error, Context);
-
-    std::string ErrMsg;
-    llvm::raw_string_ostream OS(ErrMsg);
-    Error.print("", OS);
-    EXPECT_TRUE(M) << OS.str();
-
-    return M;
-  }
-
-  llvm::LLVMContext Context;
-};
+using CompilerUtilsTest = CompilerLLVMModuleTest;
 
 TEST_F(CompilerUtilsTest, CreateKernelWrapper) {
   auto M = parseModule(R"(

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -60,6 +60,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_atomic_funcs_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_barriers_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_c11_atomic_funcs_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_group_funcs_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_local_module_scope_variables_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_mem_intrinsics_pass.h  
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_mux_math_decls_pass.h
@@ -111,6 +112,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_atomic_funcs_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_barriers_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_c11_atomic_funcs_pass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_group_funcs_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_local_module_scope_variables_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mem_intrinsics_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_mux_math_decls_pass.cpp

--- a/modules/compiler/utils/include/compiler/utils/cl_builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/cl_builtin_info.h
@@ -116,8 +116,11 @@ class CLBuiltinInfo : public BILangInfoConcept {
       const override;
 
   /// @see BuiltinInfo::mapSyncBuiltinToMuxSyncBuiltin
-  llvm::CallInst *mapSyncBuiltinToMuxSyncBuiltin(llvm::CallInst &,
-                                                 BIMuxInfoConcept &) override;
+  llvm::Instruction *mapSyncBuiltinToMuxSyncBuiltin(
+      llvm::CallInst &, BIMuxInfoConcept &) override;
+  /// @see BuiltinInfo::mapGroupBuiltinToMuxGroupBuiltin
+  llvm::Instruction *mapGroupBuiltinToMuxGroupBuiltin(
+      llvm::CallInst &, BIMuxInfoConcept &) override;
   /// @see BuiltinInfo::getPrintfBuiltin
   BuiltinID getPrintfBuiltin() const override;
   /// @see BuiltinInfo::getSubgroupLocalIdBuiltin

--- a/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
+++ b/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
@@ -63,8 +63,7 @@ llvm::Constant *getIdentityVal(llvm::RecurKind Kind, llvm::Type *Ty);
 /// @brief Represents a work-group or sub-group collective operation.
 struct GroupCollective {
   /// @brief The different operation types a group collective can represent.
-  enum class Op {
-    None,
+  enum class OpKind {
     All,
     Any,
     Reduction,
@@ -74,24 +73,24 @@ struct GroupCollective {
   };
 
   /// @brief The possible scopes of a group collective.
-  enum class Scope { None, WorkGroup, SubGroup };
+  enum class ScopeKind { WorkGroup, SubGroup, VectorGroup };
 
   /// @brief The operation type of the group collective.
-  Op op = Op::None;
+  OpKind Op = OpKind::All;
   /// @brief The scope of the group collective operation.
-  Scope scope = Scope::None;
+  ScopeKind Scope = ScopeKind::WorkGroup;
   /// @brief The llvm recurrence operation this can be mapped to. For broadcasts
   /// this will be None.
-  llvm::RecurKind recurKind = llvm::RecurKind::None;
+  llvm::RecurKind Recurrence = llvm::RecurKind::None;
   /// @brief The llvm function body for this group collective instance.
-  llvm::Function *func = nullptr;
+  llvm::Function *Func = nullptr;
   /// @brief The type the group operation is applied to. Will always be the
-  /// type of the first argument of `func`.
-  llvm::Type *type = nullptr;
+  /// type of the first argument of `Func`.
+  llvm::Type *Ty = nullptr;
   /// @brief True if the operation is logical, rather than bitwise.
-  bool isLogical = false;
+  bool IsLogical = false;
   /// @brief Returns true for Any/All type collective operations.
-  bool isAnyAll() const { return op == Op::Any || op == Op::All; }
+  bool isAnyAll() const { return Op == OpKind::Any || Op == OpKind::All; }
 };
 
 /// @brief Helper function to parse a group collective operation.

--- a/modules/compiler/utils/include/compiler/utils/replace_group_funcs_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/replace_group_funcs_pass.h
@@ -14,20 +14,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef REFSI_MUX_BUILTIN_INFO_H_INCLUDED
-#define REFSI_MUX_BUILTIN_INFO_H_INCLUDED
+/// @file
+///
+/// Replace group functions pass.
 
-#include <compiler/utils/builtin_info.h>
+#ifndef COMPILER_UTILS_REPLACE_GROUP_FUNCS_PASS_H_INCLUDED
+#define COMPILER_UTILS_REPLACE_GROUP_FUNCS_PASS_H_INCLUDED
 
-namespace refsi_m1 {
+#include <llvm/IR/PassManager.h>
 
-class RefSiM1BIMuxInfo : public compiler::utils::BIMuxInfoConcept {
+namespace compiler {
+namespace utils {
+
+/// @brief A pass that will replace calls to the group builtins with calls to
+/// the equivalent mux functions
+
+class ReplaceGroupFuncsPass final
+    : public llvm::PassInfoMixin<ReplaceGroupFuncsPass> {
  public:
-  llvm::Function *defineMuxBuiltin(
-      compiler::utils::BuiltinID ID, llvm::Module &M,
-      llvm::ArrayRef<llvm::Type *> OverloadInfo = {}) override;
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
 };
+}  // namespace utils
+}  // namespace compiler
 
-}  // namespace refsi_m1
-
-#endif  // REFSI_MUX_BUILTIN_INFO_H_INCLUDED
+#endif  // COMPILER_UTILS_REPLACE_GROUP_FUNCS_PASS_H_INCLUDED

--- a/modules/compiler/utils/source/define_mux_builtins_pass.cpp
+++ b/modules/compiler/utils/source/define_mux_builtins_pass.cpp
@@ -41,7 +41,8 @@ PreservedAnalyses compiler::utils::DefineMuxBuiltinsPass::run(
     // Define the builtin. If it declares any new dependent builtins, those
     // will be appended to the module's function list and so will be
     // encountered by later iterations.
-    if (BI.defineMuxBuiltin(BI.analyzeBuiltin(F).ID, M)) {
+    auto Builtin = BI.analyzeBuiltin(F);
+    if (BI.defineMuxBuiltin(Builtin.ID, M, Builtin.mux_overload_info)) {
       Changed = true;
     }
   }

--- a/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
+++ b/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
@@ -54,7 +54,7 @@ bool isSubGroupFunction(CallInst *CI) {
   auto *Fcn = CI->getCalledFunction();
   assert(Fcn && "virtual calls are not supported");
   if (auto GC = compiler::utils::isGroupCollective(Fcn)) {
-    return GC->scope == compiler::utils::GroupCollective::Scope::SubGroup;
+    return GC->Scope == compiler::utils::GroupCollective::ScopeKind::SubGroup;
   }
 
   return Fcn->getName() == compiler::utils::MuxBuiltins::sub_group_barrier;

--- a/modules/compiler/utils/source/replace_group_funcs_pass.cpp
+++ b/modules/compiler/utils/source/replace_group_funcs_pass.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/builtin_info.h>
+#include <compiler/utils/replace_group_funcs_pass.h>
+
+using namespace llvm;
+
+PreservedAnalyses compiler::utils::ReplaceGroupFuncsPass::run(
+    Module &M, ModuleAnalysisManager &AM) {
+  auto &BI = AM.getResult<BuiltinInfoAnalysis>(M);
+
+  SmallVector<CallInst *, 8> Calls;
+  for (auto &F : M.functions()) {
+    auto B = BI.analyzeBuiltin(F);
+    if (B.properties & eBuiltinPropertyMapToMuxGroupBuiltin) {
+      for (auto *U : F.users()) {
+        if (auto *CI = dyn_cast<CallInst>(U)) {
+          Calls.push_back(CI);
+        }
+      }
+    }
+  }
+
+  if (Calls.empty()) {
+    return PreservedAnalyses::all();
+  }
+
+  for (auto *CI : Calls) {
+    if (auto *const NewCI = BI.mapGroupBuiltinToMuxGroupBuiltin(*CI)) {
+      CI->replaceAllUsesWith(NewCI);
+      CI->eraseFromParent();
+    }
+  }
+
+  return PreservedAnalyses::none();
+}

--- a/modules/mux/include/mux/mux.h
+++ b/modules/mux/include/mux/mux.h
@@ -37,7 +37,7 @@ extern "C" {
 /// @brief Mux major version number.
 #define MUX_MAJOR_VERSION 0
 /// @brief Mux minor version number.
-#define MUX_MINOR_VERSION 77
+#define MUX_MINOR_VERSION 78
 /// @brief Mux patch version number.
 #define MUX_PATCH_VERSION 0
 /// @brief Mux combined version number.

--- a/modules/mux/targets/host/include/host/host.h
+++ b/modules/mux/targets/host/include/host/host.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Host major version number.
 #define HOST_MAJOR_VERSION 0
 /// @brief Host minor version number.
-#define HOST_MINOR_VERSION 77
+#define HOST_MINOR_VERSION 78
 /// @brief Host patch version number.
 #define HOST_PATCH_VERSION 0
 /// @brief Host combined version number.

--- a/modules/mux/targets/riscv/include/riscv/riscv.h
+++ b/modules/mux/targets/riscv/include/riscv/riscv.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Riscv major version number.
 #define RISCV_MAJOR_VERSION 0
 /// @brief Riscv minor version number.
-#define RISCV_MINOR_VERSION 77
+#define RISCV_MINOR_VERSION 78
 /// @brief Riscv patch version number.
 #define RISCV_PATCH_VERSION 0
 /// @brief Riscv combined version number.

--- a/modules/mux/tools/api/mux.xml
+++ b/modules/mux/tools/api/mux.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception</comment>
     <block>
       <define priority="high">${FUNCTION_PREFIX}_MAJOR_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} major version number.</brief></doxygen></define>
-      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>77</value>
+      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>78</value>
         <doxygen><brief>${Function_Prefix} minor version number.</brief></doxygen></define>
       <define priority="high">${FUNCTION_PREFIX}_PATCH_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} patch version number.</brief></doxygen></define>


### PR DESCRIPTION
This introduces a set of builtins to represent operations like OpenCL's
`sub_group_xxx` and `work_group_xxx` and SPIR-V `OpGroupXXX` operations
in a language-agnostic way.

It also introduces 'vector group' operations which represent sub-groups
as the vectorizer currently thinks of them: as groups of work-items
being 'simulated' together via vectorized code, despite being executed
on only one invocation. These have no direct OpenCL equivalent, but can
be used by the compiler to simulate larger sub-groups than the hardware
actually provides.

Until now, the construction kit's handling of these operations has been
centered around analysis of the OpenCL builtins, which is inflexible and
brittle. We may one day want to support IR in a format not compatible
with OpenCL-like IR, for instance. It also means that the compiler is
either constrained by the OpenCL semantics of these operations.

These builtins are not yet generated in the default pipeline, but
there's a new pass which introduces them to the module by asking the
language-level `BuiltinInfo` to replace calls to its concept of group
builtins with mux's concept of these builtins. The builtins should also
be correctly wired up through the identification and get-or-declare
APIs, but are not yet able to be *defined* by mux. This will come in a
later change.
