### PR TITLE
[builtins] Auto-generate sub-group builtins

### DIFF
--- a/modules/compiler/builtins/include/builtins/builtins-3.0.h
+++ b/modules/compiler/builtins/include/builtins/builtins-3.0.h
@@ -811,6 +811,21 @@ int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(int x);
 int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(int x);
 int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(int x);
 
+// SPV_KHR_uniform_group_arithmetic
+
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(int x);
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(int x);
+
 uint __CL_BARRIER_ATTRIBUTES sub_group_broadcast(uint x,
                                                  uint sub_group_local_id);
 uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(uint x);
@@ -822,6 +837,21 @@ uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(uint x);
 uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(uint x);
 uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(uint x);
 uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(uint x);
+
+// SPV_KHR_uniform_group_arithmetic
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(uint x);
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(uint x);
 
 long __CL_BARRIER_ATTRIBUTES sub_group_broadcast(long x,
                                                  uint sub_group_local_id);
@@ -835,6 +865,21 @@ long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(long x);
 long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(long x);
 long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(long x);
 
+// SPV_KHR_uniform_group_arithmetic
+
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(long x);
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(long x);
+
 ulong __CL_BARRIER_ATTRIBUTES sub_group_broadcast(ulong x,
                                                   uint sub_group_local_id);
 ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(ulong x);
@@ -846,6 +891,21 @@ ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(ulong x);
 ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(ulong x);
 ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(ulong x);
 ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(ulong x);
