### PR TITLE
Amy/sub group barrier id fix2

### DIFF
--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -444,8 +444,16 @@ class BuiltinInfo {
   /// @brief Returns true if the mux builtin has a barrier ID as its first
   /// operand.
   static bool isMuxBuiltinWithBarrierID(BuiltinID ID) {
-    // NOTE sub group barriers do have an ID operand, but the handle barriers
-    // pass doesn't need to know about that.
+    if (isMuxControlBarrierID(ID)) {
+      return true;
+    }
+    auto Info = isMuxGroupCollective(ID);
+    return Info && Info->isWorkGroupScope();
+  }
+
+  /// @brief Returns true if the mux builtin has a barrier ID as its first
+  /// operand, and applies at Work Group scope.
+  static bool isMuxBuiltinWithWGBarrierID(BuiltinID ID) {
     if (ID == eMuxBuiltinWorkGroupBarrier) {
       return true;
     }

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -448,7 +448,7 @@ void compiler::utils::Barrier::FindBarriers() {
         Function *callee = call_inst->getCalledFunction();
         if (callee != nullptr) {
           auto const B = bi_->analyzeBuiltin(*callee);
-          if (BuiltinInfo::isMuxBuiltinWithBarrierID(B.ID)) {
+          if (BuiltinInfo::isMuxBuiltinWithWGBarrierID(B.ID)) {
             unsigned id = ~0u;
             auto *const id_param = call_inst->getOperand(0);
             if (auto *const id_param_c = dyn_cast<ConstantInt>(id_param)) {


### PR DESCRIPTION
# Overview

Forgot to commit changes to previous PR. 

# Reason for change

Sub Group Barriers still need to be given a unique ID but the Handle Barriers Pass doesn't need to know about it.

# Description of change

Makes `BuiltinInfo::isMuxBuiltinWithBarrierID()` into two separate functions, one that returns true for any barrier and another that only returns true for work group barriers and not subgroup barriers.
