### PR TITLE
[vecz] Vectorize sub-groups on top of mux sub-groups

### DIFF
--- a/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
+++ b/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
@@ -73,15 +73,6 @@ Value *processCallSite(CallInst *CI, bool &NeedLLVMInline,
     }
   }
 
-  // Vectorized uses of the subgroup local id will have been replaced with step
-  // vectors starting from zero. Uniform uses should be replaced with zero in
-  // order to maintain equivalence between the scalar/vector forms. Do this
-  // here due to a tight coupling between the vectorized version and these
-  // remaining scalar versions.
-  if (Builtin.ID == compiler::utils::eMuxBuiltinGetSubGroupLocalId) {
-    return ConstantInt::getNullValue(CI->getType());
-  }
-
   return CI;
 }
 

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
@@ -35,7 +35,8 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
 ; CHECK-LABEL: define spir_kernel void @__vecz_nxv4_get_sub_group_size(
 ; CHECK: [[VSCALE:%.*]] = call i32 @llvm.vscale.i32()
 ; CHECK: [[W:%.*]] = shl i32 [[VSCALE]], 2
-; CHECK: store i32 [[W]], ptr addrspace(1) {{.*}}
+; CHECK: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 [[W]])
+; CHECK: store i32 [[RED]], ptr addrspace(1) {{.*}}
 }
 
 define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
