### PR TITLE
[vecz] Remove dead/discarded function demangle

### DIFF
--- a/modules/compiler/vecz/source/vectorization_context.cpp
+++ b/modules/compiler/vecz/source/vectorization_context.cpp
@@ -143,9 +143,6 @@ VectorizationResult &VectorizationContext::getOrCreateBuiltin(
     return result;
   }
 
-  compiler::utils::NameMangler Mangler(&F.getContext());
-  auto const BuiltinName = Mangler.demangleName(F.getName()).str();
-
   result.func = VectorCallee;
 
   // Gather information about the function's arguments.


### PR DESCRIPTION
I'm not entirely sure what's going on here or why the compiler didn't warn about an unused variable, but this is obviously unnecessary.