### PR TITLE
[compiler] Ensure we link against static LLVM libraries

### DIFF
--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -70,9 +70,27 @@ target_include_directories(compiler-base PUBLIC
 target_include_directories(compiler-base SYSTEM PUBLIC
   ${spirv-headers_SOURCE_DIR}/include)
 
+# Explicitly link against the individual static versions of the clang
+# libraries, as if clang was built with LLVM_LINK_LLVM_DYLIB=ON, then the
+# 'clangCodeGen' library target brings in the 'LLVM' dynamic library. It is
+# not safe for us to link with LLVM's dynamic library, due to LLVM's use of
+# global/static state.
+foreach(CLANG_LIB "clangCodeGen" "clangFrontend" "clangDriver"
+                  "clangParse" "clangSerialization" "clangSema"
+                  "clangAnalysis" "clangAST" "clangEdit" "clangASTMatchers"
+                  "clangLex" "clangBasic" "clangSupport")
+  list(APPEND CLANG_LIBS
+    "${CA_LLVM_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${CLANG_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endforeach()
+
 target_link_libraries(compiler-base PUBLIC
   builtins cargo mux spirv-ll compiler-utils vecz
-  clangCodeGen LLVMCodeGen LLVMCoroutines LLVMCoverage LLVMLTO)
+  "${CLANG_LIBS}"
+  # Link against version (for clang) on Windows.
+  $<$<BOOL:${WIN32}>:version>
+  LLVMCodeGen LLVMOption LLVMCoroutines LLVMCoverage LLVMLTO LLVMWindowsDriver
+  "$<$<VERSION_GREATER:${LLVM_VERSION_MAJOR},15>:LLVMFrontendHLSL>"
+)
 
 target_compile_definitions(compiler-base PRIVATE
   # Abacus builtins are only included as part of the .cpp files, so these

--- a/modules/compiler/tools/muxc/CMakeLists.txt
+++ b/modules/compiler/tools/muxc/CMakeLists.txt
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-llvm_map_components_to_libnames(llvm_libs all ${LLVM_TARGETS_TO_BUILD})
-
 add_ca_executable(muxc
   ${CMAKE_CURRENT_SOURCE_DIR}/muxc.h
   ${CMAKE_CURRENT_SOURCE_DIR}/muxc.cpp


### PR DESCRIPTION
If we are building with a clang/LLVM built with
`LLVM_LINK_LLVM_DYLIB=ON`, then the static clang libraries we want to
link `compiler-base` against pull in the dynamic "LLVM" library. This
isn't the case for any of our locally built LLVMs, but is the case in
some distributed versions of clang/LLVM, e.g., Ubuntu's.

We are unable to safely link against LLVM's dynamic library for various
reasons ultimately stemming from LLVM's reliance on global state. As an
LLVM library ourselves, we may end up with some LLVM symbols in our
libCL library with others in libLLVM. In the more concrete case of
`llvm::Any` this leads to subtle breakages, as seen in issue #109.

I can't find a nice way around this other than by explicitly linking
against the full paths to the filenames of the static libraries.

Also removes some unused LLVM CMake code in muxc.