@@ -68,7 +68,8 @@ define spir_kernel void @sub_group_broadcast(i32 addrspace(1)* %in, i32 addrspac
 ; CHECK-LABEL: define spir_kernel void @__vecz_nxv4_sub_group_broadcast(
 ; CHECK: [[LD:%.*]] = load <vscale x 4 x i32>, ptr addrspace(1) {{%.*}}, align 4
 ; CHECK: [[EXT:%.*]] = extractelement <vscale x 4 x i32> [[LD]], {{(i32|i64)}} 0
-; CHECK: [[INS:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXT]], {{(i32|i64)}} 0
+; CHECK: [[BDCAST:%.*]] = call spir_func i32 @__mux_sub_group_broadcast_i32(i32 [[EXT]], i32 0)
+; CHECK: [[INS:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[BDCAST]], {{(i32|i64)}} 0
 ; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[INS]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK: store <vscale x 4 x i32> [[SPLAT]], ptr addrspace(1)
 }

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_scans.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_scans.ll
@@ -42,7 +42,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_add_i32(
-; CHECK: call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4j(<vscale x 4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4j(<vscale x 4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.add.nxv4i32(<vscale x 4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_add_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[HEAD]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <vscale x 4 x i32> [[SCAN]], [[SPLAT]]
+; CHECK: store <vscale x 4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_add_i64(i64 addrspace(1)* %in, i64 addrspace(1)* %out) {
@@ -55,7 +61,13 @@ entry:
   store i64 %call1, i64 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_add_i64(
-; CHECK: call <vscale x 4 x i64> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4m(<vscale x 4 x i64> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i64> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4m(<vscale x 4 x i64> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i64 @llvm.vector.reduce.add.nxv4i64(<vscale x 4 x i64> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i64 @__mux_sub_group_scan_exclusive_add_i64(i64 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i64> poison, i64 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i64> [[HEAD]], <vscale x 4 x i64> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <vscale x 4 x i64> [[SCAN]], [[SPLAT]]
+; CHECK: store <vscale x 4 x i64> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_add_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -68,7 +80,13 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_add_f32(
-; CHECK: call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4f(<vscale x 4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4f(<vscale x 4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fadd.nxv4f32(float -0.0{{.*}}, <vscale x 4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fadd_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x float> [[HEAD]], <vscale x 4 x float> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = fadd <vscale x 4 x float> [[SCAN]], [[SPLAT]]
+; CHECK: store <vscale x 4 x float> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_smin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -81,7 +99,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_smin_i32(
-; CHECK: call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_smin_u5nxv4i(<vscale x 4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_smin_u5nxv4i(<vscale x 4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smin.nxv4i32(<vscale x 4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_smin_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[HEAD]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x i32> @llvm.smin.nxv4i32(<vscale x 4 x i32> [[SCAN]], <vscale x 4 x i32> [[SPLAT]])
+; CHECK: store <vscale x 4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_umin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -94,7 +118,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_umin_i32(
-; CHECK: call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_umin_u5nxv4j(<vscale x 4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_umin_u5nxv4j(<vscale x 4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umin.nxv4i32(<vscale x 4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_umin_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[HEAD]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x i32> @llvm.umin.nxv4i32(<vscale x 4 x i32> [[SCAN]], <vscale x 4 x i32> [[SPLAT]])
+; CHECK: store <vscale x 4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_smax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -107,7 +137,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_smax_i32(
-; CHECK: call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_smax_u5nxv4i(<vscale x 4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_smax_u5nxv4i(<vscale x 4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smax.nxv4i32(<vscale x 4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_smax_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[HEAD]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x i32> @llvm.smax.nxv4i32(<vscale x 4 x i32> [[SCAN]], <vscale x 4 x i32> [[SPLAT]])
+; CHECK: store <vscale x 4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_umax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -120,7 +156,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_umax_i32(
-; CHECK: call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_umax_u5nxv4j(<vscale x 4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_umax_u5nxv4j(<vscale x 4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umax.nxv4i32(<vscale x 4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_umax_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[HEAD]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x i32> @llvm.umax.nxv4i32(<vscale x 4 x i32> [[SCAN]], <vscale x 4 x i32> [[SPLAT]])
+; CHECK: store <vscale x 4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_fmin_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -133,7 +175,13 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_fmin_f32(
-; CHECK: call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_min_u5nxv4f(<vscale x 4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_min_u5nxv4f(<vscale x 4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmin.nxv4f32(<vscale x 4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fmin_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x float> [[HEAD]], <vscale x 4 x float> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x float> @llvm.minnum.nxv4f32(<vscale x 4 x float> [[SCAN]], <vscale x 4 x float> [[SPLAT]])
+; CHECK: store <vscale x 4 x float> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_fmax_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -146,5 +194,11 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_nxv4_reduce_scan_incl_fmax_f32(
-; CHECK: call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_max_u5nxv4f(<vscale x 4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <vscale x 4 x float> @__vecz_b_sub_group_scan_inclusive_max_u5nxv4f(<vscale x 4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmax.nxv4f32(<vscale x 4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fmax_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <vscale x 4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x float> [[HEAD]], <vscale x 4 x float> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <vscale x 4 x float> @llvm.maxnum.nxv4f32(<vscale x 4 x float> [[SCAN]], <vscale x 4 x float> [[SPLAT]])
+; CHECK: store <vscale x 4 x float> [[FINAL]],
 }

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/compute_vector_length.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/compute_vector_length.ll
@@ -41,7 +41,8 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
 ; CHECK-F2: [[WL:%.*]] = sub {{.*}} i64 [[SZ]], [[ID]]
 ; CHECK-F2: [[VL0:%.*]] = call i64 @llvm.umin.i64(i64 [[WL]], i64 2)
 ; CHECK-F2: [[VL1:%.*]] = trunc i64 [[VL0]] to i32
-; CHECK-F2: store i32 [[VL1]], ptr addrspace(1) {{.*}}
+; CHECK-F2: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 [[VL1]])
+; CHECK-F2: store i32 [[RED]], ptr addrspace(1) {{.*}}
 
 ; CHECK-S4-LABEL: define spir_kernel void @__vecz_nxv4_vp_get_sub_group_size(
 ; CHECK-S4: [[ID:%.*]] = call i64 @__mux_get_local_id(i32 0)
@@ -51,4 +52,5 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
 ; CHECK-S4: [[VF1:%.*]] = shl i64 [[VF0]], 2
 ; CHECK-S4: [[VL0:%.*]] = call i64 @llvm.umin.i64(i64 [[WL]], i64 [[VF1]])
 ; CHECK-S4: [[VL1:%.*]] = trunc i64 [[VL0]] to i32
-; CHECK-S4: store i32 [[VL1]], ptr addrspace(1) {{.*}}
+; CHECK-S4: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 [[VL1]])
+; CHECK-S4: store i32 [[RED]], ptr addrspace(1) {{.*}}

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions.ll
@@ -56,7 +56,8 @@ entry:
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i1> <i1 true, i1 true, i1 true, i1 true>, <4 x i1> [[T2]]
 ; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[I]] to i4
 ; CHECK: [[R:%.*]] = icmp eq i4 [[T3]], -1
-; CHECK: [[EXT:%.*]] = sext i1 [[R]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_all_i1(i1 [[R]])
+; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
 }
 
@@ -81,7 +82,8 @@ entry:
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i1> [[T2]], <4 x i1> zeroinitializer
 ; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[I]] to i4
 ; CHECK: [[R:%.*]] = icmp ne i4 [[T3]], 0
-; CHECK: [[EXT:%.*]] = sext i1 [[R]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_any_i1(i1 [[R]])
+; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
 }
 
@@ -102,7 +104,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_add_i64(i64 addrspace(1)* %in, i64 addrspace(1)* %out) {
@@ -122,7 +125,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> zeroinitializer
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> [[I]])
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_add_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_add_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -142,7 +146,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float -0.000000e+00, float -0.000000e+00,
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float -0.000000e+00, <4 x float> [[I]])
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fadd_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_smin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -162,7 +167,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 2147483647, i32 2147483647, 
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smin.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smin_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_umin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -182,7 +188,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umin_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_smax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -202,7 +209,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -2147483648, i32 -2147483648, 
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smax.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smax_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_umax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -222,7 +230,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umax_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_fmin_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -242,7 +251,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 0x7FF8000000000000, float 0x7FF8000000000000,
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmin.v4f32(<4 x float> [[I]])
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHEKC: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmin_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_fmax_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -262,5 +272,6 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 0xFFF8000000000000, float 0xFFF8000000000000,
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmax.v4f32(<4 x float> [[I]])
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmax_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -40,7 +40,8 @@ declare spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1)
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_mul_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -60,7 +61,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> <i64 1, i64 1, i64 1, i64 1>
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.mul.v4i64(<4 x i64> [[I]])
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_mul_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i64(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -80,7 +82,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmul.v4f32(float 1.000000e+00, <4 x float> [[I]])
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmul_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_f32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -100,7 +103,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1> 
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_and_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_and_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -120,7 +124,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[I]])
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_or_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_or_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -140,7 +145,8 @@ entry:
 ; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> zeroinitializer
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.xor.v4i64(<4 x i64> [[I]])
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_xor_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_xor_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -157,7 +163,8 @@ entry:
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_and(
 ; This doesn't generate a reduction intrinsic...
 ; CHECK: [[T:%.*]] = icmp eq i4 {{%.*}}, -1
-; CHECK: [[R:%.*]] = zext i1 [[T]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_and_i1(i1 [[T]])
+; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_and(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
@@ -176,7 +183,8 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_or(
 ; CHECK: [[T:%.*]] = icmp ne i4 {{%.*}}, 0
-; CHECK: [[R:%.*]] = zext i1 [[T]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1 [[T]])
+; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_or(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
@@ -196,7 +204,9 @@ entry:
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_xor(
 ; CHECK: [[X:%.*]] = call i4 @llvm.ctpop.i4(i4 {{%.*}})
 ; CHECK: [[T:%.*]] = and i4 [[X]], 1
-; CHECK: [[R:%.*]] = zext i4 [[T]] to i32
+; CHECK: [[C:%.*]] = icmp ne i4 [[T]], 0
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[C]])
+; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_xor(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
@@ -39,4 +39,7 @@ define spir_kernel void @sub_group_broadcast(i32 addrspace(1)* %in, i32 addrspac
 ; CHECK: [[LD:%.+]] = load i32, ptr addrspace(1) %{{.+}}, align 4
 ; CHECK: [[INS:%.+]] = insertelement <4 x i32> poison, i32 [[LD]], i64 0
 ; CHECK: [[BCAST:%.+]] = shufflevector <4 x i32> [[INS]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: store <4 x i32> [[BCAST]], ptr addrspace(1) %out, align 4
+; CHECK: %idx = tail call i32 @__mux_get_sub_group_local_id()
+; CHECK: [[EXT:%.*]] = sext i32 %idx to i64
+; CHECK: %arrayidx2 = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
+; CHECK: store <4 x i32> [[BCAST]], ptr addrspace(1) %arrayidx2, align 4

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
@@ -43,7 +43,14 @@ define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrs
   store i32 %call, i32 addrspace(1)* %arrayidx, align 4
   ret void
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_get_sub_group_local_id(
-; CHECK: store <4 x i32> <i32 0, i32 1, i32 2, i32 3>, ptr addrspace(1) %out
+; CHECK: %call = tail call spir_func i32 @__mux_get_sub_group_local_id()
+; CHECK: [[MUL:%.*]] = shl i32 %call, 2
+; CHECK: [[SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[MUL]], i64 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[ID:%.*]] = or <4 x i32> [[SPLAT]], <i32 0, i32 1, i32 2, i32 3>
+; CHECK: [[EXT:%.*]] = sext i32 %call to i64
+; CHECK: %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
+; CHECK: store <4 x i32> [[ID]], ptr addrspace(1) %arrayidx
 }
 
 define spir_kernel void @sub_group_broadcast(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
@@ -34,7 +34,8 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
   store i32 %call2, i32 addrspace(1)* %arrayidx, align 4
   ret void
 ; CHECK-LABEL: define spir_kernel void @__vecz_v4_get_sub_group_size(
-; CHECK: store i32 4, ptr addrspace(1) {{.*}}
+; CHECK: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 4)
+; CHECK: store i32 [[RED]], ptr addrspace(1) {{.*}}
 }
 
 define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_reductions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_reductions.ll
@@ -53,8 +53,8 @@ entry:
 
 ; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[T2]] to i4
 ; CHECK: [[R:%.*]] = icmp eq i4 [[T3]], 0
-
-; CHECK: [[EXT:%.*]] = sext i1 [[R]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_all_i1(i1 [[R]])
+; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
 }
 
@@ -76,8 +76,8 @@ entry:
 
 ; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[T2]] to i4
 ; CHECK: [[R:%.*]] = icmp ne i4 [[T3]], 0
-
-; CHECK: [[EXT:%.*]] = sext i1 [[R]] to i32
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_any_i1(i1 [[R]])
+; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
 }
 
@@ -94,7 +94,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_add_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 ; Given we've checked a "full" expanded reduction sequence above for LLVM < 13,
@@ -112,8 +113,9 @@ entry:
 ; intrinsic. LLVM 10 does the shift-left in a vector, LLVMs 11 and 12 do it in
 ; scalar.
 ; CHECK: [[CALL:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> {{%.*}})
-; CHECK: [[INS:%.*]] = insertelement <4 x i32> {{(undef|poison)}}, i32 [[CALL]], {{(i32|i64)}} 0
-; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[INS]], <4 x i32> {{(undef|poison)}}, <4 x i32> zeroinitializer
+; CHECK: %call1 = tail call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[CALL]])
+; CHECK: [[INS:%.*]] = insertelement <4 x i32> {{(undef|poison)}}, i32 %call1, {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[INS]], <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK: store <4 x i32> [[SPLAT]],
 }
 
@@ -130,7 +132,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_add_i64(
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> %{{.*}})
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_add_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_add_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -146,7 +149,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_add_f32(
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float -0.000000e+00, <4 x float> %{{.*}})
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fadd_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_smin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -162,7 +166,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_smin_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smin.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smin_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_umin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -178,7 +183,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_umin_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umin_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_smax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -194,7 +200,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_smax_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smax.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smax_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_umax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -210,7 +217,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_umax_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umax_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_fmin_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -226,7 +234,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_fmin_f32(
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmin.v4f32(<4 x float> %{{.*}})
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmin_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 define spir_kernel void @reduce_fmax_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -242,7 +251,8 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_fmax_f32(
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmax.v4f32(<4 x float> %{{.*}})
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmax_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
 !opencl.ocl.version = !{!0}

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -36,7 +36,8 @@ declare spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1)
 
 ; CHECK-LABEL: @__vecz_v4_reduce_mul_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_mul_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -52,7 +53,8 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_mul_i64(
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.mul.v4i64(<4 x i64> %{{.*}})
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_mul_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i64(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -68,7 +70,8 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_mul_f32(
 ; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmul.v4f32(float 1.000000e+00, <4 x float> %{{.*}})
-; CHECK: store float [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmul_f32(float [[R]])
+; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_f32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -84,7 +87,8 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_and_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_and_i32(i32 [[R]])
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_and_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -100,7 +104,7 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_or_i32(
 ; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %{{.*}})
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_or_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -116,7 +120,8 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_xor_i32(
 ; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.xor.v4i64(<4 x i64> %{{.*}})
-; CHECK: store i64 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_xor_i64(i64 [[R]])
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_xor_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -133,8 +138,9 @@ entry:
 ; CHECK-LABEL: @__vecz_v4_reduce_logical_and(
 ; This doesn't generate a reduction intrinsic...
 ; CHECK: [[T:%.*]] = icmp eq i4 {{%.*}}, -1
-; CHECK: [[R:%.*]] = zext i1 [[T]] to i32
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_and_i1(i1 [[T]])
+; CHECK: [[E:%.*]] = zext i1 %call2 to i32
+; CHECK: store i32 [[E]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_and(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -152,8 +158,9 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_logical_or(
 ; CHECK: [[T:%.*]] = icmp ne i4 {{%.*}}, 0
-; CHECK: [[R:%.*]] = zext i1 [[T]] to i32
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1 [[T]])
+; CHECK: [[E:%.*]] = zext i1 %call2 to i32
+; CHECK: store i32 [[E]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_or(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
@@ -172,8 +179,10 @@ entry:
 ; CHECK-LABEL: @__vecz_v4_reduce_logical_xor(
 ; CHECK: [[X:%.*]] = call i4 @llvm.ctpop.i4(i4 {{%.*}})
 ; CHECK: [[T:%.*]] = and i4 [[X]], 1
-; CHECK: [[R:%.*]] = zext i4 [[T]] to i32
-; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
+; CHECK: [[T0:%.*]] = icmp ne i4 [[T]], 0
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[T0]])
+; CHECK: [[E:%.*]] = zext i1 %call2 to i32
+; CHECK: store i32 [[E]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_xor(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_scans.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_scans.ll
@@ -42,7 +42,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_i32(
-; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_add_Dv4_j(<4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_add_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_add_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <4 x i32> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_add_i64(i64 addrspace(1)* %in, i64 addrspace(1)* %out) {
@@ -55,7 +61,13 @@ entry:
   store i64 %call1, i64 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_i64(
-; CHECK: call <4 x i64> @__vecz_b_sub_group_scan_inclusive_add_Dv4_m(<4 x i64> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x i64> @__vecz_b_sub_group_scan_inclusive_add_Dv4_m(<4 x i64> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i64 @__mux_sub_group_scan_exclusive_add_i64(i64 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i64> poison, i64 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i64> [[HEAD]], <4 x i64> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <4 x i64> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x i64> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_add_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -68,7 +80,13 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_f32(
-; CHECK: call <4 x float> @__vecz_b_sub_group_scan_inclusive_add_Dv4_f(<4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_add_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float -0.0{{.*}}, <4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fadd_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = fadd <4 x float> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x float> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_smin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -82,6 +100,12 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_smin_i32(
 ; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_smin_Dv4_i(<4 x i32> %{{.*}})
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smin.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_smin_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_umin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -94,7 +118,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_umin_i32(
-; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umin_Dv4_j(<4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umin_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_umin_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.umin.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_smax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -107,7 +137,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_smax_i32(
-; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_smax_Dv4_i(<4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_smax_Dv4_i(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smax.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_smax_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_umax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
@@ -120,7 +156,13 @@ entry:
   store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_umax_i32(
-; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umax_Dv4_j(<4 x i32> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umax_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_sub_group_scan_exclusive_umax_i32(i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.umax.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_fmin_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -133,7 +175,13 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_fmin_f32(
-; CHECK: call <4 x float> @__vecz_b_sub_group_scan_inclusive_min_Dv4_f(<4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_min_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmin.v4f32(<4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fmin_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x float> @llvm.minnum.v4f32(<4 x float> [[SCAN]], <4 x float> [[SPLAT]])
+; CHECK: store <4 x float> [[FINAL]],
 }
 
 define spir_kernel void @reduce_scan_incl_fmax_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
@@ -146,5 +194,11 @@ entry:
   store float %call1, float addrspace(1)* %arrayidx2, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_fmax_f32(
-; CHECK: call <4 x float> @__vecz_b_sub_group_scan_inclusive_max_Dv4_f(<4 x float> %{{.*}})
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_max_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmax.v4f32(<4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_sub_group_scan_exclusive_fmax_f32(float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x float> @llvm.maxnum.v4f32(<4 x float> [[SCAN]], <4 x float> [[SPLAT]])
+; CHECK: store <4 x float> [[FINAL]],
 }


### PR DESCRIPTION
This PR finally pulls apart the conflation between sub-groups and vectorized group operations into two distinct concepts.

A sub-group operation (also called a mux sub-group) operates on a set of individual invocations of the kernel function. How this is done is ultimately up to the target (we don't have any examples in tree so this is largely academic at this point).

These operations can be vectorized, increasing the effective apparent sub-group size from the user's point of view (but crucially not from the target's). For example, two invocations of the kernel may be considered a mux sub-group. If the kernel is vectorized by 4, now each invocation does the work of 4 work-items and, as such, 8 work-items are being operated on by the mux sub-group. This is the actual sub-group size from the semantics of OpenCL.

We'd previously discarded mux sub-groups when vectorizing, replacing them entirely with vectorized group operations.

Now, with this PR, each mux sub-group operation is widened to suit the vectorization factor. The vectorized work-items form a "vector group", which operate *on top of* the mux sub-groups.

1. The vectorized sub-group size is the sub-group reduction sum of all vector group sizes
2. The vectorized sub-group local ID is now a step vector on top of the mux sub-group ID
3. Vectorized reductions (including any/all) reduce first over the vector group then over the sub-group
4. Vectorized broadcasts pull out the work-item from the vector group and broadcast that
5. Vectorized scans are more complicated:

Each vector group performs its own scan as before:

`<a,b,c,d> -> <a,a+b,a+b+c,a+b+c+d>` (mux sub-group item 0)
`<x,y,z,w> -> <x,x+y,x+y+z,x+y+z+w>` (mux sub-group item 1)

Each consecutive sub-group invocation needs access to the previous's scan results.

We reduce the operation over the vector:

`<a,b,c,d> -> <a+b+c+d>` (mux sub-group item 0)
`<x,y,z,w> -> <x+y+z+w>` (mux sub-group item 1)

Then perform the *exclusive scan of this*, essentially to shift these results over by one:

`<a+b+c+d> -> I` (mux sub-group item 0)
`<x,y,z,w> -> <a+b+c+d>` (mux sub-group item 1)

These results are then splatted and combined with the initial vector scan result:

`<a,a+b,a+b+c,a+b+c+d> -> <I+a,I+a+b,I+a+b+c,I+a+b+c+d>` (mux sub-group item 0)
`<x,x+y,x+y+z,x+y+z+w> -> <a+b+c+d+x,a+b+c+d+x+y,a+b+c+d+x+y+z,a+b+c+d+x+y+z+w>` (mux sub-group item 1)

When these two vector groups are viewed contiguously along the whole mux sub-group, this is the final scan.