### PR TITLE
[abacus] Fix abs_diff implementation

### DIFF
--- a/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
@@ -63,8 +63,11 @@ template<typename T> inline typename TypeTraits<T>::UnsignedType abs(const T& x)
 
 template<typename T> typename TypeTraits<T>::UnsignedType abs_diff(
   const T& x, const T& y) {
-  const T lhs = y - x;
-  const T rhs = x - y;
+  typedef typename TypeTraits<T>::UnsignedType UnsignedType;
+  const UnsignedType ux = cast::as<UnsignedType>(x);
+  const UnsignedType uy = cast::as<UnsignedType>(y);
+  const UnsignedType lhs = uy - ux;
+  const UnsignedType rhs = ux - uy;
   const typename TypeTraits<T>::SignedType cond = x > y;
   return cast::as<typename TypeTraits<T>::UnsignedType>(
     relational::select(lhs, rhs, cond));

--- a/modules/compiler/builtins/abacus/generate/abacus_integer/abs_and_abs_diff.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_integer/abs_and_abs_diff.in
@@ -55,7 +55,7 @@ inline abacus_u@generate_type@ ABACUS_API abs(abacus_u@generate_type@ x) {
 /// @param[in] y A abacus_@generate_type@.
 /// @return      A abacus_u@generate_type@.
 ///
-/// The absolute value of x - y, without module overflow.
+/// The absolute value of x - y, without modulo overflow.
 ///
 /// Standards compliant implementation of OpenCL 1.2 abs_diff.
 ///
@@ -83,7 +83,7 @@ inline abacus_u@generate_type@ ABACUS_API abs_diff(abacus_@generate_type@ x, aba
 /// @param[in] y A abacus_u@generate_type@.
 /// @return      A abacus_u@generate_type@.
 ///
-/// The absolute value of x - y, without module overflow.
+/// The absolute value of x - y, without modulo overflow.
 ///
 /// Standards compliant implementation of OpenCL 1.2 abs_diff.
 ///

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -392,6 +392,7 @@ set(KERNEL_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.105_alloca_boscc_confuser.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.106_varying_lcssa_phi.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.107_byval_struct_align.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/regression.108_absdiff_int.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv.01_copy.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv.02_async_copy.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv.03_test_atomic_add.cl

--- a/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.cl
+++ b/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.cl
@@ -1,0 +1,26 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+__kernel void absdiff_int(__global int *srcA, __global int *srcB, __global uint *dst) {
+    int  tid = get_global_id(0);
+
+    int sA, sB;
+    sA = srcA[tid];
+    sB = srcB[tid];
+    uint dstVal = abs_diff(sA, sB);
+    dst[ tid ] = dstVal;
+}
+

--- a/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.spvasm32
+++ b/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.spvasm32
@@ -1,0 +1,106 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 46
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %40 "absdiff_int" %__spirv_BuiltInGlobalInvocationId
+               OpSource OpenCL_C 102000
+               OpName %__spirv_BuiltInGlobalInvocationId "__spirv_BuiltInGlobalInvocationId"
+               OpName %absdiff_int "absdiff_int"
+               OpName %srcA "srcA"
+               OpName %srcB "srcB"
+               OpName %dst "dst"
+               OpName %entry "entry"
+               OpName %srcA_addr "srcA.addr"
+               OpName %srcB_addr "srcB.addr"
+               OpName %dst_addr "dst.addr"
+               OpName %tid "tid"
+               OpName %sA "sA"
+               OpName %sB "sB"
+               OpName %dstVal "dstVal"
+               OpName %call "call"
+               OpName %arrayidx "arrayidx"
+               OpName %arrayidx1 "arrayidx1"
+               OpName %call2 "call2"
+               OpName %arrayidx3 "arrayidx3"
+               OpName %srcA_0 "srcA"
+               OpName %srcB_0 "srcB"
+               OpName %dst_0 "dst"
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+               OpDecorate %__spirv_BuiltInGlobalInvocationId Constant
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %absdiff_int LinkageAttributes "absdiff_int" Export
+               OpDecorate %srcA Alignment 4
+               OpDecorate %srcB Alignment 4
+               OpDecorate %dst Alignment 4
+               OpDecorate %srcA_addr Alignment 4
+               OpDecorate %srcB_addr Alignment 4
+               OpDecorate %dst_addr Alignment 4
+               OpDecorate %tid Alignment 4
+               OpDecorate %sA Alignment 4
+               OpDecorate %sB Alignment 4
+               OpDecorate %dstVal Alignment 4
+               OpDecorate %srcA_0 Alignment 4
+               OpDecorate %srcB_0 Alignment 4
+               OpDecorate %dst_0 Alignment 4
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+          %8 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_uint = OpTypePointer Function %_ptr_CrossWorkgroup_uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3uint Input
+%absdiff_int = OpFunction %void DontInline %8
+       %srcA = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+       %srcB = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+  %srcA_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+  %srcB_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+   %dst_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+        %tid = OpVariable %_ptr_Function_uint Function
+         %sA = OpVariable %_ptr_Function_uint Function
+         %sB = OpVariable %_ptr_Function_uint Function
+     %dstVal = OpVariable %_ptr_Function_uint Function
+               OpStore %srcA_addr %srcA Aligned 4
+               OpStore %srcB_addr %srcB Aligned 4
+               OpStore %dst_addr %dst Aligned 4
+         %23 = OpLoad %v3uint %__spirv_BuiltInGlobalInvocationId Aligned 16
+       %call = OpCompositeExtract %uint %23 0
+               OpStore %tid %call Aligned 4
+         %25 = OpLoad %_ptr_CrossWorkgroup_uint %srcA_addr Aligned 4
+         %26 = OpLoad %uint %tid Aligned 4
+   %arrayidx = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %25 %26
+         %28 = OpLoad %uint %arrayidx Aligned 4
+               OpStore %sA %28 Aligned 4
+         %29 = OpLoad %_ptr_CrossWorkgroup_uint %srcB_addr Aligned 4
+         %30 = OpLoad %uint %tid Aligned 4
+  %arrayidx1 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %29 %30
+         %32 = OpLoad %uint %arrayidx1 Aligned 4
+               OpStore %sB %32 Aligned 4
+         %33 = OpLoad %uint %sA Aligned 4
+         %34 = OpLoad %uint %sB Aligned 4
+      %call2 = OpExtInst %uint %1 s_abs_diff %33 %34
+               OpStore %dstVal %call2 Aligned 4
+         %36 = OpLoad %uint %dstVal Aligned 4
+         %37 = OpLoad %_ptr_CrossWorkgroup_uint %dst_addr Aligned 4
+         %38 = OpLoad %uint %tid Aligned 4
+  %arrayidx3 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %37 %38
+               OpStore %arrayidx3 %36 Aligned 4
+               OpReturn
+               OpFunctionEnd
+         %40 = OpFunction %void DontInline %8
+     %srcA_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+     %srcB_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %dst_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+         %44 = OpLabel
+         %45 = OpFunctionCall %void %absdiff_int %srcA_0 %srcB_0 %dst_0
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.spvasm64
+++ b/source/cl/test/UnitCL/kernels/regression.108_absdiff_int.spvasm64
@@ -1,0 +1,116 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 51
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int64
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %45 "absdiff_int" %__spirv_BuiltInGlobalInvocationId
+               OpSource OpenCL_C 102000
+               OpName %__spirv_BuiltInGlobalInvocationId "__spirv_BuiltInGlobalInvocationId"
+               OpName %absdiff_int "absdiff_int"
+               OpName %srcA "srcA"
+               OpName %srcB "srcB"
+               OpName %dst "dst"
+               OpName %entry "entry"
+               OpName %srcA_addr "srcA.addr"
+               OpName %srcB_addr "srcB.addr"
+               OpName %dst_addr "dst.addr"
+               OpName %tid "tid"
+               OpName %sA "sA"
+               OpName %sB "sB"
+               OpName %dstVal "dstVal"
+               OpName %call "call"
+               OpName %conv "conv"
+               OpName %idxprom "idxprom"
+               OpName %arrayidx "arrayidx"
+               OpName %idxprom1 "idxprom1"
+               OpName %arrayidx2 "arrayidx2"
+               OpName %call3 "call3"
+               OpName %idxprom4 "idxprom4"
+               OpName %arrayidx5 "arrayidx5"
+               OpName %srcA_0 "srcA"
+               OpName %srcB_0 "srcB"
+               OpName %dst_0 "dst"
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+               OpDecorate %__spirv_BuiltInGlobalInvocationId Constant
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %absdiff_int LinkageAttributes "absdiff_int" Export
+               OpDecorate %srcA Alignment 4
+               OpDecorate %srcB Alignment 4
+               OpDecorate %dst Alignment 4
+               OpDecorate %srcA_addr Alignment 8
+               OpDecorate %srcB_addr Alignment 8
+               OpDecorate %dst_addr Alignment 8
+               OpDecorate %tid Alignment 4
+               OpDecorate %sA Alignment 4
+               OpDecorate %sB Alignment 4
+               OpDecorate %dstVal Alignment 4
+               OpDecorate %srcA_0 Alignment 4
+               OpDecorate %srcB_0 Alignment 4
+               OpDecorate %dst_0 Alignment 4
+      %ulong = OpTypeInt 64 0
+       %uint = OpTypeInt 32 0
+    %v3ulong = OpTypeVector %ulong 3
+%_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+          %9 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_uint
+%_ptr_Function__ptr_CrossWorkgroup_uint = OpTypePointer Function %_ptr_CrossWorkgroup_uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3ulong Input
+%absdiff_int = OpFunction %void DontInline %9
+       %srcA = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+       %srcB = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+        %dst = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %entry = OpLabel
+  %srcA_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+  %srcB_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+   %dst_addr = OpVariable %_ptr_Function__ptr_CrossWorkgroup_uint Function
+        %tid = OpVariable %_ptr_Function_uint Function
+         %sA = OpVariable %_ptr_Function_uint Function
+         %sB = OpVariable %_ptr_Function_uint Function
+     %dstVal = OpVariable %_ptr_Function_uint Function
+               OpStore %srcA_addr %srcA Aligned 8
+               OpStore %srcB_addr %srcB Aligned 8
+               OpStore %dst_addr %dst Aligned 8
+         %24 = OpLoad %v3ulong %__spirv_BuiltInGlobalInvocationId Aligned 32
+       %call = OpCompositeExtract %ulong %24 0
+       %conv = OpUConvert %uint %call
+               OpStore %tid %conv Aligned 4
+         %27 = OpLoad %_ptr_CrossWorkgroup_uint %srcA_addr Aligned 8
+         %28 = OpLoad %uint %tid Aligned 4
+    %idxprom = OpSConvert %ulong %28
+   %arrayidx = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %27 %idxprom
+         %31 = OpLoad %uint %arrayidx Aligned 4
+               OpStore %sA %31 Aligned 4
+         %32 = OpLoad %_ptr_CrossWorkgroup_uint %srcB_addr Aligned 8
+         %33 = OpLoad %uint %tid Aligned 4
+   %idxprom1 = OpSConvert %ulong %33
+  %arrayidx2 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %32 %idxprom1
+         %36 = OpLoad %uint %arrayidx2 Aligned 4
+               OpStore %sB %36 Aligned 4
+         %37 = OpLoad %uint %sA Aligned 4
+         %38 = OpLoad %uint %sB Aligned 4
+      %call3 = OpExtInst %uint %1 s_abs_diff %37 %38
+               OpStore %dstVal %call3 Aligned 4
+         %40 = OpLoad %uint %dstVal Aligned 4
+         %41 = OpLoad %_ptr_CrossWorkgroup_uint %dst_addr Aligned 8
+         %42 = OpLoad %uint %tid Aligned 4
+   %idxprom4 = OpSConvert %ulong %42
+  %arrayidx5 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uint %41 %idxprom4
+               OpStore %arrayidx5 %40 Aligned 4
+               OpReturn
+               OpFunctionEnd
+         %45 = OpFunction %void DontInline %9
+     %srcA_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+     %srcB_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+      %dst_0 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+         %49 = OpLabel
+         %50 = OpFunctionCall %void %absdiff_int %srcA_0 %srcB_0 %dst_0
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/source/ktst_regression_05.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_05.cpp
@@ -177,5 +177,19 @@ TEST_P(ExecutionOpenCLC, Regression_107_Byval_Struct_Align) {
   RunGeneric1D(TestN);
 }
 
+TEST_P(Execution, Regression_108_AbsDiff_Int) {
+  // We won't vectorize if we know the local work-group size is only 1...
+  fail_if_not_vectorized_ = false;
+
+  kts::Reference1D<cl_int> refInA = [](size_t) { return 0x8c7f0aac; };
+  kts::Reference1D<cl_int> refInB = [](size_t) { return 0x1902f8c8; };
+  kts::Reference1D<cl_uint> refOut = [](size_t) { return 0x8c83ee1c; };
+
+  AddInputBuffer(1, refInA);
+  AddInputBuffer(1, refInB);
+  AddOutputBuffer(1, refOut);
+  RunGeneric1D(1);
+}
+
 // Do not add tests beyond Regression_125* here, or the file may become too
 // large to link. Instead, start a new ktst_regression_${NN}.cpp file.


### PR DESCRIPTION
Doing the subtraction in signed types would cause the compiler to assume no underflow, which is not a valid assumption. In C, the assumption that there's no underflow means clang adds `nsw` flags to the subtraction(s).

It appears that LLVM 17 was finally able to make use of these flags and optimize the IR such that our implementation was proven incorrect.