### PR TITLE
Fix for workflows continuing to run after branch pushed to again

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -16,6 +16,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   # build and run host x86_64, execute UnitCL and lit tests and build and run offline


### PR DESCRIPTION
# Overview

Fix for workflows continuing to run after branch pushed to again

# Reason for change

We were seeing multiple workflows running for the same PRs when the branch was pushed to again.

# Description of change

The fix is to add a concurrency/cancel-in-progress to the workflow.
