### PR TITLE
[host] Ensure we always check llvm::Error objects

### DIFF
--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -335,6 +335,7 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
         callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                  /*data_size*/ 0);
       }
+      llvm::consumeError(std::move(err));
       return cargo::make_unexpected(compiler::Result::FINALIZE_PROGRAM_FAILURE);
     }
     // Register this JITDylib so we can clear up its resources later.
@@ -362,6 +363,7 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
         callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                  /*data_size*/ 0);
       }
+      llvm::consumeError(std::move(err));
       return cargo::make_unexpected(compiler::Result::FINALIZE_PROGRAM_FAILURE);
     }
 
@@ -373,6 +375,7 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
         callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                  /*data_size*/ 0);
       }
+      llvm::consumeError(std::move(err));
       return cargo::make_unexpected(compiler::Result::FINALIZE_PROGRAM_FAILURE);
     }
 
@@ -388,6 +391,7 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
           callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                    /*data_size*/ 0);
         }
+        llvm::consumeError(std::move(err));
         return cargo::make_unexpected(
             compiler::Result::FINALIZE_PROGRAM_FAILURE);
       }

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -229,6 +229,7 @@ compiler::Result HostTarget::initWithBuiltins(
       callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                /*data_size*/ 0);
     }
+    llvm::consumeError(std::move(err));
     return compiler::Result::OUT_OF_MEMORY;
   }
   orc_engine = std::move(*JIT);
@@ -239,6 +240,7 @@ compiler::Result HostTarget::initWithBuiltins(
       callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                /*data_size*/ 0);
     }
+    llvm::consumeError(std::move(err));
     return compiler::Result::FAILURE;
   }
   target_machine = std::move(*TM);


### PR DESCRIPTION
In the case that no callback was provided, we weren't checking the `Error` objects before returning a generic error, which we must do or else LLVM will crash.

Since we can't do anything with the message, we just use `llvm::consumeError` which consumes it and marks it as checked without actually doing anything.