### PR TITLE
[spirv-ll] Fix segfault on invalid Function storage classes

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -2583,6 +2583,11 @@ cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
         case spv::StorageClassFunction: {
           // Visible only within the declaring function of the current
           // invocation. Regular function memory.
+          if (!IRBuilder.GetInsertBlock()) {
+            return Error{
+                "invalid SPIR-V: variables can not have a function[7] "
+                "storage class outside of a function"};
+          }
           value = IRBuilder.CreateAlloca(varTy);
           value->setName(name);
           if (initializer) {

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2362,6 +2362,7 @@ set(SPVASM_FILES
   op_opencl_arg_md.spvasm
   unsupported_capability.spvasm
   op_get_kernel_preferred_work_group_size_multiple.spvasm
+  invalid_storage_class.spvasm
   )
 
 if(SpirvAsVersionYear GREATER 2019)

--- a/modules/compiler/spirv-ll/test/spvasm/invalid_storage_class.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/invalid_storage_class.spvasm
@@ -1,0 +1,36 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; It is invalid to use the 'Function' storage class outside of a function.
+; Ensure we gracefully fail when we encounter this.
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: not spirv-ll-tool -a OpenCL -b 64 %spv_file_s 2>&1 | FileCheck %s
+
+; CHECK: variables can not have a function[7] storage class outside of a function
+
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int64
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %54 "_ZTSZN24kernel_bundle_spec_constL22CATCH2_INTERNAL_TEST_4EvE13simple_kernel"
+               OpSource OpenCL_CPP 100000
+       %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+ %my_ptr = OpVariable %_ptr_Function_uint Function


### PR DESCRIPTION
This is invalid SPIR-V (unfortunately generated by DPC++) but that doesn't mean we should segfault. Instead, report an error to the user.