### PR TITLE
[compiler] Fix a couple of lit tests with LLVM 17

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
+++ b/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
@@ -14,7 +14,8 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; RUN: veczc -k test -w 4 -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -k test -w 4 -S < %s | FileCheck %t
 
 ; ModuleID = 'Unknown buffer'
 source_filename = "Unknown buffer"
@@ -40,5 +41,6 @@ entry:
 ; The "undefs" in the above IR should "optimize" to a trap call and an unreachable
 ; terminator instruction.
 ; CHECK: define spir_kernel void @__vecz_v4_test
-; On LLVM 13+ there's no such trap: the UB is just that the function returns early.
-; CHECK: ret void
+; Before LLVM 17 there's no such trap: the UB is just that the function returns early.
+; CHECK-LT17: ret void
+; CHECK-GE17: unreachable


### PR DESCRIPTION
1. LLVM 17 re-introduced an unreachable where we haven't seen once since LLVM 13.
2. LLVM 17 changes how debug DW_OP_deref is handled when converting debug expressions. See https://reviews.llvm.org/D142160. This is apparently an improvement in debug info, but it's hard to tell. It's also unclear what we're meant to be doing with debug info in this pass as our support for debug info is generally lacking, so for now we'll just accept LLVM 17's output without questioning it too much.