+
+// SPV_KHR_uniform_group_arithmetic
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(ulong x);
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(ulong x);
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
 half __CL_BARRIER_ATTRIBUTES sub_group_broadcast(half x,
@@ -859,6 +919,12 @@ half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(half x);
 half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(half x);
 half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(half x);
 half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(half x);
+
+// SPV_KHR_uniform_group_arithmetic
+
+half __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(half x);
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(half x);
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(half x);
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
 float __CL_BARRIER_ATTRIBUTES sub_group_broadcast(float x,
@@ -873,6 +939,12 @@ float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(float x);
 float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(float x);
 float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(float x);
 
+// SPV_KHR_uniform_group_arithmetic
+
+float __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(float x);
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(float x);
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(float x);
+
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 double __CL_BARRIER_ATTRIBUTES sub_group_broadcast(double x,
                                                    uint sub_group_local_id);
@@ -885,7 +957,34 @@ double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(double x);
 double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(double x);
 double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(double x);
 double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(double x);
+
+// SPV_KHR_uniform_group_arithmetic
+
+double __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(double x);
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(double x);
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(double x);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+
+// SPV_KHR_uniform_group_arithmetic
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_xor(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_xor(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_and(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_or(bool x);
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_xor(bool x);
 
 void __CL_BARRIER_ATTRIBUTES sub_group_barrier(cl_mem_fence_flags flags);
 void __CL_BARRIER_ATTRIBUTES sub_group_barrier(cl_mem_fence_flags flags,

--- a/modules/compiler/builtins/include/builtins/clbuiltins-3.0.h
+++ b/modules/compiler/builtins/include/builtins/clbuiltins-3.0.h
@@ -67,360 +67,431 @@ uint __CL_WORK_ITEM_ATTRIBUTES get_sub_group_id(void) {
 
 uint __CL_WORK_ITEM_ATTRIBUTES get_sub_group_local_id(void) { return 0; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_all(int predicate) { return predicate; }
+int __CL_BARRIER_ATTRIBUTES sub_group_all(int predicate) { return predicate; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_any(int predicate) { return predicate; }
+int __CL_BARRIER_ATTRIBUTES sub_group_any(int predicate) { return predicate; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(int x,
+int __CL_BARRIER_ATTRIBUTES sub_group_broadcast(int x,
                                                 uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(int x) { return 0; }
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(int x) { return 0; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(int x) {
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(int x) {
   return INT_MAX;
 }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(int x) {
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(int x) {
   return INT_MIN;
 }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(int x) { return x; }
 
 // SPV_KHR_uniform_group_arithmetic
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_and(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_or(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_reduce_xor(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_mul(int x) { return 1; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_and(int x) { return ~0; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_or(int x) { return 0; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_xor(int x) { return 0; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(int x) { return x; }
 
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_mul(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_and(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_or(int x) { return x; }
-int __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_xor(int x) { return x; }
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(int x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(uint x,
+int __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(int x) { return x; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(int x) { return 1; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(int x) { return ~0; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(int x) { return 0; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(int x) { return 0; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(int x) { return x; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(int x) { return x; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(int x) { return x; }
+
+int __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(int x) { return x; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_broadcast(uint x,
                                                  uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(uint x) { return 0; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(uint x) { return 0; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(uint x) {
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(uint x) {
   return UINT_MAX;
 }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(uint x) { return 0; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(uint x) { return 0; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(uint x) { return x; }
 
 // SPV_KHR_uniform_group_arithmetic
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_and(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_or(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_reduce_xor(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_mul(uint x) { return 1; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_and(uint x) { return ~0; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_or(uint x) { return 0; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_xor(uint x) { return 0; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(uint x) { return x; }
 
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_mul(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_and(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_or(uint x) { return x; }
-uint __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_xor(uint x) { return x; }
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(uint x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(long x,
+uint __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(uint x) { return x; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(uint x) { return 1; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(uint x) { return ~0; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(uint x) { return 0; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(uint x) { return 0; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(uint x) { return x; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(uint x) { return x; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(uint x) { return x; }
+
+uint __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(uint x) { return x; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_broadcast(long x,
                                                  uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(long x) { return 0; }
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(long x) { return 0; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(long x) {
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(long x) {
   return LONG_MAX;
 }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(long x) {
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(long x) {
   return LONG_MIN;
 }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(long x) { return x; }
 
 // SPV_KHR_uniform_group_arithmetic
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_and(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_or(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_reduce_xor(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_mul(long x) { return 1; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_and(long x) { return ~0; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_or(long x) { return 0; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_xor(long x) { return 0; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(long x) { return x; }
 
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_mul(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_and(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_or(long x) { return x; }
-long __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_xor(long x) { return x; }
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(long x) { return x; }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(ulong x,
+long __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(long x) { return x; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(long x) { return 1; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(long x) { return ~0; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(long x) { return 0; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(long x) { return 0; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(long x) { return x; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(long x) { return x; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(long x) { return x; }
+
+long __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(long x) { return x; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_broadcast(ulong x,
                                                   uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(ulong x) { return x; }
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(ulong x) { return x; }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(ulong x) { return x; }
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(ulong x) { return x; }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(ulong x) { return x; }
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(ulong x) { return x; }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(ulong x) {
   return 0;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(ulong x) {
   return ULONG_MAX;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(ulong x) {
   return 0;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(ulong x) {
   return x;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(ulong x) {
   return x;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(ulong x) {
   return x;
 }
 
 // SPV_KHR_uniform_group_arithmetic
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(ulong x) { return x; }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_and(ulong x) { return x; }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_or(ulong x) { return x; }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_reduce_xor(ulong x) { return x; }
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(ulong x) { return x; }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_mul(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(ulong x) { return x; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(ulong x) { return x; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(ulong x) { return x; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(ulong x) {
   return 1;
 }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_and(ulong x) {
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(ulong x) {
   return ~0;
 }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_or(ulong x) { return 0; }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_xor(ulong x) {
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(ulong x) { return 0; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(ulong x) {
   return 0;
 }
 
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_mul(ulong x) {
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(ulong x) {
   return x;
 }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_and(ulong x) {
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(ulong x) {
   return x;
 }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_or(ulong x) { return x; }
-ulong __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_xor(ulong x) {
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(ulong x) { return x; }
+
+ulong __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(ulong x) {
   return x;
 }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-half __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(half x,
+half __CL_BARRIER_ATTRIBUTES sub_group_broadcast(half x,
                                                  uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(half x) {
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(half x) {
   return 0.0;
 }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(half x) {
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(half x) {
   return +INFINITY;
 }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(half x) {
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(half x) {
   return -INFINITY;
 }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(half x) { return x; }
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(half x) { return x; }
 
-half __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(half x) { return x; }
+// SPV_KHR_uniform_group_arithmetic
+
+half __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(half x) { return x; }
+
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(half x) {
+  return 1.0;
+}
+
+half __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(half x) { return x; }
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(float x,
+float __CL_BARRIER_ATTRIBUTES sub_group_broadcast(float x,
                                                   uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(float x) { return x; }
+float __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(float x) { return x; }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(float x) { return x; }
+float __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(float x) { return x; }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(float x) { return x; }
+float __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(float x) { return x; }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(float x) {
   return 0.0;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(float x) {
   return +INFINITY;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(float x) {
   return -INFINITY;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(float x) {
   return x;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(float x) {
   return x;
 }
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(float x) {
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(float x) {
   return x;
 }
 
 // SPV_KHR_uniform_group_arithmetic
 
-float __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(float x) { return x; }
+float __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(float x) { return x; }
+
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(float x) {
+  return 1.0;
+}
+
+float __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(float x) {
+  return x;
+}
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-double __CL_BUILTIN_ATTRIBUTES sub_group_broadcast(double x,
+double __CL_BARRIER_ATTRIBUTES sub_group_broadcast(double x,
                                                    uint sub_group_local_id) {
   (void)sub_group_local_id;
   return x;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_reduce_add(double x) { return x; }
+double __CL_BARRIER_ATTRIBUTES sub_group_reduce_add(double x) { return x; }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_reduce_min(double x) { return x; }
+double __CL_BARRIER_ATTRIBUTES sub_group_reduce_min(double x) { return x; }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_reduce_max(double x) { return x; }
+double __CL_BARRIER_ATTRIBUTES sub_group_reduce_max(double x) { return x; }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_add(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_add(double x) {
   return 0.0;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_min(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_min(double x) {
   return +INFINITY;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_max(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_max(double x) {
   return -INFINITY;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_add(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_add(double x) {
   return x;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_min(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_min(double x) {
   return x;
 }
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_max(double x) {
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_max(double x) {
   return x;
 }
 
 // SPV_KHR_uniform_group_arithmetic
 
-double __CL_BUILTIN_ATTRIBUTES sub_group_reduce_mul(double x) { return x; }
+double __CL_BARRIER_ATTRIBUTES sub_group_reduce_mul(double x) { return x; }
 
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_mul(double x) {
+  return 1.0;
+}
+
+double __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_mul(double x) {
+  return x;
+}
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_and(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_or(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_xor(bool x) { return x; }
+// SPV_KHR_uniform_group_arithmetic
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_logical_and(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_logical_or(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_reduce_logical_xor(bool x) { return x; }
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_and(bool x) { return x; }
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_mul(bool x) { return 1; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_and(bool x) { return ~0; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_or(bool x) { return 0; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_xor(bool x) { return 0; }
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_or(bool x) { return x; }
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_logical_and(bool x) {
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_xor(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_and(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_or(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_reduce_logical_xor(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_and(bool x) { return ~0; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_or(bool x) { return 0; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_xor(bool x) { return 0; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_and(bool x) {
   return ~0;
 }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_logical_or(bool x) {
-  return 0;
-}
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_exclusive_logical_xor(bool x) {
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_or(bool x) {
   return 0;
 }
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_mul(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_and(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_or(bool x) { return x; }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_xor(bool x) { return x; }
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_exclusive_logical_xor(bool x) {
+  return 0;
+}
 
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_logical_and(bool x) {
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_and(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_or(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_xor(bool x) { return x; }
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_and(bool x) {
   return x;
 }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_logical_or(bool x) {
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_or(bool x) {
   return x;
 }
-bool __CL_BUILTIN_ATTRIBUTES sub_group_scan_inclusive_logical_xor(bool x) {
+
+bool __CL_BARRIER_ATTRIBUTES sub_group_scan_inclusive_logical_xor(bool x) {
   return x;
 }
 

--- a/modules/compiler/builtins/scripts/generate_header_30.sh
+++ b/modules/compiler/builtins/scripts/generate_header_30.sh
@@ -753,15 +753,19 @@ function output_for_type()
 
 scriptDir="$(cd $(dirname $0); pwd)"
 
-# This version of clang-format used must match the version specified in the
-# root CMakeLists.txt file, so scrape that.
-CLANG_FORMAT_VERSION="$(cat "$scriptDir"/../../../CMakeLists.txt \
+# This version of clang-format used is best if it matches the version specified
+# in the root CMakeLists.txt file, so scrape that.
+CLANG_FORMAT_VERSION="$(cat "$scriptDir"/../../../../CMakeLists.txt \
   | grep 'find_package(ClangTools' \
   | sed -e 's/.*ClangTools \([0-9\.]*\) COMPONENTS.*/\1/')"
 CLANG_FORMAT_LONG="clang-format-${CLANG_FORMAT_VERSION}"
 CLANG_FORMAT_SHORT="clang-format-${CLANG_FORMAT_VERSION%.[0-9]}"
 check_bin "$CLANG_FORMAT_LONG" && CLANG_FORMAT="$CLANG_FORMAT_LONG"
 check_bin "$CLANG_FORMAT_SHORT" && CLANG_FORMAT="$CLANG_FORMAT_SHORT"
+# As a last resort, accept any version of clang-format, which is better than
+# nothing. We generally don't let anything merge if it isn't formatted
+# correctly anyway.
+check_bin "clang-format" && CLANG_FORMAT="clang-format"
 check_bin "$CLANG_FORMAT" \
   && echo "Using ${CLANG_FORMAT}." \
   || echo "Could not find ${CLANG_FORMAT_LONG} or ${CLANG_FORMAT_SHORT}."


### PR DESCRIPTION
This fixes up a mistake where recent changes to the sub-group builtin
declarations and definitions were not auto-generated using the script
and were instead done manually.

There are a few bugs that are fixed by this:

* We were missing some declarations, and only providing definitions.
* Some declarations were marked `convergent` but the definitions
  weren't. Now both are `convergent` as intended.
* We were providing 'mul' operations on the 'bool' type which isn't
  strictly required by the extension we support.

Also allow any clang-format version when using this script. The reasoning
being that some systems may not explicitly version their
clang-format binaries. If this picks up the wrong version (i.e., not the
one specified in the root CMakeLists.txt), then it's still better than
not formatting the file at all as it previously did. Our CI will ensure
everything is correctly formatted before merging.
