### PR TITLE
[compiler] Fix bugs in passing samplers as i32s

### DIFF
--- a/modules/compiler/test/lit/passes/image-arg-subst.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst.ll
@@ -56,7 +56,7 @@ entry:
 }
 
 ; We've updated the old kernel to pass samplers as i32
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) %out, ptr addrspace(1) %img, i32 %sampler1, i32 %sampler2) [[NEW_ATTRS:#[0-9]+]] {
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, i32 %sampler1, i32 %sampler2) [[NEW_ATTRS:#[0-9]+]] {
 ; CHECK:   %sampler1.ptrcast = inttoptr i32 %sampler1 to ptr addrspace(2)
 ; CHECK:   %sampler2.ptrcast = inttoptr i32 %sampler2 to ptr addrspace(2)
 ; CHECK:   call spir_kernel void @image_sampler.old(

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -41,6 +41,8 @@ size_t calcPackedArgsAllocSize(
     size_t size = 0;
     switch (descriptor.type) {
       case mux_descriptor_info_type_sampler:
+        size = sizeof(uint32_t);
+        break;
       case mux_descriptor_info_type_buffer:
       case mux_descriptor_info_type_null_buffer:
       case mux_descriptor_info_type_image:


### PR DESCRIPTION
This PR fixes a couple of issues introduced in a recent change to how samplers are passed to kernels.

When creating the new kernel wrapper, we were accidentally dropping parameter attributes, which could lead to incorrect codegen (notably when dropping the `byval` attribute).

We were also incorrectly calculating the packed argument struct size on the host target, but no known failure has resulted from that.