### PR TITLE
[compiler] Identify the event type for mux DMA builtins

### DIFF
--- a/modules/compiler/utils/source/define_mux_dma_pass.cpp
+++ b/modules/compiler/utils/source/define_mux_dma_pass.cpp
@@ -28,8 +28,8 @@ PreservedAnalyses compiler::utils::DefineMuxDmaPass::run(
 
   // Define all mux dma builtins
   for (auto &F : M.functions()) {
-    auto ID = BI.analyzeBuiltin(F).ID;
-    if (!BI.isMuxDmaBuiltinID(ID)) {
+    auto Builtin = BI.analyzeBuiltin(F);
+    if (!BI.isMuxDmaBuiltinID(Builtin.ID)) {
       continue;
     }
     LLVM_DEBUG(dbgs() << "  Defining mux DMA builtin: " << F.getName()
@@ -38,7 +38,7 @@ PreservedAnalyses compiler::utils::DefineMuxDmaPass::run(
     // Define the builtin. If it declares any new dependent builtins, those
     // will be appended to the module's function list and so will be
     // encountered by later iterations.
-    if (BI.defineMuxBuiltin(ID, M)) {
+    if (BI.defineMuxBuiltin(Builtin.ID, M, Builtin.mux_overload_info)) {
       Changed = true;
     }
   }


### PR DESCRIPTION
This helps better solidify the API consistency between the identification and declaration/definition code of overloadable builtins.

Since the mux DMA read/write builtins now require the event type to declare themselves (as the event type is up to the target), we should be returning that event type when being identified. The goal is to allow a complete round-trip of identification, declaration, and definition.