### PR TITLE
[vecz] Switch from AssertingVH to PoisoningVH

### DIFF
--- a/modules/compiler/vecz/source/include/vectorization_context.h
+++ b/modules/compiler/vecz/source/include/vectorization_context.h
@@ -47,7 +47,7 @@ class VectorizationChoices;
 struct VectorizationResult;
 class VectorizationUnit;
 
-using ActiveUnitMap = llvm::DenseMap<llvm::AssertingVH<const llvm::Function>,
+using ActiveUnitMap = llvm::DenseMap<llvm::PoisoningVH<const llvm::Function>,
                                      VectorizationUnit *>;
 
 /// @brief Holds global (per-module) vectorization state.


### PR DESCRIPTION
When using asserting value handles, if the vectorizer quits unexpectedly then the cache of vectorization units remains active. When the LLVMContext finally comes to clear its memory for functions, the value handles would assert that there are still uses of the functions we'd cached. Since this happens after the time our error handlers have been detatched we'd end up bringing down the OpenCL process, unhelpfully to users.

The intended use of the handle was to catch pointers to Functions being used as keys in the map, where if we deleted that Function LLVM may allocate a new one in its place, and we'd incorrectly end up using a cached vectorization unit for the new function.

Instead we can using a poisoning value handle, which poisons itself if the value is destroyed whilethe handle is still live. If looking up a new value in the map finds a handle from the old value, an assert is triggered. This should still be caught by our error handlers and safely dealt with, as it would happen during the compilation process.

Perhaps another solution would be to install a vecz error handler to clear up the cache so we can keep using asserting value handles. However, this seems like the intended use for the poisoning handles.