### PR TITLE
[compiler] Provide a mapping from GroupCollective -> BuiltinID

### DIFF
--- a/modules/compiler/test/group_ops.cpp
+++ b/modules/compiler/test/group_ops.cpp
@@ -418,14 +418,18 @@ define void @test_wrapper(i32 %i, float %f, i32 %sg_lid, i64 %lid_x, i64 %lid_y,
       auto Info = BI.isMuxGroupCollective(Builtin.ID);
       ASSERT_TRUE(Info) << InfoStr;
 
-      // Now check that the returned values are what we expect. We don't
-      // check 'type' or 'function' here as it's not set by either party.
+      // Now check that the returned values are what we expect.
       assert(Info && "Asserting the optional to silence a compiler warning");
       EXPECT_EQ(Info->Op, GroupOps[GroupOpIdx].Collective.Op) << InfoStr;
       EXPECT_EQ(Info->Scope, GroupOps[GroupOpIdx].Collective.Scope) << InfoStr;
       EXPECT_EQ(Info->IsLogical, GroupOps[GroupOpIdx].Collective.IsLogical)
           << InfoStr;
       EXPECT_EQ(Info->Recurrence, GroupOps[GroupOpIdx].Collective.Recurrence)
+          << InfoStr;
+
+      EXPECT_EQ(Builtin.ID, BI.getMuxGroupCollective(*Info)) << InfoStr;
+      EXPECT_EQ(Builtin.ID,
+                BI.getMuxGroupCollective(GroupOps[GroupOpIdx].Collective))
           << InfoStr;
 
       ++GroupOpIdx;

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -441,6 +441,10 @@ class BuiltinInfo {
   /// @brief Gets information about a mux group operation builtin
   static std::optional<GroupCollective> isMuxGroupCollective(BuiltinID ID);
 
+  /// @brief Returns the mux builtin ID matching the group collective, or
+  /// eBuiltinInvalid.
+  static BuiltinID getMuxGroupCollective(const GroupCollective &Group);
+
   /// @brief Returns true if the mux builtin has a barrier ID as its first
   /// operand.
   static bool isMuxBuiltinWithBarrierID(BuiltinID ID) {


### PR DESCRIPTION
This commit allows users to get the mux builtin ID corresponding to a `utils::GroupCollective`.

This could be useful to programmatically mutate a group collective, such as changing a sub-group operation to a work-group one, or changing an inclusive scan to an exclusive one.

In the absence of any concrete users, this enables round-trip testing of `ID -> GroupCollective -> ID` in `UnitCompiler`.