### PR TITLE
[compiler] Update lit tests to use mux builtins

### DIFF
--- a/modules/compiler/targets/host/test/lit/passes/add_fp_control_aarch64.ll
+++ b/modules/compiler/targets/host/test/lit/passes/add_fp_control_aarch64.ll
@@ -41,7 +41,7 @@ target triple = "aarch64-linux-gnu-elf"
 
 define spir_kernel void @add(float addrspace(1)* readonly %in1, float addrspace(1)* readonly %in2, float addrspace(1)* %out, i8 signext %i) #0 !test !0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in1, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %in2, i64 %call
@@ -52,7 +52,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 %x)
+declare i64 @__mux_get_global_id(i32 %x)
 
 ; check that we preserve the attributes on the old function, but add 'alwaysinline'
 ; FTZ-DAG: attributes [[ATTRS]] = { alwaysinline "foo"="bar" "mux-base-fn-name"="baz" }

--- a/modules/compiler/targets/host/test/lit/passes/add_fp_control_arm32.ll
+++ b/modules/compiler/targets/host/test/lit/passes/add_fp_control_arm32.ll
@@ -42,7 +42,7 @@ target triple = "armv7-unknown-linux-gnueabihf-elf"
 
 define spir_kernel void @add(float addrspace(1)* readonly %in1, float addrspace(1)* readonly %in2, float addrspace(1)* %out) #0 !test !0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in1, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %in2, i64 %call
@@ -53,7 +53,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 %x)
+declare i64 @__mux_get_global_id(i32 %x)
 
 attributes #0 = { "foo"="bar" "mux-kernel"="entry-point" "mux-base-fn-name"="baz" }
 

--- a/modules/compiler/targets/host/test/lit/passes/add_fp_control_x86.ll
+++ b/modules/compiler/targets/host/test/lit/passes/add_fp_control_x86.ll
@@ -39,7 +39,7 @@ target triple = "x86_64-unknown-unknown-elf"
 
 define spir_kernel void @add(float addrspace(1)* readonly %in1, float addrspace(1)* readonly %in2, float addrspace(1)*  %out) #0 !test !0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in1, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %in2, i64 %call
@@ -55,7 +55,7 @@ define void @foo() #1 {
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 %x)
+declare i64 @__mux_get_global_id(i32 %x)
 
 ; check that we preserve the attributes on the old function, but add 'alwaysinline'
 ; FTZ-DAG: attributes [[ATTRS]] = { alwaysinline "foo"="bar" "mux-base-fn-name"="baz" }

--- a/modules/compiler/targets/host/test/lit/passes/minimal-barrier-odd-size.ll
+++ b/modules/compiler/targets/host/test/lit/passes/minimal-barrier-odd-size.ll
@@ -27,13 +27,13 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @minimal_barrier(i32 %min_0, i32 %min_1, i32 %stride, i32 %n0, i32 %n1, i32 %n2, ptr addrspace(1) %g, ptr addrspace(3) %shared) #0 !reqd_work_group_size !0 {
 entry:
-  %call = tail call spir_func i64 @_Z12get_group_idj(i32 1) #4
+  %call = tail call i64 @__mux_get_group_id(i32 1) #4
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z12get_group_idj(i32 0) #4
+  %call1 = tail call i64 @__mux_get_group_id(i32 0) #4
   %conv2 = trunc i64 %call1 to i32
-  %call3 = tail call spir_func i64 @_Z12get_local_idj(i32 1) #4
+  %call3 = tail call i64 @__mux_get_local_id(i32 1) #4
   %conv4 = trunc i64 %call3 to i32
-  %call5 = tail call spir_func i64 @_Z12get_local_idj(i32 0) #4
+  %call5 = tail call i64 @__mux_get_local_id(i32 0) #4
   %conv6 = trunc i64 %call5 to i32
   %mul = shl nsw i32 %conv, 3
   %add = add nsw i32 %mul, %min_1
@@ -41,7 +41,7 @@ entry:
   %mul8 = shl nsw i32 %conv2, 4
   %add9 = add nsw i32 %mul8, %min_0
   %call10 = tail call spir_func i32 @_Z3minii(i32 %add9, i32 %n1) #5
-  tail call spir_func void @__mux_work_group_barrier(i32 0, i32 1, i32 272)
+  tail call void @__mux_work_group_barrier(i32 0, i32 1, i32 272)
   %cmp = icmp eq i32 %conv4, 0
   %cmp12 = icmp ult i32 %conv6, 16
   %or.cond = select i1 %cmp, i1 %cmp12, i1 false
@@ -68,7 +68,7 @@ for.body:
   br i1 %exitcond.not, label %if.end, label %for.body
 
 if.end:
-  tail call spir_func void @__mux_work_group_barrier(i32 1, i32 1, i32 272)
+  tail call void @__mux_work_group_barrier(i32 1, i32 1, i32 272)
   br i1 %cmp12, label %if.then24, label %if.end35
 
 if.then24:
@@ -90,13 +90,13 @@ if.end35:
   ret void
 }
 
-declare spir_func i64 @_Z12get_group_idj(i32)
+declare i64 @__mux_get_group_id(i32)
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 declare spir_func i32 @_Z3minii(i32, i32)
 
-declare spir_func void @__mux_work_group_barrier(i32, i32, i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
 
 attributes #0 = { "mux-kernel"="entry-point" "vecz-mode"="auto" }
 

--- a/modules/compiler/targets/host/test/lit/passes/vecz-non-power-of-2.ll
+++ b/modules/compiler/targets/host/test/lit/passes/vecz-non-power-of-2.ll
@@ -27,7 +27,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK-LABEL: define spir_kernel void @__vecz_v8_foo(
 define spir_kernel void @foo(i32 addrspace(1)* %in) #0 !reqd_work_group_size !0 {
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
@@ -36,7 +36,7 @@ define spir_kernel void @bar(i32 addrspace(1)* %in) #0 !reqd_work_group_size !1 
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" "vecz-mode"="auto" }
 

--- a/modules/compiler/targets/host/test/lit/passes/vecz-pass-opts.ll
+++ b/modules/compiler/targets/host/test/lit/passes/vecz-pass-opts.ll
@@ -27,7 +27,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK:   ]
 ; CHECK: }
 define spir_kernel void @foo(i32 addrspace(1)* %in) #0 !reqd_work_group_size !0 {
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
@@ -46,7 +46,7 @@ define spir_kernel void @bar(i32 addrspace(1)* %in) #0 !reqd_work_group_size !1 
 ; CHECK:   ]
 ; CHECK: }
 define spir_kernel void @baz(i32 addrspace(1)* %in) #0 !reqd_work_group_size !2 {
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
@@ -68,7 +68,7 @@ define spir_kernel void @whazz(i32 addrspace(1)* %in) #1 !reqd_work_group_size !
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" "vecz-mode"="auto" }
 attributes #1 = { "mux-kernel"="entry-point" "vecz-mode"="always" }

--- a/modules/compiler/targets/host/test/lit/passes/vecz.ll
+++ b/modules/compiler/targets/host/test/lit/passes/vecz.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_foo(
 define spir_kernel void @foo(i32 addrspace(1)* %in) #0 !reqd_work_group_size !0 {
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
@@ -30,7 +30,7 @@ define spir_kernel void @bar(i32 addrspace(1)* %in) #0 !reqd_work_group_size !1 
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" "vecz-mode"="auto" }
 

--- a/modules/compiler/targets/riscv/test/lit/passes/ir_to_builtins_frem.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/ir_to_builtins_frem.ll
@@ -23,7 +23,7 @@ target triple = "riscv64-unknown-unknown-elf"
 
 define dso_local spir_kernel void @add(float addrspace(1)* readonly %in1, float addrspace(1)* readonly %in2, float addrspace(1)*  writeonly %out)  {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 0)
+  %call = tail call i64 @__mux_get_global_id(i32 noundef 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in1, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float addrspace(1)* %in2, i64 %call
@@ -34,4 +34,4 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 noundef)
+declare i64 @__mux_get_global_id(i32 noundef)

--- a/modules/compiler/targets/riscv/test/lit/passes/vecz-pass-opts.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/vecz-pass-opts.ll
@@ -38,7 +38,7 @@ target triple = "riscv64-unknown-unknown-elf"
 
 define spir_kernel void @foo(i32 addrspace(1)* %a, i32 addrspace(1)* %z) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add = add nsw i32 %x, 4
@@ -51,7 +51,7 @@ entry:
 ; CHECK: Function 'bar' will not be vectorized
 define spir_kernel void @bar(i32 addrspace(1)* %a, i32 addrspace(1)* %z) #1 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add = add nsw i32 %x, 4
@@ -60,7 +60,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" }
 attributes #1 = { optnone noinline "mux-kernel"="entry-point" }

--- a/modules/compiler/targets/riscv/test/lit/passes/vecz.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/vecz.ll
@@ -44,7 +44,7 @@ target triple = "riscv64-unknown-unknown-elf"
 ; CHECK-1S-VP: call void @llvm.vp.store.nxv1i32.p1(<vscale x 1 x i32>
 define spir_kernel void @foo(i32 addrspace(1)* %a, i32 addrspace(1)* %z) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add = add nsw i32 %x, 4
@@ -57,7 +57,7 @@ entry:
 ; CHECK-NOT __vecz_{{.*}}_bar
 define spir_kernel void @bar(i32 addrspace(1)* %a, i32 addrspace(1)* %z) #1 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add = add nsw i32 %x, 4
@@ -66,7 +66,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" }
 attributes #1 = { optnone noinline "mux-kernel"="entry-point" }

--- a/modules/compiler/test/lit/passes/barriers-cfg-linear.ll
+++ b/modules/compiler/test/lit/passes/barriers-cfg-linear.ll
@@ -54,7 +54,7 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 define internal void @barrier_cfg_linear(i32 addrspace(1)* %d, i32 addrspace(1)* %a, i32 addrspace(1)* %b) !reqd_work_group_size !12 !codeplay_ca_vecz.base !14 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %call
@@ -66,17 +66,11 @@ entry:
   ret void
 }
 
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
-}
-
 declare void @__mux_work_group_barrier(i32, i32, i32)
 
 define void @__vecz_v16_barrier_cfg_linear(i32 addrspace(1)* %d, i32 addrspace(1)* %a, i32 addrspace(1)* %b) #0 !reqd_work_group_size !12 !codeplay_ca_vecz.derived !21 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %tmp.a = bitcast i32 addrspace(1)* %arrayidx to <16 x i32> addrspace(1)*
   %0 = load <16 x i32>, <16 x i32> addrspace(1)* %tmp.a, align 4

--- a/modules/compiler/test/lit/passes/barriers-cfg-loop.ll
+++ b/modules/compiler/test/lit/passes/barriers-cfg-loop.ll
@@ -51,7 +51,7 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 define void @barrier_cfg_loop(i32 addrspace(1)* %d, i32 addrspace(1)* %a) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   br label %for.body
 
 for.cond.cleanup:                                 ; preds = %for.body
@@ -71,12 +71,6 @@ for.body:                                         ; preds = %for.body, %entry
   %inc = add nuw nsw i64 %i.08, 1
   %cmp.not = icmp eq i64 %inc, 10
   br i1 %cmp.not, label %for.cond.cleanup, label %for.body
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-cfg-reduce.ll
+++ b/modules/compiler/test/lit/passes/barriers-cfg-reduce.ll
@@ -31,12 +31,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 ; CHECK: br label %sw.bb3
 
-declare spir_func i64 @_Z13get_global_idj(i32 %x)
-declare spir_func i32 @__mux_work_group_reduce_add_i32(i32 %id, i32 %x)
+declare i64 @__mux_get_global_id(i32 %x)
+declare i32 @__mux_work_group_reduce_add_i32(i32 %id, i32 %x)
 
 define internal void @reduction(i32 addrspace(1)* %d, i32 addrspace(1)* %a) #0 !reqd_work_group_size !0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %ld = load i32, i32 addrspace(1)* %arrayidx, align 4
   %reduce = call i32 @__mux_work_group_reduce_add_i32(i32 0, i32 %ld)

--- a/modules/compiler/test/lit/passes/barriers-dbg-loop-name.ll
+++ b/modules/compiler/test/lit/passes/barriers-dbg-loop-name.ll
@@ -54,7 +54,7 @@ entry:
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !63, metadata !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef)), !dbg !64
   %0 = load i32, i32* %in3.addr, align 4, !dbg !65
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %out.addr, align 8, !dbg !65
-  %call = call i64 @_Z13get_global_idj(i32 0) #4, !dbg !65, !range !66
+  %call = call i64 @__mux_get_global_id(i32 0) #4, !dbg !65, !range !66
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %call, !dbg !65
   store i32 %0, i32 addrspace(1)* %arrayidx, align 4, !dbg !65
   ret void, !dbg !67
@@ -73,13 +73,6 @@ entry:
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
-
-; Function Attrs: convergent mustprogress nofree norecurse nounwind readonly willreturn
-define internal i64 @_Z13get_global_idj(i32 %x) #2 {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x) #5
-  ret i64 %call
-}
 
 ; Function Attrs: convergent mustprogress nofree nounwind readonly willreturn
 declare i64 @__mux_get_global_id(i32 ) #3

--- a/modules/compiler/test/lit/passes/barriers-dbg.ll
+++ b/modules/compiler/test/lit/passes/barriers-dbg.ll
@@ -33,13 +33,13 @@ entry:
   store i32 addrspace(1)* %output, i32 addrspace(1)** %output.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %output.addr, metadata !26, metadata !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef)), !dbg !25
   call void @llvm.dbg.declare(metadata i64* %global_id, metadata !27, metadata !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef)), !dbg !32
-  %call = call i64 @_Z13get_global_idj(i32 0) #5, !dbg !32, !range !33
+  %call = call i64 @__mux_get_global_id(i32 0) #5, !dbg !32, !range !33
   store i64 %call, i64* %global_id, align 8, !dbg !32
   call void @llvm.dbg.declare(metadata i64* %local_id, metadata !34, metadata !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef)), !dbg !35
-  %call1 = call i64 @_Z12get_local_idj(i32 0) #5, !dbg !35, !range !33
+  %call1 = call i64 @__mux_get_local_id(i32 0) #5, !dbg !35, !range !33
   store i64 %call1, i64* %local_id, align 8, !dbg !35
   %0 = load i64, i64* %global_id, align 8, !dbg !36
-  %call2 = call i64 @_Z15get_global_sizej(i32 0) #5, !dbg !36, !range !38
+  %call2 = call i64 @__mux_get_global_size(i32 0) #5, !dbg !36, !range !38
   %cmp = icmp ult i64 %0, %call2, !dbg !36
   br i1 %cmp, label %if.then, label %if.end, !dbg !39
 
@@ -181,27 +181,6 @@ if.end:                                           ; preds = %if.then, %entry
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
-
-; Function Attrs: convergent mustprogress nofree norecurse nounwind readonly willreturn
-define internal i64 @_Z13get_global_idj(i32 %x) #2 {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x) #6
-  ret i64 %call
-}
-
-; Function Attrs: convergent mustprogress nofree norecurse nounwind readonly willreturn
-define internal i64 @_Z12get_local_idj(i32 %x) #2 {
-entry:
-  %call = tail call i64 @__mux_get_local_id(i32 %x) #6
-  ret i64 %call
-}
-
-; Function Attrs: convergent mustprogress nofree norecurse nounwind readonly willreturn
-define internal i64 @_Z15get_global_sizej(i32 %x) #2 {
-entry:
-  %call = tail call i64 @__mux_get_global_size(i32 %x) #6
-  ret i64 %call
-}
 
 ; Function Attrs: convergent nounwind
 declare void @__mux_work_group_barrier(i32, i32, i32) #3

--- a/modules/compiler/test/lit/passes/barriers-minimal-1.ll
+++ b/modules/compiler/test/lit/passes/barriers-minimal-1.ll
@@ -23,13 +23,13 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 define void @minimal_barrier(i32 %min_0, i32 %min_1, i32 %stride, i32 %n0, i32 %n1, i32 %n2, i32 addrspace(1)* %g, i32 addrspace(3)* align 64 %shared) #0 {
 entry:
-  %call = tail call i64 @_Z12get_group_idj(i32 1)
+  %call = tail call i64 @__mux_get_group_id(i32 1)
   %conv = trunc i64 %call to i32
-  %call1 = tail call i64 @_Z12get_group_idj(i32 0)
+  %call1 = tail call i64 @__mux_get_group_id(i32 0)
   %conv2 = trunc i64 %call1 to i32
-  %call3 = tail call i64 @_Z12get_local_idj(i32 1)
+  %call3 = tail call i64 @__mux_get_local_id(i32 1)
   %conv4 = trunc i64 %call3 to i32
-  %call5 = tail call i64 @_Z12get_local_idj(i32 0)
+  %call5 = tail call i64 @__mux_get_local_id(i32 0)
   %conv6 = trunc i64 %call5 to i32
   %mul = shl nsw i32 %conv, 3
   %add = add nsw i32 %mul, %min_1
@@ -85,18 +85,6 @@ if.then24:                                        ; preds = %if.end
 
 if.end35:                                         ; preds = %if.then24, %if.end
   ret void
