### PR TITLE
[compiler] Further integrate mux group builtins

### DIFF
--- a/modules/compiler/test/group_ops.cpp
+++ b/modules/compiler/test/group_ops.cpp
@@ -61,7 +61,7 @@ class GroupOpsTest : public CompilerLLVMModuleTest {
     std::string getLLVMFnString(StringRef ParamName = "%x") const {
       std::string FnStr =
           LLVMTy + " @" + MangledFnName + "(" + LLVMTy + " " + ParamName.str();
-      if (Collective.Op == GroupCollective::OpKind::Broadcast) {
+      if (Collective.isBroadcast()) {
         if (Collective.isSubGroupScope()) {
           FnStr += ", i32 %sg_lid";
         } else {

--- a/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
+++ b/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
@@ -89,6 +89,10 @@ struct GroupCollective {
   bool isScan() const {
     return Op == OpKind::ScanExclusive || Op == OpKind::ScanInclusive;
   }
+  /// @brief Returns true for reduction collective operations.
+  bool isReduction() const { return Op == OpKind::Reduction; }
+  /// @brief Returns true for broadcast collective operations.
+  bool isBroadcast() const { return Op == OpKind::Broadcast; }
   /// @brief Returns true for sub-group collective operations.
   bool isSubGroupScope() const { return Scope == ScopeKind::SubGroup; }
   /// @brief Returns true for work-group collective operations.

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -275,27 +275,15 @@ BuiltinUniformity BuiltinInfo::isBuiltinUniform(Builtin const &B,
       // not support vectorizing along y or z (see CA-2843).
       return SimdDimIdx ? eBuiltinUniformityNever
                         : eBuiltinUniformityInstanceID;
-    case eMuxBuiltinSubgroupAll:
-    case eMuxBuiltinSubgroupAny:
-    case eMuxBuiltinSubgroupBroadcast:
-    case eMuxBuiltinSubgroupReduceAdd:
-    case eMuxBuiltinSubgroupReduceFAdd:
-    case eMuxBuiltinSubgroupReduceMul:
-    case eMuxBuiltinSubgroupReduceFMul:
-    case eMuxBuiltinSubgroupReduceSMax:
-    case eMuxBuiltinSubgroupReduceUMax:
-    case eMuxBuiltinSubgroupReduceFMax:
-    case eMuxBuiltinSubgroupReduceSMin:
-    case eMuxBuiltinSubgroupReduceUMin:
-    case eMuxBuiltinSubgroupReduceFMin:
-    case eMuxBuiltinSubgroupReduceAnd:
-    case eMuxBuiltinSubgroupReduceOr:
-    case eMuxBuiltinSubgroupReduceXor:
-    case eMuxBuiltinSubgroupReduceLogicalAnd:
-    case eMuxBuiltinSubgroupReduceLogicalOr:
-    case eMuxBuiltinSubgroupReduceLogicalXor:
-      return eBuiltinUniformityAlways;
   }
+
+  // Reductions and broadcasts are always uniform
+  if (auto Info = isMuxGroupCollective(B.ID)) {
+    if (Info->isAnyAll() || Info->isReduction() || Info->isBroadcast()) {
+      return eBuiltinUniformityAlways;
+    }
+  }
+
   if (LangImpl) {
     return LangImpl->isBuiltinUniform(B, CI, SimdDimIdx);
   }

--- a/modules/compiler/utils/source/cl_builtin_info.cpp
+++ b/modules/compiler/utils/source/cl_builtin_info.cpp
@@ -1006,7 +1006,6 @@ Builtin CLBuiltinInfo::analyzeBuiltin(Function const &Callee) const {
 
   bool IsConvergent = false;
   unsigned Properties = eBuiltinPropertyNone;
-  llvm::SmallVector<llvm::Type *, 2> OverloadInfo;
   switch (ID) {
     default:
       // Assume convergence on unknown builtins.
@@ -1278,10 +1277,6 @@ Builtin CLBuiltinInfo::analyzeBuiltin(Function const &Callee) const {
     case eCLBuiltinWorkgroupScanLogicalXorExclusive:
       IsConvergent = true;
       Properties |= eBuiltinPropertyMapToMuxGroupBuiltin;
-      if (ID != eCLBuiltinWorkgroupAll && ID != eCLBuiltinWorkgroupAny &&
-          ID != eCLBuiltinSubgroupAll && ID != eCLBuiltinSubgroupAny) {
-        OverloadInfo.push_back(Callee.getArg(0)->getType());
-      }
       break;
   }
 

--- a/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
@@ -122,20 +122,9 @@ static bool isSubgroupBroadcastOrReduction(
   if (!Callee) {
     return false;
   }
-  auto const Builtin = BI.analyzeBuiltin(*Callee);
-  if (auto Info = BI.isMuxGroupCollective(Builtin.ID);
-      Info && Info->isSubGroupScope()) {
-    switch (Info->Op) {
-      default:
-        return false;
-      case compiler::utils::GroupCollective::OpKind::Any:
-      case compiler::utils::GroupCollective::OpKind::All:
-      case compiler::utils::GroupCollective::OpKind::Reduction:
-      case compiler::utils::GroupCollective::OpKind::Broadcast:
-        return true;
-    }
-  }
-  return false;
+  auto Info = BI.isMuxGroupCollective(BI.analyzeBuiltin(*Callee).ID);
+  return Info && Info->isSubGroupScope() &&
+         (Info->isAnyAll() || Info->isReduction() || Info->isBroadcast());
 }
 
 void UniformValueResult::findVectorLeaves(


### PR DESCRIPTION
This PR just better integrates the new mux group builtins by:

* providing helper methods for common queries
* tidying up some code
* refactoring the degenerate sub-groups pass to use builtin IDs and not function name manipulation.