### PR TITLE
[compiler] Update to build with LLVM 17

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/creation_apis_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/creation_apis_helper.h
@@ -16,7 +16,6 @@
 #ifndef MULTI_LLVM_CREATION_APIS_HELPER_H_INCLUDED
 #define MULTI_LLVM_CREATION_APIS_HELPER_H_INCLUDED
 
-#include <llvm/ADT/None.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>

--- a/modules/compiler/multi_llvm/include/multi_llvm/opaque_pointers.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/opaque_pointers.h
@@ -18,26 +18,22 @@
 
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Type.h>
+#include <multi_llvm/llvm_version.h>
 
 namespace multi_llvm {
-inline bool isOpaquePointerTy(llvm::Type *Ty) {
-  if (auto *PTy = llvm::dyn_cast<llvm::PointerType>(Ty)) {
-    return PTy->isOpaque();
-  }
-  return false;
-}
-
 inline bool isOpaqueOrPointeeTypeMatches(llvm::PointerType *PTy, llvm::Type *) {
   (void)PTy;
+#if LLVM_VERSION_LESS(17, 0)
   assert(PTy->isOpaque() && "No support for typed pointers in LLVM 15+");
+#endif
   return true;
 }
 
 inline llvm::Type *getPtrElementType(llvm::PointerType *PTy) {
-  if (PTy->isOpaque()) {
-    return nullptr;
-  }
-  assert(false && "No support for typed pointers");
+  (void)PTy;
+#if LLVM_VERSION_LESS(17, 0)
+  assert(PTy->isOpaque() && "No support for typed pointers in LLVM 15+");
+#endif
   return nullptr;
 }
 

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -77,7 +77,6 @@
 #include <llvm/Transforms/IPO/ForceFunctionAttrs.h>
 #include <llvm/Transforms/IPO/GlobalDCE.h>
 #include <llvm/Transforms/IPO/Inliner.h>
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/Scalar/ADCE.h>
 #include <llvm/Transforms/Scalar/BDCE.h>
 #include <llvm/Transforms/Scalar/DCE.h>

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -259,7 +259,9 @@ Expected<std::unique_ptr<Module>> driver::convertInputToIR() {
                  ->getLLVMContext()
           : LLVMCtx.get();
   assert(LLVMContextToUse && "Missing LLVM Context");
+#if LLVM_VERSION_LESS(17, 0)
   LLVMContextToUse->setOpaquePointers(true);
+#endif
 
   // Assume that .bc and .ll files are already IR unless told otherwise.
   if (InputLanguage == "ir" ||

--- a/modules/compiler/utils/include/compiler/utils/StructTypeRemapper.h
+++ b/modules/compiler/utils/include/compiler/utils/StructTypeRemapper.h
@@ -26,6 +26,7 @@
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
+#include <multi_llvm/llvm_version.h>
 #include <multi_llvm/vector_type_helper.h>
 
 namespace compiler {
@@ -56,11 +57,13 @@ class StructTypeRemapper final : public llvm::ValueMapTypeRemapper {
         return newStructType;
       }
     } else if (auto *ptrType = llvm::dyn_cast<llvm::PointerType>(srcType)) {
+#if LLVM_VERSION_LESS(17, 0)
       // Nominally support opaque pointer remapping from LLVM 13 onwards.
       if (ptrType->isOpaque()) {
         return srcType;
       }
       assert(ptrType->isOpaque() && "Can only remap opaque pointers");
+#endif
       return srcType;
     } else if (auto *arrayType = llvm::dyn_cast<llvm::ArrayType>(srcType)) {
       auto *arrayElementType = arrayType->getElementType();

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -19,6 +19,7 @@
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/pass_functions.h>
 #include <compiler/utils/scheduling.h>
+#include <llvm/ADT/StringExtras.h>
 #include <llvm/ADT/StringSwitch.h>
 
 using namespace llvm;

--- a/modules/compiler/utils/source/mangling.cpp
+++ b/modules/compiler/utils/source/mangling.cpp
@@ -251,12 +251,12 @@ bool NameMangler::mangleType(raw_ostream &O, Type *Ty, TypeQualifiers Quals,
   } else if (Ty->isPointerTy()) {
     PointerType *PtrTy = cast<PointerType>(Ty);
     unsigned AddressSpace = PtrTy->getAddressSpace();
-    if (PtrTy->isOpaque()) {
-      O << "u3ptr";
-      manglePointerQuals(O, Qual, AddressSpace);
-      return true;
-    }
-    return false;
+#if LLVM_VERSION_LESS(17, 0)
+    assert(PtrTy->isOpaque() && "No support for typed pointers past LLVM 15");
+#endif
+    O << "u3ptr";
+    manglePointerQuals(O, Qual, AddressSpace);
+    return true;
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
   } else if (Ty->isTargetExtTy()) {
     if (auto Name = mangleBuiltinType(Ty)) {

--- a/modules/compiler/vecz/source/transform/builtin_inlining_pass.cpp
+++ b/modules/compiler/vecz/source/transform/builtin_inlining_pass.cpp
@@ -107,15 +107,17 @@ static Value *emitBuiltinMemSet(Function *F, IRBuilder<> &B,
   }
 
   Value *DstPtr = Args[0];
-  auto *DstPtrTy = cast<PointerType>(DstPtr->getType());
-
   Type *Int8Ty = B.getInt8Ty();
+
+#if LLVM_VERSION_LESS(17, 0)
+  auto *DstPtrTy = cast<PointerType>(DstPtr->getType());
   // FIXME: We implicitly assume pointers to i8 by doing byte-wise stores,
   // below. See CA-4331.
   if (!DstPtrTy->isOpaque() &&
       multi_llvm::getPtrElementType(DstPtrTy) != Int8Ty) {
     return nullptr;
   }
+#endif
 
   Value *StoredValue = Args[1];
   bool IsVolatile = (Args.back() == ConstantInt::getTrue(Context));
@@ -210,11 +212,11 @@ static Value *emitBuiltinMemCpy(Function *F, IRBuilder<> &B,
 
   Value *DstPtr = Args[0];
   Value *SrcPtr = Args[1];
+  Type *Int8Ty = B.getInt8Ty();
 
+#if LLVM_VERSION_LESS(17, 0)
   auto *DstPtrTy = cast<PointerType>(DstPtr->getType());
   auto *SrcPtrTy = cast<PointerType>(DstPtr->getType());
-
-  Type *Int8Ty = B.getInt8Ty();
   // FIXME: We implicitly assume pointers to i8 by doing byte-wise loads and
   // stores, below. See CA-4331.
   if ((!DstPtrTy->isOpaque() &&
@@ -223,6 +225,7 @@ static Value *emitBuiltinMemCpy(Function *F, IRBuilder<> &B,
         multi_llvm::getPtrElementType(SrcPtrTy) != Int8Ty))) {
     return nullptr;
   }
+#endif
 
   bool IsVolatile = (Args.back() == ConstantInt::getTrue(Context));
   llvm::StoreInst *MC = nullptr;

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -286,7 +286,9 @@ int main(const int argc, const char *const argv[]) {
 
   llvm::SMDiagnostic err;
   llvm::LLVMContext context;
+#if LLVM_VERSION_LESS(17, 0)
   context.setOpaquePointers(true);
+#endif
 
   std::unique_ptr<llvm::Module> module =
       llvm::parseIRFile(InputFilename, err, context);


### PR DESCRIPTION
Some headers have been moved, and `PointerType::isOpaque` warns that it's always true, which is pretty noisy.