-}
-
-define internal i64 @_Z12get_group_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_group_id(i32 %x)
-  ret i64 %call
-}
-
-define internal i64 @_Z12get_local_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_local_id(i32 %x)
-  ret i64 %call
 }
 
 define internal i32 @_Z3minii(i32 %x, i32 %y) {

--- a/modules/compiler/test/lit/passes/barriers-minimal-2.ll
+++ b/modules/compiler/test/lit/passes/barriers-minimal-2.ll
@@ -25,9 +25,9 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 define void @minimal_barrier_2(i32 addrspace(1)* %output) #0 {
 entry:
-  %call1 = tail call i64 @_Z12get_local_idj(i32 0)
+  %call1 = tail call i64 @__mux_get_local_id(i32 0)
   %conv2 = trunc i64 %call1 to i32
-  %call457 = tail call i64 @_Z14get_local_sizej(i32 0)
+  %call457 = tail call i64 @__mux_get_local_size(i32 0)
   %cmp58.not = icmp eq i64 %call457, 0
   br i1 %cmp58.not, label %for.cond.cleanup, label %for.body.lr.ph
 
@@ -39,7 +39,7 @@ for.body.lr.ph:                                   ; preds = %entry
 
 for.cond.cleanup:                                 ; preds = %for.inc30, %entry
   %my_value.0.lcssa = phi i32 [ 0, %entry ], [ %my_value.3, %for.inc30 ]
-  %call36 = tail call i64 @_Z13get_global_idj(i32 0)
+  %call36 = tail call i64 @__mux_get_global_id(i32 0)
   %cmp37 = icmp eq i64 %call36, 1
   br i1 %cmp37, label %if.then39, label %if.end41
 
@@ -58,14 +58,14 @@ if.then:                                          ; preds = %for.body
 
 if.end:                                           ; preds = %if.then, %for.body
   %my_value.1 = phi i32 [ %0, %if.then ], [ %my_value.059, %for.body ]
-  %call1252 = tail call i64 @_Z14get_local_sizej(i32 0)
+  %call1252 = tail call i64 @__mux_get_local_size(i32 0)
   %cmp1353.not = icmp eq i64 %call1252, 0
   br i1 %cmp1353.not, label %for.cond.cleanup15, label %for.body16
 
 for.cond.cleanup15:                               ; preds = %for.body16, %if.end
   %my_value.2.lcssa = phi i32 [ %my_value.1, %if.end ], [ %add21, %for.body16 ]
   %call12.lcssa = phi i64 [ 0, %if.end ], [ %call12, %for.body16 ]
-  %call22 = tail call i64 @_Z12get_local_idj(i32 0)
+  %call22 = tail call i64 @__mux_get_local_id(i32 0)
   %cmp24 = icmp ugt i64 %call22, %call12.lcssa
   br i1 %cmp24, label %if.then26, label %for.inc30
 
@@ -84,7 +84,7 @@ for.body16:                                       ; preds = %for.body16, %if.end
   %add21 = add nsw i32 %add20, %4
   %inc = add i32 %j.055, 1
   %conv11 = zext i32 %inc to i64
-  %call12 = tail call i64 @_Z14get_local_sizej(i32 0)
+  %call12 = tail call i64 @__mux_get_local_size(i32 0)
   %cmp13 = icmp ugt i64 %call12, %conv11
   br i1 %cmp13, label %for.body16, label %for.cond.cleanup15
 
@@ -98,7 +98,7 @@ for.inc30:                                        ; preds = %if.then26, %for.con
   %6 = trunc i64 %call12.lcssa to i32
   %conv34 = add i32 %i.060, %6
   %conv3 = zext i32 %conv34 to i64
-  %call4 = tail call i64 @_Z14get_local_sizej(i32 0)
+  %call4 = tail call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ugt i64 %call4, %conv3
   br i1 %cmp, label %for.body, label %for.cond.cleanup
 
@@ -108,24 +108,6 @@ if.then39:                                        ; preds = %for.cond.cleanup
 
 if.end41:                                         ; preds = %if.then39, %for.cond.cleanup
   ret void
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
-}
-
-define internal i64 @_Z12get_local_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_local_id(i32 %x)
-  ret i64 %call
-}
-
-define internal i64 @_Z14get_local_sizej(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_local_size(i32 %x)
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-minimal-32-1.ll
+++ b/modules/compiler/test/lit/passes/barriers-minimal-32-1.ll
@@ -25,18 +25,18 @@ target datalayout = "e-i64:64-p:32:32-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 
 define void @minimal_barrier_2(i32 addrspace(1)* %output) #0 {
 if.end:
-  %call1 = tail call i32 @_Z12get_local_idj(i32 0)
+  %call1 = tail call i32 @__mux_get_local_id(i32 0)
   %arrayidx = getelementptr inbounds [4 x i32], [4 x i32] addrspace(3)* @minimal_barrier_2.cache, i32 0, i32 %call1
   br label %for.body9
 
 for.cond.cleanup:                                 ; preds = %if.then17, %for.cond.cleanup8
   %my_value.3 = phi i32 [ %4, %if.then17 ], [ %add13, %for.cond.cleanup8 ]
-  %call25 = tail call i32 @_Z13get_global_idj(i32 0)
+  %call25 = tail call i32 @__mux_get_global_id(i32 0)
   %cmp26 = icmp eq i32 %call25, 1
   br i1 %cmp26, label %if.then27, label %if.end29
 
 for.cond.cleanup8:                                ; preds = %for.body9
-  %call14 = tail call i32 @_Z12get_local_idj(i32 0)
+  %call14 = tail call i32 @__mux_get_local_id(i32 0)
   %cmp16 = icmp ugt i32 %call14, %call6
   br i1 %cmp16, label %if.then17, label %for.cond.cleanup
 
@@ -54,7 +54,7 @@ for.body9:                                        ; preds = %for.body9, %if.end
   %3 = load i32, i32 addrspace(3)* getelementptr inbounds ([4 x i32], [4 x i32] addrspace(3)* @minimal_barrier_2.cache, i32 0, i32 3), align 4
   %add13 = add nsw i32 %add12, %3
   %inc = add nuw nsw i32 %j.047, 1
-  %call6 = tail call i32 @_Z14get_local_sizej(i32 0)
+  %call6 = tail call i32 @__mux_get_local_size(i32 0)
   %cmp7 = icmp ult i32 %inc, %call6
   br i1 %cmp7, label %for.body9, label %for.cond.cleanup8
 
@@ -69,24 +69,6 @@ if.then27:                                        ; preds = %for.cond.cleanup
 
 if.end29:                                         ; preds = %if.then27, %for.cond.cleanup
   ret void
-}
-
-define internal i32 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i32 @__mux_get_global_id(i32 %x)
-  ret i32 %call
-}
-
-define internal i32 @_Z12get_local_idj(i32 %x) {
-entry:
-  %call = tail call i32 @__mux_get_local_id(i32 %x)
-  ret i32 %call
-}
-
-define internal i32 @_Z14get_local_sizej(i32 %x) {
-entry:
-  %call = tail call i32 @__mux_get_local_size(i32 %x)
-  ret i32 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-tidy-geps-1.ll
+++ b/modules/compiler/test/lit/passes/barriers-tidy-geps-1.ll
@@ -25,12 +25,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK: i32 @tidy_barrier.mux-barrier-region
 
 ; makes sure the global id call got duplicated after the barrier
-; CHECK: call {{.*}}i64 @_Z13get_global_idj(i32 {{()?}}0)
+; CHECK: call {{.*}}i64 @__mux_get_global_id(i32 {{()?}}0)
 
 define void @tidy_barrier(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call i64 @_Z13get_global_idj(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call1
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add.ptr = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
@@ -40,12 +40,6 @@ entry:
   %mul = mul nsw i32 %1, %0
   store i32 %mul, i32 addrspace(1)* %add.ptr2, align 4
   ret void
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-tidy-geps-2.ll
+++ b/modules/compiler/test/lit/passes/barriers-tidy-geps-2.ll
@@ -25,12 +25,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK: i32 @tidy_barrier.mux-barrier-region.1
 
 ; makes sure the global id call got duplicated after the barrier
-; CHECK: call {{.*}}i64 @_Z13get_global_idj(i32 {{()?}}0)
+; CHECK: call {{.*}}i64 @__mux_get_global_id(i32 {{()?}}0)
 
 define void @tidy_barrier(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call i64 @_Z13get_global_idj(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %0 = shl i64 %call1, 32
   %idxprom = ashr exact i64 %0, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %idxprom
@@ -44,12 +44,6 @@ entry:
   %mul = mul nsw i32 %3, %1
   store i32 %mul, i32 addrspace(1)* %add.ptr4, align 4
   ret void
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-tidy-geps-vecz-2.ll
+++ b/modules/compiler/test/lit/passes/barriers-tidy-geps-vecz-2.ll
@@ -29,16 +29,14 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK-DAG: shufflevector <[[N]] x i32> %{{.+}}, <[[N]] x i32> {{poison|undef}}, <[[N]] x i32> zeroinitializer
 
 ; makes sure the global id call got duplicated after the barrier
-; CHECK-DAG: call {{.*}}i{{32|64}} @_Z13get_global_idj(i{{32|64}}{{.*}} 0)
-
-declare i64 @_Z13get_global_idj(i32 %x)
+; CHECK-DAG: call {{.*}}i{{32|64}} @__mux_get_global_id(i{{32|64}}{{.*}} 0)
 
 declare void @__mux_work_group_barrier(i32, i32, i32) #2
 
 define void @tidy_barrier(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0) #4
-  %call1 = tail call i64 @_Z13get_global_idj(i32 1) #4
+  %call = tail call i64 @__mux_get_global_id(i32 0) #4
+  %call1 = tail call i64 @__mux_get_global_id(i32 1) #4
   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %in, i64 %call1
   %0 = load i32, ptr addrspace(1) %arrayidx, align 4
   %.splatinsert = insertelement <16 x i32> poison, i32 %0, i64 0

--- a/modules/compiler/test/lit/passes/barriers-tidy-geps-vecz.ll
+++ b/modules/compiler/test/lit/passes/barriers-tidy-geps-vecz.ll
@@ -25,12 +25,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK: i32 @tidy_barrier.mux-barrier-region.1
 
 ; makes sure the global id call got duplicated after the barrier
-; CHECK: call {{.*}}i64 @_Z13get_global_idj(i32 {{()?}}0)
+; CHECK: call {{.*}}i64 @__mux_get_global_id(i32 {{()?}}0)
 
 define void @tidy_barrier(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call i64 @_Z13get_global_idj(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %0 = shl i64 %call1, 32
   %idxprom = ashr exact i64 %0, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %idxprom
@@ -44,12 +44,6 @@ entry:
   %mul = mul nsw i32 %3, %1
   store i32 %mul, i32 addrspace(1)* %add.ptr4, align 4
   ret void
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x)
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-tidy.ll
+++ b/modules/compiler/test/lit/passes/barriers-tidy.ll
@@ -25,12 +25,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK: i32 @tidy_barrier.mux-barrier-region.1
 
 ; makes sure the global id call got duplicated after the barrier
-; CHECK: call {{.*}}i64 @_Z13get_global_idj(i32 {{()?}}0)
+; CHECK: call {{.*}}i64 @__mux_get_global_id(i32 {{()?}}0)
 
 define void @tidy_barrier(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = tail call i64 @_Z13get_global_idj(i32 0) #4
-  %call1 = tail call i64 @_Z13get_global_idj(i32 1) #4
+  %call = tail call i64 @__mux_get_global_id(i32 0) #4
+  %call1 = tail call i64 @__mux_get_global_id(i32 1) #4
   %0 = shl i64 %call1, 32
   %idxprom = ashr exact i64 %0, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %idxprom
@@ -44,12 +44,6 @@ entry:
   %arrayidx6 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %idxprom3
   store i32 %mul, i32 addrspace(1)* %arrayidx6, align 4
   ret void
-}
-
-define internal i64 @_Z13get_global_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_global_id(i32 %x) #5
-  ret i64 %call
 }
 
 declare void @__mux_work_group_barrier(i32, i32, i32)

--- a/modules/compiler/test/lit/passes/barriers-vmap-bug.ll
+++ b/modules/compiler/test/lit/passes/barriers-vmap-bug.ll
@@ -22,12 +22,6 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 @barrier_bug.tmp = internal addrspace(3) global [1024 x float] undef, align 4
 
-define internal i64 @_Z12get_local_idj(i32 %x) {
-entry:
-  %call = tail call i64 @__mux_get_local_id(i32 %x) #4
-  ret i64 %call
-}
-
 define void @barrier_bug(float addrspace(1)* %data, i32 %n) #0 {
 entry:
   %cmp3.not = icmp eq i32 %n, 0
@@ -43,7 +37,7 @@ for.cond.cleanup:                                 ; preds = %wibble.exit, %entry
 
 for.body:                                         ; preds = %wibble.exit, %for.body.preheader
   %i.04 = phi i32 [ %add, %wibble.exit ], [ 0, %for.body.preheader ]
-  %call.i = tail call i64 @_Z12get_local_idj(i32 0) #5
+  %call.i = tail call i64 @__mux_get_local_id(i32 0) #5
   %conv.i = trunc i64 %call.i to i32
   %i.0.highbits35.i = lshr i32 %conv.i, %shl.mask.i
   %cmp36.i = icmp eq i32 %i.0.highbits35.i, 0

--- a/modules/compiler/test/lit/passes/encode-builtin-range-metadata.ll
+++ b/modules/compiler/test/lit/passes/encode-builtin-range-metadata.ll
@@ -27,21 +27,14 @@ target triple = "spir64-unknown-unknown"
 target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; RANGES-LABEL: define spir_kernel void @foo
-; RANGES: call i32 @_Z12get_work_dimv(), !range ![[WORKDIM:[0-9]+]]
-; RANGES: call i32 @__mux_get_work_dim(), !range ![[WORKDIM]]
-; RANGES: call i64 @_Z14get_local_sizej(i32 0), !range ![[LOCALSIZEX:[0-9]+]]
-; RANGES: call i64 @__mux_get_local_size(i32 0), !range ![[LOCALSIZEX]]
-; RANGES: call i64 @_Z14get_local_sizej(i32 1), !range ![[LOCALSIZEY:[0-9]+]]
-; RANGES: call i64 @__mux_get_local_size(i32 1), !range ![[LOCALSIZEY]]
-; RANGES-NOT: call i64 @_Z14get_local_sizej(i32 2), !range
+; RANGES: call i32 @__mux_get_work_dim(), !range ![[WORKDIM:[0-9]+]]
+; RANGES: call i64 @__mux_get_local_size(i32 0), !range ![[LOCALSIZEX:[0-9]+]]
+; RANGES: call i64 @__mux_get_local_size(i32 1), !range ![[LOCALSIZEY:[0-9]+]]
 ; RANGES-NOT: call i64 @__mux_get_local_size(i32 2), !range
-; RANGES: call i64 @_Z12get_local_idj(i32 0), !range ![[LOCALID:[0-9]+]]
-; RANGES: call i64 @__mux_get_local_id(i32 0), !range ![[LOCALID]]
+; RANGES: call i64 @__mux_get_local_id(i32 0), !range ![[LOCALID:[0-9]+]]
 
-; LOCAL-RANGES-NOT: call i64 @_Z15get_global_sizej(i32 0), !range
 ; LOCAL-RANGES-NOT: call i64 @__mux_get_global_size(i32 0), !range
-; GLOBAL-RANGES:    call i64 @_Z15get_global_sizej(i32 0), !range ![[GLOBALSIZE:[0-9]+]]
-; GLOBAL-RANGES:    call i64 @__mux_get_global_size(i32 0), !range ![[GLOBALSIZE]]
+; GLOBAL-RANGES:    call i64 @__mux_get_global_size(i32 0), !range ![[GLOBALSIZE:[0-9]+]]
 
 ; Check that without ranges we can't optimize anything meaningful
 ; IC-NO-RANGES-LABEL: define spir_kernel void @foo
@@ -54,25 +47,19 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; IC-RANGES-LABEL: define spir_kernel void @foo
 ; IC-RANGES: call void @ext(i1 true, i64 %lsizex, i64 1)
 define spir_kernel void @foo() {
-  %dims = call i32 @_Z12get_work_dimv()
-  %dims.mux = call i32 @__mux_get_work_dim()
+  %dims = call i32 @__mux_get_work_dim()
   %cmp_dims = icmp slt i32 %dims, 5
 
-  %lsizex = call i64 @_Z14get_local_sizej(i32 0)
-  %lsizex.mux = call i64 @__mux_get_local_size(i32 0)
+  %lsizex = call i64 @__mux_get_local_size(i32 0)
   %tmp0 = trunc i64 %lsizex to i32
   %tmp1 = sext i32 %tmp0 to i64
 
-  %lsizey = call i64 @_Z14get_local_sizej(i32 1)
-  %lsizey.mux = call i64 @__mux_get_local_size(i32 1)
-  %lsizez = call i64 @_Z14get_local_sizej(i32 2)
-  %lsizez.mux = call i64 @__mux_get_local_size(i32 2)
+  %lsizey = call i64 @__mux_get_local_size(i32 1)
+  %lsizez = call i64 @__mux_get_local_size(i32 2)
 
-  %lid = call i64 @_Z12get_local_idj(i32 0)
-  %lid.mux = call i64 @__mux_get_local_id(i32 0)
+  %lid = call i64 @__mux_get_local_id(i32 0)
 
-  %gsize = call i64 @_Z15get_global_sizej(i32 0)
-  %gsize.mux = call i64 @__mux_get_global_size(i32 0)
+  %gsize = call i64 @__mux_get_global_size(i32 0)
 
   call void @ext(i1 %cmp_dims, i64 %tmp1, i64 %lsizey)
   ret void
@@ -85,11 +72,6 @@ declare void @ext(i1, i64, i64)
 ; RANGES: ![[LOCALSIZEY]] = !{i64 1, i64 2}
 ; RANGES: ![[LOCALID]] = !{i64 0, i64 8}
 ; GLOBAL-RANGES: ![[GLOBALSIZE]] = !{i64 1, i64 65}
-
-declare i32 @_Z12get_work_dimv()
-declare i64 @_Z12get_local_idj(i32)
-declare i64 @_Z14get_local_sizej(i32)
-declare i64 @_Z15get_global_sizej(i32)
 
 declare i32 @__mux_get_work_dim()
 declare i64 @__mux_get_local_id(i32)

--- a/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
@@ -23,10 +23,10 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr %img, i32 %sampler1, i32 %sampler2) {{#[0-9]+}} {
 define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = tail call i64 @__mux_get_global_id(i32 0) #3
   %conv = trunc i64 %call to i32
   %conv1 = sitofp i32 %conv to float
-  %call2 = tail call spir_func i64 @_Z15get_global_sizej(i32 0) #3
+  %call2 = tail call i64 @__mux_get_global_size(i32 0) #3
   %conv3 = uitofp i64 %call2 to float
   %div = fmul float %conv3, 5.000000e-01
   %div4 = fdiv float %conv1, %div
@@ -49,9 +49,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func i64 @_Z15get_global_sizej(i32) #1
+declare i64 @__mux_get_global_size(i32) #1
 
 declare spir_func <4 x i32> @_Z12read_imageui14ocl_image1d_ro11ocl_samplerf(ptr addrspace(1), ptr addrspace(2), float) #2
 

--- a/modules/compiler/test/lit/passes/image-arg-subst.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst.ll
@@ -25,10 +25,10 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK: define internal spir_kernel void @image_sampler.old(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, ptr addrspace(2) %sampler1, ptr addrspace(2) %sampler2) [[OLD_ATTRS:#[0-9]+]] {
 define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, ptr addrspace(2) %sampler1, ptr addrspace(2) %sampler2) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = tail call i64 @__mux_get_global_id(i32 0) #3
   %conv = trunc i64 %call to i32
   %conv1 = sitofp i32 %conv to float
-  %call2 = tail call spir_func i64 @_Z15get_global_sizej(i32 0) #3
+  %call2 = tail call i64 @__mux_get_global_size(i32 0) #3
   %conv3 = uitofp i64 %call2 to float
   %div = fmul float %conv3, 5.000000e-01
   %div4 = fdiv float %conv1, %div
@@ -65,9 +65,9 @@ entry:
 ; CHECK:   ret void
 ; CHECK: }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func i64 @_Z15get_global_sizej(i32) #1
+declare i64 @__mux_get_global_size(i32) #1
 
 declare spir_func <4 x i32> @_Z12read_imageui14ocl_image1d_ro11ocl_samplerf(ptr addrspace(1), ptr addrspace(2), float) #2
 

--- a/modules/compiler/test/lit/passes/link-builtins.ll
+++ b/modules/compiler/test/lit/passes/link-builtins.ll
@@ -21,13 +21,12 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; Without a target, there's no builtins to link
 ; CHECK: declare spir_func i32 @_Z3absi(i32)
-; CHECK: declare spir_func i64 @_Z13get_global_idj(i32)
 
 declare spir_func i32 @_Z3absi(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @foo(i32 addrspace(1)* %in) {
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %addr = getelementptr i32, i32 addrspace(1)* %in, i64 %gid
   %x = load i32, i32 addrspace(1)* %addr
   %abs = call i32 @_Z3absi(i32 %x)

--- a/modules/compiler/test/lit/passes/printf-1.ll
+++ b/modules/compiler/test/lit/passes/printf-1.ll
@@ -22,11 +22,11 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 @.str = private unnamed_addr addrspace(2) constant [10 x i8] c"id = %lu\0A\00", align 1
 
 ; CHECK-LABEL: define spir_kernel void @do_printf(
-; CHECK: %id = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %id = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: = call spir_func i32 @0(ptr addrspace(1) %0, i64 %id)
 define spir_kernel void @do_printf(i32 addrspace(1)* %a) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %id = call i64 @__mux_get_global_id(i32 0)
   %call1 = tail call spir_func i32 (i8 addrspace(2)*, ...) @printf(i8 addrspace(2)* getelementptr inbounds ([10 x i8], [10 x i8] addrspace(2)* @.str, i64 0, i64 0), i64 %id)
   ret void
 }
@@ -43,6 +43,6 @@ entry:
 ; CHECK: [[VAL_PTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PTR]], i32 [[NEXT_IDX]]
 ; CHECK: store i64 %1, ptr addrspace(1) [[VAL_PTR]]
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func i32 @printf(i8 addrspace(2)*, ...)

--- a/modules/compiler/test/lit/passes/printf-errors.ll
+++ b/modules/compiler/test/lit/passes/printf-errors.ll
@@ -41,7 +41,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK-DAG: warning: /tmp/printf.cl:11:0: the '*' width sub-specifier is not supported
 define spir_kernel void @do_printf(ptr addrspace(1) %a) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %id = call i64 @__mux_get_global_id(i32 0)
   %c0 = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @invalid_length_modifier_z, i64 zeroinitializer), !dbg !9
   %c1 = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @vector_without_length, <2 x i32> zeroinitializer), !dbg !10
   %c2 = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @ran_off_end_1, i32 zeroinitializer), !dbg !11
@@ -54,7 +54,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func i32 @printf(ptr addrspace(2), ...)
 

--- a/modules/compiler/test/lit/passes/software-division.ll
+++ b/modules/compiler/test/lit/passes/software-division.ll
@@ -24,7 +24,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK: [[SAFE:%.*]] = select i1 [[CMP]], i64 1, i64 %gid
 ; CHECK: udiv i64 %x.conv, [[SAFE]]
 define spir_kernel void @zero_udiv(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %gid
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %x.conv = sext i32 %x to i64
@@ -44,7 +44,7 @@ define spir_kernel void @zero_udiv(i32 addrspace(1)* %in, i32 addrspace(1)* %out
 ; CHECK: [[SAFE:%.*]] = select i1 [[CMP5]], i64 1, i64 %gid
 ; CHECK: sdiv i64 %x.conv, [[SAFE]]
 define spir_kernel void @zero_sdiv(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %gid
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %x.conv = sext i32 %x to i64
@@ -61,7 +61,7 @@ define spir_kernel void @zero_sdiv(i32 addrspace(1)* %in, i32 addrspace(1)* %out
 ; CHECK: [[SAFE:%.*]] = select i1 [[CMP]], i64 1, i64 %gid
 ; CHECK: udiv i64 %x.conv, [[SAFE]]
 define spir_kernel void @zero_udiv_optnone(i32 addrspace(1)* %in, i32 addrspace(1)* %out) optnone noinline {
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %gid
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %x.conv = sext i32 %x to i64
@@ -72,4 +72,4 @@ define spir_kernel void @zero_udiv_optnone(i32 addrspace(1)* %in, i32 addrspace(
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/test/lit/passes/unordered-barriers.ll
+++ b/modules/compiler/test/lit/passes/unordered-barriers.ll
@@ -40,9 +40,9 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 
 define void @unordered_barriers(ptr addrspace(1) %srcptr, ptr addrspace(1) %dstptr) #0 {
 entry:
-  %call = tail call i64 @_Z12get_local_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_local_id(i32 0) #6
   %conv = trunc i64 %call to i32
-  %call1 = tail call i64 @_Z13get_global_idj(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 0)
   %0 = add nsw i32 %conv, -1
   %1 = icmp ult i32 %0, 32
   br i1 %1, label %if.then, label %if.end
@@ -74,10 +74,6 @@ if.end21:                                         ; preds = %if.then17, %if.end
   store float %total_sum.2, ptr addrspace(1) %arrayidx23, align 4
   ret void
 }
-
-declare i64 @_Z12get_local_idj(i32 %x)
-
-declare i64 @_Z13get_global_idj(i32 %x)
 
 declare void @__mux_work_group_barrier(i32, i32, i32)
 

--- a/modules/compiler/test/lit/passes/vecz.ll
+++ b/modules/compiler/test/lit/passes/vecz.ll
@@ -23,7 +23,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @foo(i32 addrspace(1)* %a, i32 addrspace(1)* %z) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %x = load i32, i32 addrspace(1)* %arrayidx, align 4
   %add = add nsw i32 %x, 4
@@ -32,6 +32,6 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_1.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_2.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -41,7 +41,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_3.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_4.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_5.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -52,7 +52,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD1:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/AArch64/shuffled_load_aarch64_6.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -44,7 +44,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define {{(dso_local )?}}spir_kernel void @load16
 ; CHECK: [[LOAD:%.+]] = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32.p1

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_killer.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_killer.ll
@@ -21,15 +21,15 @@ source_filename = "Unknown buffer"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 @boscc_killer.shared = internal unnamed_addr addrspace(3) global i32 undef, align 4
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @boscc_killer(float addrspace(1)* %A, float addrspace(1)* %B, i32 %N, i32 %lda) {
 entry:
-  %gid0 = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %gid0 = tail call i64 @__mux_get_local_id(i32 0)
   %cmp0 = icmp eq i64 %gid0, 0
   br i1 %cmp0, label %if.then, label %if.end
 
@@ -78,7 +78,7 @@ if.then3:                             ; preds = %for.cond.exit, %if.then53
   %v23 = load float, float addrspace(1)* %arrayidxB, align 16
   %arrayidxA = getelementptr inbounds float, float addrspace(1)* %A, i64 %gid0
   store float %v23, float addrspace(1)* %arrayidxA, align 16
-  %call149 = tail call spir_func i64 @_Z14get_local_sizej(i32 0) #6
+  %call149 = tail call i64 @__mux_get_local_size(i32 0) #6
   %conv152 = add i64 %call149, %gid0
   %cmp71 = icmp slt i64 %conv152, 0
   br label %exit

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge.ll
@@ -21,13 +21,13 @@ source_filename = "Unknown buffer"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32) #0
-declare spir_func i64 @_Z14get_local_sizej(i32) #0
+declare i64 @__mux_get_local_id(i32) #0
+declare i64 @__mux_get_local_size(i32) #0
 
 define spir_kernel void @boscc_merge(i32 %n, float addrspace(1)* %out, i64 %x) {
 entry:
-  %lid = tail call spir_func i64 @_Z12get_local_idj(i32 0)
-  %lsize = tail call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %lid = tail call i64 @__mux_get_local_id(i32 0)
+  %lsize = tail call i64 @__mux_get_local_size(i32 0)
   %out_ptr = getelementptr inbounds float, float addrspace(1)* %out, i64 %x
   %lid_sum_lsize = add i64 %lid, %lsize
   %cmp1 = icmp ult i64 %lsize, %x

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge2.ll
@@ -24,8 +24,8 @@ target triple = "spir64-unknown-unknown"
 declare float @llvm.fmuladd.f32(float, float, float) #2
 declare void @__mux_work_group_barrier(i32, i32, i32) #3
 declare spir_func float @_Z3maxff(float, float) #1
-declare spir_func i64 @_Z12get_local_idj(i32) #1
-declare spir_func i64 @_Z12get_group_idj(i32) #1
+declare i64 @__mux_get_local_id(i32) #1
+declare i64 @__mux_get_group_id(i32) #1
 
 @fuse_conv2d_broadcast_add_relu_1_kernel0.pad_temp_shared = internal addrspace(3) global [640 x float] undef, align 4
 @fuse_conv2d_broadcast_add_relu_1_kernel0.input1_shared = internal addrspace(3) global [1152 x float] undef, align 4
@@ -42,38 +42,38 @@ for.cond:                                         ; preds = %for.inc, %entry
   br i1 %cmp1, label %if.then, label %if.else
 
 if.then:                                      ; preds = %for.cond
-  %call1 = call spir_func i64 @_Z12get_local_idj(i32 0) #5
-  %call2 = call spir_func i64 @_Z12get_group_idj(i32 1) #5
+  %call1 = call i64 @__mux_get_local_id(i32 0) #5
+  %call2 = call i64 @__mux_get_group_id(i32 1) #5
   %idx1 = getelementptr inbounds [640 x float], [640 x float] addrspace(3)* @fuse_conv2d_broadcast_add_relu_1_kernel0.pad_temp_shared, i64 0, i64 %call1
   store float 0.000000e+00, float addrspace(3)* %idx1, align 4
   %cmp2 = icmp sgt i64 %call2, %call1
   br i1 %cmp2, label %if.then2, label %land.lhs.true1
 
 land.lhs.true1:                                 ; preds = %if.then
-  %call3 = call spir_func i64 @_Z12get_group_idj(i32 1) #5
-  %call4 = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call3 = call i64 @__mux_get_group_id(i32 1) #5
+  %call4 = call i64 @__mux_get_local_id(i32 0) #5
   %cmp3 = icmp slt i64 %call3, %call4
   br i1 %cmp3, label %land.lhs.true2, label %if.then2
 
 land.lhs.true2:                                 ; preds = %land.lhs.true1
-  %call5 = call spir_func i64 @_Z12get_local_idj(i32 0) #5
-  %call6 = call spir_func i64 @_Z12get_group_idj(i32 0) #5
+  %call5 = call i64 @__mux_get_local_id(i32 0) #5
+  %call6 = call i64 @__mux_get_group_id(i32 0) #5
   %cmp4 = icmp sgt i64 %call6, %call5
   br i1 %cmp4, label %if.then2, label %land.lhs.true3
 
 land.lhs.true3:                                 ; preds = %land.lhs.true2
-  %call7 = call spir_func i64 @_Z12get_group_idj(i32 0) #5
-  %call8 = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call7 = call i64 @__mux_get_group_id(i32 0) #5
+  %call8 = call i64 @__mux_get_local_id(i32 0) #5
   %cmp5 = icmp slt i64 %call7, %call8
   br i1 %cmp5, label %cond.true4, label %if.then2
 
 cond.true4:                                     ; preds = %land.lhs.true3
-  %call9 = call spir_func i64 @_Z12get_local_idj(i32 1) #5
+  %call9 = call i64 @__mux_get_local_id(i32 1) #5
   %idx2 = getelementptr inbounds float, float addrspace(1)* %input0, i64 %call9
   br label %if.then2
 
 if.then2:                                      ; preds = %cond.true4, %land.lhs.true3, %land.lhs.true2, %land.lhs.true1, %if.then
-  %call10 = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call10 = call i64 @__mux_get_local_id(i32 0) #5
   %conv = trunc i64 %call10 to i32
   %idx3 = sext i32 %conv to i64
   %idx4 = getelementptr inbounds [1152 x float], [1152 x float] addrspace(3)* @fuse_conv2d_broadcast_add_relu_1_kernel0.input1_shared, i64 0, i64 %idx3

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge3.ll
@@ -22,15 +22,15 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func <4 x float> @_Z6vload4mPU3AS1Kf(i64, float addrspace(1)*)
 
 define spir_kernel void @boscc_merge3(float addrspace(1)* %out, i64 %n, float %m) {
 entry:
-  %gid0 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #0
-  %gid1 = tail call spir_func i64 @_Z13get_global_idj(i32 1) #0
+  %gid0 = tail call i64 @__mux_get_global_id(i32 0) #0
+  %gid1 = tail call i64 @__mux_get_global_id(i32 1) #0
   %cmp1 = icmp slt i64 %gid0, %n
   br i1 %cmp1, label %if.then1, label %end
 

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/duplicate_preheader.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/duplicate_preheader.ll
@@ -28,11 +28,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: noduplicate
 declare void @__mux_work_group_barrier(i32, i32, i32) #1
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 define spir_kernel void @duplicate_preheader(i32 addrspace(1)* %out, i32 %n) {
 entry:
-  %id = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %id = tail call i64 @__mux_get_local_id(i32 0)
   %cmp = icmp sgt i64 %id, 3
   br i1 %cmp, label %if.then, label %if.end
 

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops1.ll
@@ -22,10 +22,10 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z15get_global_sizej(i32) #0
+declare i64 @__mux_get_global_size(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func float @_Z3madfff(float, float, float) #0
@@ -33,8 +33,8 @@ declare spir_func float @_Z3madfff(float, float, float) #0
 ; Function Attrs: nounwind
 define spir_kernel void @nested_loops1(i32 %n, float addrspace(1)* %out) #1 {
 entry:
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0) #0
-  %gsize = tail call spir_func i64 @_Z15get_global_sizej(i32 0) #0
+  %gid = tail call i64 @__mux_get_global_id(i32 0) #0
+  %gsize = tail call i64 @__mux_get_global_size(i32 0) #0
   %trunc_gid = trunc i64 %gid to i32
   %trunc_gsize = trunc i64 %gsize to i32
   %cmp1 = icmp slt i32 %trunc_gid, %n

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops2.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @nested_loops2(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %conv, 16
   br i1 %cmp, label %if.then, label %if.end25
@@ -83,7 +83,7 @@ if.end25:                                         ; preds = %for.cond, %entry
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops3.ll
@@ -22,7 +22,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 ; Function Attrs: nounwind readnone speculatable
 declare float @llvm.fmuladd.f32(float, float, float) #1
@@ -30,7 +30,7 @@ declare float @llvm.fmuladd.f32(float, float, float) #1
 ; Function Attrs: convergent nounwind
 define spir_kernel void @nested_loops3(float addrspace(1)* %symmat, float addrspace(1)* %data, i32 %m, i32 %n) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %conv = trunc i64 %call to i32
   %sub = add nsw i32 %m, -1
   %cmp = icmp sgt i32 %sub, %conv

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops4.ll
@@ -21,10 +21,10 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z15get_global_sizej(i32) #0
+declare i64 @__mux_get_global_size(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func float @_Z3dotDv2_fS_(<2 x float>, <2 x float>) #0
@@ -36,8 +36,8 @@ declare spir_func i32 @_Z6mul_hijj(i32, i32) #0
 
 define spir_kernel void @nested_loops4(i32 %n, float addrspace(1)* %out) {
 entry:
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0) #0
-  %gsize = tail call spir_func i64 @_Z15get_global_sizej(i32 0) #0
+  %gid = tail call i64 @__mux_get_global_id(i32 0) #0
+  %gsize = tail call i64 @__mux_get_global_size(i32 0) #0
   %trunc_gid = trunc i64 %gid to i32
   %trunc_gsize = trunc i64 %gsize to i32
   %cmp1 = icmp slt i32 %trunc_gid, %n

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/nested_loops5.ll
@@ -21,14 +21,14 @@ source_filename = "Unknown buffer"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_size(i32)
 
 define spir_kernel void @nested_loops5(float addrspace(1)*) {
 entry:
-  %lid = tail call spir_func i64 @_Z12get_local_idj(i32 0)
-  %lsize = tail call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %lid = tail call i64 @__mux_get_local_id(i32 0)
+  %lsize = tail call i64 @__mux_get_local_size(i32 0)
   %cmp1 = icmp ult i64 %lid, %lsize
   br i1 %cmp1, label %loop, label %end
 

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization0.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization0.ll
@@ -103,7 +103,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization0(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %rem = srem i32 %conv, 5
   %cmp = icmp eq i32 %rem, 0
@@ -233,7 +233,7 @@ if.end73:                                         ; preds = %if.end70, %if.end41
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization1.ll
@@ -95,7 +95,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization1(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -186,7 +186,7 @@ early:                                            ; preds = %for.end34, %for.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization10.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization10.ll
@@ -163,7 +163,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization10(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -318,7 +318,7 @@ s:                                                ; preds = %for.cond68, %for.co
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization11.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization11.ll
@@ -148,7 +148,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization11(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -263,7 +263,7 @@ n46:                                              ; preds = %i44, %for.cond35
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization12.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization12.ll
@@ -215,7 +215,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -433,7 +433,7 @@ v:                                                ; preds = %for.cond107, %for.c
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization13.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization13.ll
@@ -98,8 +98,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization13(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
+  %call1 = call i64 @__mux_get_global_size(i32 0) #2
   %add = add i64 %call, 1
   %cmp = icmp ult i64 %add, %call1
   br i1 %cmp, label %if.then, label %if.else
@@ -164,10 +164,10 @@ if.end17:                                         ; preds = %sw.bb14, %if.else, 
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z15get_global_sizej(i32) #1
+declare i64 @__mux_get_global_size(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization14.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization14.ll
@@ -101,7 +101,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization14(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %n, 5
   br i1 %cmp, label %for.cond, label %while.body
@@ -200,7 +200,7 @@ early:                                            ; preds = %for.end49, %for.end
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization15.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization15.ll
@@ -147,7 +147,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization15(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -274,7 +274,7 @@ q:                                                ; preds = %for.cond59, %for.co
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization16.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization16.ll
@@ -109,7 +109,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization16(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %n, 5
   br i1 %cmp, label %for.cond, label %while.body
@@ -220,7 +220,7 @@ early:                                            ; preds = %for.cond52, %for.en
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization17.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization17.ll
@@ -132,7 +132,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -251,7 +251,7 @@ p:                                                ; preds = %for.cond60, %for.en
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization18.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization18.ll
@@ -111,7 +111,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -194,7 +194,7 @@ if.end42:                                         ; preds = %if.else40, %i38
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization19.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization19.ll
@@ -120,7 +120,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -207,7 +207,7 @@ j:                                                ; preds = %for.cond40, %for.co
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization2.ll
@@ -93,7 +93,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization2(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else17
@@ -187,7 +187,7 @@ end:                                              ; preds = %i42, %h
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization20.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization20.ll
@@ -106,7 +106,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization20(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -159,7 +159,7 @@ g:                                                ; preds = %for.cond, %e, %whil
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization21.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization21.ll
@@ -102,7 +102,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization21(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -141,7 +141,7 @@ f:                                                ; preds = %e, %if.else, %while
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization22.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization22.ll
@@ -112,7 +112,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization22(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -172,7 +172,7 @@ h:                                                ; preds = %for.cond, %f, %if.e
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization3.ll
@@ -91,7 +91,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization3(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else17
@@ -185,7 +185,7 @@ end:                                              ; preds = %i42, %for.cond
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization4.ll
@@ -82,7 +82,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization4(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %0 = icmp eq i32 %conv, -2147483648
   %1 = icmp eq i32 %n, -1
@@ -141,7 +141,7 @@ g:                                                ; preds = %f, %e
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization5.ll
@@ -90,7 +90,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %rem1 = and i32 %conv, 1
   %cmp = icmp eq i32 %rem1, 0
@@ -160,7 +160,7 @@ g:                                                ; preds = %f, %if.then
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization6.ll
@@ -87,7 +87,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization6(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -142,7 +142,7 @@ early:                                            ; preds = %e, %while.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization7.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization7.ll
@@ -104,7 +104,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else5
@@ -167,7 +167,7 @@ i29:                                              ; preds = %h, %for.cond19
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization8.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization8.ll
@@ -84,7 +84,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization8(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %0 = icmp eq i32 %conv, -2147483648
   %1 = icmp eq i32 %n, -1
@@ -144,7 +144,7 @@ g:                                                ; preds = %f, %e
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization9.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization9.ll
@@ -77,7 +77,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization9(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -112,7 +112,7 @@ while.end:                                        ; preds = %for.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/printf.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/printf.ll
@@ -38,7 +38,7 @@ entry:
   store i32 addrspace(1)* %in2, i32 addrspace(1)** %in2.addr, align 8
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
   store i32 addrspace(1)* %status, i32 addrspace(1)** %status.addr, align 8
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %call = call i64 @__mux_get_global_id(i32 0) #4
   store i64 %call, i64* %tid, align 8
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %in1.addr, align 8
   %1 = load i64, i64* %tid, align 8
@@ -58,17 +58,17 @@ entry:
   %9 = load i64, i64* %tid, align 8
   %conv = trunc i64 %9 to i32
   %10 = load i32, i32* %sum, align 4
-  %11 = call spir_func i64 @_Z14get_num_groupsj(i32 0)
+  %11 = call i64 @__mux_get_num_groups(i32 0)
   %12 = trunc i64 %11 to i32
-  %13 = call spir_func i64 @_Z14get_num_groupsj(i32 1)
+  %13 = call i64 @__mux_get_num_groups(i32 1)
   %14 = trunc i64 %13 to i32
-  %15 = call spir_func i64 @_Z14get_num_groupsj(i32 2)
+  %15 = call i64 @__mux_get_num_groups(i32 2)
   %16 = trunc i64 %15 to i32
-  %17 = call spir_func i64 @_Z12get_group_idj(i32 0)
+  %17 = call i64 @__mux_get_group_id(i32 0)
   %18 = trunc i64 %17 to i32
-  %19 = call spir_func i64 @_Z12get_group_idj(i32 1)
+  %19 = call i64 @__mux_get_group_id(i32 1)
   %20 = trunc i64 %19 to i32
-  %21 = call spir_func i64 @_Z12get_group_idj(i32 2)
+  %21 = call i64 @__mux_get_group_id(i32 2)
   %22 = trunc i64 %21 to i32
   %23 = mul i32 %12, %20
   %24 = mul i32 %14, %16
@@ -117,9 +117,9 @@ store.i:                                          ; preds = %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z12get_group_idj(i32)
-declare spir_func i64 @_Z14get_num_groupsj(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_group_id(i32)
+declare i64 @__mux_get_num_groups(i32)
 
 ; We can't vectorize this control flow
 ; CHECK: Error: Failed to vectorize function 'printf_add'

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/basic_mem2reg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/basic_mem2reg.ll
@@ -24,7 +24,7 @@ entry:
   %d = alloca i32
   %e = alloca i32
   %f = alloca float
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %sum = add i32 %a, %b
   store i32 %sum, i32* %d, align 4
   store i32 %sum, i32* %e, align 4
@@ -43,12 +43,12 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @foo(i32*)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(i32 %a, i32 %b, ptr %c, float %rf)
 ; CHECK: %e = alloca i32
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %sum = add i32 %a, %b
 ; CHECK: store i32 %sum, ptr %e
 ; CHECK: %call = call spir_func i32 @foo(ptr{{.*}} %e)

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/basic_vecz_mem2reg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/basic_vecz_mem2reg.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @load_store_type_mismatch_no_bitcast(ptr addrspace(1) %p) {
   %data = alloca i32, align 4
-  %1 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %1 = tail call i64 @__mux_get_global_id(i32 0) #4
   %2 = getelementptr inbounds i32, ptr addrspace(1) %p, i64 %1
   %3 = load i32, ptr addrspace(1) %2, align 4
   store i32 %3, ptr %data, align 4
@@ -33,7 +33,7 @@ define spir_kernel void @load_store_type_mismatch_no_bitcast(ptr addrspace(1) %p
 
 define spir_kernel void @load_type_size_mismatch_no_bitcast(ptr addrspace(1) %p) {
   %data = alloca i32, align 4
-  %1 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %1 = tail call i64 @__mux_get_global_id(i32 0) #4
   %2 = getelementptr inbounds i32, ptr addrspace(1) %p, i64 %1
   %3 = load i32, ptr addrspace(1) %2, align 4
   store i32 %3, ptr %data, align 4
@@ -43,7 +43,7 @@ define spir_kernel void @load_type_size_mismatch_no_bitcast(ptr addrspace(1) %p)
 
 define spir_kernel void @store_type_size_mismatch_no_bitcast(ptr addrspace(1) %p) {
   %data = alloca i32, align 4
-  %1 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %1 = tail call i64 @__mux_get_global_id(i32 0) #4
   %2 = getelementptr inbounds i16, ptr addrspace(1) %p, i64 %1
   %3 = load i16, ptr addrspace(1) %2, align 4
   store i16 %3, ptr %data, align 2
@@ -51,7 +51,7 @@ define spir_kernel void @store_type_size_mismatch_no_bitcast(ptr addrspace(1) %p
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_v4_load_store_type_mismatch_no_bitcast(ptr addrspace(1) %p)
 ; CHECK-NOT: alloca i32

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/builtin_pointer_return.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/builtin_pointer_return.ll
@@ -19,7 +19,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %s
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func float @_Z5fractfPf(float, float*)
 declare spir_func <2 x float> @_Z5fractDv2_fPS_(<2 x float>, <2 x float>*)
@@ -31,7 +31,7 @@ declare spir_func <8 x float> @_Z5fractDv8_fPS_(<8 x float>, <8 x float>*)
 
 define spir_kernel void @fract_v1(float* %xptr, float* %outptr, float* %ioutptr) {
   %iouta = alloca float
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.x = getelementptr inbounds float, float* %xptr, i64 %idx
   %x = load float, float* %arrayidx.x, align 4
   %out = call spir_func float @_Z5fractfPf(float %x, float* %iouta)
@@ -49,7 +49,7 @@ define spir_kernel void @fract_v1(float* %xptr, float* %outptr, float* %ioutptr)
 
 define spir_kernel void @fract_v2(<2 x float>* %xptr, <2 x float>* %outptr, <2 x float>* %ioutptr) {
   %iouta = alloca <2 x float>
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.x = getelementptr inbounds <2 x float>, <2 x float>* %xptr, i64 %idx
   %x = load <2 x float>, <2 x float>* %arrayidx.x, align 8
   %out = call spir_func <2 x float> @_Z5fractDv2_fPS_(<2 x float> %x, <2 x float>* %iouta)

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/control_flow_conversion_ptrs.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/control_flow_conversion_ptrs.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_varying_if_ptr(i32 %a, ptr %b, ptr %on_true, ptr %on_false) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/interleaved_load_ooo.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/interleaved_load_ooo.ll
@@ -23,9 +23,9 @@ target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @interleaved_load_4(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %conv, %mul
@@ -53,5 +53,5 @@ entry:
 ; CHECK:  %deinterleave1 = shufflevector <4 x i32> [[TMP0]], <4 x i32> [[TMP2]], <4 x i32> <i32 1, i32 3, i32 5, i32 7>
 ; CHECK:  %sub1 = sub nsw <4 x i32> %deinterleave1, %deinterleave
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare <4 x i32> @__vecz_b_interleaved_load4_2_Dv4_jPU3AS1j(i32 addrspace(1)*)

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/load_add_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/load_add_store.ll
@@ -19,11 +19,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @load_add_store(ptr %aptr, ptr %bptr, ptr %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, ptr %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, ptr %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, ptr %zptr, i64 %idx
@@ -33,7 +33,7 @@ entry:
   store i32 %sum, ptr %arrayidxz, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_load_add_store(ptr %aptr, ptr %bptr, ptr %zptr)
-; CHECK: %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %arrayidxa = getelementptr inbounds i32, ptr %aptr, i64 %idx
 ; CHECK: %arrayidxb = getelementptr inbounds i32, ptr %bptr, i64 %idx
 ; CHECK: %arrayidxz = getelementptr inbounds i32, ptr %zptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/masked_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/masked_store.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_varying_if(i32 %a, ptr %b, float %on_true, float %on_false) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -46,7 +46,7 @@ if.end:
 define spir_kernel void @test_varying_if_as3(i32 %a, ptr addrspace(3) %b, float %on_true, float %on_false) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/remove_intptr.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/remove_intptr.ll
@@ -26,7 +26,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: store i64 %remove_intptr1, ptr addrspace(1) %out, align 8
 define spir_kernel void @intptr_cast_i8(i8 addrspace(1)* %in, i64 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i8 addrspace(1)* %in to i64
   %shl = shl i64 %call, 2
   %add = add i64 %shl, %0
@@ -43,7 +43,7 @@ entry:
 ; CHECK: store i64 %remove_intptr1, ptr addrspace(1) %out, align 8
 define spir_kernel void @intptr_cast_i16(i16 addrspace(1)* %in, i64 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i16 addrspace(1)* %in to i64
   %shl = shl i64 %call, 2
   %add = add i64 %shl, %0
@@ -51,4 +51,4 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/OpaquePointers/ternary_transform.ll
+++ b/modules/compiler/vecz/test/lit/llvm/OpaquePointers/ternary_transform.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_positive(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -35,7 +35,7 @@ entry:
 
 define spir_kernel void @test_positive_gep_different_type(i64 %a, i64 %b, i8* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @test_negative(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   %c1 = getelementptr i64, i64* %c, i64 0
@@ -61,7 +61,7 @@ entry:
 
 define spir_kernel void @test_vector_scalar_cond(i64 %a, <2 x i32> %b, <2 x i32>* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr <2 x i32>, <2 x i32>* %c, i64 %gid
   %c1 = getelementptr <2 x i32>, <2 x i32>* %c, i64 0
@@ -71,10 +71,10 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_test_positive(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid
 ; CHECK: store i64 %b, ptr %c0, align 4
@@ -87,7 +87,7 @@ declare spir_func i64 @_Z13get_global_idj(i32)
 ; CHECK: call void @__vecz_b_masked_store4_mu3ptrb(i64 1, ptr %[[GEP2]], i1 %[[XOR]])
 
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_test_positive_gep_different_type(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid
 ; CHECK: store i64 %b, ptr %c0, align 4
@@ -100,7 +100,7 @@ declare spir_func i64 @_Z13get_global_idj(i32)
 ; CHECK: call void @__vecz_b_masked_store4_hu3ptrb(i8 1, ptr %[[GEP2]], i1 %[[XOR]])
 
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_test_negative(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid
 ; CHECK: %c1 = getelementptr i64, ptr %c, i64 0
@@ -109,7 +109,7 @@ declare spir_func i64 @_Z13get_global_idj(i32)
 
 ; Note: we don't perform this transform on vector accesses - see CA-4337.
 ; CHECK: define spir_kernel void @__vecz_v4_test_vector_scalar_cond(i64 %a, <2 x i32> %b, ptr %c)
-; CHECK:   %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK:   %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK:   %cond = icmp eq i64 %a, %gid
 ; CHECK:   %c0 = getelementptr <2 x i32>, ptr %c, i64 %gid
 ; CHECK:   %c1 = getelementptr <2 x i32>, ptr %c, i64 0

--- a/modules/compiler/vecz/test/lit/llvm/PartialScalarization/define_interleaved_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/PartialScalarization/define_interleaved_store.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/PartialScalarization/define_interleaved_store_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/PartialScalarization/define_interleaved_store_as_masked.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/PartialScalarization/vector_phi_uniform.ll
+++ b/modules/compiler/vecz/test/lit/llvm/PartialScalarization/vector_phi_uniform.ll
@@ -23,13 +23,13 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_loop(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %call, 0
   br i1 %cmp, label %for.end, label %for.cond
 
 for.cond:                                         ; preds = %entry, %for.body
   %storemerge = phi <4 x i32> [ %inc, %for.body ], [ zeroinitializer, %entry ]
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %call1 = call i64 @__mux_get_global_size(i32 0)
   %conv = trunc i64 %call1 to i32
   %splat.splatinsert = insertelement <4 x i32> undef, i32 %conv, i32 0
   %splat.splat = shufflevector <4 x i32> %splat.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -77,8 +77,8 @@ for.end:                                          ; preds = %entry, %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_global_size(i32)
 
 ; This test checks if a uniform <4 x i32> phi is not scalarized
 ; CHECK: define spir_kernel void @__vecz_v4_vector_loop

--- a/modules/compiler/vecz/test/lit/llvm/PartialScalarization/vector_phi_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/PartialScalarization/vector_phi_varying.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_loop(i32 addrspace(1)* %in, <4 x i32> addrspace(1)* %in2, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %initaddr = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %in2, i64 %call
   %init = load <4 x i32>, <4 x i32> addrspace(1)* %initaddr
   %cmp = icmp eq i64 %call, 0
@@ -31,7 +31,7 @@ entry:
 
 for.cond:                                         ; preds = %entry, %for.body
   %storemerge = phi <4 x i32> [ %inc, %for.body ], [ %init, %entry ]
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %call1 = call i64 @__mux_get_global_size(i32 0)
   %conv = trunc i64 %call1 to i32
   %0 = extractelement <4 x i32> %storemerge, i64 0
   %cmp2 = icmp slt i32 %0, %conv
@@ -77,8 +77,8 @@ for.end:                                          ; preds = %entry, %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_global_size(i32)
 
 ; This test checks if a varying <4 x i32> phi gets scalarized
 ; if it is only accessed through individually extracted elements.

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/broadcast_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/broadcast_vector.ll
@@ -21,11 +21,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define dso_local spir_kernel void @vector_broadcast_const(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -37,7 +37,7 @@ entry:
 
 define dso_local spir_kernel void @vector_broadcast(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> %addend, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -49,7 +49,7 @@ entry:
 
 define dso_local spir_kernel void @vector_broadcast_illegal(<32 x float> addrspace(1)* nocapture readonly %in, <32 x float> %addend, <32 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <32 x float>, <32 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <32 x float> addrspace(1)* %arrayidx to <32 x float> addrspace(1)*
   %1 = load <32 x float>, <32 x float> addrspace(1)* %0, align 64
@@ -61,7 +61,7 @@ entry:
 
 define dso_local spir_kernel void @vector_broadcast_regression(<4 x float> addrspace(1)* nocapture readonly %in, i32 %nancode, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x i32> addrspace(1)*
   %1 = load <4 x i32>, <4 x i32> addrspace(1)* %0, align 16
@@ -81,7 +81,7 @@ entry:
 define dso_local spir_kernel void @vector_broadcast_insertpt(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> %addend, i32 %nancode, <4 x float> addrspace(1)* nocapture %out, <4 x i32> addrspace(1)* nocapture %out2) local_unnamed_addr #0 {
 entry:
   %existing.alloc = alloca <4 x i32>
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   store <4 x i32> zeroinitializer, <4 x i32>* %existing.alloc
   %scalar = bitcast <4 x i32>* %existing.alloc to i32*
   store i32 1, i32* %scalar
@@ -99,7 +99,7 @@ entry:
 
 define dso_local spir_kernel void @vector_mask_broadcast(<4 x float> addrspace(1)* nocapture readonly %in, <4 x i1> %input, <4 x float> %woof, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -112,7 +112,7 @@ entry:
 }
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> shufflevector (<vscale x 16 x float> insertelement (<vscale x 16 x float> {{(undef|poison)}}, float 0x7FF0000020000000, {{i32|i64}} 0), <vscale x 16 x float> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer), ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
@@ -125,7 +125,7 @@ entry:
 ; CHECK-NEXT:  [[XLEN:%.*]] = call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:  [[TMP0:%.*]] = shl i64 [[XLEN]], 4
 ; CHECK-NEXT:  [[TMP1:%.*]] = call <vscale x 16 x float> @llvm.riscv.vrgather.vv.nxv16f32.i64(<vscale x 16 x float> undef, <vscale x 16 x float> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[TMP0]])
-; CHECK-NEXT:  [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:  [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:  [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:  [[TMP3:%.*]] = load <vscale x 16 x float>, ptr addrspace(1) [[ARRAYIDX]], align 4
 ; CHECK-NEXT:  [[TMP4:%.*]] = fadd <vscale x 16 x float> [[TMP3]], [[TMP1]]
@@ -142,7 +142,7 @@ entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = {{s|z}}ext <vscale x 128 x i32> [[IDX1]] to <vscale x 128 x i64>
 ; CHECK-NEXT:    [[VEC_ALLOC:%.*]] = getelementptr inbounds float, ptr [[FIXLEN_ALLOC]], <vscale x 128 x i64> [[TMP0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <vscale x 128 x float> @llvm.masked.gather.nxv128f32.nxv128p0(<vscale x 128 x ptr> [[VEC_ALLOC]], i32 4, <vscale x 128 x i1> shufflevector (<vscale x 128 x i1> insertelement (<vscale x 128 x i1> poison, i1 true, {{i32|i64}} 0), <vscale x 128 x i1> poison, <vscale x 128 x i32> zeroinitializer), <vscale x 128 x float> undef)
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <32 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = load <vscale x 128 x float>, ptr addrspace(1) [[ARRAYIDX]], align 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = fadd <vscale x 128 x float> [[TMP3]], [[TMP1]]
@@ -152,7 +152,7 @@ entry:
 ;
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_regression(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <vscale x 16 x i32>, ptr addrspace(1) [[ARRAYIDX]], align 4
 ; CHECK-NEXT:    [[AND1_I_I_I1_I1:%.*]] = and <vscale x 16 x i32> [[TMP1]], shufflevector (<vscale x 16 x i32> insertelement (<vscale x 16 x i32> {{(undef|poison)}}, i32 2139095040, {{i32|i64}} 0), <vscale x 16 x i32> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer)
@@ -176,7 +176,7 @@ entry:
 ; CHECK-NEXT:  [[XLEN:%.*]] = call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:  [[TMP0:%.*]] = shl i64 [[XLEN]], 4
 ; CHECK-NEXT:  [[TMP1:%.*]] = call <vscale x 16 x float> @llvm.riscv.vrgather.vv.nxv16f32.i64(<vscale x 16 x float> undef, <vscale x 16 x float> [[VS21]], <vscale x 16 x i32> [[VS13]], i64 [[TMP0]])
-; CHECK-NEXT:  [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:  [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:  store <4 x i32> zeroinitializer, ptr [[EXISTINGALLOC]], align 16
 ; CHECK-NEXT:  store i32 1, ptr [[EXISTINGALLOC]], align 16
 ; CHECK-NEXT:  [[V:%.*]] = load <4 x i32>, ptr [[EXISTINGALLOC]], align 16

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/extract_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/extract_element.ll
@@ -25,11 +25,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @extract_element(<4 x float> addrspace(1)* nocapture readonly %in, i32 %idx, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -43,7 +43,7 @@ entry:
 
 define spir_kernel void @extract_element_ilegal(<32 x float> addrspace(1)* nocapture readonly %in, i32 %idx, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <32 x float>, <32 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <32 x float> addrspace(1)* %arrayidx to <32 x float> addrspace(1)*
   %1 = load <32 x float>, <32 x float> addrspace(1)* %0, align 64
@@ -55,7 +55,7 @@ entry:
 
 define spir_kernel void @extract_element_uniform(<4 x float> %in, i32 %idx, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %0 = extractelement <4 x float> %in, i32 %idx
   %arrayidx3 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
   store float %0, float addrspace(1)* %arrayidx3, align 4
@@ -64,7 +64,7 @@ entry:
 
 define spir_kernel void @extract_element_uniform_vec(<4 x float> %in, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %i = urem i64 %call, 4
   %0 = extractelement <4 x float> %in, i64 %i
   %arrayidx3 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
@@ -74,7 +74,7 @@ entry:
 
 define spir_kernel void @extract_element_varying_indices(<4 x float> addrspace(1)* %in, i32 addrspace(1)* %idxs, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidxidx = getelementptr inbounds i32, i32 addrspace(1)* %idxs, i64 %call
   %idx = load i32, i32 addrspace(1)* %arrayidxidx
   %i = urem i32 %idx, 4
@@ -88,7 +88,7 @@ entry:
 
 define spir_kernel void @extract_element_bool(<4 x i32> addrspace(1)* %a, <4 x i32> addrspace(1)* %b, i32 %idx, i32 addrspace(1)* nocapture %out, <4 x i32> addrspace(1)* nocapture %out2) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %a, i64 %call
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %b, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/insert_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/insert_element.ll
@@ -24,11 +24,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @insert_element(<4 x float> addrspace(1)* nocapture readonly %in, float %val, i32 %idx, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -40,7 +40,7 @@ entry:
 
 define spir_kernel void @insert_element_uniform(<4 x float> %in, float %val, i32 %idx, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %0 = insertelement <4 x float> %in, float %val, i32 %idx
   %arrayidx3 = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %out, i64 %call
   store <4 x float> %0, <4 x float> addrspace(1)* %arrayidx3, align 4
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @insert_element_varying_indices(<4 x float> addrspace(1)* nocapture readonly %in, i32 addrspace(1)* %idxs, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxidx = getelementptr inbounds i32, i32 addrspace(1)* %idxs, i64 %call
   %idx = load i32, i32 addrspace(1)* %arrayidxidx
   %i = urem i32 %idx, 4
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @insert_element_illegal(<32 x float> addrspace(1)* nocapture readonly %in, i32 addrspace(1)* %idxs, <32 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxidx = getelementptr inbounds i32, i32 addrspace(1)* %idxs, i64 %call
   %idx = load i32, i32 addrspace(1)* %arrayidxidx, align 4
   %i = urem i32 %idx, 32
@@ -81,7 +81,7 @@ entry:
 
 define spir_kernel void @insert_element_bool(<4 x i32> addrspace(1)* %a, <4 x i32> addrspace(1)* %b, i32 %val, i32 %idx, <4 x i32> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %a, i64 %call
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %b, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x i32> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %in.ptr = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %in, i64 %gid
   %in.data = load <4 x i32>, <4 x i32> addrspace(1)* %in.ptr
   %out.data = shufflevector <4 x i32> %in.data, <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It checks that a single-operand shuffle that doesn't change the length is packetized to a gather intrinsic.
 ; CHECK: define spir_kernel void @__vecz_nxv4_f({{.*}}) {{.*}} {

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_bool.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_bool.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x i32> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %in.ptr = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %in, i64 %gid
   %in.data = load <4 x i32>, <4 x i32> addrspace(1)* %in.ptr
   %in.bool = icmp ne <4 x i32> %in.data, zeroinitializer
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It checks that a single-operand shuffle that doesn't change the length is packetized to a gather intrinsic,
 ; and that it works with a vector of i1 type by temporarily extending to i8.

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_concat.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_concat.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<2 x i32> addrspace(1)* %a, <2 x i32> addrspace(1)* %b, <4 x i32> addrspace(1)* %out) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %a.ptr = getelementptr inbounds <2 x i32>, <2 x i32> addrspace(1)* %a, i64 %gid
   %a.data = load <2 x i32>, <2 x i32> addrspace(1)* %a.ptr
   %b.ptr = getelementptr inbounds <2 x i32>, <2 x i32> addrspace(1)* %b, i64 %gid
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It checks that a two-operand shuffle is packetized to a gather intrinsics and a select.
 ; CHECK: define spir_kernel void @__vecz_nxv4_f({{.*}}) {{.*}} {

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_narrow.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_narrow.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x i32> addrspace(1)* %in, <2 x i32> addrspace(1)* %out) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %in.ptr = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %in, i64 %gid
   %in.data = load <4 x i32>, <4 x i32> addrspace(1)* %in.ptr
   %out.data = shufflevector <4 x i32> %in.data, <4 x i32> undef, <2 x i32> <i32 0, i32 2>
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It checks that a single-operand shuffle that narrows the vector is packetized to a gather intrinsic.
 ; CHECK: define spir_kernel void @__vecz_nxv4_f({{.*}}) {{.*}} {

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_wider.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/packetize_shuffle_wider.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<2 x i32> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %in.ptr = getelementptr inbounds <2 x i32>, <2 x i32> addrspace(1)* %in, i64 %gid
   %in.data = load <2 x i32>, <2 x i32> addrspace(1)* %in.ptr
   %out.data = shufflevector <2 x i32> %in.data, <2 x i32> undef, <4 x i32> <i32 1, i32 0, i32 1, i32 0>
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It checks that a single-operand shuffle that widens the vector is packetized to a gather intrinsic.
 ; CHECK: define spir_kernel void @__vecz_nxv4_f({{.*}}) {{.*}} {

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/select_scalar_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/select_scalar_vector.ll
@@ -20,11 +20,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @select_scalar_vector(i32* %aptr, i32* %bptr, <2 x i32>* %cptr, <2 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxc = getelementptr inbounds <2 x i32>, <2 x i32>* %cptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/vp_memops.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/vp_memops.ll
@@ -27,7 +27,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @store_element(i32 %0, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp ne i64 %call, 0
   br i1 %cond, label %do, label %ret
 
@@ -62,7 +62,7 @@ ret:
 
 define spir_kernel void @load_element(i32 addrspace(1)* %a, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp ne i64 %call, 0
   br i1 %cond, label %do, label %ret
 
@@ -97,4 +97,4 @@ ret:
 ; CHECK-LOAD-16-NEXT: [[TMP7:%.*]] = call <vscale x 16 x i32> @llvm.masked.load.nxv16i32.p1(ptr addrspace(1) [[TMP0]], i32 4, <vscale x 16 x i1> [[TMP6]], <vscale x 16 x i32> {{undef|poison}})
 ; CHECK-LOAD-16-NEXT: ret <vscale x 16 x i32> [[TMP7]]
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/RISCV/vp_vsetvli.ll
+++ b/modules/compiler/vecz/test/lit/llvm/RISCV/vp_vsetvli.ll
@@ -21,11 +21,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @load_add_store(i32* %aptr, i32* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/broadcast_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/broadcast_vector.ll
@@ -20,11 +20,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define dso_local spir_kernel void @vector_broadcast_const(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -36,7 +36,7 @@ entry:
 
 define dso_local spir_kernel void @vector_broadcast(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> %addend, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -48,7 +48,7 @@ entry:
 
 define dso_local spir_kernel void @vector_broadcast_regression(<4 x float> addrspace(1)* nocapture readonly %in, i32 %nancode, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x i32> addrspace(1)*
   %1 = load <4 x i32>, <4 x i32> addrspace(1)* %0, align 16
@@ -68,7 +68,7 @@ entry:
 define dso_local spir_kernel void @vector_broadcast_insertpt(<4 x float> addrspace(1)* nocapture readonly %in, <4 x float> %addend, i32 %nancode, <4 x float> addrspace(1)* nocapture %out, <4 x i32> addrspace(1)* nocapture %out2) local_unnamed_addr #0 {
 entry:
   %existing.alloc = alloca <4 x i32>
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   store <4 x i32> zeroinitializer, <4 x i32>* %existing.alloc
   %scalar = bitcast <4 x i32>* %existing.alloc to i32*
   store i32 1, i32* %scalar
@@ -86,7 +86,7 @@ entry:
 
 define dso_local spir_kernel void @vector_mask_broadcast(<4 x float> addrspace(1)* nocapture readonly %in, <4 x i1> %input, <4 x float> %woof, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -99,7 +99,7 @@ entry:
 }
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> shufflevector (<vscale x 16 x float> insertelement (<vscale x 16 x float> {{(undef|poison)}}, float 0x7FF8000020000000, {{(i32|i64)}} 0), <vscale x 16 x float> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer), ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
@@ -113,7 +113,7 @@ entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = {{s|z}}ext <vscale x 16 x i32> [[IDX1]] to <vscale x 16 x i64>
 ; CHECK-NEXT:    [[VEC_ALLOC:%.*]] = getelementptr inbounds float, ptr [[FIXLEN_ALLOC]], <vscale x 16 x i64> [[TMP0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <vscale x 16 x float> @llvm.masked.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> [[VEC_ALLOC]], i32 4, <vscale x 16 x i1> shufflevector (<vscale x 16 x i1> insertelement (<vscale x 16 x i1> poison, i1 true, {{(i32|i64)}} 0), <vscale x 16 x i1> poison, <vscale x 16 x i32> zeroinitializer), <vscale x 16 x float> undef)
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = load <vscale x 16 x float>, ptr addrspace(1) [[ARRAYIDX]], align 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = fadd <vscale x 16 x float> [[TMP3]], [[TMP1]]
@@ -123,7 +123,7 @@ entry:
 
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_regression(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <vscale x 16 x i32>, ptr addrspace(1) [[ARRAYIDX]], align 4
 ; CHECK-NEXT:    [[AND1_I_I_I1_I1:%.*]] = and <vscale x 16 x i32> [[TMP1]], shufflevector (<vscale x 16 x i32> insertelement (<vscale x 16 x i32> {{(undef|poison)}}, i32 2139095040, {{i32|i64}} 0), <vscale x 16 x i32> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer)
@@ -149,7 +149,7 @@ entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = {{s|z}}ext <vscale x 16 x i32> [[IDX14]] to <vscale x 16 x i64>
 ; CHECK-NEXT:    [[VEC_ALLOC5:%.*]] = getelementptr inbounds float, ptr [[FIXLEN_ALLOC1]], <vscale x 16 x i64> [[TMP0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <vscale x 16 x float> @llvm.masked.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> [[VEC_ALLOC5]], i32 4, <vscale x 16 x i1> shufflevector (<vscale x 16 x i1> insertelement (<vscale x 16 x i1> poison, i1 true, {{i32|i64}} 0), <vscale x 16 x i1> poison, <vscale x 16 x i32> zeroinitializer), <vscale x 16 x float> {{(undef|poison)}})
-; CHECK-NEXT:    [[CALL:%.*]] = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:    store <4 x i32> zeroinitializer, ptr [[EXISTING_ALLOC]], align 16
 ; CHECK-NEXT:    store i32 1, ptr [[EXISTING_ALLOC]], align 16
 ; CHECK-NEXT:    [[V:%.*]] = load <4 x i32>, ptr [[EXISTING_ALLOC]], align 16

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/builtins.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @builtins(float* %aptr, float* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds float, float* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds float, float* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z9isgreaterff(float, float)
 
 ; CHECK: void @__vecz_nxv4_builtins

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/cast.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/cast.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @cast(i32* %aptr, float* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxz = getelementptr inbounds float, float* %zptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -32,4 +32,4 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_nxv8_cast
 ; CHECK: sitofp <vscale x 8 x i32> {{%[0-9]+}} to <vscale x 8 x float>
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_interleaved_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_interleaved_store.ll
@@ -22,11 +22,11 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2)
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528)
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -46,9 +46,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_interleaved_store_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_interleaved_store_as_masked.ll
@@ -22,11 +22,11 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2)
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528)
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -46,9 +46,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func void @_Z7barrierj(i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
 
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>)
 

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_masked_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_masked_load.ll
@@ -22,13 +22,13 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @dont_mask_workitem_builtins(i32 addrspace(2)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %conv, 0
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry
-  %call2 = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call2 = call i64 @__mux_get_global_id(i32 0)
   %conv3 = trunc i64 %call2 to i32
   %idxprom = sext i32 %conv3 to i64
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %idxprom
@@ -39,8 +39,8 @@ if.then:                                          ; preds = %entry
   br label %if.end
 
 if.else:                                          ; preds = %entry
-  %call8 = call spir_func i64 @_Z14get_local_sizej(i32 0)
-  %call9 = call spir_func i64 @_Z12get_group_idj(i32 0)
+  %call8 = call i64 @__mux_get_local_size(i32 0)
+  %call9 = call i64 @__mux_get_group_id(i32 0)
   %mul = mul i64 %call9, %call8
   %add = add i64 %mul, %call
   %sext = shl i64 %add, 32
@@ -53,15 +53,15 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func void @_Z7barrierj(i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_size(i32)
 
-declare spir_func i64 @_Z12get_group_idj(i32)
+declare i64 @__mux_get_group_id(i32)
 
 ; Test if the masked load is defined correctly
 ; CHECK: define <vscale x 4 x i32> @__vecz_b_masked_load4_u5nxv4ju3ptrU3AS2u5nxv4b(ptr addrspace(2){{( %0)?}}, <vscale x 4 x i1>{{( %1)?}})

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_masked_scatter_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_masked_scatter_gather.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @masked_scatter(i32 addrspace(1)* %a, i32 addrspace(1)* %b, i32 addrspace(1)* %b_index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -51,7 +51,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @masked_gather(i32 addrspace(1)* %a, i32 addrspace(1)* %a_index, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -75,7 +75,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the masked scatter store is defined correctly
 ; CHECK: define void @__vecz_b_masked_scatter_store4_u5nxv4ju14nxv4u3ptrU3AS1u5nxv4b(<vscale x 4 x i32>{{( %0)?}}, <vscale x 4 x ptr addrspace(1)>{{( %1)?}}, <vscale x 4 x i1>{{( %2)?}})

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
@@ -24,11 +24,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @extract_element(<4 x float> addrspace(1)* nocapture readonly %in, i32 %idx, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -40,7 +40,7 @@ entry:
 
 define spir_kernel void @extract_element_uniform(<4 x float> %in, i32 %idx, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %0 = extractelement <4 x float> %in, i32 %idx
   %arrayidx3 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
   store float %0, float addrspace(1)* %arrayidx3, align 4
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @extract_element_uniform_vec(<4 x float> %in, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %i = urem i64 %call, 4
   %0 = extractelement <4 x float> %in, i64 %i
   %arrayidx3 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
@@ -59,7 +59,7 @@ entry:
 
 define spir_kernel void @extract_element_varying_indices(<4 x float> addrspace(1)* %in, i32 addrspace(1)* %idxs, float addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidxidx = getelementptr inbounds i32, i32 addrspace(1)* %idxs, i64 %call
   %idx = load i32, i32 addrspace(1)* %arrayidxidx
   %i = urem i32 %idx, 4
@@ -73,7 +73,7 @@ entry:
 
 define spir_kernel void @extract_element_bool(<4 x i32> addrspace(1)* %a, <4 x i32> addrspace(1)* %b, i32 %idx, i32 addrspace(1)* nocapture %out, <4 x i32> addrspace(1)* nocapture %out2) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %a, i64 %call
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %b, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/fadd.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/fadd.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @fadd(float* %aptr, float* %bptr, float* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds float, float* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds float, float* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds float, float* %zptr, i64 %idx
@@ -37,4 +37,4 @@ entry:
 ; CHECK: load <vscale x 4 x float>, ptr
 ; CHECK: fadd <vscale x 4 x float>
 ; CHECK: store <vscale x 4 x float>
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/fail_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/fail_builtins.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @fail_builtins(float* %aptr, float* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds float, float* %aptr, i64 %idx
   %arrayidxz = getelementptr inbounds float, float* %zptr, i64 %idx
   %a = load float, float* %arrayidxa, align 4
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func float @_Z4tanff(float)
 
 ; We can't scalarize this builtin call

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
@@ -23,11 +23,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @insert_element(<4 x float> addrspace(1)* nocapture readonly %in, float %val, i32 %idx, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = bitcast <4 x float> addrspace(1)* %arrayidx to <4 x float> addrspace(1)*
   %1 = load <4 x float>, <4 x float> addrspace(1)* %0, align 16
@@ -39,7 +39,7 @@ entry:
 
 define spir_kernel void @insert_element_uniform(<4 x float> %in, float %val, i32 %idx, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %0 = insertelement <4 x float> %in, float %val, i32 %idx
   %arrayidx3 = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %out, i64 %call
   store <4 x float> %0, <4 x float> addrspace(1)* %arrayidx3, align 4
@@ -48,7 +48,7 @@ entry:
 
 define spir_kernel void @insert_element_varying_indices(<4 x float> addrspace(1)* nocapture readonly %in, i32 addrspace(1)* %idxs, <4 x float> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxidx = getelementptr inbounds i32, i32 addrspace(1)* %idxs, i64 %call
   %idx = load i32, i32 addrspace(1)* %arrayidxidx
   %i = urem i32 %idx, 4
@@ -64,7 +64,7 @@ entry:
 
 define spir_kernel void @insert_element_bool(<4 x i32> addrspace(1)* %a, <4 x i32> addrspace(1)* %b, i32 %val, i32 %idx, <4 x i32> addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #6
+  %call = tail call i64 @__mux_get_global_id(i32 0) #6
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %a, i64 %call
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %b, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/interleaved_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/interleaved_load.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @load_interleaved(i32 addrspace(1)* nocapture readonly %input, i32 addrspace(1)* nocapture %output, i32 %stride) local_unnamed_addr {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %0 = trunc i64 %call to i32
   %conv1 = mul i32 %0, %stride
   %idxprom = sext i32 %conv1 to i64
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define void @__vecz_b_interleaved_store4_V_u5nxv4ju3ptrU3AS1(<vscale x 4 x i32> [[ARG0:%.*]], ptr addrspace(1) [[ARG1:%.*]], i64 [[ARG2:%.*]]) {
 ; CHECK-NEXT: entry:

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/intrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/intrinsics.ll
@@ -24,7 +24,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @ctpop(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -40,7 +40,7 @@ entry:
 
 define spir_kernel void @ctlz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @cttz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -72,7 +72,7 @@ entry:
 
 define spir_kernel void @sadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -90,7 +90,7 @@ entry:
 
 define spir_kernel void @uadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -108,7 +108,7 @@ entry:
 
 define spir_kernel void @ssub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -126,7 +126,7 @@ entry:
 
 define spir_kernel void @usub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -163,7 +163,7 @@ declare <2 x i8> @llvm.ssub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i32 @llvm.usub.sat.i32(i32, i32)
 declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_nxv2_ctpop
 ; CTPOP: = call <vscale x 2 x i32> @llvm.ctpop.nxv2i32(<vscale x 2 x i32> %{{.*}})

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/load_add_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/load_add_store.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load_add_store(i32* %aptr, i32* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx
@@ -37,4 +37,4 @@ entry:
 ; CHECK: [[rhs:%[0-9a-z]+]] = load <vscale x 4 x i32>, ptr
 ; CHECK: [[sum:%[0-9a-z]+]] = add <vscale x 4 x i32> [[lhs]], [[rhs]]
 ; CHECK: store <vscale x 4 x i32> [[sum]],
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/load_binops_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/load_binops_store.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load_binops_store(i32* %aptr, i32* %bptr, i32* %cptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxc = getelementptr inbounds i32, i32* %cptr, i64 %idx
@@ -44,4 +44,4 @@ entry:
 ; CHECK: mul <vscale x 4 x i32>
 ; CHECK: ashr <vscale x 4 x i32>
 ; CHECK: store <vscale x 4 x i32>
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/metadata.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/metadata.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
 target triple = "spir-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %load = load i32, i32 addrspace(1)* %in
   %slot = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %idx
   store i32 %load, i32 addrspace(1)* %slot

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/packetize_mask_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/packetize_mask_varying.ll
@@ -24,7 +24,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; a single varying splatted bit.
 define spir_kernel void @mask_varying(<4 x i32>* %aptr, <4 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %mod_idx = urem i64 %idx, 2
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32>* %aptr, i64 %idx
   %ins = insertelement <4 x i1> undef, i1 true, i32 0
@@ -52,5 +52,5 @@ if.end:
 
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare <4 x i32> @__vecz_b_masked_load4_Dv4_jPDv4_jDv4_b(<4 x i32>*, <4 x i1>)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/scalable_auto.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/scalable_auto.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @cast(i32* %aptr, float* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxz = getelementptr inbounds float, float* %zptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -34,4 +34,4 @@ entry:
 ; appropriate scalable vectorization factor.
 ; CHECK: define spir_kernel void @__vecz_nxv[[VF:[0-9]+]]_cast
 ; CHECK: sitofp <vscale x [[VF]] x i32> {{%[0-9]+}} to <vscale x [[VF]] x float>
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @select_scalar_scalar(i32* %aptr, i32* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx
@@ -35,7 +35,7 @@ entry:
 
 define spir_kernel void @select_vector_vector(<2 x i32>* %aptr, <2 x i32>* %bptr, <2 x i32>* %cptr, <2 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds <2 x i32>, <2 x i32>* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i32>, <2 x i32>* %bptr, i64 %idx
   %arrayidxc = getelementptr inbounds <2 x i32>, <2 x i32>* %cptr, i64 %idx
@@ -49,7 +49,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_nxv4_select_scalar_scalar
 ; CHECK: [[lhs:%[0-9a-z]+]] = load <vscale x 4 x i32>, ptr

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select_scalar_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select_scalar_vector.ll
@@ -20,11 +20,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @select_scalar_vector(i32* %aptr, i32* %bptr, <2 x i32>* %cptr, <2 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxc = getelementptr inbounds <2 x i32>, <2 x i32>* %cptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/shuffle.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/shuffle.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @do_shuffle_splat(i32* %aptr, <4 x i32>* %bptr, <4 x i32>* %zptr) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32>* %bptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -45,7 +45,7 @@ define spir_kernel void @do_shuffle_splat(i32* %aptr, <4 x i32>* %bptr, <4 x i32
 }
 
 define spir_kernel void @do_shuffle_splat_uniform(i32 %a, <4 x i32>* %bptr, <4 x i32>* %zptr) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32>* %bptr, i64 %idx
   %b = load <4 x i32>, <4 x i32>* %arrayidxb, align 16
   %insert = insertelement <4 x i32> undef, i32 %a, i32 0
@@ -59,4 +59,4 @@ define spir_kernel void @do_shuffle_splat_uniform(i32 %a, <4 x i32>* %bptr, <4 x
 ; CHECK: store <vscale x 16 x i32> [[splat]], ptr
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/vectors.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/vectors.ll
@@ -21,7 +21,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load_add_store(<4 x i32>* %aptr, <4 x i32>* %bptr, <4 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32>* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32>* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds <4 x i32>, <4 x i32>* %zptr, i64 %idx
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_nxv4_load_add_store
 ; CHECK: [[lhs:%[0-9a-z]+]] = load <vscale x 16 x i32>, ptr

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/verification_fail_phi.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/verification_fail_phi.ll
@@ -21,11 +21,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @regression_phis(i64 addrspace(1)* %xs, i64 addrspace(1)* %ys, i32 addrspace(1)* %out, i64 %lim) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.x = getelementptr inbounds i64, i64 addrspace(1)* %xs, i64 %call
   %x = load i64, i64 addrspace(1)* %arrayidx.x, align 4
   %cond = icmp eq i64 %call, 0

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/widen_vload.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/widen_vload.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @widen_vload(<4 x i32>* %aptr, <4 x i32>* %zptr) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %mod_idx = urem i64 %idx, 2
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32>* %aptr, i64 %mod_idx
   %v = load <4 x i32>, <4 x i32>* %arrayidxa, align 16
@@ -32,4 +32,4 @@ define spir_kernel void @widen_vload(<4 x i32>* %aptr, <4 x i32>* %zptr) {
 ; CHECK: %v4 = call <vscale x 16 x i32> @__vecz_b_gather_load16_u6nxv16ju10nxv16u3ptr(<vscale x 16 x ptr> %{{.*}})
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/workitem_funcs.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/workitem_funcs.ll
@@ -25,7 +25,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @store_ult(i32* %out, i64* %N) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %0 = load i64, i64* %N, align 8
   %cmp = icmp ult i64 %call, %0
   %conv = zext i1 %cmp to i32
@@ -34,7 +34,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_nxv4_store_ult
 ; CHECK:   [[step:%[0-9.a-z]+]] = call <vscale x 4 x i64> @llvm.experimental.stepvector.nxv4i64()

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
@@ -20,11 +20,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @foo(float addrspace(1)* nocapture readonly %a, i32 addrspace(1)* nocapture %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %a, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %cmp = fcmp oeq float %0, 0.000000e+00

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/choice.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/choice.ll
@@ -21,11 +21,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @foo(float* %aptr, float* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds float, float* %aptr, i64 %idx
   %arrayidxz = getelementptr inbounds float, float* %zptr, i64 %idx
   %a = load float, float* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_interleaved_load_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_interleaved_load_store.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
@@ -45,9 +45,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_masked_load_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_masked_load_store.ll
@@ -24,13 +24,13 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @dont_mask_workitem_builtins(i32 addrspace(2)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %conv, 0
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry
-  %call2 = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call2 = call i64 @__mux_get_global_id(i32 0)
   %conv3 = trunc i64 %call2 to i32
   %idxprom = sext i32 %conv3 to i64
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %idxprom
@@ -41,8 +41,8 @@ if.then:                                          ; preds = %entry
   br label %if.end
 
 if.else:                                          ; preds = %entry
-  %call8 = call spir_func i64 @_Z14get_local_sizej(i32 0)
-  %call9 = call spir_func i64 @_Z12get_group_idj(i32 0)
+  %call8 = call i64 @__mux_get_local_size(i32 0)
+  %call9 = call i64 @__mux_get_group_id(i32 0)
   %mul = mul i64 %call9, %call8
   %add = add i64 %mul, %call
   %sext = shl i64 %add, 32
@@ -55,13 +55,13 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_size(i32)
 
-declare spir_func i64 @_Z12get_group_idj(i32)
+declare i64 @__mux_get_group_id(i32)
 
 ; Test if the masked store is defined correctly
 ; CHECK: define void @__vecz_b_masked_store4_vp_Dv4_ju3ptrU3AS1Dv4_bj(<4 x i32>{{( %0)?}}, ptr addrspace(1){{( %1)?}}, <4 x i1>{{( %2)?}}, i32{{( %3)?}}) {

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_masked_scatter_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/define_masked_scatter_gather.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @masked_scatter(i32 addrspace(1)* %a, i32 addrspace(1)* %b, i32 addrspace(1)* %b_index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -57,7 +57,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @masked_gather(i32 addrspace(1)* %a, i32 addrspace(1)* %a_index, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -81,7 +81,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the vector-predicated gather load is defined correctly
 ; CHECK: define <vscale x 4 x i32> @__vecz_b_masked_gather_load4_vp_u5nxv4ju14nxv4u3ptrU3AS1u5nxv4bj(<vscale x 4 x ptr addrspace(1)>{{( %0)?}}, <vscale x 4 x i1>{{( %1)?}}, i32{{( %2)?}})

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/load_add_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/load_add_store.ll
@@ -24,11 +24,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @load_add_store_i32(i32* %aptr, i32* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @load_add_store_v4i32(<4 x i32>* %aptr, <4 x i32>* %bptr, <4 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32>* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <4 x i32>, <4 x i32>* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds <4 x i32>, <4 x i32>* %zptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/packetize_mask_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/packetize_mask_varying.ll
@@ -24,7 +24,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; a single varying splatted bit.
 define spir_kernel void @mask_varying(<4 x i32>* %aptr, <4 x i32>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %mod_idx = urem i64 %idx, 2
   %arrayidxa = getelementptr inbounds <4 x i32>, <4 x i32>* %aptr, i64 %idx
   %ins = insertelement <4 x i1> undef, i1 true, i32 0
@@ -49,5 +49,5 @@ if.end:
 ; CHECK: [[RESPLAT:%.*]] = shufflevector <4 x i1> [[REINS]], <4 x i1> poison, <4 x i32> zeroinitializer
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare <4 x i32> @__vecz_b_masked_load4_Dv4_jPDv4_jDv4_b(<4 x i32>*, <4 x i1>)

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/scatter_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/scatter_gather.ll
@@ -20,12 +20,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; With VP all gathers become masked ones.
 define spir_kernel void @unmasked_gather(i32 addrspace(1)* %a, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %rem
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
@@ -42,7 +42,7 @@ entry:
 ; With VP all scatters become masked ones.
 define spir_kernel void @unmasked_scatter(i32 addrspace(1)* %a, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/udiv.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/udiv.ll
@@ -21,11 +21,11 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @udiv(i32* %aptr, i32* %bptr, i32* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, i32* %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, i32* %zptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/define_interleaved_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/define_interleaved_load.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/define_interleaved_load_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/define_interleaved_load_as_masked.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/delete_packetized_memop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/delete_packetized_memop.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @memop_loop_dep(i32 addrspace(1)* %in, i32 addrspace(1)* %out, i32 %i, i32 %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
@@ -52,7 +52,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func <4 x i32> @_Z6vload4mPKU3AS1i(i64, i32 addrspace(1)*)
 

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_constant_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_constant_index.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @extract_constant_index(<4 x i64> addrspace(1)* %in, i32 %x, i64 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x i64>, <4 x i64> addrspace(1)* %in, i64 %call
   %0 = load <4 x i64>, <4 x i64> addrspace(1)* %arrayidx, align 4
   %vecext = extractelement <4 x i64> %0, i32 0;
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; CHECK: define spir_kernel void @__vecz_v4_extract_constant_index
 ; CHECK: %[[LD:.+]] = load <16 x i64>

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @extract_runtime_index(<4 x float> addrspace(1)* %in, i32 %x, float addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 4
   %vecext = extractelement <4 x float> %0, i32 %x

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index2.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @extract_runtime_index(i32 addrspace(1)* %in, <4 x i8> %x, i8 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %vecext = extractelement <4 x i8> %x, i32 %0

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/extractelement_runtime_index3.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @extract_runtime_index(<4 x float> addrspace(1)* %in, i32 addrspace(1)* %x, float addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %x, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_constant_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_constant_index.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @constant_index(<4 x i32>* %in, i32* %inval, <4 x i32>* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32>* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32>* %arrayidx
   %arrayidx2 = getelementptr inbounds i32, i32* %inval, i64 %call

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_constant_index_constant_value.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_constant_index_constant_value.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @constant_index(<4 x i32>* %in, <4 x i32>* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32>* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32>* %arrayidx
   %arrayidx2 = getelementptr inbounds <4 x i32>, <4 x i32>* %out, i64 %call

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_runtime_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/insertelement_runtime_index.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @runtime_index(<4 x i32>* %in, <4 x i32>* %out, i32* %index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32>* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32>* %arrayidx
   %arrayidx1 = getelementptr inbounds <4 x i32>, <4 x i32>* %out, i64 %call

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/interleaved_safety.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/interleaved_safety.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2
@@ -72,13 +72,13 @@ attributes #3 = { nobuiltin nounwind }
 
 ; Function start
 ; CHECK: define spir_kernel void @__vecz_v4_f
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 
 ; There should be exactly six vector loads and one store in the code
 ; CHECK: load <16 x double>
 
 ; And in between them there should be a barrier call
-; CHECK: call spir_func void @_Z7barrierj
+; CHECK: call void @__mux_work_group_barrier
 ; CHECK: call void @__vecz_b_interleaved_store8_4_Dv4_du3ptrU3AS1(<4 x double> <double 1.600000e+01, double 1.600000e+01, double 1.600000e+01, double 1.600000e+01>
 ; CHECK: load <16 x double>
 ; CHECK: load <16 x double>

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isfiniteDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isfiniteDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_isfiniteDv4_d
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 ; CHECK: and <16 x i64>
 ; CHECK: icmp slt <16 x i64>
 ; CHECK: sext <16 x i1>

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isfiniteDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isfiniteDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float>)
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isinfDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isinfDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double>)
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isinfDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isinfDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float>)
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnanDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnanDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double>)
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnanDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnanDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float>)
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnormalDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnormalDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnormalDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/onearg_relationals_isnormalDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float>)
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/scalar_vector_user.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/scalar_vector_user.ll
@@ -22,7 +22,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:1:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z12get_local_idj(i32) #0
+declare i64 @__mux_get_local_id(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func <4 x float> @_Z3madDv4_fS_S_(<4 x float>, <4 x float>, <4 x float>) #0
@@ -35,7 +35,7 @@ declare spir_func float @_Z3madfff(float, float, float) local_unnamed_addr #2
 
 define spir_kernel void @scalar_vector_user(float addrspace(1)* %inout, i64 %n) {
 entry:
-  %lid = tail call spir_func i64 @_Z12get_local_idj(i32 0) #0
+  %lid = tail call i64 @__mux_get_local_id(i32 0) #0
   %inout.address = getelementptr inbounds float, float addrspace(1)* %inout, i64 %lid
   br label %loop
 

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/vector_copy.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/vector_copy.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_copy(<4 x i32> addrspace(1)* %out, <4 x i32> addrspace(1)* %in) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidx, align 16
   %arrayidx1 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %out, i64 %call
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; It makes sure the vector load and store are preserved right through to packetization
 ; and then widened, instead of being scalarized across work-items first

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/vector_phi_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/vector_phi_varying.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_loop(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %call.trunc = trunc i64 %call to i32
   %call.splatinsert = insertelement <4 x i32> undef, i32 %call.trunc, i32 0
   %call.splat = shufflevector <4 x i32> %call.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -32,7 +32,7 @@ entry:
 
 for.cond:                                         ; preds = %entry, %for.body
   %storemerge = phi <4 x i32> [ %inc, %for.body ], [ zeroinitializer, %entry ]
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %call1 = call i64 @__mux_get_global_size(i32 0)
   %conv = trunc i64 %call1 to i32
   %splat.splatinsert = insertelement <4 x i32> undef, i32 %conv, i32 0
   %splat.splat = shufflevector <4 x i32> %splat.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -80,8 +80,8 @@ for.end:                                          ; preds = %entry, %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_global_size(i32)
 
 ; This test checks if a varying <4 x i32> phi is scalarized into 4 i32 phis
 ; and then re-packetized

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_abs.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_abs.ll
@@ -20,14 +20,14 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare i32 @llvm.abs.i32(i32, i1)
 declare <2 x i32> @llvm.abs.v2i32(<2 x i32>, i1)
 
 define spir_kernel void @absff(i32* %pa, i32* %pb) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr i32, i32* %pa, i64 %idx
   %b = getelementptr i32, i32* %pb, i64 %idx
   %la = load i32, i32* %a, align 16
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @absvf(<2 x i32>* %pa, <2 x i32>* %pb) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <2 x i32>, <2 x i32>* %pa, i64 %idx
   %b = getelementptr <2 x i32>, <2 x i32>* %pb, i64 %idx
   %la = load <2 x i32>, <2 x i32>* %a, align 16
@@ -49,7 +49,7 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_v4_absff(ptr %pa, ptr %pb)
 ; CHECK: entry:
-; CHECK: %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %a = getelementptr i32, ptr %pa, i64 %idx
 ; CHECK: %b = getelementptr i32, ptr %pb, i64 %idx
 ; CHECK: %[[T0:.*]] = load <4 x i32>, ptr %a, align 4
@@ -59,7 +59,7 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_v4_absvf(ptr %pa, ptr %pb)
 ; CHECK: entry:
-; CHECK: %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %a = getelementptr <2 x i32>, ptr %pa, i64 %idx
 ; CHECK: %b = getelementptr <2 x i32>, ptr %pb, i64 %idx
 ; CHECK: %[[T0:.*]] = load <8 x i32>, ptr %a, align 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_binops.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_binops.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @widen_binops(<4 x i32>* %pa, <4 x i32>* %pb, <4 x i64>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x i32>, <4 x i32>* %pa, i64 %idx
   %b = getelementptr <4 x i32>, <4 x i32>* %pb, i64 %idx
   %d = getelementptr <4 x i64>, <4 x i64>* %pd, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_copysign.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_copysign.ll
@@ -20,14 +20,14 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare float @llvm.copysign.f32(float, float)
 declare <2 x float> @llvm.copysign.v2f32(<2 x float>, <2 x float>)
 
 define spir_kernel void @copysignff(float* %pa, float* %pb, float* %pc) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr float, float* %pa, i64 %idx
   %b = getelementptr float, float* %pb, i64 %idx
   %c = getelementptr float, float* %pc, i64 %idx
@@ -40,7 +40,7 @@ entry:
 
 define spir_kernel void @copysignvf(<2 x float>* %pa, <2 x float>* %pb, <2 x float>* %pc) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <2 x float>, <2 x float>* %pa, i64 %idx
   %b = getelementptr <2 x float>, <2 x float>* %pb, i64 %idx
   %c = getelementptr <2 x float>, <2 x float>* %pc, i64 %idx
@@ -53,7 +53,7 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_v4_copysignff(ptr %pa, ptr %pb, ptr %pc)
 ; CHECK: entry:
-; CHECK: %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %a = getelementptr float, ptr %pa, i64 %idx
 ; CHECK: %b = getelementptr float, ptr %pb, i64 %idx
 ; CHECK: %c = getelementptr float, ptr %pc, i64 %idx
@@ -65,7 +65,7 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_v4_copysignvf(ptr %pa, ptr %pb, ptr %pc)
 ; CHECK: entry:
-; CHECK: %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %a = getelementptr <2 x float>, ptr %pa, i64 %idx
 ; CHECK: %b = getelementptr <2 x float>, ptr %pb, i64 %idx
 ; CHECK: %c = getelementptr <2 x float>, ptr %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fma.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fma.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(<4 x float>* %pa, <4 x float>* %pb, <4 x float>* %pc, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx
   %b = getelementptr <4 x float>, <4 x float>* %pb, i64 %idx
   %c = getelementptr <4 x float>, <4 x float>* %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmin_vector_scalar.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmin_vector_scalar.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Function Attrs: nounwind readnone
 declare spir_func <4 x float> @_Z4fminDv4_ff(<4 x float>, float)
@@ -38,7 +38,7 @@ declare spir_func <16 x float> @_Z4fminDv16_fS_(<16 x float>, <16 x float>)
 
 define spir_kernel void @fmin_vector_scalar(<4 x float>* %pa, float* %pb, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx
   %b = getelementptr float, float* %pb, i64 %idx
   %d = getelementptr <4 x float>, <4 x float>* %pd, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(<4 x float>* %pa, <4 x float>* %pb, <4 x float>* %pc, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx
   %b = getelementptr <4 x float>, <4 x float>* %pb, i64 %idx
   %c = getelementptr <4 x float>, <4 x float>* %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd2.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(<4 x float>* %pa, <4 x float>* %pb, <4 x float>* %pc, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %idx2 = shl i64 %idx, 1
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx2
   %b = getelementptr <4 x float>, <4 x float>* %pb, i64 %idx2

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd_phi.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fmuladd_phi.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(<4 x float>* %pa, <4 x float>* %pb, <4 x float>* %pc, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx
   %b = getelementptr <4 x float>, <4 x float>* %pb, i64 %idx
   %c = getelementptr <4 x float>, <4 x float>* %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fshl.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fshl.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(i8* %pa, i8* %pb, i8* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr i8, i8* %pa, i64 %idx
   %b = getelementptr i8, i8* %pb, i64 %idx
   %d = getelementptr i8, i8* %pd, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fshr.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_fshr.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(i8* %pa, i8* %pb, i8* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr i8, i8* %pa, i64 %idx
   %b = getelementptr i8, i8* %pb, i64 %idx
   %d = getelementptr i8, i8* %pd, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_shufflevector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_shufflevector.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @widen_shufflevector(<2 x float> addrspace(1)* %a, <2 x float> addrspace(1)* %b, <4 x float> addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidxa = getelementptr inbounds <2 x float>, <2 x float> addrspace(1)* %a, i64 %call
   %arrayidxb = getelementptr inbounds <2 x float>, <2 x float> addrspace(1)* %b, i64 %call
   %la = load <2 x float>, <2 x float> addrspace(1)* %arrayidxa, align 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_sqrt.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorWidening/widen_sqrt.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func float @_Z4sqrtf(float)
 declare spir_func <2 x float> @_Z4sqrtDv2_f(<2 x float>)
 declare spir_func <4 x float> @_Z4sqrtDv4_f(<4 x float>)
@@ -29,7 +29,7 @@ declare spir_func <16 x float> @_Z4sqrtDv16_f(<16 x float>)
 define spir_kernel void @test_sqrt(<2 x float> addrspace(1)* %in2, <2 x float> addrspace(1)* %out2,
                                    <4 x float> addrspace(1)* %in4, <4 x float> addrspace(1)* %out4) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %arrayin2 = getelementptr inbounds <2 x float>, <2 x float> addrspace(1)* %in2, i64 %gid
   %arrayin4 = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in4, i64 %gid
   %arrayout2 = getelementptr inbounds <2 x float>, <2 x float> addrspace(1)* %out2, i64 %gid

--- a/modules/compiler/vecz/test/lit/llvm/alloca_alias.ll
+++ b/modules/compiler/vecz/test/lit/llvm/alloca_alias.ll
@@ -24,7 +24,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 define spir_kernel void @alloca_alias(i32 addrspace(1)* %out, i32 %index) {
 entry:
   %myStructs = alloca [2 x %struct.testStruct], align 16
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = bitcast [2 x %struct.testStruct]* %myStructs to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %0)
   %1 = trunc i64 %call to i32
@@ -58,7 +58,7 @@ entry:
 
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8*)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func void @_Z7vstore3Dv3_imPU3AS1i(<3 x i32>, i64, i32 addrspace(1)*)
 

--- a/modules/compiler/vecz/test/lit/llvm/arm_neon_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/arm_neon_store.ll
@@ -25,14 +25,14 @@ target triple = "armv7-unknown-linux-gnueabihf"
 ; Function Attrs: nounwind
 define spir_kernel void @short3_char3_codegen(i8 addrspace(1)* %src, i16 addrspace(1)* %dest) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %call = call spir_func i32 @_Z13get_global_idj(i32 0) #3
+  %call = call i32 @__mux_get_global_id(i32 0) #3
   %call1 = call spir_func <3 x i8> @_Z6vload3jPU3AS1Kc(i32 %call, i8 addrspace(1)* %src) #3
   %call3 = call spir_func <3 x i16> @_Z14convert_short3Dv3_c(<3 x i8> %call1) #3
   call spir_func void @_Z7vstore3Dv3_sjPU3AS1s(<3 x i16> %call3, i32 %call, i16 addrspace(1)* %dest) #3
   ret void
 }
 
-declare spir_func i32 @_Z13get_global_idj(i32) #1
+declare i32 @__mux_get_global_id(i32) #1
 
 declare spir_func <3 x i8> @_Z6vload3jPU3AS1Kc(i32, i8 addrspace(1)*) #1
 

--- a/modules/compiler/vecz/test/lit/llvm/async_workgroup_copy_uniform.ll
+++ b/modules/compiler/vecz/test/lit/llvm/async_workgroup_copy_uniform.ll
@@ -25,9 +25,9 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(i32 addrspace(1)* %input, i32 addrspace(3)* %output, i32 addrspace(1)* %elements) {
   %ev = alloca %opencl.event_t*, align 8
-  %1 = call spir_func i64 @_Z13get_global_idj(i32 0)
-  %2 = call spir_func i64 @_Z12get_group_idj(i32 0)
-  %3 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %1 = call i64 @__mux_get_global_id(i32 0)
+  %2 = call i64 @__mux_get_group_id(i32 0)
+  %3 = call i64 @__mux_get_local_size(i32 0)
   %4 = mul i64 %3, %2
   %5 = getelementptr inbounds i32, i32 addrspace(1)* %input, i64 %4
   %6 = mul i64 %3, %2
@@ -42,9 +42,9 @@ define spir_kernel void @test(i32 addrspace(1)* %input, i32 addrspace(3)* %outpu
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z12get_group_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_group_id(i32)
+declare i64 @__mux_get_local_size(i32)
 declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1iPKU3AS3im9ocl_event(i32 addrspace(1)*, i32 addrspace(3)*, i64, %opencl.event_t*)
 declare spir_func void @_Z17wait_group_eventsiP9ocl_event(i32, %opencl.event_t**)
 

--- a/modules/compiler/vecz/test/lit/llvm/atomic_cmpxchg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/atomic_cmpxchg.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @atomic_cmpxchg_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -42,7 +42,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_atomicrmw_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -62,7 +62,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_rmw(i32 addrspace(1)* %counter2, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = atomicrmw add i32 addrspace(1)* %counter2, i32 1 seq_cst
   %idxprom = sext i32 %0 to i64
@@ -71,7 +71,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; We no longer support instantiating atomic instructions in diverged blocks,
 ; since they require masking. FileCheck does not support comments, so the CHECKs

--- a/modules/compiler/vecz/test/lit/llvm/atomicrmw.ll
+++ b/modules/compiler/vecz/test/lit/llvm/atomicrmw.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @atomic_cmpxchg_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -42,7 +42,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_atomicrmw_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -62,7 +62,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_rmw(i32 addrspace(1)* %counter2, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = atomicrmw add i32 addrspace(1)* %counter2, i32 1 seq_cst
   %idxprom = sext i32 %0 to i64
@@ -71,7 +71,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; We no longer support instantiating atomic instructions in diverged blocks,
 ; since they require masking. FileCheck does not support comments, so the CHECKs

--- a/modules/compiler/vecz/test/lit/llvm/atomicrmw_uniform.ll
+++ b/modules/compiler/vecz/test/lit/llvm/atomicrmw_uniform.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @atomic_cmpxchg_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -42,7 +42,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_atomicrmw_builtin(i32 addrspace(1)* %counter, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %do.body
 
@@ -62,7 +62,7 @@ do.end:                                           ; preds = %do.body
 
 define spir_kernel void @atomic_rmw(i32 addrspace(1)* %counter2, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = atomicrmw add i32 addrspace(1)* %counter2, i32 1 seq_cst
   %idxprom = sext i32 %0 to i64
@@ -71,7 +71,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_v4_atomic_rmw
 ; CHECK: atomicrmw add ptr addrspace(1) %counter2, i32 1 seq_cst

--- a/modules/compiler/vecz/test/lit/llvm/basic_mem2reg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/basic_mem2reg.ll
@@ -24,7 +24,7 @@ entry:
   %d = alloca i32
   %e = alloca i32
   %f = alloca float
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %sum = add i32 %a, %b
   store i32 %sum, i32* %d, align 4
   store i32 %sum, i32* %e, align 4
@@ -43,13 +43,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @foo(i32*)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(i32 %a, i32 %b, ptr %c, float %rf)
 ; CHECK: entry:
 ; CHECK: %e = alloca i32
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %sum = add i32 %a, %b
 ; CHECK: store i32 %sum, ptr %e
 ; CHECK: %call = call spir_func i32 @foo(ptr{{.*}} %e)

--- a/modules/compiler/vecz/test/lit/llvm/bitcast_function.ll
+++ b/modules/compiler/vecz/test/lit/llvm/bitcast_function.ll
@@ -28,7 +28,7 @@ entry:
   %gid = alloca i64, align 8
   store i32* %in, i32** %in.addr, align 8
   store i32* %out, i32** %out.addr, align 8
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   store i64 %call, i64* %gid, align 8
   %0 = load i64, i64* %gid, align 8
   %rem = urem i64 %0, 16
@@ -65,7 +65,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @foo(i32, i32 addrspace(1)*)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(

--- a/modules/compiler/vecz/test/lit/llvm/branch_splitting_and.ll
+++ b/modules/compiler/vecz/test/lit/llvm/branch_splitting_and.ll
@@ -23,8 +23,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @split_branch(i32 addrspace(1)* noalias %a, i32 addrspace(1)* noalias %b, i32 addrspace(1)* noalias %d) #0 {
 entry:
-  %x = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %y = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %x = call i64 @__mux_get_global_id(i32 0) #2
+  %y = call i64 @__mux_get_global_id(i32 1) #2
   %a_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %x
   %b_gep = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %y
   %varying = load i32, i32 addrspace(1)* %a_gep
@@ -45,7 +45,7 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a conditional branch based on an AND of both
 ; a uniform and a varying value gets split into two separate branches

--- a/modules/compiler/vecz/test/lit/llvm/branch_splitting_or.ll
+++ b/modules/compiler/vecz/test/lit/llvm/branch_splitting_or.ll
@@ -23,8 +23,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @split_branch(i32 addrspace(1)* noalias %a, i32 addrspace(1)* noalias %b, i32 addrspace(1)* noalias %d) #0 {
 entry:
-  %x = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %y = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %x = call i64 @__mux_get_global_id(i32 0) #2
+  %y = call i64 @__mux_get_global_id(i32 1) #2
   %a_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %x
   %b_gep = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %y
   %varying = load i32, i32 addrspace(1)* %a_gep
@@ -45,7 +45,7 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a conditional branch based on an OR of both
 ; a uniform and a varying value gets split into two separate branches

--- a/modules/compiler/vecz/test/lit/llvm/builtin_inlining_addsat.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_inlining_addsat.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @saddsatc(i8 addrspace(1)* %lhs, i8 addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %lhs, i64 %call
   %0 = load i8, i8 addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds i8, i8 addrspace(1)* %rhs, i64 %call
@@ -33,7 +33,7 @@ entry:
 
 define spir_kernel void @uaddsatc(i8 addrspace(1)* %lhs, i8 addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %lhs, i64 %call
   %0 = load i8, i8 addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds i8, i8 addrspace(1)* %rhs, i64 %call
@@ -45,7 +45,7 @@ entry:
 
 define spir_kernel void @saddsati(i32 addrspace(1)* %lhs, i32 addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %lhs, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %rhs, i64 %call
@@ -57,7 +57,7 @@ entry:
 
 define spir_kernel void @uaddsati(i32 addrspace(1)* %lhs, i32 addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %lhs, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %rhs, i64 %call
@@ -69,7 +69,7 @@ entry:
 
 define spir_kernel void @saddsati4(<4 x i32> addrspace(1)* %lhs, <4 x i32> addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %lhs, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %rhs, i64 %call
@@ -81,7 +81,7 @@ entry:
 
 define spir_kernel void @uaddsati4(<4 x i32> addrspace(1)* %lhs, <4 x i32> addrspace(1)* %rhs) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %lhs, i64 %call
   %0 = load <4 x i32>, <4 x i32> addrspace(1)* %arrayidx, align 1
   %arrayidx1 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %rhs, i64 %call
@@ -91,7 +91,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i8 @_Z7add_satcc(i8, i8)
 declare spir_func i8 @_Z7add_sathh(i8, i8)
 declare spir_func i32 @_Z7add_satii(i32, i32)

--- a/modules/compiler/vecz/test/lit/llvm/builtin_inlining_fmax.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_inlining_fmax.ll
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func float @_Z4fmaxff(float, float)
 declare spir_func <2 x float> @_Z4fmaxDv2_ff(<2 x float>, float)

--- a/modules/compiler/vecz/test/lit/llvm/builtin_inlining_fmin.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_inlining_fmin.ll
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func float @_Z4fminff(float, float)
 declare spir_func <2 x float> @_Z4fminDv2_ff(<2 x float>, float)

--- a/modules/compiler/vecz/test/lit/llvm/builtin_inlining_negative.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_inlining_negative.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_normalize(float %a, float %b, i32* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %norm = call spir_func float @_Z9normalizef(float %a)
   %normi = fptosi float %norm to i32
   %c0 = getelementptr i32, i32* %c, i64 %gid
@@ -31,14 +31,14 @@ entry:
 
 define spir_kernel void @test_rhadd(i32 %a, i32 %b, i32* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %add = call spir_func i32 @_Z5rhaddjj(i32 %a, i32 %b)
   %c0 = getelementptr i32, i32* %c, i64 %gid
   store i32 %add, i32* %c0, align 4
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func float @_Z9normalizef(float)
 declare spir_func i32 @_Z5rhaddjj(i32, i32)
 
@@ -46,7 +46,7 @@ declare spir_func i32 @_Z5rhaddjj(i32, i32)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_rhadd(i32 %a, i32 %b, ptr %c)
 ; CHECK: entry:
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %add = call spir_func i32 @_Z5rhaddjj(i32 %a, i32 %b)
 ; CHECK: %c0 = getelementptr i32, ptr %c, i64 %gid
 ; CHECK: store i32 %add, ptr %c0, align 4

--- a/modules/compiler/vecz/test/lit/llvm/builtin_inlining_positive.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_inlining_positive.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(float %a, float %b, i32* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cmp = call spir_func i32 @_Z9isgreaterff(float %a, float %b)
   %c0 = getelementptr i32, i32* %c, i64 %gid
   store i32 %cmp, i32* %c0, align 4
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z9isgreaterff(float, float)
 declare spir_func i32 @_Z6islessff(float, float)
 declare spir_func i32 @_Z7isequalff(float, float)
@@ -49,7 +49,7 @@ define spir_func i32 @opt_Z7isequalff(float, float) {
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(float %a, float %b, ptr %c)
 ; CHECK: entry:
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %relational = fcmp ogt float %a, %b
 ; CHECK: %relational[[R1:[0-9]+]] = zext i1 %relational to i32
 ; CHECK: %c0 = getelementptr i32, ptr %c, i64 %gid

--- a/modules/compiler/vecz/test/lit/llvm/builtin_pointer_return.ll
+++ b/modules/compiler/vecz/test/lit/llvm/builtin_pointer_return.ll
@@ -19,7 +19,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %s
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func float @_Z5fractfPf(float, float*)
 declare spir_func <2 x float> @_Z5fractDv2_fPS_(<2 x float>, <2 x float>*)
@@ -31,7 +31,7 @@ declare spir_func <8 x float> @_Z5fractDv8_fPS_(<8 x float>, <8 x float>*)
 
 define spir_kernel void @fract_v1(float* %xptr, float* %outptr, float* %ioutptr) {
   %iouta = alloca float
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.x = getelementptr inbounds float, float* %xptr, i64 %idx
   %x = load float, float* %arrayidx.x, align 4
   %out = call spir_func float @_Z5fractfPf(float %x, float* %iouta)
@@ -49,7 +49,7 @@ define spir_kernel void @fract_v1(float* %xptr, float* %outptr, float* %ioutptr)
 
 define spir_kernel void @fract_v2(<2 x float>* %xptr, <2 x float>* %outptr, <2 x float>* %ioutptr) {
   %iouta = alloca <2 x float>
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.x = getelementptr inbounds <2 x float>, <2 x float>* %xptr, i64 %idx
   %x = load <2 x float>, <2 x float>* %arrayidx.x, align 8
   %out = call spir_func <2 x float> @_Z5fractDv2_fPS_(<2 x float> %x, <2 x float>* %iouta)

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_cantduplicate.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_cantduplicate.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_cantinline.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_cantinline.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_optnone.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_optnone.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_user_undefined.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_failure_user_undefined.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_builtin.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_builtin.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_instrinsic.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_instrinsic.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_user_defined.ll
+++ b/modules/compiler/vecz/test/lit/llvm/call_instantiation_success_user_defined.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @instrinsic(float* %in1, float* %in2, float* %in3, float* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in1, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, float* %in2, i64 %call
@@ -38,7 +38,7 @@ entry:
 
 define spir_kernel void @builtin(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3absi(i32 %0)
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @user_defined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @defined(i32* %add.ptr, i32* %add.ptr1)
@@ -58,7 +58,7 @@ entry:
 
 define spir_kernel void @user_undefined(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @undefined(i32* %add.ptr, i32* %add.ptr1)
@@ -67,7 +67,7 @@ entry:
 
 define spir_kernel void @cantinline(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds i32, i32* %in, i64 %call
   %add.ptr1 = getelementptr inbounds i32, i32* %out, i64 %call
   call spir_func void @dontinline(i32* %add.ptr, i32* %add.ptr1)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @cantduplicate(i32* %in, i32* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %call1 = tail call spir_func i32 @_Z3clzi(i32 %0) #1
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @optnone(i32* %in, i32* %out) #2 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32* %in, i64 %call
   %0 = load i32, i32* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32* %out, i64 %call
@@ -100,7 +100,7 @@ entry:
 declare float @llvm.fmuladd.f32(float, float, float)
 declare spir_func i32 @_Z3absi(i32)
 declare spir_func i32 @_Z3clzi(i32) #1
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func void @undefined(i32*, i32*)
 
 ; Functions with definitions

--- a/modules/compiler/vecz/test/lit/llvm/constant_address.ll
+++ b/modules/compiler/vecz/test/lit/llvm/constant_address.ll
@@ -21,14 +21,14 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %out) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0) #1
+  %gid = call i64 @__mux_get_global_id(i32 0) #1
   %conv = trunc i64 %gid to i32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 3
   store i32 %conv, i32 addrspace(1)* %arrayidx, align 4
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
@@ -52,7 +52,7 @@ attributes #1 = { nounwind readnone }
 
 ; CHECK: define spir_kernel void @__vecz_v4_test
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT: %conv = trunc i64 %gid to i32
 ; CHECK-NEXT: %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 3
 ; CHECK-NEXT: store i32 %conv, ptr addrspace(1) %arrayidx, align 4

--- a/modules/compiler/vecz/test/lit/llvm/contiguous_allocas.ll
+++ b/modules/compiler/vecz/test/lit/llvm/contiguous_allocas.ll
@@ -26,8 +26,8 @@ define spir_kernel void @test(<2 x float> addrspace(1)* nocapture readonly %in, 
 entry:
   %a.sroa.0 = alloca <2 x float>, align 8
   %b.sroa.2 = alloca <2 x float>, align 8
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_local_id(i32 0)
   %a.sroa.0.0..sroa_cast = bitcast <2 x float>* %a.sroa.0 to i8*
   %b.sroa.2.0..sroa_cast = bitcast <2 x float>* %b.sroa.2 to i8*
   %arrayidx2 = getelementptr inbounds [16 x <2 x float>], [16 x <2 x float>] addrspace(3)* @entry_test_alloca.lm, i64 0, i64 %call1
@@ -64,8 +64,8 @@ for.body11:                                       ; preds = %for.body11, %for.bo
   br i1 %cmp8, label %for.body11, label %for.cond.cleanup10
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
-declare spir_func i64 @_Z12get_local_idj(i32) local_unnamed_addr
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr
+declare i64 @__mux_get_local_id(i32) local_unnamed_addr
 
 ; Check that all the allocas come before anything else
 ; CHECK: define spir_kernel void @__vecz_v4_test(

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_nested_loops.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_nested_loops.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; A nested loop, in the form of
 ;

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_order_y.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_order_y.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call = call i64 @__mux_get_global_id(i32 1)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call = call i64 @__mux_get_global_id(i32 1)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call = call i64 @__mux_get_global_id(i32 1)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call = call i64 @__mux_get_global_id(i32 1)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; A nested loop, in the form of
 ;

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_order_z.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_order_z.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 2)
+  %call = call i64 @__mux_get_global_id(i32 2)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 2)
+  %call = call i64 @__mux_get_global_id(i32 2)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 2)
+  %call = call i64 @__mux_get_global_id(i32 2)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 2)
+  %call = call i64 @__mux_get_global_id(i32 2)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; A nested loop, in the form of
 ;

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_ptrs.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_ptrs.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_varying_if_ptr(i32 %a, i32** %b, i32* %on_true, i32* %on_false) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -53,7 +53,7 @@ if.end:
 define spir_kernel void @test_varying_if_ptrptr(i32 %a, i32*** %b, i32** %on_true, i32** %on_false) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_if.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_if.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This tests a uniform if statement that shouldn't be touched by the CFC pass
 ; CHECK: define spir_kernel void @__vecz_v4_test_uniform_if(i32 %a, ptr %b)

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_loop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_loop.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This tests for a uniform loop that should remain untouched by the CFC pass
 ; CHECK: define spir_kernel void @__vecz_v4_test_uniform_loop(i32 %a, ptr %b)

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_varying_if.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_varying_if.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Check for a varying that needs masked operations
 ; CHECK: define spir_kernel void @__vecz_v4_test_varying_if(i32 %a, ptr %b)

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_varying_loop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_varying_loop.ll
@@ -42,7 +42,7 @@ if.end:                                           ; preds = %if.else, %if.then
 define spir_kernel void @test_varying_if(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @test_uniform_loop(i32 %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -87,7 +87,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_varying_loop(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -112,7 +112,7 @@ for.end:                                          ; preds = %for.cond
 
 define spir_kernel void @test_nested_loops(i32* %a, i32* %b)  {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %sub = sub nsw i32 16, %conv
   br label %for.cond
@@ -153,7 +153,7 @@ for.end14:                                        ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; The loop's start condition depends on the global ID
 ; Note that the mask names are hardcoded in vecz, if they change they need to be

--- a/modules/compiler/vecz/test/lit/llvm/convert3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/convert3.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @convert3(i64 addrspace(1)* %src, float addrspace(1)* %dest) local_unnamed_addr {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %call1 = tail call spir_func <3 x i64> @_Z6vload3mPU3AS1Kl(i64 %call, i64 addrspace(1)* %src)
   %call2 = tail call spir_func <3 x float> @_Z14convert_float3Dv3_l(<3 x i64> %call1)
   tail call spir_func void @_Z7vstore3Dv3_fmPU3AS1f(<3 x float> %call2, i64 %call, float addrspace(1)* %dest)
@@ -32,7 +32,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr
 
 ; Function Attrs: convergent nounwind
 declare spir_func void @_Z7vstore3Dv3_fmPU3AS1f(<3 x float>, i64, float addrspace(1)*) local_unnamed_addr

--- a/modules/compiler/vecz/test/lit/llvm/convert4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/convert4.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nofree nounwind
 define spir_kernel void @convert4(<4 x i64> addrspace(1)* nocapture readonly %in, <4 x float> addrspace(1)* nocapture %out) local_unnamed_addr {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i64>, <4 x i64> addrspace(1)* %in, i64 %call
   %0 = load <4 x i64>, <4 x i64> addrspace(1)* %arrayidx, align 32
   %call1 = tail call spir_func <4 x float> @_Z14convert_float4Dv4_l(<4 x i64> %0)
@@ -34,7 +34,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr
 
 ; Function Attrs: convergent nounwind readnone
 declare spir_func <4 x float> @_Z14convert_float4Dv4_l(<4 x i64>) local_unnamed_addr

--- a/modules/compiler/vecz/test/lit/llvm/convert_contiguity.ll
+++ b/modules/compiler/vecz/test/lit/llvm/convert_contiguity.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
 define spir_kernel void @convert_contiguity(float addrspace(1)* %m_ptr) {
-  %1 = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %1 = call i64 @__mux_get_global_id(i32 0)
   %2 = call spir_func i32 @_Z12convert_uintm(i64 %1)
   %3 = icmp slt i32 %2, 100
   %4 = select i1 %3, float 1.000000e+00, float 0.000000e+00
@@ -38,7 +38,7 @@ declare spir_func i32 @_Z12convert_uintm(i64)
 declare spir_func i64 @_Z12convert_longi(i32)
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; It checks that the store address was identified as congituous through the
 ; OpenCL convert builtin function

--- a/modules/compiler/vecz/test/lit/llvm/define_gather_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_gather_load.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the scatter store is defined correctly
 ; CHECK: define <4 x i64> @__vecz_b_gather_load4_Dv4_mDv4_u3ptr(<4 x ptr>{{( %0)?}}) {

--- a/modules/compiler/vecz/test/lit/llvm/define_gather_load_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_gather_load_as_masked.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the scatter store is defined correctly
 ; CHECK: define <4 x i64> @__vecz_b_gather_load4_Dv4_mDv4_u3ptr(<4 x ptr>{{( %0)?}}) {

--- a/modules/compiler/vecz/test/lit/llvm/define_interleaved_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_interleaved_load.ll
@@ -22,11 +22,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -46,9 +46,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func void @_Z7barrierj(i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>)

--- a/modules/compiler/vecz/test/lit/llvm/define_interleaved_load_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_interleaved_load_as_masked.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/define_interleaved_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_interleaved_store.ll
@@ -22,11 +22,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2)
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528)
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -46,9 +46,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func void @_Z7barrierj(i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>)

--- a/modules/compiler/vecz/test/lit/llvm/define_interleaved_store_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_interleaved_store_as_masked.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2

--- a/modules/compiler/vecz/test/lit/llvm/define_masked_gather_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_masked_gather_load.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @masked_scatter(i32 addrspace(1)* %a, i32 addrspace(1)* %b, i32 addrspace(1)* %b_index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -50,7 +50,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @masked_gather(i32 addrspace(1)* %a, i32 addrspace(1)* %a_index, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -74,7 +74,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the masked gather load is defined correctly
 ; CHECK: define <4 x i32> @__vecz_b_masked_gather_load4_Dv4_jDv4_u3ptrU3AS1Dv4_b(<4 x ptr addrspace(1)>{{( %0)?}}, <4 x i1>{{( %1)?}})

--- a/modules/compiler/vecz/test/lit/llvm/define_masked_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_masked_load.ll
@@ -23,13 +23,13 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @dont_mask_workitem_builtins(i32 addrspace(2)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call = call i64 @__mux_get_local_id(i32 0) #5
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %conv, 0
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry
-  %call2 = call spir_func i64 @_Z13get_global_idj(i32 0) #5
+  %call2 = call i64 @__mux_get_global_id(i32 0) #5
   %conv3 = trunc i64 %call2 to i32
   %idxprom = sext i32 %conv3 to i64
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %idxprom
@@ -40,8 +40,8 @@ if.then:                                          ; preds = %entry
   br label %if.end
 
 if.else:                                          ; preds = %entry
-  %call8 = call spir_func i64 @_Z14get_local_sizej(i32 0) #5
-  %call9 = call spir_func i64 @_Z12get_group_idj(i32 0) #5
+  %call8 = call i64 @__mux_get_local_size(i32 0) #5
+  %call9 = call i64 @__mux_get_group_id(i32 0) #5
   %mul = mul i64 %call9, %call8
   %add = add i64 %mul, %call
   %sext = shl i64 %add, 32
@@ -54,13 +54,13 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z12get_local_idj(i32) #1
+declare i64 @__mux_get_local_id(i32) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func i64 @_Z14get_local_sizej(i32) #1
+declare i64 @__mux_get_local_size(i32) #1
 
-declare spir_func i64 @_Z12get_group_idj(i32) #1
+declare i64 @__mux_get_group_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/define_masked_scatter_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_masked_scatter_store.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @masked_scatter(i32 addrspace(1)* %a, i32 addrspace(1)* %b, i32 addrspace(1)* %b_index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -50,7 +50,7 @@ if.end:                                           ; preds = %if.else, %if.then
 
 define spir_kernel void @masked_gather(i32 addrspace(1)* %a, i32 addrspace(1)* %a_index, i32 addrspace(1)* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %rem = urem i64 %call, 3
   %cmp = icmp eq i64 %rem, 0
   br i1 %cmp, label %if.else, label %if.then
@@ -74,7 +74,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the masked scatter store is defined correctly
 ; CHECK: define void @__vecz_b_masked_scatter_store4_Dv4_jDv4_u3ptrU3AS1Dv4_b(<4 x i32>{{( %0)?}}, <4 x ptr addrspace(1)>{{( %1)?}}, <4 x i1>{{( %2)?}})

--- a/modules/compiler/vecz/test/lit/llvm/define_masked_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_masked_store.ll
@@ -23,13 +23,13 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @dont_mask_workitem_builtins(i32 addrspace(2)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call = call i64 @__mux_get_local_id(i32 0) #5
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %conv, 0
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry
-  %call2 = call spir_func i64 @_Z13get_global_idj(i32 0) #5
+  %call2 = call i64 @__mux_get_global_id(i32 0) #5
   %conv3 = trunc i64 %call2 to i32
   %idxprom = sext i32 %conv3 to i64
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %idxprom
@@ -40,8 +40,8 @@ if.then:                                          ; preds = %entry
   br label %if.end
 
 if.else:                                          ; preds = %entry
-  %call8 = call spir_func i64 @_Z14get_local_sizej(i32 0) #5
-  %call9 = call spir_func i64 @_Z12get_group_idj(i32 0) #5
+  %call8 = call i64 @__mux_get_local_size(i32 0) #5
+  %call9 = call i64 @__mux_get_group_id(i32 0) #5
   %mul = mul i64 %call9, %call8
   %add = add i64 %mul, %call
   %sext = shl i64 %add, 32
@@ -54,13 +54,13 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z12get_local_idj(i32) #1
+declare i64 @__mux_get_local_id(i32) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func i64 @_Z14get_local_sizej(i32) #1
+declare i64 @__mux_get_local_size(i32) #1
 
-declare spir_func i64 @_Z12get_group_idj(i32) #1
+declare i64 @__mux_get_group_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/define_scatter_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_scatter_store.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the scatter store is defined correctly
 ; CHECK: define void @__vecz_b_scatter_store4_Dv4_mDv4_u3ptr(<4 x i64>{{( %0)?}}, <4 x ptr>{{( %1)?}}) {

--- a/modules/compiler/vecz/test/lit/llvm/define_scatter_store_as_masked.ll
+++ b/modules/compiler/vecz/test/lit/llvm/define_scatter_store_as_masked.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Test if the scatter store is defined correctly
 ; CHECK: define void @__vecz_b_scatter_store4_Dv4_mDv4_u3ptr(<4 x i64>{{( %0)?}}, <4 x ptr>{{( %1)?}}) {

--- a/modules/compiler/vecz/test/lit/llvm/delete_packetized_memop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/delete_packetized_memop.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @memop_loop_dep(i32 addrspace(1)* %in, i32 addrspace(1)* %out, i32 %i, i32 %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
@@ -52,7 +52,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func <4 x i32> @_Z6vload4mPKU3AS1i(i64, i32 addrspace(1)*)
 

--- a/modules/compiler/vecz/test/lit/llvm/early-cse-mul-swap.ll
+++ b/modules/compiler/vecz/test/lit/llvm/early-cse-mul-swap.ll
@@ -22,23 +22,23 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z15get_global_sizej(i32) #1
+declare i64 @__mux_get_global_size(i32) #1
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @multiple_dimensions_0(i32 addrspace(1)* %output) #2 {
 entry:
-  %call.i = call spir_func i64 @_Z13get_global_idj(i32 0) #3
-  %call1.i = call spir_func i64 @_Z15get_global_sizej(i32 1) #3
+  %call.i = call i64 @__mux_get_global_id(i32 0) #3
+  %call1.i = call i64 @__mux_get_global_size(i32 1) #3
   %mul.i = mul i64 %call1.i, %call.i
-  %call2.i = call spir_func i64 @_Z15get_global_sizej(i32 2) #3
+  %call2.i = call i64 @__mux_get_global_size(i32 2) #3
   %mul3.i = mul i64 %mul.i, %call2.i
-  %call4.i = call spir_func i64 @_Z13get_global_idj(i32 1) #3
+  %call4.i = call i64 @__mux_get_global_id(i32 1) #3
   %mul6.i = mul i64 %call2.i, %call4.i
   %add.i = add i64 %mul6.i, %mul3.i
-  %call7.i = call spir_func i64 @_Z13get_global_idj(i32 2) #3
+  %call7.i = call i64 @__mux_get_global_id(i32 2) #3
   %add8.i = add i64 %add.i, %call7.i
   %conv = trunc i64 %add8.i to i32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %output, i64 %add8.i
@@ -72,7 +72,7 @@ attributes #3 = { convergent nobuiltin nounwind readonly }
 ; CHECK: define spir_kernel void @__vecz_v4_multiple_dimensions_0
 
 ; make sure the stride calculation uses the correct operand of the multiply
-; CHECK: %[[CALL1:.+]] = call spir_func i64 @_Z15get_global_sizej(i32 1)
-; CHECK: %[[CALL2:.+]] = call spir_func i64 @_Z15get_global_sizej(i32 2)
+; CHECK: %[[CALL1:.+]] = call i64 @__mux_get_global_size(i32 1)
+; CHECK: %[[CALL2:.+]] = call i64 @__mux_get_global_size(i32 2)
 ; CHECK: %[[NEWMUL:.+]] = mul i64 %[[CALL1]], %[[CALL2]]
 ; CHECK: call void @__vecz_b_interleaved_store4_V_Dv4_ju3ptrU3AS1({{.+}} %[[NEWMUL]])

--- a/modules/compiler/vecz/test/lit/llvm/emit_memintrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/emit_memintrinsics.ll
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: norecurse nounwind
 define spir_kernel void @entry(i64 addrspace(1)* %result, %struct.S2* %result2) {
 entry:
-  %gid = call i64 @_Z12get_local_idj(i32 0)
+  %gid = call i64 @__mux_get_local_id(i32 0)
   %sa = alloca %struct.S2, align 16
   %sb = alloca %struct.S2, align 16
   %sa_i8 = bitcast %struct.S2* %sa to i8*
@@ -63,7 +63,7 @@ declare void @llvm.memset.p1i8.i64(i8 addrspace(1)* nocapture, i8, i64, i32, i1)
 declare void @llvm.memcpy.p1i8.p0i8.i64(i8 addrspace(1)* nocapture, i8* nocapture readonly, i64, i32, i1)
 declare void @llvm.memcpy.p0i8.p1i8.i64(i8* nocapture, i8 addrspace(1)* nocapture readonly, i64, i32, i1)
 
-declare i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 ; Sanity checks: Make sure the non-vecz entry function is still in place and
 ; contains memset and memcpy. This is done in order to prevent future bafflement

--- a/modules/compiler/vecz/test/lit/llvm/emit_no_unaligned_memintrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/emit_no_unaligned_memintrinsics.ll
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: norecurse nounwind
 define spir_kernel void @entry(i64 addrspace(1)* %result, %struct.S2* %result2) {
 entry:
-  %gid = call i64 @_Z12get_local_idj(i32 0)
+  %gid = call i64 @__mux_get_local_id(i32 0)
   %sa = alloca %struct.S2, align 16
   %sb = alloca %struct.S2, align 16
   %sa_i8 = bitcast %struct.S2* %sa to i8*
@@ -64,7 +64,7 @@ declare void @llvm.memset.p1i8.i64(i8 addrspace(1)* nocapture, i8, i64, i32, i1)
 declare void @llvm.memcpy.p1i8.p0i8.i64(i8 addrspace(1)* nocapture, i8* nocapture readonly, i64, i32, i1)
 declare void @llvm.memcpy.p0i8.p1i8.i64(i8* nocapture, i8 addrspace(1)* nocapture readonly, i64, i32, i1)
 
-declare i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 ; Sanity checks: Make sure the non-vecz entry function is still in place and
 ; contains memset and memcpy. This is done in order to prevent future bafflement

--- a/modules/compiler/vecz/test/lit/llvm/expect_assume.ll
+++ b/modules/compiler/vecz/test/lit/llvm/expect_assume.ll
@@ -19,7 +19,7 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare void @llvm.assume(i1)
 declare i32 @llvm.expect.i32(i32, i32)
@@ -40,7 +40,7 @@ declare i32 @llvm.expect.i32(i32, i32)
 ; CHECK: store <4 x i32> [[SUM]], ptr %arrayidxz, align 4
 define spir_kernel void @assume(ptr %aptr, ptr %bptr, ptr %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, ptr %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, ptr %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, ptr %zptr, i64 %idx
@@ -73,7 +73,7 @@ entry:
 
 define spir_kernel void @expect(ptr %aptr, ptr %bptr, ptr %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, ptr %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds i32, ptr %bptr, i64 %idx
   %arrayidxz = getelementptr inbounds i32, ptr %zptr, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/extractelement_constant_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/extractelement_constant_index.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @extract_constant_index(<4 x float> addrspace(1)* %in, i32 %x, float addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 4
   %vecext = extractelement <4 x float> %0, i32 0;
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; CHECK: define spir_kernel void @__vecz_v4_extract_constant_index
 ; CHECK: call <4 x float> @__vecz_b_interleaved_load4_4_Dv4

--- a/modules/compiler/vecz/test/lit/llvm/extractelement_runtime_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/extractelement_runtime_index.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @extract_runtime_index(<4 x float> addrspace(1)* %in, i32 %x, float addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 4
   %vecext = extractelement <4 x float> %0, i32 %x

--- a/modules/compiler/vecz/test/lit/llvm/gep_duplication.ll
+++ b/modules/compiler/vecz/test/lit/llvm/gep_duplication.ll
@@ -27,7 +27,7 @@ entry:
   %global_id = alloca i32, align 4
   %myStruct = alloca %struct.testStruct, align 4
   store ptr addrspace(1) %out, ptr %out.addr, align 8
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   store i32 %conv, ptr %global_id, align 4
   %x = getelementptr inbounds %struct.testStruct, ptr %myStruct, i32 0, i32 0
@@ -67,7 +67,7 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v{{[0-9]+}}_gep_duplication
 ; CHECK: entry:

--- a/modules/compiler/vecz/test/lit/llvm/gep_elim_opaque.ll
+++ b/modules/compiler/vecz/test/lit/llvm/gep_elim_opaque.ll
@@ -18,8 +18,8 @@
 ; RUN: veczc -k test -vecz-simd-width=4 -vecz-passes=gep-elim -S < %s | FileCheck %s
 
 ; ModuleID = 'kernel.opencl'
-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "spir64-unknown-unknown"
+target datalayout = "e-m:e-i32:32-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
 
 %struct.mystruct = type { [2 x i32], ptr }
 
@@ -27,7 +27,7 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %output) {
 entry:
   %foo = alloca [4 x %struct.mystruct], align 4
-  %call = tail call spir_func i32 @_Z13get_global_idj(i32 0)
+  %call = tail call spir_func i32 @__mux_get_global_id(i32 0)
   store i32 20, ptr %foo, align 4
   %arrayidx4 = getelementptr inbounds [2 x i32], ptr %foo, i32 0, i32 1
   store i32 22, ptr %arrayidx4, align 4
@@ -43,7 +43,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i32 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(
 

--- a/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
@@ -43,7 +43,7 @@ entry:
   call void @llvm.dbg.value(metadata float addrspace(1)* %in2f, i64 0, metadata !21, metadata !38), !dbg !41
   call void @llvm.dbg.value(metadata i32 addrspace(1)* %out1i, i64 0, metadata !22, metadata !38), !dbg !41
   call void @llvm.dbg.value(metadata float addrspace(1)* %out1f, i64 0, metadata !23, metadata !38), !dbg !41
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #4, !dbg !42
+  %call = call i64 @__mux_get_global_id(i32 0) #4, !dbg !42
   call void @llvm.dbg.value(metadata i64 %call, i64 0, metadata !24, metadata !38), !dbg !42
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in1i, i64 %call, !dbg !43
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4, !dbg !43
@@ -57,7 +57,7 @@ entry:
   ret void, !dbg !47
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #3
+declare i64 @__mux_get_global_id(i32) #3
 
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.value(metadata, i64, metadata, metadata) #1

--- a/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
@@ -39,7 +39,7 @@ entry:
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !13, metadata !29), !dbg !30
   call void @llvm.dbg.declare(metadata i32* %tid, metadata !14, metadata !29), !dbg !31
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !31
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   %conv = trunc i64 %call to i32, !dbg !31
   store i32 %conv, i32* %tid, align 4, !dbg !31
   call void @llvm.dbg.declare(metadata <3 x i32>* %tmp, metadata !15, metadata !29), !dbg !32
@@ -84,7 +84,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 declare spir_func <3 x i32> @_Z6vload3mPKU3AS1i(i64, i32 addrspace(1)*) #2
 

--- a/modules/compiler/vecz/test/lit/llvm/insertelement_constant_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/insertelement_constant_index.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @constant_index(<4 x i32>* %in, <4 x i32>* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32>* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32>* %arrayidx
   %arrayidx2 = getelementptr inbounds <4 x i32>, <4 x i32>* %out, i64 %call

--- a/modules/compiler/vecz/test/lit/llvm/insertelement_runtime_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/insertelement_runtime_index.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @runtime_index(<4 x i32>* %in, <4 x i32>* %out, i32* %index) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i32>, <4 x i32>* %in, i64 %call
   %0 = load <4 x i32>, <4 x i32>* %arrayidx
   %arrayidx1 = getelementptr inbounds <4 x i32>, <4 x i32>* %out, i64 %call

--- a/modules/compiler/vecz/test/lit/llvm/instantiate_constants.ll
+++ b/modules/compiler/vecz/test/lit/llvm/instantiate_constants.ll
@@ -28,7 +28,7 @@ entry:
   %0 = bitcast [1 x i16]* %data to i8*
   %arraydecay = getelementptr inbounds [1 x i16], [1 x i16]* %data, i64 0, i64 0
   %1 = bitcast [1 x i16]* %data to half*
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #5
+  %call = tail call i64 @__mux_get_global_id(i32 0) #5
   %arrayidx7 = getelementptr inbounds half, half addrspace(1)* %p, i64 %call
   %arrayidx = bitcast half addrspace(1)* %arrayidx7 to i16 addrspace(1)*
   %2 = load i16, i16 addrspace(1)* %arrayidx, align 2, !tbaa !9
@@ -40,7 +40,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #2
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr #2
 
 ; Function Attrs: convergent nounwind
 declare spir_func float @_Z11vloada_halfmPKDh(i64, half*) local_unnamed_addr #3

--- a/modules/compiler/vecz/test/lit/llvm/interleaved_defuse_instantiated.ll
+++ b/modules/compiler/vecz/test/lit/llvm/interleaved_defuse_instantiated.ll
@@ -26,7 +26,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @printf_kernel(i32 addrspace(1)* %in, i32 addrspace(1)* %stridesX, i32 addrspace(1)* %dst, i32 %width, i32 %height) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %cmp = icmp eq i32 %width, 13
   br i1 %cmp, label %if.then, label %if.end
 
@@ -43,7 +43,7 @@ if.end:                                           ; preds = %if.then, %entry
 
 define spir_kernel void @test_float(float* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %mul = fmul float %0, %0
@@ -54,7 +54,7 @@ entry:
 
 
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...) #1
 

--- a/modules/compiler/vecz/test/lit/llvm/interleaved_load16.ll
+++ b/modules/compiler/vecz/test/lit/llvm/interleaved_load16.ll
@@ -24,8 +24,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) #0 !shave_original_kernel !10 {
 entry:
-  %call = call spir_func i32 @_Z13get_global_idj(i32 0) #2
-  %call1 = call spir_func i32 @_Z13get_global_idj(i32 1) #2
+  %call = call i32 @__mux_get_global_id(i32 0) #2
+  %call1 = call i32 @__mux_get_global_id(i32 1) #2
   %mul = mul nsw i32 %call1, %stride
   %add = add nsw i32 %mul, %call
   %mul2 = shl nsw i32 %add, 1
@@ -46,7 +46,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i32 @_Z13get_global_idj(i32) #1
+declare i32 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/interleaved_load_ooo.ll
+++ b/modules/compiler/vecz/test/lit/llvm/interleaved_load_ooo.ll
@@ -23,9 +23,9 @@ target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @interleaved_load_4(i32 addrspace(1)* %out, i32 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %conv, %mul
@@ -54,5 +54,5 @@ entry:
 ; CHECK:  %sub1 = sub nsw <4 x i32> %deinterleave1, %deinterleave
 
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare <4 x i32> @__vecz_b_interleaved_load4_2_Dv4_jPU3AS1j(i32 addrspace(1)*)

--- a/modules/compiler/vecz/test/lit/llvm/interleaved_safety.ll
+++ b/modules/compiler/vecz/test/lit/llvm/interleaved_safety.ll
@@ -23,11 +23,11 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @f(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e, i8 addrspace(1)* %flag) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %add.ptr = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %.cast = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %add.ptr, i64 0, i64 0
   %0 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
-  call spir_func void @_Z7barrierj(i32 2) #3
+  call void @__mux_work_group_barrier(i32 0, i32 2, i32 528) #3
   store double 1.600000e+01, double addrspace(1)* %.cast, align 8
   %1 = load <4 x double>, <4 x double> addrspace(1)* %add.ptr, align 32
   %vecins5 = shufflevector <4 x double> %0, <4 x double> %1, <4 x i32> <i32 0, i32 1, i32 6, i32 undef>
@@ -47,9 +47,9 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func void @_Z7barrierj(i32) #1
+declare void @__mux_work_group_barrier(i32, i32, i32) #1
 
 ; Function Attrs: nounwind readnone
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>) #2
@@ -72,14 +72,14 @@ attributes #3 = { nobuiltin nounwind }
 
 ; Function start
 ; CHECK: define spir_kernel void @__vecz_v4_f
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 
 ; There should be exactly 4 interleaved loads and one store in the code
 ; CHECK: call <4 x double> @__vecz_b_interleaved_load8_4_Dv4_du3ptrU3AS1
 ; CHECK: call <4 x double> @__vecz_b_interleaved_load8_4_Dv4_du3ptrU3AS1
 
 ; And in between them there should be a barrier call
-; CHECK: call spir_func void @_Z7barrierj
+; CHECK: call void @__mux_work_group_barrier
 ; CHECK: call void @__vecz_b_interleaved_store8_4_Dv4_du3ptrU3AS1(<4 x double> <double 1.600000e+01, double 1.600000e+01, double 1.600000e+01, double 1.600000e+01>
 ; CHECK: call <4 x double> @__vecz_b_interleaved_load8_4_Dv4_du3ptrU3AS1
 ; CHECK: call <4 x double> @__vecz_b_interleaved_load8_4_Dv4_du3ptrU3AS1

--- a/modules/compiler/vecz/test/lit/llvm/intrinsics-scalarize.ll
+++ b/modules/compiler/vecz/test/lit/llvm/intrinsics-scalarize.ll
@@ -30,7 +30,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @ctpop(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -46,7 +46,7 @@ entry:
 
 define spir_kernel void @ctlz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -62,7 +62,7 @@ entry:
 
 define spir_kernel void @cttz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -78,7 +78,7 @@ entry:
 
 define spir_kernel void @sadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -96,7 +96,7 @@ entry:
 
 define spir_kernel void @uadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -114,7 +114,7 @@ entry:
 
 define spir_kernel void @ssub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -132,7 +132,7 @@ entry:
 
 define spir_kernel void @usub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -169,7 +169,7 @@ declare <2 x i8> @llvm.ssub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i32 @llvm.usub.sat.i32(i32, i32)
 declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_v2_ctpop
 ; CTPOP: = call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})

--- a/modules/compiler/vecz/test/lit/llvm/intrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/intrinsics.ll
@@ -30,7 +30,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @ctpop(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -46,7 +46,7 @@ entry:
 
 define spir_kernel void @ctlz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -62,7 +62,7 @@ entry:
 
 define spir_kernel void @cttz(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxb = getelementptr inbounds <2 x i8>, <2 x i8>* %bptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
@@ -78,7 +78,7 @@ entry:
 
 define spir_kernel void @sadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -96,7 +96,7 @@ entry:
 
 define spir_kernel void @uadd_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -114,7 +114,7 @@ entry:
 
 define spir_kernel void @ssub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -132,7 +132,7 @@ entry:
 
 define spir_kernel void @usub_sat(i32* %aptr, <2 x i8>* %bptr, i32* %yptr, <2 x i8>* %zptr) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i32, i32* %aptr, i64 %idx
   %arrayidxy = getelementptr inbounds i32, i32* %yptr, i64 %idx
   %a = load i32, i32* %arrayidxa, align 4
@@ -169,7 +169,7 @@ declare <2 x i8> @llvm.ssub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i32 @llvm.usub.sat.i32(i32, i32)
 declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_v2_ctpop
 ; CTPOP: = call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})

--- a/modules/compiler/vecz/test/lit/llvm/irreducible_loop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/irreducible_loop.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @irreducible_loop(i32 addrspace(1)* %src, i32 addrspace(1)* %dst) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx4 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %call
   %ld = load i32, i32 addrspace(1)* %arrayidx4, align 4
   %cmp = icmp sgt i32 %ld, -1
@@ -45,7 +45,7 @@ do.end:                                           ; preds = %label
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_v4_irreducible_loop
 ; CHECK: entry:

--- a/modules/compiler/vecz/test/lit/llvm/loop_call_instantiation.ll
+++ b/modules/compiler/vecz/test/lit/llvm/loop_call_instantiation.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 (i8 addrspace(2)*, ...) @printf(i8 addrspace(2)* getelementptr inbounds ([23 x i8], [23 x i8] addrspace(2)* @.str, i64 0, i64 0), i64 %call, i32 %0)
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test(ptr addrspace(1) %in)

--- a/modules/compiler/vecz/test/lit/llvm/masked_calls_max_builtin.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masked_calls_max_builtin.ll
@@ -29,7 +29,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @entry(ptr addrspace(1) %input, ptr addrspace(1) %output) {
 entry:
-  %call = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = tail call i64 @__mux_get_local_id(i32 0)
   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %input, i64 %call
   %0 = load i32, ptr addrspace(1) %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds i32, ptr addrspace(1) %output, i64 %call
@@ -74,7 +74,7 @@ if.end:
   ret void
 }
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 declare spir_func i32 @_Z3maxii(i32, i32)
 

--- a/modules/compiler/vecz/test/lit/llvm/masked_interleaved.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masked_interleaved.ll
@@ -26,7 +26,7 @@ entry:
   %results.addr = alloca i32 addrspace(1)*, align 8
   %tid = alloca i32, align 4
   store i32 addrspace(1)* %results, i32 addrspace(1)** %results.addr, align 8
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   store i32 %conv, i32* %tid, align 4
   %0 = load i32, i32* %tid, align 4
@@ -47,7 +47,7 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/masked_interleaved_as_scatter.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masked_interleaved_as_scatter.ll
@@ -26,7 +26,7 @@ entry:
   %results.addr = alloca i32 addrspace(1)*, align 8
   %tid = alloca i32, align 4
   store i32 addrspace(1)* %results, i32 addrspace(1)** %results.addr, align 8
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   store i32 %conv, i32* %tid, align 4
   %0 = load i32, i32* %tid, align 4
@@ -47,7 +47,7 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/masked_interleaved_group.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masked_interleaved_group.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @mask(i8 addrspace(1)* %out, i8 addrspace(1)* %in) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %call.tr = trunc i64 %call to i32
   %conv = shl i32 %call.tr, 1
   %idx.ext = sext i32 %conv to i64
@@ -53,7 +53,7 @@ if.end:                                           ; preds = %if.else, %if.then
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/masked_interleaved_group2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masked_interleaved_group2.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @mask(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i8 addrspace(1)* %doit) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %call.tr = trunc i64 %call to i32
   %conv = shl i32 %call.tr, 1
   %idx.ext = sext i32 %conv to i64
@@ -59,7 +59,7 @@ if.end:                                           ; preds = %if.else, %if.then, 
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/masking_exit_blocks.ll
+++ b/modules/compiler/vecz/test/lit/llvm/masking_exit_blocks.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %add = add i64 %call, 1
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %add
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
@@ -51,7 +51,7 @@ if.end1:                                          ; preds = %if.end
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride.ll
@@ -21,14 +21,14 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %call
   store i32 %0, i32 addrspace(1)* %arrayidx1, align 4
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: store <

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride10.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride10.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nsw i32 %conv, %n
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _scatter_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride11.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride11.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nsw i32 %conv, %n
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride12.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride12.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nsw i32 %conv, %n
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride13.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride13.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nsw i32 %conv, %n
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _scatter_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride14.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride14.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %mul = mul nuw nsw i64 %call, 18
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %mul
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride15.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride15.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = shl i32 %n, 1
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride16.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride16.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = shl nuw nsw i64 %call, 1
   %mul = mul nuw nsw i64 %add, %call
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _scatter_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride17.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride17.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %mul = mul nsw i32 %conv2, %n
@@ -34,7 +34,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: store <

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride18.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride18.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 addrspace(1)* readnone %r) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = add nuw nsw i64 %call, 255
   %idxprom = and i64 %conv, 255
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %src, i64 %idxprom
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _gather_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride2.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nuw nsw i64 %call, 9
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %add
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: store <

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride3.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %mul = mul nuw nsw i64 %call, 9
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %mul
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride4.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nsw i32 %conv, %n
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: store <

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride5.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %mul = mul nuw nsw i64 %call, 5
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %mul
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride6.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = shl nuw nsw i64 %call, 1
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %add
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride7.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride7.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %mul = mul nuw nsw i64 %call, %call
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %mul
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _scatter_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride8.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride8.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %1 = mul nuw nsw i64 %call, 9
   %mul = add nuw nsw i64 %1, 81
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/memop_stride9.ll
+++ b/modules/compiler/vecz/test/lit/llvm/memop_stride9.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @test(i32 addrspace(1)* %src, i32 addrspace(1)* %dst, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %0 = load i32, i32 addrspace(1)* %src, align 4
   %add = add nuw nsw i32 %conv, 9
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @test
 ; CHECK: _interleaved_

--- a/modules/compiler/vecz/test/lit/llvm/multiple_exit_blocks.ll
+++ b/modules/compiler/vecz/test/lit/llvm/multiple_exit_blocks.ll
@@ -22,13 +22,13 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:1:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @multiple_exit_blocks(i64 %n) {
 entry:
-  %gid = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %lid = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %lid = tail call i64 @__mux_get_local_id(i32 0)
   %cmp1 = icmp slt i64 %lid, %n
   %cmp2 = icmp slt i64 %gid, %n
   br i1 %cmp2, label %if.then, label %if.end

--- a/modules/compiler/vecz/test/lit/llvm/multiple_kernels_inlining.ll
+++ b/modules/compiler/vecz/test/lit/llvm/multiple_kernels_inlining.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @foo1(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @foo2(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
@@ -45,7 +45,7 @@ entry:
 
 ; CHECK: define spir_kernel void @__vecz_v4_foo3(ptr addrspace(1) %in, ptr addrspace(1) %out)
 ; CHECK-NOT: call spir_kernel
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 ; CHECK: load <4 x i32>, ptr addrspace(1) %{{.+}}, align 4
 ; CHECK: store <4 x i32> %{{.+}}, ptr addrspace(1) %{{.+}}, align 4
 ; CHECK: ret void

--- a/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations.ll
+++ b/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations.ll
@@ -55,7 +55,7 @@ entry:
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !13, metadata !29), !dbg !30
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !31
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
   %0 = load i64, i64* %tid, align 8, !dbg !32
@@ -82,7 +82,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations_nested.ll
+++ b/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations_nested.ll
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @add(i32 addrspace(1)* %in1, i32 addrspace(1)* %in2, i32 addrspace(1)* %out) {
 entry:
-  %tid = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %tid = call i64 @__mux_get_global_id(i32 0) #3
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in1, i64 %tid
   %i1 = load i32, i32 addrspace(1)* %arrayidx, align 16
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %in2, i64 %tid
@@ -36,7 +36,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 ; CHECK: define spir_kernel void @add(ptr addrspace(1) %in1, ptr addrspace(1) %in2, ptr addrspace(1) %out){{.*}} !codeplay_ca_vecz.base ![[BASE_1:[0-9]+]]
 ; CHECK: define spir_kernel void @__vecz_v2_add(ptr addrspace(1) %in1, ptr addrspace(1) %in2, ptr addrspace(1) %out){{.*}} !codeplay_ca_vecz.base ![[BASE_2:[0-9]+]] !codeplay_ca_vecz.derived ![[DERIVED_1:[0-9]+]] {

--- a/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations_vp.ll
+++ b/modules/compiler/vecz/test/lit/llvm/multiple_vectorizations_vp.ll
@@ -18,12 +18,12 @@
 ; equal width but with one enabling vector predication.
 ; RUN: veczc -k add:1s,1sp -S < %s | FileCheck %s
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: define spir_kernel void @add(
 define spir_kernel void @add(ptr addrspace(1) %in1, ptr addrspace(1) %in2, ptr addrspace(1) %out) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx.in1 = getelementptr inbounds i32, ptr addrspace(1) %in1, i64 %idx
   %arrayidx.in2 = getelementptr inbounds i32, ptr addrspace(1) %in1, i64 %idx
   %in1.v = load i32, ptr addrspace(1) %arrayidx.in1, align 4

--- a/modules/compiler/vecz/test/lit/llvm/no_instantiate_memop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/no_instantiate_memop.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @priv(i32 addrspace(3)* %a) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %for.cond
 
@@ -43,7 +43,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/no_over_scalarization.ll
+++ b/modules/compiler/vecz/test/lit/llvm/no_over_scalarization.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @memop_loop_dep(i32 addrspace(1)* %in, i32 addrspace(1)* %out, i32 %i, i32 %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
@@ -52,7 +52,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare spir_func <4 x i32> @_Z6vload4mPKU3AS1i(i64, i32 addrspace(1)*)
 

--- a/modules/compiler/vecz/test/lit/llvm/no_redundant_bitcasts.ll
+++ b/modules/compiler/vecz/test/lit/llvm/no_redundant_bitcasts.ll
@@ -20,11 +20,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-s128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @memop_loop_dep(i32 addrspace(1)* %in, i32 addrspace(1)* %out, i32 %i, i32 %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp1 = icmp slt i32 %i, %e
   br i1 %cmp1, label %for.body.lr.ph, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/no_vecz1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/no_vecz1.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @no_vecz1(i32 addrspace(1)* %out, i32 %n) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %call, 0
   br i1 %cmp, label %for.cond.preheader, label %if.end
 
@@ -35,7 +35,7 @@ if.end:                                           ; preds = %for.cond.preheader,
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK-NOT: insertelement
 ; CHECK-NOT: shufflevector

--- a/modules/compiler/vecz/test/lit/llvm/no_vecz2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/no_vecz2.ll
@@ -22,7 +22,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 define spir_kernel void @no_vecz2(i32 addrspace(1)* %out, i32 %n, i32 addrspace(1)* %m) {
 entry:
   %0 = load i32, i32 addrspace(1)* %m, align 4
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %call, 0
   br i1 %cmp, label %for.cond.preheader, label %if.end
 
@@ -49,7 +49,7 @@ if.end:                                           ; preds = %for.cond.cleanup28,
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @{{(__vecz_v16_)?}}no_vecz2
 ; CHECK-NOT: extractelement

--- a/modules/compiler/vecz/test/lit/llvm/offset_info_analysis.ll
+++ b/modules/compiler/vecz/test/lit/llvm/offset_info_analysis.ll
@@ -23,9 +23,9 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @offset_info_analysis(i8 addrspace(1)* noalias %in, i8 addrspace(1)* noalias %out, i32 %width) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
-  %call1 = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %call1 = call i64 @__mux_get_global_id(i32 1) #2
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %width
   %0 = xor i32 %width, -1
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a 'xor' as a binop operand does correctly get analyzed.
 ; and masked properly

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfiniteDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfiniteDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_isfiniteDv4_d
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 ; CHECK: and <4 x i64>
 ; CHECK: and <4 x i64>
 ; CHECK: and <4 x i64>

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfiniteDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfiniteDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float>)
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfinited.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfinited.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfinitef.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isfinitef.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double>)
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float>)
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfd.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinfd.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinff.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isinff.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double>)
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float>)
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnand.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnand.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanf.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnanf.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalDv4_d.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalDv4_d.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalDv4_f.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalDv4_f.ll
@@ -19,12 +19,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float>)
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormald.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormald.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalf.ll
+++ b/modules/compiler/vecz/test/lit/llvm/onearg_relationals_isnormalf.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare spir_func i32 @_Z5isinfd(double)
 declare spir_func i32 @_Z5isinff(float)
 declare spir_func i32 @_Z5isnand(double)
@@ -43,7 +43,7 @@ declare spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double>)
 
 define spir_kernel void @test_isfinitef(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isfinitef(float %0)
@@ -54,7 +54,7 @@ entry:
 
 define spir_kernel void @test_isfinited(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isfinited(double %0)
@@ -65,7 +65,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> %0)
@@ -76,7 +76,7 @@ entry:
 
 define spir_kernel void @test_isfiniteDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isfiniteDv4_d(<4 x double> %0)
@@ -87,7 +87,7 @@ entry:
 
 define spir_kernel void @test_isinff(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isinff(float %0)
@@ -98,7 +98,7 @@ entry:
 
 define spir_kernel void @test_isinfd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isinfd(double %0)
@@ -109,7 +109,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> %0)
@@ -120,7 +120,7 @@ entry:
 
 define spir_kernel void @test_isinfDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isinfDv4_d(<4 x double> %0)
@@ -131,7 +131,7 @@ entry:
 
 define spir_kernel void @test_isnormalf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z8isnormalf(float %0)
@@ -142,7 +142,7 @@ entry:
 
 define spir_kernel void @test_isnormald(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z8isnormald(double %0)
@@ -153,7 +153,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> %0)
@@ -164,7 +164,7 @@ entry:
 
 define spir_kernel void @test_isnormalDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z8isnormalDv4_d(<4 x double> %0)
@@ -175,7 +175,7 @@ entry:
 
 define spir_kernel void @test_isnanf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z5isnanf(float %0)
@@ -186,7 +186,7 @@ entry:
 
 define spir_kernel void @test_isnand(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z5isnand(double %0)
@@ -197,7 +197,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> %0)
@@ -208,7 +208,7 @@ entry:
 
 define spir_kernel void @test_isnanDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z5isnanDv4_d(<4 x double> %0)
@@ -219,7 +219,7 @@ entry:
 
 define spir_kernel void @test_signbitf(float addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %call1 = call spir_func i32 @_Z7signbitf(float %0)
@@ -230,7 +230,7 @@ entry:
 
 define spir_kernel void @test_signbitd(double addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds double, double addrspace(1)* %in, i64 %call
   %0 = load double, double addrspace(1)* %arrayidx, align 8
   %call1 = call spir_func i32 @_Z7signbitd(double %0)
@@ -241,7 +241,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_f(<4 x float> addrspace(1)* %in, <4 x i32> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %in, i64 %call
   %0 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
   %call1 = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> %0)
@@ -252,7 +252,7 @@ entry:
 
 define spir_kernel void @test_signbitDv4_d(<4 x double> addrspace(1)* %in, <4 x i64> addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %in, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %call1 = call spir_func <4 x i64> @_Z7signbitDv4_d(<4 x double> %0)

--- a/modules/compiler/vecz/test/lit/llvm/opencl_metadata1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/opencl_metadata1.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(2)* %in, i32 addrspace(1)* %out, i8 addrspace(2)* %text, double %f) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %call
   %0 = load i32, i32 addrspace(2)* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
@@ -31,11 +31,11 @@ entry:
 
 define spir_kernel void @second_test(i32 %a, i32 %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 !opencl.kernels = !{!0, !6}
 !opencl.kernel_wg_size_info = !{!12}

--- a/modules/compiler/vecz/test/lit/llvm/opencl_metadata2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/opencl_metadata2.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(2)* %in, i32 addrspace(1)* %out, i8 addrspace(2)* %text, double %f) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %call
   %0 = load i32, i32 addrspace(2)* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
@@ -31,11 +31,11 @@ entry:
 
 define spir_kernel void @second_test(i32 %a, i32 %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 !opencl.kernels = !{!0, !6}
 !opencl.kernel_wg_size_info = !{!12}

--- a/modules/compiler/vecz/test/lit/llvm/overaligned_allocas.ll
+++ b/modules/compiler/vecz/test/lit/llvm/overaligned_allocas.ll
@@ -26,8 +26,8 @@ define spir_kernel void @test(<2 x float> addrspace(1)* nocapture readonly %in, 
 entry:
   %a.sroa.0 = alloca <2 x float>, align 16
   %b.sroa.2 = alloca <2 x float>, align 16
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_local_id(i32 0)
   %a.sroa.0.0..sroa_cast = bitcast <2 x float>* %a.sroa.0 to i8*
   %b.sroa.2.0..sroa_cast = bitcast <2 x float>* %b.sroa.2 to i8*
   %arrayidx2 = getelementptr inbounds [16 x <2 x float>], [16 x <2 x float>] addrspace(3)* @entry_test_alloca.lm, i64 0, i64 %call1
@@ -64,8 +64,8 @@ for.body11:                                       ; preds = %for.body11, %for.bo
   br i1 %cmp8, label %for.body11, label %for.cond.cleanup10
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
-declare spir_func i64 @_Z12get_local_idj(i32) local_unnamed_addr
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr
+declare i64 @__mux_get_local_id(i32) local_unnamed_addr
 
 ; Check that all the allocas come before anything else
 ; CHECK: define spir_kernel void @__vecz_v4_test(

--- a/modules/compiler/vecz/test/lit/llvm/packetization_branch.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_branch.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test_branch(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -41,7 +41,7 @@ if.end:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks if the branch conditions and the branch BBs are vectorized
 ; and masked properly
@@ -49,7 +49,7 @@ declare spir_func i64 @_Z13get_global_idj(i32)
 ; CHECK: %conv = sext i32 %a to i64
 ; CHECK: %[[A_SPLATINSERT:.+]] = insertelement <4 x i64> {{poison|undef}}, i64 %conv, {{i32|i64}} 0
 ; CHECK: %[[A_SPLAT:.+]] = shufflevector <4 x i64> %[[A_SPLATINSERT]], <4 x i64> {{poison|undef}}, <4 x i32> zeroinitializer
-; CHECK: %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %call = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %[[GID_SPLATINSERT:.+]] = insertelement <4 x i64> {{poison|undef}}, i64 %call, {{i32|i64}} 0
 ; CHECK: %[[GID_SPLAT:.+]] = shufflevector <4 x i64> %[[GID_SPLATINSERT:.+]], <4 x i64> {{poison|undef}}, <4 x i32> zeroinitializer
 ; CHECK: %[[GID:.+]] = add <4 x i64> %[[GID_SPLAT]], <i64 0, i64 1, i64 2, i64 3>

--- a/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
@@ -39,7 +39,7 @@ entry:
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !13, metadata !29), !dbg !30
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !31
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
   %0 = load i64, i64* %tid, align 8, !dbg !32
@@ -66,7 +66,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/modules/compiler/vecz/test/lit/llvm/packetization_nonvarying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_nonvarying.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test_branch(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -43,7 +43,7 @@ if.end:
 
 define spir_kernel void @test_uniform_branch(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i32 %a, 42
   br i1 %cmp, label %if.then, label %if.else
 
@@ -67,7 +67,7 @@ if.end:
 }
 
 define spir_func void @test_nonvarying_loadstore(i32* %a, i32* %b, i32* %c) {
-  %index = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %index = call i64 @__mux_get_global_id(i32 0)
   %a.i = getelementptr i32, i32* %a, i64 %index
   %b.i = getelementptr i32, i32* %b, i64 %index
   %c.i = getelementptr i32, i32* %c, i64 %index
@@ -78,11 +78,11 @@ define spir_func void @test_nonvarying_loadstore(i32* %a, i32* %b, i32* %c) {
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks if a simple kernel is vectorized without any masks
 ; CHECK: define spir_func void @__vecz_v4_test_nonvarying_loadstore(ptr %a, ptr %b, ptr %c)
-; CHECK: %index = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %index = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %a.i = getelementptr i32, ptr %a, i64 %index
 ; CHECK: %b.i = getelementptr i32, ptr %b, i64 %index
 ; CHECK: %c.i = getelementptr i32, ptr %c, i64 %index

--- a/modules/compiler/vecz/test/lit/llvm/packetization_uniform_branch.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_uniform_branch.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test_branch(i32 %a, i32* %b) {
 entry:
   %conv = sext i32 %a to i64
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %conv, %call
   br i1 %cmp, label %if.then, label %if.else
 
@@ -43,7 +43,7 @@ if.end:
 
 define spir_kernel void @test_uniform_branch(i32 %a, i32* %b) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i32 %a, 42
   br i1 %cmp, label %if.then, label %if.else
 
@@ -67,7 +67,7 @@ if.end:
 }
 
 define spir_func void @test_nonvarying_loadstore(i32* %a, i32* %b, i32* %c) {
-  %index = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %index = call i64 @__mux_get_global_id(i32 0)
   %a.i = getelementptr i32, i32* %a, i64 %index
   %b.i = getelementptr i32, i32* %b, i64 %index
   %c.i = getelementptr i32, i32* %c, i64 %index
@@ -78,12 +78,12 @@ define spir_func void @test_nonvarying_loadstore(i32* %a, i32* %b, i32* %c) {
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks if the if blocks are vectorized without masks and if the phi
 ; node is also vectorized properly
 ; CHECK: define spir_kernel void @__vecz_v4_test_uniform_branch(i32 %a, ptr %b)
-; CHECK: %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %call = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %[[SPLATINSERT:.+]] = insertelement <4 x i64> {{poison|undef}}, i64 %call, {{i32|i64}} 0
 ; CHECK: %[[SPLAT:.+]] = shufflevector <4 x i64> %[[SPLATINSERT]], <4 x i64> {{poison|undef}}, <4 x i32> zeroinitializer
 ; CHECK: %[[GID:.+]] = add <4 x i64> %[[SPLAT]], <i64 0, i64 1, i64 2, i64 3>

--- a/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(%struct.T addrspace(1)* %in, %struct.T addrspace(1)* %out, i32 addrspace(1)* %offsets) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %offsets, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %conv = sext i32 %0 to i64
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; Check if we can packetize GEPs on structs
 ; Note that we only need to packetize the non-uniform operands..

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_conditional.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_conditional.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_conditional.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_conditional.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_noreduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_noreduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_noreduce2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_noreduce2.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_reduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_default_reduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0
@@ -154,7 +154,7 @@ if.end:                                           ; preds = %entry, %if.then
 ; CHECK: define spir_kernel void @__vecz_v4_reduce(ptr addrspace(3) %in, ptr addrspace(3) %out)
 ; CHECK: insertelement <4 x i64> {{poison|undef}}, i64
 ; CHECK: shufflevector <4 x i64>
-; CHECK: %[[LOCAL_SIZE:[^ ]+]] = call spir_func i64 @_Z14get_local_sizej(i32 0)
+; CHECK: %[[LOCAL_SIZE:[^ ]+]] = call i64 @__mux_get_local_size(i32 0)
 ; CHECK: icmp {{(ugt|ult)}} i64 %[[LOCAL_SIZE]], {{(1|2)}}
 ; CHECK-NEXT: br
 ; CHECK: phi i32

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_conditional.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_conditional.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_noreduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_noreduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_noreduce2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_noreduce2.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_reduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_loops_reduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_noreduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_noreduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -62,13 +62,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -95,13 +95,13 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 
@@ -129,7 +129,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind
 define spir_kernel void @conditional(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %0 = load i32, i32 addrspace(1)* %in, align 4
   %rem1 = and i32 %0, 1
   %tobool = icmp eq i32 %rem1, 0

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_noreduce2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_noreduce2.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @noreduce2(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/packetize_uniform_reduce.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_uniform_reduce.ll
@@ -20,20 +20,20 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z14get_local_sizej(i32)
+declare i64 @__mux_get_local_id(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_local_size(i32)
 
 ; Function Attrs: nounwind
 define spir_kernel void @reduce(i32 addrspace(3)* %in, i32 addrspace(3)* %out) {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call = call i64 @__mux_get_local_id(i32 0)
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
   %storemerge = phi i32 [ 1, %entry ], [ %mul6, %for.inc ]
   %conv = zext i32 %storemerge to i64
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0)
+  %call1 = call i64 @__mux_get_local_size(i32 0)
   %cmp = icmp ult i64 %conv, %call1
   br i1 %cmp, label %for.body, label %for.end
 

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization0.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization0.ll
@@ -128,7 +128,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization0(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %rem = srem i32 %conv, 5
   %cmp = icmp eq i32 %rem, 0
@@ -258,7 +258,7 @@ if.end73:                                         ; preds = %if.end70, %if.end41
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization1.ll
@@ -89,7 +89,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization1(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -180,7 +180,7 @@ early:                                            ; preds = %for.end34, %for.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization10.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization10.ll
@@ -161,7 +161,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization10(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -316,7 +316,7 @@ s:                                                ; preds = %for.cond68, %for.co
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization11.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization11.ll
@@ -146,7 +146,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization11(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -261,7 +261,7 @@ n46:                                              ; preds = %i44, %for.cond35
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization12.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization12.ll
@@ -213,7 +213,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -431,7 +431,7 @@ v:                                                ; preds = %for.cond107, %for.c
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization13.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization13.ll
@@ -96,8 +96,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization13(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
+  %call1 = call i64 @__mux_get_global_size(i32 0) #2
   %add = add i64 %call, 1
   %cmp = icmp ult i64 %add, %call1
   br i1 %cmp, label %if.then, label %if.else
@@ -162,10 +162,10 @@ if.end17:                                         ; preds = %sw.bb14, %if.else, 
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z15get_global_sizej(i32) #1
+declare i64 @__mux_get_global_size(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization14.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization14.ll
@@ -94,7 +94,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization14(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %n, 5
   br i1 %cmp, label %for.cond, label %while.body
@@ -193,7 +193,7 @@ early:                                            ; preds = %for.end49, %for.end
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization15.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization15.ll
@@ -145,7 +145,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization15(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -272,7 +272,7 @@ q:                                                ; preds = %for.cond59, %for.co
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization16.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization16.ll
@@ -100,7 +100,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization16(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %n, 5
   br i1 %cmp, label %for.cond, label %while.body
@@ -211,7 +211,7 @@ early:                                            ; preds = %for.cond52, %for.en
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization17.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization17.ll
@@ -130,7 +130,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -249,7 +249,7 @@ p:                                                ; preds = %for.cond60, %for.en
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization18.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization18.ll
@@ -109,7 +109,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -192,7 +192,7 @@ if.end42:                                         ; preds = %if.else40, %i38
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization19.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization19.ll
@@ -118,7 +118,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -205,7 +205,7 @@ j:                                                ; preds = %for.cond40, %for.co
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization2.ll
@@ -89,7 +89,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization2(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else17
@@ -183,7 +183,7 @@ end:                                              ; preds = %i42, %h
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization20.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization20.ll
@@ -100,7 +100,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization20(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -153,7 +153,7 @@ g:                                                ; preds = %for.cond, %e, %whil
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization21.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization21.ll
@@ -96,7 +96,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization21(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -135,7 +135,7 @@ f:                                                ; preds = %e, %if.else, %while
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization22.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization22.ll
@@ -108,7 +108,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization22(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -168,7 +168,7 @@ h:                                                ; preds = %for.cond, %f, %if.e
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization23.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization23.ll
@@ -97,7 +97,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @partial_linearization23(i32 addrspace(1)* %out, i32 %n) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else7
@@ -236,7 +236,7 @@ end:                                              ; preds = %i24, %h
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v4_partial_linearization23
 ; CHECK: i24:

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization3.ll
@@ -87,7 +87,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization3(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else17
@@ -181,7 +181,7 @@ end:                                              ; preds = %i42, %for.cond
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization4.ll
@@ -80,7 +80,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization4(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %0 = icmp eq i32 %conv, -2147483648
   %1 = icmp eq i32 %n, -1
@@ -139,7 +139,7 @@ g:                                                ; preds = %f, %e
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization5.ll
@@ -88,7 +88,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %rem1 = and i32 %conv, 1
   %cmp = icmp eq i32 %rem1, 0
@@ -158,7 +158,7 @@ g:                                                ; preds = %f, %if.then
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization6.ll
@@ -85,7 +85,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization6(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -140,7 +140,7 @@ early:                                            ; preds = %e, %while.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization7.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization7.ll
@@ -95,7 +95,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %n, 10
   br i1 %cmp, label %if.then, label %if.else5
@@ -158,7 +158,7 @@ i29:                                              ; preds = %h, %for.cond19
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization8.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization8.ll
@@ -82,7 +82,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization8(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %0 = icmp eq i32 %conv, -2147483648
   %1 = icmp eq i32 %n, -1
@@ -142,7 +142,7 @@ g:                                                ; preds = %f, %e
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization9.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization9.ll
@@ -70,7 +70,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @partial_linearization9(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -105,7 +105,7 @@ while.end:                                        ; preds = %for.end
 }
 
 ; Function Attrs: nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization_exit_masks.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization_exit_masks.ll
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %out, i32 %n) {
 entry:
-  %call = tail call spir_func i32 @_Z13get_global_idj(i32 0)
+  %call = tail call i32 @__mux_get_global_id(i32 0)
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %for.body.preheader, label %if.end.thread
 
@@ -60,6 +60,6 @@ if.end2:
   ret void
 }
 
-declare spir_func i32 @_Z13get_global_idj(i32)
+declare i32 @__mux_get_global_id(i32)
 
 declare spir_func i32 @_Z3maxii(i32, i32)

--- a/modules/compiler/vecz/test/lit/llvm/pass_pipeline.ll
+++ b/modules/compiler/vecz/test/lit/llvm/pass_pipeline.ll
@@ -39,10 +39,10 @@ target triple = "spir64-unknown-unknown"
 ; PASSES2-NOT: Running pass:
 
 define spir_kernel void @foo(i32 addrspace(1)* %out) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %idx
   store i32 0, i32 addrspace(1)* %arrayidx, align 4
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/pass_pipeline_printafter.ll
+++ b/modules/compiler/vecz/test/lit/llvm/pass_pipeline_printafter.ll
@@ -20,25 +20,25 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: IR Dump After Simplify masked memory operations{{( on __vecz_v2_foo)?}}
 ; CHECK-NEXT: define spir_kernel void @__vecz_v2_foo(ptr addrspace(1) %out) #0 {
-; CHECK-NEXT:   %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:   %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 %idx
 ; CHECK-NEXT:   store i32 0, ptr addrspace(1) %arrayidx, align 4
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }
 
 ; CHECK: define spir_kernel void @__vecz_v2_foo(ptr addrspace(1) %out) {{.*}} {
-; CHECK-NEXT:   %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK-NEXT:   %idx = call i64 @__mux_get_global_id(i32 0)
 ; CHECK-NEXT:   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 %idx
 ; CHECK-NEXT:   store <2 x i32> zeroinitializer, ptr addrspace(1) %arrayidx, align 4
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }
 
 define spir_kernel void @foo(i32 addrspace(1)* %out) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %idx
   store i32 0, i32 addrspace(1)* %arrayidx, align 4
   ret void

--- a/modules/compiler/vecz/test/lit/llvm/phi_interleaved.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_interleaved.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @codegen_2(i32 addrspace(1)* nocapture readonly %in, i32 addrspace(1)* nocapture %out, i32 %size, i32 %reps) local_unnamed_addr {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = sext i32 %reps to i64
   %mul = mul i64 %call, %conv
   %add = add i64 %call, 1
@@ -60,7 +60,7 @@ for.inc:                                          ; preds = %if.then, %for.body
   br i1 %cmp, label %for.body, label %for.cond.cleanup
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr
 
 !llvm.module.flags = !{!0}
 !opencl.ocl.version = !{!1}

--- a/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
@@ -35,7 +35,7 @@ entry:
   store i32 addrspace(3)* %b, i32 addrspace(3)** %b.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(3)** %b.addr, metadata !13, metadata !30), !dbg !31
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !30), !dbg !32
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #3, !dbg !32
+  %call = call i64 @__mux_get_local_id(i32 0) #3, !dbg !32
   store i64 %call, i64* %tid, align 8, !dbg !32
   call void @llvm.dbg.declare(metadata i32* %i, metadata !19, metadata !30), !dbg !33
   %0 = load i64, i64* %tid, align 8, !dbg !33
@@ -74,7 +74,7 @@ for.end:                                          ; preds = %for.cond
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z12get_local_idj(i32) #2
+declare i64 @__mux_get_local_id(i32) #2
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/modules/compiler/vecz/test/lit/llvm/phi_scatter_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_scatter_gather.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @phi_memory(i32 addrspace(1)* %input, i32 addrspace(1)* %output, i32 %size) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %idx.ext = sext i32 %conv to i64
   %add.ptr = getelementptr inbounds i32, i32 addrspace(1)* %output, i64 %idx.ext
@@ -49,7 +49,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/phi_scatter_gather_2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_scatter_gather_2.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @phi_memory(i32 addrspace(1)* %input, i32 addrspace(1)* %output, i64 %size) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %add.ptr = getelementptr inbounds i32, i32 addrspace(1)* %output, i64 %call
   br label %for.cond
 
@@ -46,7 +46,7 @@ for.end:                                          ; preds = %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/predicate_with_switch.ll
+++ b/modules/compiler/vecz/test/lit/llvm/predicate_with_switch.ll
@@ -19,16 +19,16 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 @predicate_with_switch.tmpIn = internal addrspace(3) global [16 x i32] undef, align 4
 
 define spir_kernel void @predicate_with_switch(i32 addrspace(1)* %A, i32 addrspace(1)* %B) #0 {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #2
-  %call1 = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_local_id(i32 0) #2
+  %call1 = call i64 @__mux_get_global_id(i32 0) #2
   switch i64 %call, label %if.end [
     i64 0, label %return
     i64 200, label %return

--- a/modules/compiler/vecz/test/lit/llvm/preserve-fast-math.ll
+++ b/modules/compiler/vecz/test/lit/llvm/preserve-fast-math.ll
@@ -20,7 +20,7 @@
 
 define spir_kernel void @fast_nan(float addrspace(1)* %src1, float addrspace(1)* %src2, i16 addrspace(1)* %dst, i32 %width) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %src1, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %src2, i64 %call
@@ -32,4 +32,4 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/printf_float.ll
+++ b/modules/compiler/vecz/test/lit/llvm/printf_float.ll
@@ -26,7 +26,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @printf_kernel(i32 addrspace(1)* %in, i32 addrspace(1)* %stridesX, i32 addrspace(1)* %dst, i32 %width, i32 %height) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %call = call i64 @__mux_get_global_id(i32 0) #3
   %cmp = icmp eq i32 %width, 13
   br i1 %cmp, label %if.then, label %if.end
 
@@ -43,7 +43,7 @@ if.end:                                           ; preds = %if.then, %entry
 
 define spir_kernel void @test_float(float* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds float, float* %in, i64 %call
   %0 = load float, float* %arrayidx, align 4
   %mul = fmul float %0, %0
@@ -54,7 +54,7 @@ entry:
 
 
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...) #1
 

--- a/modules/compiler/vecz/test/lit/llvm/regression_by_all.ll
+++ b/modules/compiler/vecz/test/lit/llvm/regression_by_all.ll
@@ -79,7 +79,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @regression_by_all(i32 addrspace(1)* %out, i32 %n) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
   %rem1 = and i32 %n, 1
   %cmp = icmp eq i32 %rem1, 0
@@ -116,7 +116,7 @@ e:                                                ; preds = %for.cond, %d
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v4_regression_by_all
 ; CHECK: br i1 %[[CMP:.+]], label %[[D:.+]], label %[[IFELSE:.+]]

--- a/modules/compiler/vecz/test/lit/llvm/remove_intptr.ll
+++ b/modules/compiler/vecz/test/lit/llvm/remove_intptr.ll
@@ -26,7 +26,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: store i64 %remove_intptr1, ptr addrspace(1) %out, align 8
 define spir_kernel void @intptr_cast_i8(i8 addrspace(1)* %in, i64 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i8 addrspace(1)* %in to i64
   %shl = shl i64 %call, 2
   %add = add i64 %shl, %0
@@ -41,7 +41,7 @@ entry:
 ; CHECK: store i64 %remove_intptr1, ptr addrspace(1) %out, align 8
 define spir_kernel void @intptr_cast_i16(i16 addrspace(1)* %in, i64 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i16 addrspace(1)* %in to i64
   %shl = shl i64 %call, 2
   %add = add i64 %shl, %0
@@ -49,4 +49,4 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/remove_intptr_2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/remove_intptr_2.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @remove_intptr(i8 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i8 addrspace(1)* %in to i64
   %shl = shl nuw nsw i64 %call, 2
   %add = add i64 %shl, %0
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v4_remove_intptr
 ; CHECK-NOT: ptrtoint

--- a/modules/compiler/vecz/test/lit/llvm/remove_intptr_phi.ll
+++ b/modules/compiler/vecz/test/lit/llvm/remove_intptr_phi.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @remove_intptr(i8 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = ptrtoint i8 addrspace(1)* %in to i64
   %shl = shl nuw nsw i64 %call, 2
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %shl
@@ -42,7 +42,7 @@ for.body:                                         ; preds = %for.body, %entry
   br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v4_remove_intptr
 ; CHECK-NOT: ptrtoint

--- a/modules/compiler/vecz/test/lit/llvm/roscc_simplify.ll
+++ b/modules/compiler/vecz/test/lit/llvm/roscc_simplify.ll
@@ -21,7 +21,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @add(i32 addrspace(1)* %in1, i32 addrspace(1)* %in2, i32 addrspace(1)* %out, i64 addrspace(1)* %N) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %0 = load i64, i64 addrspace(1)* %N, align 8
   %cmp = icmp ult i64 %call, %0
   br i1 %cmp, label %if.then, label %if.end
@@ -40,7 +40,7 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @__vecz_v16_add
 ; CHECK: entry:

--- a/modules/compiler/vecz/test/lit/llvm/scalar_vector_user.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalar_vector_user.ll
@@ -22,7 +22,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:1:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z12get_local_idj(i32) #0
+declare i64 @__mux_get_local_id(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func <4 x float> @_Z3madDv4_fS_S_(<4 x float>, <4 x float>, <4 x float>) #0
@@ -35,7 +35,7 @@ declare spir_func float @_Z3madfff(float, float, float) local_unnamed_addr #2
 
 define spir_kernel void @scalar_vector_user(float addrspace(1)* %inout, i64 %n) {
 entry:
-  %lid = tail call spir_func i64 @_Z12get_local_idj(i32 0) #0
+  %lid = tail call i64 @__mux_get_local_id(i32 0) #0
   %inout.address = getelementptr inbounds float, float addrspace(1)* %inout, i64 %lid
   br label %loop
 

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_calls.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_calls.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_calls(<4 x float>* %pa, <4 x float>* %pb, <4 x i32>* %pc, <4 x float>* %pd) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x float>, <4 x float>* %pa, i64 %idx
   %b = getelementptr <4 x float>, <4 x float>* %pb, i64 %idx
   %c = getelementptr <4 x i32>, <4 x i32>* %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
@@ -42,7 +42,7 @@ entry:
   store <2 x i32> addrspace(1)* %out, <2 x i32> addrspace(1)** %out.addr, align 8
   call void @llvm.dbg.declare(metadata <2 x i32> addrspace(1)** %out.addr, metadata !18, metadata !34), !dbg !35
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !19, metadata !34), !dbg !36
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !36
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !36
   store i64 %call, i64* %tid, align 8, !dbg !36
   call void @llvm.dbg.declare(metadata <2 x i32>* %a, metadata !23, metadata !34), !dbg !37
   %0 = load i64, i64* %tid, align 8, !dbg !37
@@ -72,7 +72,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_instructions.ll
@@ -19,11 +19,11 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define spir_kernel void @test_instructions(<4 x i32>* %pa, <4 x i32>* %pb, <4 x i32>* %pc) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %a = getelementptr <4 x i32>, <4 x i32>* %pa, i64 %idx
   %b = getelementptr <4 x i32>, <4 x i32>* %pb, i64 %idx
   %c = getelementptr <4 x i32>, <4 x i32>* %pc, i64 %idx

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_masked_load_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_masked_load_store.ll
@@ -19,14 +19,14 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare <2 x float> @__vecz_b_masked_load4_Dv2_fPDv2_fDv2_b(<2 x float>*, <2 x i1>)
 declare void @__vecz_b_masked_store4_Dv2_fPDv2_fDv2_b(<2 x float>, <2 x float>*, <2 x i1>)
 
 define spir_kernel void @scalarize_masked_memops(<2 x float>* %pa, <2 x float>* %pz) {
 entry:
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %head = insertelement <2 x i64> undef, i64 %idx, i64 0
   %splat = shufflevector <2 x i64> %head, <2 x i64> undef, <2 x i32> zeroinitializer
   %idxs = add <2 x i64> %splat, <i64 0, i64 1>
@@ -36,7 +36,7 @@ entry:
   %zptr = getelementptr <2 x float>, <2 x float>* %pz, i64 %idx
   call void @__vecz_b_masked_store4_Dv2_fPDv2_fDv2_b(<2 x float> %ld, <2 x float>* %zptr, <2 x i1> %mask)
   ret void
- ; CHECK:  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+ ; CHECK:  %idx = call i64 @__mux_get_global_id(i32 0)
  ; CHECK:  %[[IDXS0:.*]] = add i64 %idx, 0
  ; CHECK:  %[[IDXS1:.*]] = add i64 %idx, 1
  ; CHECK:  %[[MASK0:.*]] = icmp slt i64 %[[IDXS0]], 8

--- a/modules/compiler/vecz/test/lit/llvm/scalarize-gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarize-gather.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @splat(i32 addrspace(1)* %data, i32 addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 0)
+  %call = tail call i64 @__mux_get_global_id(i32 noundef 0)
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %data, i64 %call
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
   %splat.splatinsert = insertelement <4 x i32> poison, i32 %0, i64 0
@@ -34,7 +34,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 noundef)
+declare i64 @__mux_get_global_id(i32 noundef)
 declare spir_func i32 @not_scalarizable(<4 x i32> noundef)
 
 ; It checks that the scalarizer scalarizes the add and reconstructs the vector

--- a/modules/compiler/vecz/test/lit/llvm/scalarize-splat.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarize-splat.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @splat(float addrspace(1)* %data, float addrspace(1)* %out) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 0)
+  %call = tail call i64 @__mux_get_global_id(i32 noundef 0)
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %data, i64 %call
   %0 = load float, float addrspace(1)* %arrayidx, align 4
   %splat.splatinsert = insertelement <4 x float> poison, float %0, i64 0
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32 noundef)
+declare i64 @__mux_get_global_id(i32 noundef)
 declare spir_func float @not_scalarizable(<4 x float> noundef)
 
 ; It checks that the scalarizer turns the original vector splat back into a vector splat,

--- a/modules/compiler/vecz/test/lit/llvm/scalarize_mixed_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarize_mixed_gep.ll
@@ -18,10 +18,10 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 define void @bar(i64** %ptrptrs, i64 %val) {
-  %idx = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %idx = call i64 @__mux_get_global_id(i32 0)
   %arrayidxa = getelementptr inbounds i64*, i64** %ptrptrs, i64 %idx
   %ptrs = load i64*, i64** %arrayidxa, align 4
   %addr = getelementptr inbounds i64, i64* %ptrs, <4 x i32> <i32 2, i32 2, i32 2, i32 2>

--- a/modules/compiler/vecz/test/lit/llvm/scan_fact.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scan_fact.ll
@@ -24,20 +24,20 @@ target triple = "spir64-unknown-unknown"
 @scan_fact.temp = internal addrspace(3) global [16 x i32] undef, align 4
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z12get_local_idj(i32) #0
+declare i64 @__mux_get_local_id(i32) #0
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z14get_local_sizej(i32) #0
+declare i64 @__mux_get_local_size(i32) #0
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @scan_fact(i32 addrspace(1)* %out, i32 addrspace(1)* %in) #1 {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #3
-  %call1 = call spir_func i64 @_Z13get_global_idj(i32 0) #3
-  %call2 = call spir_func i64 @_Z14get_local_sizej(i32 0) #3
+  %call = call i64 @__mux_get_local_id(i32 0) #3
+  %call1 = call i64 @__mux_get_global_id(i32 0) #3
+  %call2 = call i64 @__mux_get_local_size(i32 0) #3
   %mul = shl i64 %call1, 1
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %mul
   %0 = load i32, i32 addrspace(1)* %arrayidx, align 4

--- a/modules/compiler/vecz/test/lit/llvm/select-no-crash.ll
+++ b/modules/compiler/vecz/test/lit/llvm/select-no-crash.ll
@@ -26,7 +26,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @test(i32 addrspace(1)* %out, i32 %n) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   br label %while.body
 
@@ -86,7 +86,7 @@ h:                                                ; preds = %for.cond, %f, %if.e
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_1.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_2.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -41,7 +41,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_3.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_4.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_5.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -52,7 +52,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/shuffled_load_6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/shuffled_load_6.ll
@@ -21,9 +21,9 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @load16(i8 addrspace(1)* %out, i8 addrspace(1)* %in, i32 %stride) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
   %conv = trunc i64 %call to i32
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
   %conv2 = trunc i64 %call1 to i32
   %mul = mul nsw i32 %conv2, %stride
   %add = add nsw i32 %mul, %conv
@@ -44,7 +44,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; CHECK: spir_kernel void @load16
 ; CHECK: load <4 x i8>

--- a/modules/compiler/vecz/test/lit/llvm/squash_extract_sext.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_extract_sext.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @squash(<4 x i8> addrspace(1)* %data, i32 addrspace(1)* %output) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %gid = call i64 @__mux_get_global_id(i64 0) #2
   %data.ptr = getelementptr inbounds <4 x i8>, <4 x i8> addrspace(1)* %data, i64 %gid
   %data.ld = load <4 x i8>, <4 x i8> addrspace(1)* %data.ptr, align 8
   %ele0 = extractelement <4 x i8> %data.ld, i32 0
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64) #1
+declare i64 @__mux_get_global_id(i64) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/squash_extract_sext_bigendian.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_extract_sext_bigendian.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @squash(<4 x i8> addrspace(1)* %data, i32 addrspace(1)* %output) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %gid = call i64 @__mux_get_global_id(i64 0) #2
   %data.ptr = getelementptr inbounds <4 x i8>, <4 x i8> addrspace(1)* %data, i64 %gid
   %data.ld = load <4 x i8>, <4 x i8> addrspace(1)* %data.ptr, align 8
   %ele0 = extractelement <4 x i8> %data.ld, i32 3
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64) #1
+declare i64 @__mux_get_global_id(i64) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/squash_extract_zext.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_extract_zext.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @squash(<4 x i8> addrspace(1)* %data, i32 addrspace(1)* %output) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %gid = call i64 @__mux_get_global_id(i64 0) #2
   %data.ptr = getelementptr inbounds <4 x i8>, <4 x i8> addrspace(1)* %data, i64 %gid
   %data.ld = load <4 x i8>, <4 x i8> addrspace(1)* %data.ptr, align 8
   %ele0 = extractelement <4 x i8> %data.ld, i32 0
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64) #1
+declare i64 @__mux_get_global_id(i64) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/squash_extract_zext_bigendian.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_extract_zext_bigendian.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @squash(<4 x i8> addrspace(1)* %data, i32 addrspace(1)* %output) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %gid = call i64 @__mux_get_global_id(i64 0) #2
   %data.ptr = getelementptr inbounds <4 x i8>, <4 x i8> addrspace(1)* %data, i64 %gid
   %data.ld = load <4 x i8>, <4 x i8> addrspace(1)* %data.ptr, align 8
   %ele0 = extractelement <4 x i8> %data.ld, i32 3
@@ -42,7 +42,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64) #1
+declare i64 @__mux_get_global_id(i64) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/squash_float2_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_float2_gather.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @squash(i64 addrspace(1)* %idx, <2 x float> addrspace(1)* %data, <2 x float> addrspace(1)* %output) #0 {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %gid = call i64 @__mux_get_global_id(i64 0) #2
   %idx.ptr = getelementptr inbounds i64, i64 addrspace(1)* %idx, i64 %gid
   %idx.ld = load i64, i64 addrspace(1)* %idx.ptr, align 8
   %data.ptr = getelementptr inbounds <2 x float>, <2 x float> addrspace(1)* %data, i64 %idx.ld
@@ -33,7 +33,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64) #1
+declare i64 @__mux_get_global_id(i64) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -43,7 +43,7 @@ attributes #2 = { nobuiltin nounwind }
 ; gather load
 ;
 ; CHECK: void @__vecz_v4_squash
-; CHECK:  %[[GID:.+]] = call spir_func i64 @_Z13get_global_idj(i64 0) #[[ATTRS:[0-9]+]]
+; CHECK:  %[[GID:.+]] = call i64 @__mux_get_global_id(i64 0) #[[ATTRS:[0-9]+]]
 ; CHECK:  %[[IDX_PTR:.+]] = getelementptr inbounds i64, ptr addrspace(1) %idx, i64 %[[GID]]
 ; CHECK:  %[[WIDE_LOAD:.+]] = load <4 x i64>, ptr addrspace(1) %[[IDX_PTR]], align 8
 ; CHECK:  %[[DATA_PTR:.+]] = getelementptr inbounds <2 x float>, ptr addrspace(1) %data, <4 x i64> %[[WIDE_LOAD]]

--- a/modules/compiler/vecz/test/lit/llvm/stride_aligned.ll
+++ b/modules/compiler/vecz/test/lit/llvm/stride_aligned.ll
@@ -43,34 +43,34 @@ target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @foo(%struct.PerItemKernelInfo addrspace(1)* nocapture noundef writeonly %info) !reqd_work_group_size !11 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 0)
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 1)
-  %call2 = tail call spir_func i64 @_Z13get_global_idj(i32 noundef 2)
-  %call3 = tail call spir_func i64 @_Z15get_global_sizej(i32 noundef 0)
-  %call5 = tail call spir_func i64 @_Z15get_global_sizej(i32 noundef 1)
+  %call = tail call i64 @__mux_get_global_id(i32 noundef 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 noundef 1)
+  %call2 = tail call i64 @__mux_get_global_id(i32 noundef 2)
+  %call3 = tail call i64 @__mux_get_global_size(i32 noundef 0)
+  %call5 = tail call i64 @__mux_get_global_size(i32 noundef 1)
   %mul7 = mul nuw nsw i64 %call5, %call2
   %reass.add = add nuw nsw i64 %mul7, %call1
   %reass.mul = mul nuw nsw i64 %reass.add, %call3
   %add8 = add nuw nsw i64 %reass.mul, %call
   %vecinit = insertelement <4 x i64> undef, i64 %call3, i64 0
   %vecinit11 = insertelement <4 x i64> %vecinit, i64 %call5, i64 1
-  %call12 = tail call spir_func i64 @_Z15get_global_sizej(i32 noundef 2)
+  %call12 = tail call i64 @__mux_get_global_size(i32 noundef 2)
   %vecinit13 = insertelement <4 x i64> %vecinit11, i64 %call12, i64 2
-  %call14 = tail call spir_func i64 @_Z15get_global_sizej(i32 noundef 3)
+  %call14 = tail call i64 @__mux_get_global_size(i32 noundef 3)
   %vecinit15 = insertelement <4 x i64> %vecinit13, i64 %call14, i64 3
   %global_size = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 0
   store <4 x i64> %vecinit15, <4 x i64> addrspace(1)* %global_size, align 1
-  %call16 = tail call spir_func i32 @_Z12get_work_dimv()
+  %call16 = tail call i32 @__mux_get_work_dim()
   %work_dim = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 1
   store i32 %call16, i32 addrspace(1)* %work_dim, align 1
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_size(i32)
 
-declare spir_func i32 @_Z12get_work_dimv()
+declare i32 @__mux_get_work_dim()
 
 !11 = !{i32 4, i32 1, i32 1}
 

--- a/modules/compiler/vecz/test/lit/llvm/stride_aligned_scalarized.ll
+++ b/modules/compiler/vecz/test/lit/llvm/stride_aligned_scalarized.ll
@@ -23,34 +23,34 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @foo(%struct.PerItemKernelInfo addrspace(1)* %info) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
-  %call2 = tail call spir_func i64 @_Z13get_global_idj(i32 2)
-  %call3 = tail call spir_func i64 @_Z15get_global_sizej(i32 0)
-  %call5 = tail call spir_func i64 @_Z15get_global_sizej(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
+  %call2 = tail call i64 @__mux_get_global_id(i32 2)
+  %call3 = tail call i64 @__mux_get_global_size(i32 0)
+  %call5 = tail call i64 @__mux_get_global_size(i32 1)
   %mul7 = mul nuw nsw i64 %call5, %call2
   %reass.add = add nuw nsw i64 %mul7, %call1
   %reass.mul = mul nuw nsw i64 %reass.add, %call3
   %add8 = add nuw nsw i64 %reass.mul, %call
   %vecinit = insertelement <4 x i64> undef, i64 %call3, i64 0
   %vecinit11 = insertelement <4 x i64> %vecinit, i64 %call5, i64 1
-  %call12 = tail call spir_func i64 @_Z15get_global_sizej(i32 2)
+  %call12 = tail call i64 @__mux_get_global_size(i32 2)
   %vecinit13 = insertelement <4 x i64> %vecinit11, i64 %call12, i64 2
-  %call14 = tail call spir_func i64 @_Z15get_global_sizej(i32 3)
+  %call14 = tail call i64 @__mux_get_global_size(i32 3)
   %vecinit15 = insertelement <4 x i64> %vecinit13, i64 %call14, i64 3
   %global_size = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 0
   store <4 x i64> %vecinit15, <4 x i64> addrspace(1)* %global_size, align 1
-  %call16 = tail call spir_func i32 @_Z12get_work_dimv()
+  %call16 = tail call i32 @__mux_get_work_dim()
   %work_dim = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 1
   store i32 %call16, i32 addrspace(1)* %work_dim, align 1
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_size(i32)
 
-declare spir_func i32 @_Z12get_work_dimv()
+declare i32 @__mux_get_work_dim()
 
 ; CHECK: spir_kernel void @foo
 ; CHECK: call void @__vecz_b_interleaved_store1_5_Dv4_m{{(u3ptrU3AS1|PU3AS1m)}}(<4 x i64>

--- a/modules/compiler/vecz/test/lit/llvm/stride_misaligned.ll
+++ b/modules/compiler/vecz/test/lit/llvm/stride_misaligned.ll
@@ -23,34 +23,34 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @foo(%struct.PerItemKernelInfo addrspace(1)* %info) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
-  %call2 = tail call spir_func i64 @_Z13get_global_idj(i32 2)
-  %call3 = tail call spir_func i64 @_Z15get_global_sizej(i32 0)
-  %call5 = tail call spir_func i64 @_Z15get_global_sizej(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
+  %call2 = tail call i64 @__mux_get_global_id(i32 2)
+  %call3 = tail call i64 @__mux_get_global_size(i32 0)
+  %call5 = tail call i64 @__mux_get_global_size(i32 1)
   %mul7 = mul nuw nsw i64 %call5, %call2
   %reass.add = add nuw nsw i64 %mul7, %call1
   %reass.mul = mul nuw nsw i64 %reass.add, %call3
   %add8 = add nuw nsw i64 %reass.mul, %call
   %vecinit = insertelement <4 x i64> undef, i64 %call3, i64 0
   %vecinit11 = insertelement <4 x i64> %vecinit, i64 %call5, i64 1
-  %call12 = tail call spir_func i64 @_Z15get_global_sizej(i32 2)
+  %call12 = tail call i64 @__mux_get_global_size(i32 2)
   %vecinit13 = insertelement <4 x i64> %vecinit11, i64 %call12, i64 2
-  %call14 = tail call spir_func i64 @_Z15get_global_sizej(i32 3)
+  %call14 = tail call i64 @__mux_get_global_size(i32 3)
   %vecinit15 = insertelement <4 x i64> %vecinit13, i64 %call14, i64 3
   %global_size = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 0
   store <4 x i64> %vecinit15, <4 x i64> addrspace(1)* %global_size, align 1
-  %call16 = tail call spir_func i32 @_Z12get_work_dimv()
+  %call16 = tail call i32 @__mux_get_work_dim()
   %work_dim = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 1
   store i32 %call16, i32 addrspace(1)* %work_dim, align 1
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_size(i32)
 
-declare spir_func i32 @_Z12get_work_dimv()
+declare i32 @__mux_get_work_dim()
 
 ; CHECK: spir_kernel void @foo
 ; CHECK: store <4 x i64>

--- a/modules/compiler/vecz/test/lit/llvm/stride_misaligned_scalarized.ll
+++ b/modules/compiler/vecz/test/lit/llvm/stride_misaligned_scalarized.ll
@@ -23,34 +23,34 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define spir_kernel void @foo(%struct.PerItemKernelInfo addrspace(1)* %info) {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0)
-  %call1 = tail call spir_func i64 @_Z13get_global_idj(i32 1)
-  %call2 = tail call spir_func i64 @_Z13get_global_idj(i32 2)
-  %call3 = tail call spir_func i64 @_Z15get_global_sizej(i32 0)
-  %call5 = tail call spir_func i64 @_Z15get_global_sizej(i32 1)
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %call1 = tail call i64 @__mux_get_global_id(i32 1)
+  %call2 = tail call i64 @__mux_get_global_id(i32 2)
+  %call3 = tail call i64 @__mux_get_global_size(i32 0)
+  %call5 = tail call i64 @__mux_get_global_size(i32 1)
   %mul7 = mul nuw nsw i64 %call5, %call2
   %reass.add = add nuw nsw i64 %mul7, %call1
   %reass.mul = mul nuw nsw i64 %reass.add, %call3
   %add8 = add nuw nsw i64 %reass.mul, %call
   %vecinit = insertelement <4 x i64> undef, i64 %call3, i64 0
   %vecinit11 = insertelement <4 x i64> %vecinit, i64 %call5, i64 1
-  %call12 = tail call spir_func i64 @_Z15get_global_sizej(i32 2)
+  %call12 = tail call i64 @__mux_get_global_size(i32 2)
   %vecinit13 = insertelement <4 x i64> %vecinit11, i64 %call12, i64 2
-  %call14 = tail call spir_func i64 @_Z15get_global_sizej(i32 3)
+  %call14 = tail call i64 @__mux_get_global_size(i32 3)
   %vecinit15 = insertelement <4 x i64> %vecinit13, i64 %call14, i64 3
   %global_size = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 0
   store <4 x i64> %vecinit15, <4 x i64> addrspace(1)* %global_size, align 1
-  %call16 = tail call spir_func i32 @_Z12get_work_dimv()
+  %call16 = tail call i32 @__mux_get_work_dim()
   %work_dim = getelementptr inbounds %struct.PerItemKernelInfo, %struct.PerItemKernelInfo addrspace(1)* %info, i64 %add8, i32 1
   store i32 %call16, i32 addrspace(1)* %work_dim, align 1
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_size(i32)
 
-declare spir_func i32 @_Z12get_work_dimv()
+declare i32 @__mux_get_work_dim()
 
 ; CHECK: spir_kernel void @foo
 ; CHECK: call void @__vecz_b_scatter_store1_Dv4_mDv4_{{(u3ptrU3AS1|PU3AS1m)}}(<4 x i64>

--- a/modules/compiler/vecz/test/lit/llvm/struct_phi.ll
+++ b/modules/compiler/vecz/test/lit/llvm/struct_phi.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(i32* %in, i32* %out, %struct_type* %sin) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %inp = getelementptr inbounds i32, i32* %in, i64 %call
   %oup = getelementptr inbounds i32, i32* %out, i64 %call
   %o = load i32, i32* %oup
@@ -71,7 +71,7 @@ for.end:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare void @llvm.memset.p0i8.i32(i8*,i8,i32,i32,i1)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test

--- a/modules/compiler/vecz/test/lit/llvm/struct_select.ll
+++ b/modules/compiler/vecz/test/lit/llvm/struct_select.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test(%struct_type* %in1, %struct_type* %in2, %struct_type* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %in1p = getelementptr inbounds %struct_type, %struct_type* %in1, i64 %call
   %in2p = getelementptr inbounds %struct_type, %struct_type* %in2, i64 %call
   %outp = getelementptr inbounds %struct_type, %struct_type* %out, i64 %call
@@ -36,7 +36,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare void @llvm.memset.p0i8.i32(i8*,i8,i32,i32,i1)
 
 ; CHECK: define spir_kernel void @__vecz_v4_test

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
@@ -19,17 +19,17 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare spir_func i32 @_Z16get_sub_group_idv()
-declare spir_func i32 @__mux_get_sub_group_local_id()
-declare spir_func i32 @__mux_sub_group_broadcast_i32(i32, i32)
+declare i32 @__mux_get_sub_group_id()
+declare i32 @__mux_get_sub_group_local_id()
+declare i32 @__mux_sub_group_broadcast_i32(i32, i32)
 
 ; It makes sure broadcast still works when its source operand is uniform
 define spir_kernel void @sub_group_broadcast(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
-  %call = tail call spir_func i32 @_Z16get_sub_group_idv()
+  %call = tail call i32 @__mux_get_sub_group_id()
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i32 %call
   %v = load i32, i32 addrspace(1)* %arrayidx, align 4
-  %broadcast = call spir_func i32 @__mux_sub_group_broadcast_i32(i32 %v, i32 0)
-  %idx = tail call spir_func i32 @__mux_get_sub_group_local_id()
+  %broadcast = call i32 @__mux_sub_group_broadcast_i32(i32 %v, i32 0)
+  %idx = tail call i32 @__mux_get_sub_group_local_id()
   %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i32 %idx
   store i32 %broadcast, i32 addrspace(1)* %arrayidx2, align 4
   ret void

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_different_strides.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_different_strides.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_shift = shl i64 %gid, 1
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
@@ -34,13 +34,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is applied when the source GEPs have
 ; constant strides, even though they are different.
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_ternary(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %gid_shift = shl i64 %gid, 1
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_divergent_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_divergent_gep.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_offset = add i64 %gid, 16
   %gid_mashed = xor i64 %gid, 12462
   %cond = icmp eq i64 %a, %gid
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform pass is not applied when the GEP index
 ; is divergent, which would result in a scatter store regardless.

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_divergent_source.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_divergent_source.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_offset = add i64 %gid, 16
   %gid_mashed = xor i64 %gid, 12462
   %cond = icmp eq i64 %a, %gid
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform pass is not applied when a source GEP
 ; is divergent, which would result in a scatter store regardless.

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_negative.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_negative.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_negative(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   %c1 = getelementptr i64, i64* %c, i64 0
@@ -30,13 +30,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is not applied when the select is not
 ; accessed through an additional GEP.
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_negative(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid
 ; CHECK: %c1 = getelementptr i64, ptr %c, i64 0

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_positive.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_positive.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_offset = add i64 %gid, 16
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
@@ -34,13 +34,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is applied when the source GEPs have
 ; equal constant strides.
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_ternary(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %gid_offset = add i64 %gid, 16
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_cond_diff_strides.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_cond_diff_strides.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_shift = shl i64 %gid, 1
   %cond = icmp eq i64 %a, 0
   %c0 = getelementptr i64, i64* %c, i64 %gid
@@ -34,13 +34,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is applied when the condition is
 ; uniform, and the source GEPs have different constant strides.
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_ternary(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %gid_shift = shl i64 %gid, 1
 ; CHECK: %cond = icmp eq i64 %a, 0
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_condition.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_condition.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_offset = add i64 %gid, 16
   %cond = icmp eq i64 %a, 0
   %c0 = getelementptr i64, i64* %c, i64 %gid
@@ -34,7 +34,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is not applied when the condition is
 ; uniform, and the two strides are the same.

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_condition_packetized.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_condition_packetized.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %gid_offset = add i64 %gid, 16
   %cond = icmp eq i64 %a, 0
   %c0 = getelementptr i64, i64* %c, i64 %gid
@@ -34,7 +34,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is not applied when the condition is
 ; uniform and the two strides are equal, and that the result is a contiguous

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_source.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_source.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 %gid
   store i64 %b, i64* %c0, align 4
@@ -33,13 +33,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is applied when one of the source GEPs
 ; is uniform
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_ternary(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 %gid
 ; CHECK: store i64 %b, ptr %c0, align 4

--- a/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_sources.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ternary_transform_uniform_sources.ll
@@ -21,7 +21,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @test_ternary(i64 %a, i64 %b, i64* %c) {
 entry:
-  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid = call i64 @__mux_get_global_id(i32 0)
   %cond = icmp eq i64 %a, %gid
   %c0 = getelementptr i64, i64* %c, i64 1
   store i64 %b, i64* %c0, align 4
@@ -33,13 +33,13 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This checks that the ternary transform is applied when the source GEPs are
 ; both uniform.
 
 ; CHECK: define spir_kernel void @__vecz_v4_test_ternary(i64 %a, i64 %b, ptr %c)
-; CHECK: %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: %gid = call i64 @__mux_get_global_id(i32 0)
 ; CHECK: %cond = icmp eq i64 %a, %gid
 ; CHECK: %c0 = getelementptr i64, ptr %c, i64 1
 ; CHECK: store i64 %b, ptr %c0, align 4

--- a/modules/compiler/vecz/test/lit/llvm/too_large_simdwidth_packetization.ll
+++ b/modules/compiler/vecz/test/lit/llvm/too_large_simdwidth_packetization.ll
@@ -37,7 +37,7 @@ entry:
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !13, metadata !29), !dbg !30
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !31
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
   %0 = load i64, i64* %tid, align 8, !dbg !32
@@ -64,7 +64,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone }

--- a/modules/compiler/vecz/test/lit/llvm/too_large_simdwidth_scalarization.ll
+++ b/modules/compiler/vecz/test/lit/llvm/too_large_simdwidth_scalarization.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @add(<128 x i32>* %in1, <128 x i32>* %in2, <128 x i32>* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %in1p = getelementptr inbounds <128 x i32>, <128 x i32>* %in1, i64 %call
   %in1v = load <128 x i32>, <128 x i32>* %in1p, align 4
   %in2p = getelementptr inbounds <128 x i32>, <128 x i32>* %in2, i64 %call
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 ; We do not expect this test to succeed
 ; XFAIL: *

--- a/modules/compiler/vecz/test/lit/llvm/undef_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/undef_debug_info.ll
@@ -35,7 +35,7 @@ entry:
   store <4 x i16> addrspace(1)* %dst, <4 x i16> addrspace(1)** %dst.addr, align 8
   call void @llvm.dbg.declare(metadata <4 x i16> addrspace(1)** %dst.addr, metadata !19, metadata !32), !dbg !33
   call void @llvm.dbg.declare(metadata i32* %tid, metadata !20, metadata !32), !dbg !34
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #3, !dbg !34
+  %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !34
   %conv = trunc i64 %call to i32, !dbg !34
   store i32 %conv, i32* %tid, align 4, !dbg !34
   call void @llvm.dbg.declare(metadata <4 x i16>* %tmp, metadata !22, metadata !32), !dbg !35
@@ -57,7 +57,7 @@ entry:
 ; Function Attrs: nounwind readnone
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare i64 @__mux_get_global_id(i32) #2
 
 declare spir_func <4 x i16> @_Z9as_short4Dv3_t(<3 x i16>) #2
 

--- a/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
+++ b/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
@@ -18,19 +18,16 @@
 
 ; ModuleID = 'Unknown buffer'
 source_filename = "Unknown buffer"
-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "spir64-unknown-unknown"
+target datalayout = "e-m:e-i32:32-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i32 @_Z14get_local_sizej(i32) #2
-
-; Function Attrs: convergent nounwind readonly
-declare spir_func i32 @_Z12get_local_idj(i32) #2
+declare i32 @__mux_get_local_id(i32) #2
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @test() #0 {
 entry:
-  %call8 = call spir_func i32 @_Z12get_local_idj(i32 0) #3
+  %call8 = call i32 @__mux_get_local_id(i32 0) #3
   %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* undef, i32 %call8
   %0 = load i8, i8 addrspace(1)* %arrayidx, align 1
   %conv9 = uitofp i8 %0 to float

--- a/modules/compiler/vecz/test/lit/llvm/uniform_address_base.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_address_base.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @uniform_address_index(i32 addrspace(1)* nocapture readonly %in, i32 addrspace(1)* nocapture %out, i32 %a, i32 %b) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %0 = icmp eq i32 %a, -2147483648
   %1 = icmp eq i32 %b, -1
   %2 = and i1 %0, %1
@@ -40,7 +40,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #1
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr #1
 
 ; It tests to ensure that the array index is correctly identified
 ; as having a uniform stride and generates plain vector loads and not
@@ -48,7 +48,7 @@ declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #1
 
 ; CHECK: define spir_kernel void @__vecz_v4_uniform_address_index
 ; CHECK: entry:
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 ; CHECK-DAG: %[[INA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %in, i32 %[[X:.+]]
 ; CHECK-DAG: %[[LOAD:.+]] = load <4 x i32>, ptr addrspace(1) %[[INA]]
 ; CHECK-DAG: %[[OUTA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %out, i32 %[[X:.+]]

--- a/modules/compiler/vecz/test/lit/llvm/uniform_address_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_address_index.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @uniform_address_index(i32 addrspace(1)* nocapture readonly %in, i32 addrspace(1)* nocapture %out, i32 %a, i32 %b) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %0 = icmp eq i32 %a, -2147483648
   %1 = icmp eq i32 %b, -1
   %2 = and i1 %0, %1
@@ -40,7 +40,7 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #1
+declare i64 @__mux_get_global_id(i32) local_unnamed_addr #1
 
 ; It tests to ensure that the array index is correctly identified
 ; as having a uniform stride and generates plain vector loads and not
@@ -48,7 +48,7 @@ declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #1
 
 ; CHECK: define spir_kernel void @__vecz_v4_uniform_address_index
 ; CHECK: entry:
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
+; CHECK: call i64 @__mux_get_global_id(i32 0)
 ; CHECK-DAG: %[[INA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %in, i32 %[[X:.+]]
 ; CHECK-DAG: %[[LOAD:.+]] = load <4 x i32>, ptr addrspace(1) %[[INA]]
 ; CHECK-DAG: %[[OUTA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %out, i32 %[[X:.+]]

--- a/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi1.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %id = call i64 @__mux_get_global_id(i64 0) #2
   %init_addr = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %id
   %load = load i32, i32 addrspace(1)* %init_addr
   br label %loop
@@ -39,7 +39,7 @@ merge:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64)
+declare i64 @__mux_get_global_id(i64)
 
 ; It checks that the stride analysis can tell the store is contiguous through the PHI node.
 

--- a/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi2.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %id = call i64 @__mux_get_global_id(i64 0) #2
   %init_addr = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %id
   %load = load i32, i32 addrspace(1)* %init_addr
   br label %loop
@@ -39,7 +39,7 @@ merge:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64)
+declare i64 @__mux_get_global_id(i64)
 
 ; It checks that the stride analysis can tell the store is contiguous through the PHI node.
 ; Same as uniform_loop_contiguous_phi1.ll except with the PHI node incoming values reversed.

--- a/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi3.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %id = call i64 @__mux_get_global_id(i64 0) #2
   %init_addr = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %id
   %load = load i32, i32 addrspace(1)* %init_addr
   br label %loop
@@ -40,7 +40,7 @@ merge:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64)
+declare i64 @__mux_get_global_id(i64)
 
 ; It checks that the stride analysis can tell the store is contiguous through the PHI node.
 ; Same as uniform_loop_contiguous_phi1.ll except with the index GEP inside the loop.

--- a/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi4.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_loop_contiguous_phi4.ll
@@ -21,7 +21,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* %in) {
 entry:
-  %id = call spir_func i64 @_Z13get_global_idj(i64 0) #2
+  %id = call i64 @__mux_get_global_id(i64 0) #2
   %init_addr = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %id
   %load = load i32, i32 addrspace(1)* %init_addr
   br label %loop
@@ -40,7 +40,7 @@ merge:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i64)
+declare i64 @__mux_get_global_id(i64)
 
 ; It checks that the stride analysis can tell the store is contiguous through the PHI node.
 ; Same as uniform_loop_contiguous_phi3.ll except with the PHI node incoming values reversed.

--- a/modules/compiler/vecz/test/lit/llvm/uniform_reassociation1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_reassociation1.ll
@@ -23,8 +23,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @uniform_reassociation(i32 addrspace(1)* noalias %a, i32 addrspace(1)* noalias %b, i32 addrspace(1)* noalias %d) #0 {
 entry:
-  %x = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %y = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %x = call i64 @__mux_get_global_id(i32 0) #2
+  %y = call i64 @__mux_get_global_id(i32 1) #2
   %a_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %x
   %b_gep = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %y
   %c_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %y
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a sum of a varying value with two uniform values
 ; gets re-associated from (Varying + Uniform) + Uniform

--- a/modules/compiler/vecz/test/lit/llvm/uniform_reassociation2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_reassociation2.ll
@@ -23,8 +23,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @uniform_reassociation(i32 addrspace(1)* noalias %a, i32 addrspace(1)* noalias %b, i32 addrspace(1)* noalias %d) #0 {
 entry:
-  %x = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %y = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %x = call i64 @__mux_get_global_id(i32 0) #2
+  %y = call i64 @__mux_get_global_id(i32 1) #2
   %a_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %x
   %b_gep = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %x
   %c_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %y
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a sum of a varying value with two uniform values
 ; gets re-associated from (Varying + Uniform) + Varying

--- a/modules/compiler/vecz/test/lit/llvm/uniform_reassociation3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_reassociation3.ll
@@ -23,8 +23,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @uniform_reassociation(i32 addrspace(1)* noalias %a, i32 addrspace(1)* noalias %b, i32 addrspace(1)* noalias %d) #0 {
 entry:
-  %x = call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %y = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %x = call i64 @__mux_get_global_id(i32 0) #2
+  %y = call i64 @__mux_get_global_id(i32 1) #2
   %a_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %x
   %b_gep = getelementptr inbounds i32, i32 addrspace(1)* %b, i64 %x
   %c_gep = getelementptr inbounds i32, i32 addrspace(1)* %a, i64 %y
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 ; This test checks that a sum of a varying value with two uniform values
 ; gets re-associated from Varying + (Varying + Uniform)

--- a/modules/compiler/vecz/test/lit/llvm/user_calls.ll
+++ b/modules/compiler/vecz/test/lit/llvm/user_calls.ll
@@ -24,9 +24,9 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @entry(i64* %input, i64* %output) {
 entry:
-  %gid = call i64 @_Z12get_local_idj(i32 0)
+  %gid = call i64 @__mux_get_local_id(i32 0)
   %i1ptr = getelementptr i64, i64* %output, i64 %gid
-  call spir_func void @_Z9mem_fencej(i32 1)
+  call void @__mux_mem_barrier(i32 2, i32 264) 
   %ii = call i64 @functionD(i64* %input)
   %ib = trunc i64 %ii to i1
   call void @functionA(i64* %i1ptr, i1 %ib)
@@ -63,18 +63,18 @@ entry:
   ret i64 %r
 }
 
-declare spir_func void @_Z9mem_fencej(i32)
+declare void @__mux_mem_barrier(i32, i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 
-declare i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 ; CHECK: define spir_kernel void @__vecz_v[[WIDTH:[0-9]+]]_entry
 ; CHECK: entry:
-; Check that we didn't mask the get_local_id call
-; CHECK: %gid = call i64 @_Z12get_local_idj(i32 0)
+; Check that we didn't mask the __mux_get_local_id call
+; CHECK: %gid = call i64 @__mux_get_local_id(i32 0)
 ; Check that we didn't mask the mem_fence call
-; CHECK: call spir_func void @_Z9mem_fencej(i32 1)
+; CHECK: call void @__mux_mem_barrier(i32 2, i32 264)
 ; Check that we instantiated functionA without a mask
 ; CHECK: call void @functionA(ptr {{.+}}, i1 %ib)
 ; CHECK: call void @functionA(ptr {{.+}}, i1 %ib)

--- a/modules/compiler/vecz/test/lit/llvm/varying_load1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/varying_load1.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @varying_load1(i32 addrspace(1)* %out, i32 %n, i32 addrspace(1)* %meta) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
   %cmp = icmp slt i32 %conv, 11
   br i1 %cmp, label %if.then, label %if.end16
@@ -70,7 +70,7 @@ if.end16:                                         ; preds = %if.end, %if.then12,
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/varying_load2.ll
+++ b/modules/compiler/vecz/test/lit/llvm/varying_load2.ll
@@ -24,8 +24,8 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @varying_load2(i32 addrspace(1)* %input, i32 addrspace(1)* %out) #0 {
 entry:
-  %call1 = call spir_func i64 @_Z14get_local_sizej(i32 0) #3
-  %call2 = call spir_func i64 @_Z12get_local_idj(i32 0) #3
+  %call1 = call i64 @__mux_get_local_size(i32 0) #3
+  %call2 = call i64 @__mux_get_local_id(i32 0) #3
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %input, i64 %call2
   %cmp = icmp ne i64 %call2, 0
   br i1 %cmp, label %for.cond.preheader, label %if.end14
@@ -36,7 +36,7 @@ for.cond.preheader:                               ; preds = %entry
 for.cond:                                         ; preds = %for.cond.preheader, %for.inc
   %max.0 = phi i32 [ %max.1, %for.inc ], [ 0, %for.cond.preheader ]
   %storemerge = phi i64 [ %inc, %for.inc ], [ 0, %for.cond.preheader ]
-  %call6 = call spir_func i64 @_Z14get_local_sizej(i32 0) #3
+  %call6 = call i64 @__mux_get_local_size(i32 0) #3
   %cmp7 = icmp ult i64 %storemerge, %call6
   br i1 %cmp7, label %for.body, label %for.end
 
@@ -65,11 +65,11 @@ if.end14:                                         ; preds = %for.end, %entry
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z12get_local_idj(i32) #1
+declare i64 @__mux_get_local_id(i32) #1
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z14get_local_sizej(i32) #1
+declare i64 @__mux_get_local_size(i32) #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent nounwind readonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/modules/compiler/vecz/test/lit/llvm/vector_intrinsics_scalarization.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_intrinsics_scalarization.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @fmuladd(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %arrayidx1 = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %c, i64 %call
@@ -49,7 +49,7 @@ entry:
 
 define spir_kernel void @fma(<4 x double> addrspace(1)* %a, <4 x double> addrspace(1)* %b, <4 x double> addrspace(1)* %c, <4 x double> addrspace(1)* %d, <4 x double> addrspace(1)* %e) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %b, i64 %call
   %0 = load <4 x double>, <4 x double> addrspace(1)* %arrayidx, align 32
   %arrayidx1 = getelementptr inbounds <4 x double>, <4 x double> addrspace(1)* %c, i64 %call
@@ -74,7 +74,7 @@ entry:
 ; CHECK-NOT: call double @llvm.fma.v4f64(
 ; CHECK: ret void
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare <4 x double> @llvm.fma.v4f64(<4 x double>, <4 x double>, <4 x double>)
 declare <4 x double> @llvm.fmuladd.v4f64(<4 x double>, <4 x double>, <4 x double>)

--- a/modules/compiler/vecz/test/lit/llvm/vector_phi_uniform.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_phi_uniform.ll
@@ -23,13 +23,13 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_loop(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %cmp = icmp eq i64 %call, 0
   br i1 %cmp, label %for.end, label %for.cond
 
 for.cond:                                         ; preds = %entry, %for.body
   %storemerge = phi <4 x i32> [ %inc, %for.body ], [ zeroinitializer, %entry ]
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %call1 = call i64 @__mux_get_global_size(i32 0)
   %conv = trunc i64 %call1 to i32
   %splat.splatinsert = insertelement <4 x i32> undef, i32 %conv, i32 0
   %splat.splat = shufflevector <4 x i32> %splat.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -77,8 +77,8 @@ for.end:                                          ; preds = %entry, %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_global_size(i32)
 
 ; This test checks if a uniform <4 x i32> phi is not scalarized
 ; CHECK: define spir_kernel void @__vecz_v4_vector_loop

--- a/modules/compiler/vecz/test/lit/llvm/vector_phi_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_phi_varying.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @vector_loop(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %call.trunc = trunc i64 %call to i32
   %call.splatinsert = insertelement <4 x i32> undef, i32 %call.trunc, i32 0
   %call.splat = shufflevector <4 x i32> %call.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -32,7 +32,7 @@ entry:
 
 for.cond:                                         ; preds = %entry, %for.body
   %storemerge = phi <4 x i32> [ %inc, %for.body ], [ zeroinitializer, %entry ]
-  %call1 = call spir_func i64 @_Z15get_global_sizej(i32 0)
+  %call1 = call i64 @__mux_get_global_size(i32 0)
   %conv = trunc i64 %call1 to i32
   %splat.splatinsert = insertelement <4 x i32> undef, i32 %conv, i32 0
   %splat.splat = shufflevector <4 x i32> %splat.splatinsert, <4 x i32> undef, <4 x i32> zeroinitializer
@@ -80,8 +80,8 @@ for.end:                                          ; preds = %entry, %for.cond
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
-declare spir_func i64 @_Z15get_global_sizej(i32)
+declare i64 @__mux_get_global_id(i32)
+declare i64 @__mux_get_global_size(i32)
 
 ; This test checks if a varying <4 x i32> phi is scalarized into 4 i32 phis
 ; and then re-packetized

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf.ll
@@ -28,7 +28,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(<4 x i8>* %out, <4 x i8>* %in1, <4 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i8>, <4 x i8>* %in1, i64 %call
   %0 = load <4 x i8>, <4 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <4 x i8>, <4 x i8>* %in2, i64 %call
@@ -42,7 +42,7 @@ entry:
 
 define spir_kernel void @test32(<32 x i8>* %out, <32 x i8>* %in1, <32 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <32 x i8>, <32 x i8>* %in1, i64 %call
   %0 = load <32 x i8>, <32 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <32 x i8>, <32 x i8>* %in2, i64 %call
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @test64(<64 x i8>* %out, <64 x i8>* %in1, <64 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <64 x i8>, <64 x i8>* %in1, i64 %call
   %0 = load <64 x i8>, <64 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <64 x i8>, <64 x i8>* %in2, i64 %call
@@ -70,7 +70,7 @@ entry:
 
 define spir_kernel void @test_float_vectors(<2 x float>* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <2 x float>, <2 x float>* %in, i64 %call
   %0 = load <2 x float>, <2 x float>* %arrayidx, align 8
   %mul = fmul <2 x float> %0, %0
@@ -78,7 +78,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf32.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf32.ll
@@ -28,7 +28,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(<4 x i8>* %out, <4 x i8>* %in1, <4 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i8>, <4 x i8>* %in1, i64 %call
   %0 = load <4 x i8>, <4 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <4 x i8>, <4 x i8>* %in2, i64 %call
@@ -42,7 +42,7 @@ entry:
 
 define spir_kernel void @test32(<32 x i8>* %out, <32 x i8>* %in1, <32 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <32 x i8>, <32 x i8>* %in1, i64 %call
   %0 = load <32 x i8>, <32 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <32 x i8>, <32 x i8>* %in2, i64 %call
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @test64(<64 x i8>* %out, <64 x i8>* %in1, <64 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <64 x i8>, <64 x i8>* %in1, i64 %call
   %0 = load <64 x i8>, <64 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <64 x i8>, <64 x i8>* %in2, i64 %call
@@ -70,7 +70,7 @@ entry:
 
 define spir_kernel void @test_float_vectors(<2 x float>* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <2 x float>, <2 x float>* %in, i64 %call
   %0 = load <2 x float>, <2 x float>* %arrayidx, align 8
   %mul = fmul <2 x float> %0, %0
@@ -78,7 +78,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf64.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf64.ll
@@ -28,7 +28,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(<4 x i8>* %out, <4 x i8>* %in1, <4 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i8>, <4 x i8>* %in1, i64 %call
   %0 = load <4 x i8>, <4 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <4 x i8>, <4 x i8>* %in2, i64 %call
@@ -42,7 +42,7 @@ entry:
 
 define spir_kernel void @test32(<32 x i8>* %out, <32 x i8>* %in1, <32 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <32 x i8>, <32 x i8>* %in1, i64 %call
   %0 = load <32 x i8>, <32 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <32 x i8>, <32 x i8>* %in2, i64 %call
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @test64(<64 x i8>* %out, <64 x i8>* %in1, <64 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <64 x i8>, <64 x i8>* %in1, i64 %call
   %0 = load <64 x i8>, <64 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <64 x i8>, <64 x i8>* %in2, i64 %call
@@ -70,7 +70,7 @@ entry:
 
 define spir_kernel void @test_float_vectors(<2 x float>* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <2 x float>, <2 x float>* %in, i64 %call
   %0 = load <2 x float>, <2 x float>* %arrayidx, align 8
   %mul = fmul <2 x float> %0, %0
@@ -78,7 +78,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf_floats.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf_floats.ll
@@ -28,7 +28,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(<4 x i8>* %out, <4 x i8>* %in1, <4 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i8>, <4 x i8>* %in1, i64 %call
   %0 = load <4 x i8>, <4 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <4 x i8>, <4 x i8>* %in2, i64 %call
@@ -42,7 +42,7 @@ entry:
 
 define spir_kernel void @test32(<32 x i8>* %out, <32 x i8>* %in1, <32 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <32 x i8>, <32 x i8>* %in1, i64 %call
   %0 = load <32 x i8>, <32 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <32 x i8>, <32 x i8>* %in2, i64 %call
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @test64(<64 x i8>* %out, <64 x i8>* %in1, <64 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <64 x i8>, <64 x i8>* %in1, i64 %call
   %0 = load <64 x i8>, <64 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <64 x i8>, <64 x i8>* %in2, i64 %call
@@ -70,7 +70,7 @@ entry:
 
 define spir_kernel void @test_float_vectors(<2 x float>* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <2 x float>, <2 x float>* %in, i64 %call
   %0 = load <2 x float>, <2 x float>* %arrayidx, align 8
   %mul = fmul <2 x float> %0, %0
@@ -78,7 +78,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf_floats_no_double_support.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf_floats_no_double_support.ll
@@ -28,7 +28,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test(<4 x i8>* %out, <4 x i8>* %in1, <4 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <4 x i8>, <4 x i8>* %in1, i64 %call
   %0 = load <4 x i8>, <4 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <4 x i8>, <4 x i8>* %in2, i64 %call
@@ -42,7 +42,7 @@ entry:
 
 define spir_kernel void @test32(<32 x i8>* %out, <32 x i8>* %in1, <32 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <32 x i8>, <32 x i8>* %in1, i64 %call
   %0 = load <32 x i8>, <32 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <32 x i8>, <32 x i8>* %in2, i64 %call
@@ -56,7 +56,7 @@ entry:
 
 define spir_kernel void @test64(<64 x i8>* %out, <64 x i8>* %in1, <64 x i8>* %in2) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <64 x i8>, <64 x i8>* %in1, i64 %call
   %0 = load <64 x i8>, <64 x i8>* %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds <64 x i8>, <64 x i8>* %in2, i64 %call
@@ -70,7 +70,7 @@ entry:
 
 define spir_kernel void @test_float_vectors(<2 x float>* %in) {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %call = call i64 @__mux_get_global_id(i32 0)
   %arrayidx = getelementptr inbounds <2 x float>, <2 x float>* %in, i64 %call
   %0 = load <2 x float>, <2 x float>* %arrayidx, align 8
   %mul = fmul <2 x float> %0, %0
@@ -78,7 +78,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 
 declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 

--- a/modules/compiler/vecz/test/lit/llvm/vecz_blend_div_loop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vecz_blend_div_loop.ll
@@ -24,9 +24,9 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent nounwind
 define spir_kernel void @blend_div_loop(i8 addrspace(1)* %src1ptr, i32 %src1_step, i32 %src1_offset, i8 addrspace(1)* %dstptr, i32 %dst_step, i32 %dst_offset, i32 %dst_rows, i32 %dst_cols, i8 addrspace(1)* %src2ptr, i32 %src2_step, i32 %src2_offset, i8 addrspace(1)* %src3ptr, i32 %src3_step, i32 %src3_offset, i32 %rowsPerWI) #0 {
 entry:
-  %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
-  %call1 = call spir_func i64 @_Z13get_global_idj(i32 1) #2
+  %call1 = call i64 @__mux_get_global_id(i32 1) #2
   %0 = trunc i64 %call1 to i32
   %conv3 = mul i32 %0, %rowsPerWI
   %cmp = icmp slt i32 %conv, %dst_cols
@@ -134,7 +134,7 @@ if.end62:                                         ; preds = %for.cond, %entry
 }
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
 ; Function Attrs: convergent nounwind readonly
 declare spir_func i32 @_Z5mad24iii(i32, i32, i32) #1

--- a/modules/compiler/vecz/test/lit/llvm/vecz_scalar_gather_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vecz_scalar_gather_load.ll
@@ -22,16 +22,16 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z12get_group_idj(i32)
+declare i64 @__mux_get_group_id(i32)
 
 ; Function Attrs: convergent nounwind readonly
-declare spir_func i64 @_Z12get_local_idj(i32)
+declare i64 @__mux_get_local_id(i32)
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @vecz_scalar_gather_load(i32 addrspace(1)* %row_indices, i32 addrspace(1)* %row_blocks, float addrspace(1)* %result) {
 entry:
-  %call1 = call spir_func i64 @_Z12get_group_idj(i32 0)
-  %call2 = call spir_func i64 @_Z12get_local_idj(i32 0)
+  %call1 = call i64 @__mux_get_group_id(i32 0)
+  %call2 = call i64 @__mux_get_local_id(i32 0)
   %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %row_blocks, i64 %call1
   %load1 = load i32, i32 addrspace(1)* %arrayidx1, align 4
   %add1 = add i64 %call1, 1

--- a/modules/compiler/vecz/test/lit/llvm/vecz_scalar_interleaved_load.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vecz_scalar_interleaved_load.ll
@@ -22,12 +22,12 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind readnone
-declare spir_func i64 @_Z13get_global_idj(i32) #0
+declare i64 @__mux_get_global_id(i32) #0
 
 define spir_kernel void @vecz_scalar_interleaved_load(float addrspace(1)* %out, i64 %n, float %m) {
 entry:
-  %gid0 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #0
-  %gid1 = tail call spir_func i64 @_Z13get_global_idj(i32 1) #0
+  %gid0 = tail call i64 @__mux_get_global_id(i32 0) #0
+  %gid1 = tail call i64 @__mux_get_global_id(i32 1) #0
   %cmp1 = icmp slt i64 %gid0, %n
   br i1 %cmp1, label %if.then1, label %end
 

--- a/modules/compiler/vecz/test/lit/llvm/workitem_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/workitem_builtins.ll
@@ -23,14 +23,14 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @dont_mask_workitem_builtins(i32 addrspace(2)* %in, i32 addrspace(1)* %out) #0 {
 entry:
-  %call = call spir_func i64 @_Z12get_local_idj(i32 0) #5
+  %call = call i64 @__mux_get_local_id(i32 0) #5
   %conv = trunc i64 %call to i32
   %cmp = icmp sgt i32 %conv, 0
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry
   fence syncscope("singlethread") acq_rel
-  %call2 = call spir_func i64 @_Z13get_global_idj(i32 0) #5
+  %call2 = call i64 @__mux_get_global_id(i32 0) #5
   %conv3 = trunc i64 %call2 to i32
   %idxprom = sext i32 %conv3 to i64
   %arrayidx = getelementptr inbounds i32, i32 addrspace(2)* %in, i64 %idxprom
@@ -41,8 +41,8 @@ if.then:                                          ; preds = %entry
   br label %if.end
 
 if.else:                                          ; preds = %entry
-  %call8 = call spir_func i64 @_Z14get_local_sizej(i32 0) #5
-  %call9 = call spir_func i64 @_Z12get_group_idj(i32 0) #5
+  %call8 = call i64 @__mux_get_local_size(i32 0) #5
+  %call9 = call i64 @__mux_get_group_id(i32 0) #5
   %mul = mul i64 %call9, %call8
   %add = add i64 %mul, %call
   %sext = shl i64 %add, 32
@@ -55,13 +55,13 @@ if.end:                                           ; preds = %if.else, %if.then
   ret void
 }
 
-declare spir_func i64 @_Z12get_local_idj(i32) #1
+declare i64 @__mux_get_local_id(i32) #1
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+declare i64 @__mux_get_global_id(i32) #1
 
-declare spir_func i64 @_Z14get_local_sizej(i32) #1
+declare i64 @__mux_get_local_size(i32) #1
 
-declare spir_func i64 @_Z12get_group_idj(i32) #1
+declare i64 @__mux_get_group_id(i32) #1
 
 attributes #0 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -86,20 +86,19 @@ attributes #6 = { nounwind }
 ; CHECK: define spir_kernel void @__vecz_v[[WIDTH:[0-9]+]]_dont_mask_workitem_builtins(
 
 ; Check if the builtins are still here
-; CHECK: call spir_func i64 @_Z12get_local_idj(i32 0)
-; CHECK: call spir_func i64 @_Z14get_local_sizej(i32 0)
-; CHECK: call spir_func i64 @_Z12get_group_idj(i32 0)
+; CHECK: call i64 @__mux_get_local_id(i32 0)
+; CHECK: call i64 @__mux_get_local_size(i32 0)
+; CHECK: call i64 @__mux_get_group_id(i32 0)
 ; CHECK: fence syncscope("singlethread") acq_rel
-; CHECK: call spir_func i64 @_Z13get_global_idj(i32 0)
-; CHECK-NOT: call spir_func i64 @__vecz_b_masked__Z13get_global_idj(i32
-; CHECK-NOT: call spir_func i64 @__vecz_b_masked__Z14get_local_sizej(i32
-; CHECK-NOT: call spir_func i64 @__vecz_b_masked__Z12get_group_idj(i32
+; CHECK: call i64 @__mux_get_global_id(i32 0)
+; CHECK-NOT: call spir_func i64 @__vecz_b_masked___mux_get_global_id(i32
+; CHECK-NOT: call spir_func i64 @__vecz_b_masked___mux_get_local_size(i32
+; CHECK-NOT: call spir_func i64 @__vecz_b_masked___mux_get_group_id(i32
 
 ; Function end
 ; CHECK: ret void
 
 ; Also check that we haven't declared the masked functions
-; CHECK-NOT: define private spir_func void @__vecz_b_masked__Z7barrierj(i32)
-; CHECK-NOT: define private spir_func i64 @__vecz_b_masked__Z13get_global_idj(i32, i1)
-; CHECK-NOT: define private spir_func i64 @__vecz_b_masked__Z14get_local_sizej(i32, i1)
-; CHECK-NOT: define private spir_func i64 @__vecz_b_masked__Z12get_group_idj(i32, i1)
+; CHECK-NOT: define private spir_func i64 @__vecz_b_masked___mux_get_group_id(i32, i1)
+; CHECK-NOT: define private spir_func i64 @__vecz_b_masked___mux_get_local_size(i32, i1)
+; CHECK-NOT: define private spir_func i64 @__vecz_b_masked___mux_get_group_id(i32, i1)

--- a/modules/compiler/vecz/test/lit/test/invalid_cached_vu_regression.ll
+++ b/modules/compiler/vecz/test/lit/test/invalid_cached_vu_regression.ll
@@ -5,7 +5,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_kernel void @noduplicate(i32 addrspace(1)* %in1, i32 addrspace(1)* %out) {
 entry:
-  %tid = call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %tid = call i64 @__mux_get_global_id(i32 0) #3
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in1, i64 %tid
   %i1 = load i32, i32 addrspace(1)* %arrayidx, align 16
   %dec = call i32 @llvm.loop.decrement.reg.i32(i32 %i1, i32 4)
@@ -14,7 +14,7 @@ entry:
   ret void
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32)
+declare i64 @__mux_get_global_id(i32)
 declare i32 @llvm.loop.decrement.reg.i32(i32, i32)
 
 ;CHECK: Failed to vectorize function 'noduplicate'


### PR DESCRIPTION
This updates our various lit tests to take in mux builtins rather than OpenCL builtins. This should make them more or less agnostic to the language implementation, making them reusable with other input IRs.

Most OpenCL work-item, group, and barrier/fence builtins have been updated (except of course those used to test the `LowerToMuxBuiltinsPass`) but some remain, e.g., math functions. Those are almost exclusively used in a context the compiler doesn't care or understand (it's just another user function) so those will likely remain.