### PR TITLE
Increase refsi elf size to cope with SYCL CTS large file creation

### DIFF
--- a/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
+++ b/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
@@ -28,7 +28,9 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+// The upper region can be up to the tdcm start point at 0x10000000
+// We will make it approx 128MB to give some latitude
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 // Memory area for per-hart storage.
 constexpr const uint64_t G_HART_LOCAL_BASE = 0x20800000;

--- a/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
@@ -30,7 +30,9 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+// The upper region can be up to the tdcm start point at 0x10000000
+// We will make it approx 128MB to give some latitude
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 constexpr const uint64_t REFSI_MAX_HARTS = 64;
 

--- a/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
@@ -29,7 +29,9 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+// The upper region can be up to the tdcm start point at 0x10000000
+// We will make it approx 128MB to give some latitude
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 refsi_m1_hal_device::refsi_m1_hal_device(refsi_device_t device,
                                          riscv::hal_device_info_riscv_t *info,


### PR DESCRIPTION
# Overview

The memory available for ELF files in RefSi has been increased to 128MB.

# Reason for change

Some of the ELF files being created are greater than 1MB in SYCL CTS, but the refsi simulators were only setting aside less than 1MB. This caused tests to fail.


# Description of change

Changed defines to give a larger ELF File size in the RefSi drivers and HAL libraries
