### PR TITLE
[compiler] Add mux sub-group shuffle builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Upgrade guidance:
     DMA builtins.
   * 0.78.0: to introduce mux builtins for sub-group, work-group, and
     vector-group operations.
+  * 0.79.0: to introduce mux builtins for sub-group shuffle operations.
 * The `compiler::ImageArgumentSubstitutionPass` now replaces sampler typed
   parameters in kernel functions with i32 parameters via a wrapper function.
   The `host` target as a consequence now passes samplers to kernels as 32-bit

--- a/doc/modules/mux/changes.rst
+++ b/doc/modules/mux/changes.rst
@@ -11,6 +11,11 @@ version increases mean backward compatible bug fixes have been applied.
    Versions prior to 1.0.0 may contain breaking changes in minor
    versions as the API is still under development.
 
+0.79.0
+------
+
+* Added sub-group shuffle builtins.
+
 0.78.0
 ------
 

--- a/doc/specifications/mux-runtime-spec.rst
+++ b/doc/specifications/mux-runtime-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Runtime Specification
 ================================
 
-   This is version 0.78.0 of the specification.
+   This is version 0.79.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,

--- a/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
@@ -2516,6 +2516,44 @@ class OpGroupLogicalXorKHR
   OpGroupLogicalXorKHR(OpCode const &other) : OpGroupOperation(other) {}
 };
 
+class OpSubgroupShuffle : public OpResult {
+ public:
+  OpSubgroupShuffle(OpCode const &other)
+      : OpResult(other, spv::OpSubgroupShuffleINTEL) {}
+  spv::Id Data() const { return getValueAtOffset(3); }
+  spv::Id InvocationId() const { return getValueAtOffset(4); }
+  static const spv::Op ClassCode = spv::OpSubgroupShuffleINTEL;
+};
+
+class OpSubgroupShuffleUp : public OpResult {
+ public:
+  OpSubgroupShuffleUp(OpCode const &other)
+      : OpResult(other, spv::OpSubgroupShuffleUpINTEL) {}
+  spv::Id Previous() const { return getValueAtOffset(3); }
+  spv::Id Current() const { return getValueAtOffset(4); }
+  spv::Id Delta() const { return getValueAtOffset(5); }
+  static const spv::Op ClassCode = spv::OpSubgroupShuffleUpINTEL;
+};
+
+class OpSubgroupShuffleDown : public OpResult {
+ public:
+  OpSubgroupShuffleDown(OpCode const &other)
+      : OpResult(other, spv::OpSubgroupShuffleDownINTEL) {}
+  spv::Id Current() const { return getValueAtOffset(3); }
+  spv::Id Next() const { return getValueAtOffset(4); }
+  spv::Id Delta() const { return getValueAtOffset(5); }
+  static const spv::Op ClassCode = spv::OpSubgroupShuffleDownINTEL;
+};
+
+class OpSubgroupShuffleXor : public OpResult {
+ public:
+  OpSubgroupShuffleXor(OpCode const &other)
+      : OpResult(other, spv::OpSubgroupShuffleXorINTEL) {}
+  spv::Id Data() const { return getValueAtOffset(3); }
+  spv::Id Value() const { return getValueAtOffset(4); }
+  static const spv::Op ClassCode = spv::OpSubgroupShuffleXorINTEL;
+};
+
 class OpReadPipe : public OpResult {
  public:
   OpReadPipe(OpCode const &other) : OpResult(other, spv::OpReadPipe) {}

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <compiler/utils/builtin_info.h>
 #include <compiler/utils/target_extension_types.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
@@ -6755,6 +6756,100 @@ template <>
 cargo::optional<Error> Builder::create<OpGroupLogicalXorKHR>(
     const OpGroupLogicalXorKHR *op) {
   generateReduction(op, "logical_xor");
+  return cargo::nullopt;
+}
+
+template <>
+cargo::optional<Error> Builder::create<OpSubgroupShuffle>(
+    const OpSubgroupShuffle *op) {
+  std::string muxBuiltinName = "__mux_sub_group_shuffle_";
+
+  auto *data = module.getValue(op->Data());
+  SPIRV_LL_ASSERT_PTR(data);
+
+  auto *invocation_id = module.getValue(op->InvocationId());
+  SPIRV_LL_ASSERT_PTR(invocation_id);
+
+  auto retTy = module.getType(op->IdResultType());
+  SPIRV_LL_ASSERT_PTR(retTy);
+
+  muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
+
+  auto *const ci = createBuiltinCall(
+      muxBuiltinName, retTy, {data, invocation_id}, /*convergent*/ true);
+  module.addID(op->IdResult(), op, ci);
+  return cargo::nullopt;
+}
+
+template <>
+cargo::optional<Error> Builder::create<OpSubgroupShuffleUp>(
+    const OpSubgroupShuffleUp *op) {
+  std::string muxBuiltinName = "__mux_sub_group_shuffle_up_";
+
+  auto *previous = module.getValue(op->Previous());
+  SPIRV_LL_ASSERT_PTR(previous);
+
+  auto *current = module.getValue(op->Current());
+  SPIRV_LL_ASSERT_PTR(current);
+
+  auto *delta = module.getValue(op->Delta());
+  SPIRV_LL_ASSERT_PTR(delta);
+
+  auto retTy = module.getType(op->IdResultType());
+  SPIRV_LL_ASSERT_PTR(retTy);
+
+  muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
+
+  auto *const ci = createBuiltinCall(
+      muxBuiltinName, retTy, {previous, current, delta}, /*convergent*/ true);
+  module.addID(op->IdResult(), op, ci);
+  return cargo::nullopt;
+}
+
+template <>
+cargo::optional<Error> Builder::create<OpSubgroupShuffleDown>(
+    const OpSubgroupShuffleDown *op) {
+  std::string muxBuiltinName = "__mux_sub_group_shuffle_down_";
+
+  auto *current = module.getValue(op->Current());
+  SPIRV_LL_ASSERT_PTR(current);
+
+  auto *next = module.getValue(op->Next());
+  SPIRV_LL_ASSERT_PTR(next);
+
+  auto *delta = module.getValue(op->Delta());
+  SPIRV_LL_ASSERT_PTR(delta);
+
+  auto retTy = module.getType(op->IdResultType());
+  SPIRV_LL_ASSERT_PTR(retTy);
+
+  muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
+
+  auto *const ci = createBuiltinCall(
+      muxBuiltinName, retTy, {current, next, delta}, /*convergent*/ true);
+  module.addID(op->IdResult(), op, ci);
+  return cargo::nullopt;
+}
+
+template <>
+cargo::optional<Error> Builder::create<OpSubgroupShuffleXor>(
+    const OpSubgroupShuffleXor *op) {
+  std::string muxBuiltinName = "__mux_sub_group_shuffle_xor_";
+
+  auto *data = module.getValue(op->Data());
+  SPIRV_LL_ASSERT_PTR(data);
+
+  auto *value = module.getValue(op->Value());
+  SPIRV_LL_ASSERT_PTR(value);
+
+  auto retTy = module.getType(op->IdResultType());
+  SPIRV_LL_ASSERT_PTR(retTy);
+
+  muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
+
+  auto *const ci = createBuiltinCall(muxBuiltinName, retTy, {data, value},
+                                     /*convergent*/ true);
+  module.addID(op->IdResult(), op, ci);
   return cargo::nullopt;
 }
 

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -17,6 +17,7 @@
 #include <spirv-ll/builder.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
+#include <spirv/unified1/spirv.hpp>
 
 spirv_ll::Context::Context()
     : llvmContext(new llvm::LLVMContext), llvmContextIsOwned(true) {}
@@ -970,6 +971,18 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
         break;
       case spv::OpGroupLogicalXorKHR:
         error = builder.create<OpGroupLogicalXorKHR>(op);
+        break;
+      case spv::OpSubgroupShuffleINTEL:
+        error = builder.create<OpSubgroupShuffle>(op);
+        break;
+      case spv::OpSubgroupShuffleUpINTEL:
+        error = builder.create<OpSubgroupShuffleUp>(op);
+        break;
+      case spv::OpSubgroupShuffleDownINTEL:
+        error = builder.create<OpSubgroupShuffleDown>(op);
+        break;
+      case spv::OpSubgroupShuffleXorINTEL:
+        error = builder.create<OpSubgroupShuffleXor>(op);
         break;
       case spv::OpReadPipe:
         error = builder.create<OpReadPipe>(op);

--- a/modules/compiler/spirv-ll/source/opcodes.cpp
+++ b/modules/compiler/spirv-ll/source/opcodes.cpp
@@ -315,6 +315,10 @@ bool OpCode::hasResult() const {
     case spv::OpSubgroupBallotKHR:
     case spv::OpSubgroupFirstInvocationKHR:
     case spv::OpSubgroupReadInvocationKHR:
+    case spv::OpSubgroupShuffleINTEL:
+    case spv::OpSubgroupShuffleUpINTEL:
+    case spv::OpSubgroupShuffleDownINTEL:
+    case spv::OpSubgroupShuffleXorINTEL:
     case spv::OpTranspose:
     case spv::OpUConvert:
     case spv::OpUDiv:

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2374,7 +2374,12 @@ endif()
 
 if (SpirvAsVersionYear GREATER_EQUAL 2022)
   list(APPEND SPVASM_FILES
-    intel_opt_none.spvasm)
+    intel_opt_none.spvasm
+    subgroup_shuffle_intel.spvasm
+    subgroup_shuffle_up_intel.spvasm
+    subgroup_shuffle_down_intel.spvasm
+    subgroup_shuffle_xor_intel.spvasm
+  )
 endif()
 
 if (SpirvAsVersionYear GREATER 2022)

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_down_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_down_intel.spvasm
@@ -1,0 +1,74 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: spirv-as-v2022+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
+; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Float64
+               OpCapability Int64
+               OpCapability Groups
+               OpCapability Int8
+               OpCapability SubgroupShuffleINTEL
+
+               OpExtension "SPV_INTEL_subgroups"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource OpenCL_CPP 100000
+
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+
+                      %void = OpTypeVoid
+                    %double = OpTypeFloat 64
+%_ptr_CrossWorkgroup_double = OpTypePointer CrossWorkgroup %double
+                      %uint = OpTypeInt 32 0
+  %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+                     %ulong = OpTypeInt 64 0
+                   %v3ulong = OpTypeVector %ulong 3
+        %_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+ %_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+
+                        %35 = OpTypeFunction %void %_ptr_CrossWorkgroup_double %_ptr_CrossWorkgroup_ulong
+
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3ulong Input
+
+         %uint_1 = OpConstant %uint 1
+
+; CHECK: call spir_func double @__mux_sub_group_shuffle_down_f64(double %{{.*}}, double %{{.*}}, i32 1)
+          %36 = OpFunction %void None %35
+%_arg_out_acc = OpFunctionParameter %_ptr_CrossWorkgroup_double
+%_arg_inp_acc = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
+       %entry = OpLabel
+
+          %26 = OpLoad %v3ulong %__spirv_BuiltInGlobalInvocationId
+          %24 = OpCompositeExtract %ulong %26 0
+
+   %inp_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %_arg_inp_acc %24
+   %out_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %_arg_out_acc %24
+
+          %38 = OpLoad %ulong %inp_ptr_i Aligned 8
+%conv_i_i_i_i = OpConvertUToF %double %38
+
+ %call1_i_i_i = OpSubgroupShuffleDownINTEL %double %conv_i_i_i_i %conv_i_i_i_i %uint_1
+
+                OpStore %out_ptr_i %call1_i_i_i Aligned 8
+
+                OpReturn
+                OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_intel.spvasm
@@ -1,0 +1,84 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: spirv-as-v2022+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
+; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Float64
+               OpCapability Int64
+               OpCapability Groups
+               OpCapability Int8
+               OpCapability SubgroupShuffleINTEL
+
+               OpExtension "SPV_INTEL_subgroups"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource OpenCL_CPP 100000
+
+               OpName %__spirv_BuiltInSubgroupSize "__spirv_BuiltInSubgroupSize"
+
+               OpDecorate %__spirv_BuiltInSubgroupSize LinkageAttributes "__spirv_BuiltInSubgroupSize" Import
+               OpDecorate %__spirv_BuiltInSubgroupSize Constant
+               OpDecorate %__spirv_BuiltInSubgroupSize BuiltIn SubgroupSize
+               OpDecorate %__spirv_BuiltInSubgroupSize Alignment 4
+
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+
+                      %void = OpTypeVoid
+                    %double = OpTypeFloat 64
+%_ptr_CrossWorkgroup_double = OpTypePointer CrossWorkgroup %double
+                      %uint = OpTypeInt 32 0
+  %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+                     %ulong = OpTypeInt 64 0
+                   %v3ulong = OpTypeVector %ulong 3
+        %_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+ %_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+
+                        %35 = OpTypeFunction %void %_ptr_CrossWorkgroup_double %_ptr_CrossWorkgroup_ulong
+
+%__spirv_BuiltInSubgroupSize = OpVariable %_ptr_CrossWorkgroup_uint CrossWorkgroup
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3ulong Input
+
+%uint_4294967295 = OpConstant %uint 4294967295
+
+; CHECK: call spir_func double @__mux_sub_group_shuffle_f64(double %{{.*}}, i32 %{{.*}})
+          %36 = OpFunction %void None %35
+%_arg_out_acc = OpFunctionParameter %_ptr_CrossWorkgroup_double
+%_arg_inp_acc = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
+       %entry = OpLabel
+
+          %26 = OpLoad %v3ulong %__spirv_BuiltInGlobalInvocationId
+          %24 = OpCompositeExtract %ulong %26 0
+
+   %inp_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %_arg_inp_acc %24
+   %out_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %_arg_out_acc %24
+
+          %38 = OpLoad %ulong %inp_ptr_i Aligned 8
+%conv_i_i_i_i = OpConvertUToF %double %38
+
+          %78 = OpLoad %uint %__spirv_BuiltInSubgroupSize Aligned 4
+       %dec_i = OpIAdd %uint %78 %uint_4294967295
+ %call1_i_i_i = OpSubgroupShuffleINTEL %double %conv_i_i_i_i %dec_i
+
+                OpStore %out_ptr_i %call1_i_i_i Aligned 8
+
+                OpReturn
+                OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_up_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_up_intel.spvasm
@@ -1,0 +1,74 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: spirv-as-v2022+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
+; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Float64
+               OpCapability Int64
+               OpCapability Groups
+               OpCapability Int8
+               OpCapability SubgroupShuffleINTEL
+
+               OpExtension "SPV_INTEL_subgroups"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource OpenCL_CPP 100000
+
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+
+                      %void = OpTypeVoid
+                    %double = OpTypeFloat 64
+%_ptr_CrossWorkgroup_double = OpTypePointer CrossWorkgroup %double
+                      %uint = OpTypeInt 32 0
+  %_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+                     %ulong = OpTypeInt 64 0
+                   %v3ulong = OpTypeVector %ulong 3
+        %_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+ %_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+
+                        %35 = OpTypeFunction %void %_ptr_CrossWorkgroup_double %_ptr_CrossWorkgroup_ulong
+
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3ulong Input
+
+         %uint_1 = OpConstant %uint 1
+
+; CHECK: call spir_func double @__mux_sub_group_shuffle_up_f64(double %{{.*}}, double %{{.*}}, i32 1)
+          %36 = OpFunction %void None %35
+%_arg_out_acc = OpFunctionParameter %_ptr_CrossWorkgroup_double
+%_arg_inp_acc = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
+       %entry = OpLabel
+
+          %26 = OpLoad %v3ulong %__spirv_BuiltInGlobalInvocationId
+          %24 = OpCompositeExtract %ulong %26 0
+
+   %inp_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %_arg_inp_acc %24
+   %out_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_double %_arg_out_acc %24
+
+          %38 = OpLoad %ulong %inp_ptr_i Aligned 8
+%conv_i_i_i_i = OpConvertUToF %double %38
+
+ %call1_i_i_i = OpSubgroupShuffleUpINTEL %double %conv_i_i_i_i %conv_i_i_i_i %uint_1
+
+                OpStore %out_ptr_i %call1_i_i_i Aligned 8
+
+                OpReturn
+                OpFunctionEnd

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_xor_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_xor_intel.spvasm
@@ -1,0 +1,141 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: spirv-as-v2022+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 \
+; RUN:   -c GenericPointer -c SubgroupShuffleINTEL \
+; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Float16Buffer
+               OpCapability Int64
+               OpCapability GenericPointer
+               OpCapability Int8
+               OpCapability SubgroupShuffleINTEL
+               OpExtension "SPV_INTEL_subgroups"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %31 "permute_sub_group_kernel" %permute_sub_group_kernel %__spirv_BuiltInSubgroupSize %__spirv_BuiltInLocalInvocationId %__spirv_BuiltInWorkgroupSize
+               OpSource OpenCL_CPP 100000
+               OpName %entry "entry"
+               OpName %for_cond_i "for.cond.i"
+               OpName %for_body_i "for.body.i"
+               OpName %exit_label "exit"
+               OpDecorate %permute_sub_group_kernel LinkageAttributes "permute_sub_group_kernel" Import
+               OpDecorate %permute_sub_group_kernel Constant
+               OpDecorate %permute_sub_group_kernel BuiltIn SubgroupLocalInvocationId
+               OpDecorate %permute_sub_group_kernel Alignment 4
+               OpDecorate %__spirv_BuiltInSubgroupSize LinkageAttributes "__spirv_BuiltInSubgroupSize" Import
+               OpDecorate %__spirv_BuiltInSubgroupSize Constant
+               OpDecorate %__spirv_BuiltInSubgroupSize BuiltIn SubgroupSize
+               OpDecorate %__spirv_BuiltInSubgroupSize Alignment 4
+               OpDecorate %__spirv_BuiltInLocalInvocationId LinkageAttributes "__spirv_BuiltInLocalInvocationId" Import
+               OpDecorate %__spirv_BuiltInLocalInvocationId Constant
+               OpDecorate %__spirv_BuiltInLocalInvocationId BuiltIn LocalInvocationId
+               OpDecorate %__spirv_BuiltInLocalInvocationId Alignment 32
+               OpDecorate %__spirv_BuiltInWorkgroupSize LinkageAttributes "__spirv_BuiltInWorkgroupSize" Import
+               OpDecorate %__spirv_BuiltInWorkgroupSize Constant
+               OpDecorate %__spirv_BuiltInWorkgroupSize BuiltIn WorkgroupSize
+               OpDecorate %__spirv_BuiltInWorkgroupSize Alignment 32
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+               OpDecorate %_arg_res_acc Alignment 1
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+      %uchar = OpTypeInt 8 0
+  %ulong_129 = OpConstant %ulong 129
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+    %uchar_0 = OpConstant %uchar 0
+    %uchar_1 = OpConstant %uchar 1
+     %uint_2 = OpConstant %uint 2
+    %ulong_3 = OpConstant %ulong 3
+    %ulong_2 = OpConstant %ulong 2
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+    %v3ulong = OpTypeVector %ulong 3
+    %_ptr_Input_v3ulong = OpTypePointer Input %v3ulong
+%_ptr_CrossWorkgroup_v3ulong = OpTypePointer CrossWorkgroup %v3ulong
+%_arr_uchar_ulong_129 = OpTypeArray %uchar %ulong_129
+%_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uchar = OpTypePointer CrossWorkgroup %uchar
+         %30 = OpTypeFunction %void %_ptr_CrossWorkgroup_uchar
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+      %float = OpTypeFloat 32
+       %half = OpTypeFloat 16
+       %bool = OpTypeBool
+%_arr_ulong_ulong_3 = OpTypeArray %ulong %ulong_3
+%_ptr_Function__arr_ulong_ulong_3 = OpTypePointer Function %_arr_ulong_ulong_3
+%_ptr_Generic__arr_ulong_ulong_3 = OpTypePointer Generic %_arr_ulong_ulong_3
+%_ptr_Function_uchar = OpTypePointer Function %uchar
+        %203 = OpTypeFunction %void %_ptr_Generic__arr_ulong_ulong_3 %ulong %uint
+        %228 = OpTypeFunction %void %_ptr_Generic__arr_ulong_ulong_3 %ulong
+%permute_sub_group_kernel = OpVariable %_ptr_CrossWorkgroup_uint CrossWorkgroup
+%__spirv_BuiltInSubgroupSize = OpVariable %_ptr_CrossWorkgroup_uint CrossWorkgroup
+%__spirv_BuiltInLocalInvocationId = OpVariable %_ptr_CrossWorkgroup_v3ulong CrossWorkgroup
+%__spirv_BuiltInWorkgroupSize = OpVariable %_ptr_CrossWorkgroup_v3ulong CrossWorkgroup
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3ulong Input
+       %true = OpConstantTrue %bool
+
+         %31 = OpFunction %void None %30
+%_arg_res_acc = OpFunctionParameter %_ptr_CrossWorkgroup_uchar
+      %entry = OpLabel
+         %26 = OpLoad %v3ulong %__spirv_BuiltInGlobalInvocationId
+         %43 = OpCompositeExtract %ulong %26 0
+         %45 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %__spirv_BuiltInWorkgroupSize %uint_0 %uint_0
+         %46 = OpLoad %ulong %45 Aligned 32
+         %48 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %__spirv_BuiltInLocalInvocationId %uint_0 %uint_1
+         %49 = OpLoad %ulong %48 Aligned 8
+         %50 = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_ulong %__spirv_BuiltInLocalInvocationId %uint_0 %uint_0
+         %51 = OpLoad %ulong %50 Aligned 32
+         %52 = OpLoad %uint %permute_sub_group_kernel Aligned 4
+      %add_i = OpIAdd %uint %52 %uint_1
+%conv_i_i_i_i = OpConvertUToF %float %add_i
+%conv_i_i_i_i_i = OpFConvert %half %conv_i_i_i_i
+         %58 = OpLoad %uint %__spirv_BuiltInSubgroupSize Aligned 4
+               OpBranch %for_cond_i
+ %for_cond_i = OpLabel
+    %res_0_i = OpPhi %bool %true %entry %and26_i %for_body_i
+   %mask_0_i = OpPhi %uint %uint_1 %entry %shl_i %for_body_i
+  %cmp_not_i = OpIEqual %bool %mask_0_i %uint_0
+               OpBranchConditional %cmp_not_i %exit_label %for_body_i
+
+; CHECK-LABEL: for.cond.i:
+; CHECK: call spir_func half @__mux_sub_group_shuffle_xor_f16(half %{{.*}}, i32 %{{.*}})
+
+ %for_body_i = OpLabel
+%call3_i_i_i = OpSubgroupShuffleXorINTEL %half %conv_i_i_i_i_i %mask_0_i
+      %xor_i = OpBitwiseXor %uint %52 %mask_0_i
+     %add5_i = OpIAdd %uint %xor_i %uint_1
+%conv_i_i_i32_i = OpConvertUToF %float %add5_i
+%conv_i_i_i_i33_i = OpFConvert %half %conv_i_i_i32_i
+%cmp_i_i_i_i = OpFOrdEqual %bool %call3_i_i_i %conv_i_i_i_i33_i
+     %cmp9_i = OpUGreaterThanEqual %bool %xor_i %58
+         %73 = OpSelect %bool %cmp_i_i_i_i %true %cmp9_i
+    %and26_i = OpLogicalAnd %bool %res_0_i %73
+      %shl_i = OpShiftLeftLogical %uint %mask_0_i %uint_1
+               OpBranch %for_cond_i
+%exit_label = OpLabel
+  %add_ptr_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %_arg_res_acc %43
+%mul_i_i_i_i = OpIMul %ulong %49 %46
+%add_i_i_i_i = OpIAdd %ulong %mul_i_i_i_i %51
+%arrayidx_i_i = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_uchar %add_ptr_i %add_i_i_i_i
+%frombool17_i = OpSelect %uchar %res_0_i %uchar_1 %uchar_0
+               OpStore %arrayidx_i_i %frombool17_i Aligned 1
+               OpReturn
+               OpFunctionEnd

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -24,6 +24,7 @@
 #include <spirv-ll/builder.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
+#include <spirv/unified1/spirv.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -480,6 +481,7 @@ cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
         "SPV_KHR_uniform_group_instructions",
         "SPV_INTEL_optnone",
         "SPV_INTEL_memory_access_aliasing",
+        "SPV_INTEL_subgroups",
     });
   } else {
     for (auto extension : extensions) {

--- a/modules/compiler/test/lit/passes/define-subgroup-shuffles.ll
+++ b/modules/compiler/test/lit/passes/define-subgroup-shuffles.ll
@@ -1,0 +1,40 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes define-mux-builtins,verify < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+declare i64 @__mux_sub_group_shuffle_i64(i64 %val, i32 %lid)
+; CHECK-LABEL: define i64 @__mux_sub_group_shuffle_i64(i64 %val, i32 %lid) {
+; CHECK: ret i64 %val
+
+declare half @__mux_sub_group_shuffle_xor_f16(half %val, i32 %xor_val)
+; CHECK-LABEL: define half @__mux_sub_group_shuffle_xor_f16(half %val, i32 %xor_val) {
+; CHECK: ret half %val
+
+declare i8 @__mux_sub_group_shuffle_down_i8(i8 %curr, i8 %next, i32 %delta)
+; CHECK-LABEL: define i8 @__mux_sub_group_shuffle_down_i8(i8 %curr, i8 %next, i32 %delta) {
+; CHECK: %eqzero = icmp eq i32 %delta, 0
+; CHECK: %sel = select i1 %eqzero, i8 %curr, i8 %next
+; CHECK: ret i8 %sel
+
+declare float @__mux_sub_group_shuffle_up_f32(float %prev, float %curr, i32 %delta)
+; CHECK-LABEL: define float @__mux_sub_group_shuffle_up_f32(float %prev, float %curr, i32 %delta) {
+; CHECK: %eqzero = icmp eq i32 %delta, 0
+; CHECK: %sel = select i1 %eqzero, float %curr, float %prev
+; CHECK: ret float %sel

--- a/modules/compiler/test/lit/passes/degenerate-sub-group-shuffles.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-group-shuffles.ll
@@ -1,0 +1,82 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes degenerate-sub-groups,verify < %s | FileCheck %s
+
+; Check that the DegenerateSubGroupPass correctly replaces sub-group
+; builtins with work-group collective calls.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-LABEL: define spir_kernel void @kernel(i32 %x) #0
+; CHECK: call i32 @__mux_get_sub_group_local_id()
+; CHECK: call i32 @__mux_sub_group_shuffle_i32(i32 %x, i32 %lid)
+define spir_kernel void @kernel(i32 %x) #0 {
+entry:
+  %lid = call i32 @__mux_get_sub_group_local_id()
+  %call = call i32 @__mux_sub_group_shuffle_i32(i32 %x, i32 %lid)
+  ret void
+}
+
+; CHECK-LABEL: define spir_func i32 @linear_id_helper() {
+; CHECK: %lid = call i32 @__mux_get_sub_group_local_id()
+define spir_func i32 @linear_id_helper() {
+entry:
+  %lid = call i32 @__mux_get_sub_group_local_id()
+  ret i32 %lid
+}
+
+; CHECK-LABEL: define spir_func i32 @shuffle_helper(i32 %x) {
+; CHECK: = call i32 @linear_id_helper()
+; CHECK: = call i32 @__mux_sub_group_shuffle_i32(i32 %x, i32 %lid)
+define spir_func i32 @shuffle_helper(i32 %x) {
+entry:
+  %lid = call i32 @linear_id_helper()
+  %shuffle = call i32 @__mux_sub_group_shuffle_i32(i32 %x, i32 %lid)
+  ret i32 %shuffle
+}
+
+; CHECK-LABEL: define spir_kernel void @kernel_caller(i32 %x) #0 {
+; CHECK:  %call = call i32 @shuffle_helper(i32 %x)
+define spir_kernel void @kernel_caller(i32 %x) #0 {
+entry:
+  %call = call i32 @shuffle_helper(i32 %x)
+  ret void
+}
+
+; CHECK-LABEL: define spir_kernel void @degenerate_caller.degenerate-subgroups(ptr %out) #1 {
+; CHECK:  %call = call i32 @linear_id_helper.degenerate-subgroups()
+; CHECK: }
+
+; CHECK-LABEL: define spir_func i32 @linear_id_helper.degenerate-subgroups() #2 {
+; CHECK: %0 = call i64 @__mux_get_local_linear_id()
+; CHECK: %1 = trunc i64 %0 to i32
+define spir_kernel void @degenerate_caller(ptr %out) #0 {
+entry:
+  %call = call i32 @linear_id_helper()
+  store i32 %call, ptr %out
+  ret void
+}
+
+declare i32 @__mux_get_sub_group_local_id()
+declare i32 @__mux_sub_group_shuffle_i32(i32, i32)
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+; CHECK: attributes #0 = { "mux-kernel"="entry-point" }
+; CHECK: attributes #1 = { "mux-base-fn-name"="degenerate_caller" "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
+; CHECK: attributes #2 = { "mux-base-fn-name"="linear_id_helper" }

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
@@ -22,11 +22,26 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
+; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test
+; CHECK: (i32 [[X:%.*]]) #[[ATTR1:[0-9]+]]
+; CHECK: entry:
+; CHECK: [[RESULT:%.*]] = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[X]])
+; CHECK: ret i32 [[RESULT]]
+; CHECK: }
 define spir_func i32 @sub_group_reduce_add_test(i32 %x) #0 {
 entry:
   %call = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 %x)
   ret i32 %call
 }
+
+; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
+
+; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test.degenerate-subgroups
+; CHECK: (i32 [[Y:%.*]]) #[[ATTR0:[0-9]+]]
+; CHECK: entry:
+; CHECK: [[RESULT:%.*]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[Y]])
+; CHECK: ret i32 [[RESULT]]
+; CHECK: }
 
 declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
 
@@ -36,20 +51,5 @@ attributes #0 = { "mux-kernel"="entry-point" }
 
 !0 = !{i32 3, i32 0}
 
-; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test.degenerate-subgroups
-; CHECK: (i32 [[Y:%.*]]) #[[ATTR0:[0-9]+]]
-; CHECK: entry:
-; CHECK: [[RESULT:%.*]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[Y]])
-; CHECK: ret i32 [[RESULT]]
-; CHECK: }
-
-; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test
-; CHECK: (i32 [[X:%.*]]) #[[ATTR1:[0-9]+]]
-; CHECK: entry:
-; CHECK: [[RESULT:%.*]] = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[X]])
-; CHECK: ret i32 [[RESULT]]
-; CHECK: }
-
-; CHECK-DAG: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
-; CHECK-DAG: attributes #[[ATTR0]] = { "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
+; CHECK-DAG: attributes #[[ATTR0]] = { "mux-base-fn-name"="sub_group_reduce_add_test" "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
 ; CHECK-DAG: attributes #[[ATTR1]] = { "mux-kernel"="entry-point" }

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
@@ -29,65 +29,27 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
+; CHECK: define spir_func i32 @clone_this(i32 [[X6:%.+]]) {
+; CHECK: entry:
+; CHECK:   [[R6:%.+]] = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[X6]])
+; CHECK:   ret i32 [[R6]]
+; CHECK: }
 define spir_func i32 @clone_this(i32 %x) {
 entry:
   %call = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 %x)
   ret i32 %call
 }
 
-define spir_func i32 @shared(i32 %x) {
-entry:
-  %sqr = mul i32 %x, %x
-  ret i32 %sqr
-}
-
-define spir_func i32 @sub_groups(i32 %x) #0 {
-entry:
-  %call1 = call spir_func i32 @clone_this(i32 %x)
-  %call2 = call spir_func i32 @shared(i32 %x)
-  %add = add i32 %call1, %call2
-  ret i32 %add
-}
-
-define spir_func i32 @no_sub_groups(i32 %x) #0 {
-entry:
-  %call = call spir_func i32 @shared(i32 %x)
-  ret i32 %call
-}
-
-declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
-
-!opencl.ocl.version = !{!0}
-
-!0 = !{i32 3, i32 0}
-
-attributes #0 = { "mux-kernel"="entry-point" }
-
-; CHECK: define spir_func i32 @clone_this.degenerate-subgroups(i32 [[X1:%.+]]) {
-; CHECK: entry:
-; CHECK:   [[R1:%.+]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[X1]])
-; CHECK:   ret i32 [[R1]]
-; CHECK: }
-
 ; CHECK: define spir_func i32 @shared(i32 [[X2:%.+]]) {
 ; CHECK: entry:
 ; CHECK:   [[R2:%.+]] = mul i32 [[X2]], [[X2]]
 ; CHECK:   ret i32 [[R2]]
 ; CHECK: }
-
-; CHECK: define spir_func i32 @sub_groups.degenerate-subgroups(i32 [[X3:%.+]]) #[[ATTR0:[0-9]+]] {
-; CHECK: entry:
-; CHECK:   [[C3_1:%.+]] = call spir_func i32 @clone_this.degenerate-subgroups(i32 [[X3]])
-; CHECK:   [[C3_2:%.+]] = call spir_func i32 @shared(i32 [[X3]])
-; CHECK:   [[R3:%.+]] = add i32 [[C3_1]], [[C3_2]]
-; CHECK:   ret i32 [[R3:%.+]]
-; CHECK: }
-
-; CHECK: define spir_func i32 @no_sub_groups(i32 [[X4:%.+]]) #[[ATTR0]] {
-; CHECK: entry:
-; CHECK:   [[R4:%.+]] = call spir_func i32 @shared(i32 [[X4]])
-; CHECK:   ret i32 [[R4]]
-; CHECK: }
+define spir_func i32 @shared(i32 %x) {
+entry:
+  %sqr = mul i32 %x, %x
+  ret i32 %sqr
+}
 
 ; CHECK: define spir_func i32 @sub_groups(i32 [[X5:%.+]]) #[[ATTR1:[0-9]+]] {
 ; CHECK: entry:
@@ -96,13 +58,49 @@ attributes #0 = { "mux-kernel"="entry-point" }
 ; CHECK:   [[R5:%.+]] = add i32 [[C5_1]], [[C5_2]]
 ; CHECK:   ret i32 [[R5]]
 ; CHECK: }
+define spir_func i32 @sub_groups(i32 %x) #0 {
+entry:
+  %call1 = call spir_func i32 @clone_this(i32 %x)
+  %call2 = call spir_func i32 @shared(i32 %x)
+  %add = add i32 %call1, %call2
+  ret i32 %add
+}
 
-; CHECK: define spir_func i32 @clone_this(i32 [[X6:%.+]]) {
+; CHECK: define spir_func i32 @no_sub_groups(i32 [[X4:%.+]]) #[[ATTR0:[0-9]+]] {
 ; CHECK: entry:
-; CHECK:   [[R6:%.+]] = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[X6]])
-; CHECK:   ret i32 [[R6]]
+; CHECK:   [[R4:%.+]] = call spir_func i32 @shared(i32 [[X4]])
+; CHECK:   ret i32 [[R4]]
+; CHECK: }
+define spir_func i32 @no_sub_groups(i32 %x) #0 {
+entry:
+  %call = call spir_func i32 @shared(i32 %x)
+  ret i32 %call
+}
+
+declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
+; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
+
+; CHECK: define spir_func i32 @sub_groups.degenerate-subgroups(i32 [[X3:%.+]]) #[[ATTR2:[0-9]+]] {
+; CHECK: entry:
+; CHECK:   [[C3_1:%.+]] = call spir_func i32 @clone_this.degenerate-subgroups(i32 [[X3]])
+; CHECK:   [[C3_2:%.+]] = call spir_func i32 @shared(i32 [[X3]])
+; CHECK:   [[R3:%.+]] = add i32 [[C3_1]], [[C3_2]]
+; CHECK:   ret i32 [[R3:%.+]]
 ; CHECK: }
 
-; CHECK-DAG: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
+; CHECK: define spir_func i32 @clone_this.degenerate-subgroups(i32 [[X1:%.+]]) #[[ATTR3:[0-9]+]] {
+; CHECK: entry:
+; CHECK:   [[R1:%.+]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[X1]])
+; CHECK:   ret i32 [[R1]]
+; CHECK: }
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
 ; CHECK-DAG: attributes #[[ATTR0]] = { "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
 ; CHECK-DAG: attributes #[[ATTR1]] = { "mux-kernel"="entry-point" }
+; CHECK-DAG: attributes #[[ATTR2]] = { "mux-base-fn-name"="sub_groups" "mux-degenerate-subgroups" "mux-kernel"="entry-point" }
+; CHECK-DAG: attributes #[[ATTR3]] = { "mux-base-fn-name"="clone_this" }

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -124,12 +124,20 @@ enum BaseBuiltinID {
       eMuxBuiltin##SCOPE##groupScanLogicalOrInclusive,                         \
       eMuxBuiltin##SCOPE##groupScanLogicalOrExclusive,                         \
       eMuxBuiltin##SCOPE##groupScanLogicalXorInclusive,                        \
-      eLastMux##SCOPE##groupCollectiveBuiltin,                                 \
-      eMuxBuiltin##SCOPE##groupScanLogicalXorExclusive =                       \
-          eLastMux##SCOPE##groupCollectiveBuiltin
+      eMuxBuiltin##SCOPE##groupScanLogicalXorExclusive
   GROUP_BUILTINS(Work),
+  eLastMuxWorkgroupCollectiveBuiltin =
+      eMuxBuiltinWorkgroupScanLogicalXorExclusive,
   GROUP_BUILTINS(Sub),
+  // Extra subgroup shuffle operations
+  eMuxBuiltinSubgroupShuffle,
+  eMuxBuiltinSubgroupShuffleUp,
+  eMuxBuiltinSubgroupShuffleDown,
+  eMuxBuiltinSubgroupShuffleXor,
+  eLastMuxSubgroupCollectiveBuiltin = eMuxBuiltinSubgroupShuffleXor,
   GROUP_BUILTINS(Vec),
+  eLastMuxVecgroupCollectiveBuiltin =
+      eMuxBuiltinVecgroupScanLogicalXorExclusive,
 
   // Marker - target builtins should start from here.
   eFirstTargetBuiltin,

--- a/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
+++ b/modules/compiler/utils/include/compiler/utils/group_collective_helpers.h
@@ -69,6 +69,10 @@ struct GroupCollective {
     ScanInclusive,
     ScanExclusive,
     Broadcast,
+    Shuffle,
+    ShuffleUp,
+    ShuffleDown,
+    ShuffleXor,
   };
 
   /// @brief The possible scopes of a group collective.
@@ -93,6 +97,10 @@ struct GroupCollective {
   bool isReduction() const { return Op == OpKind::Reduction; }
   /// @brief Returns true for broadcast collective operations.
   bool isBroadcast() const { return Op == OpKind::Broadcast; }
+  bool isShuffleLike() const {
+    return Op == OpKind::Shuffle || Op == OpKind::ShuffleUp ||
+           Op == OpKind::ShuffleDown || Op == OpKind::ShuffleXor;
+  }
   /// @brief Returns true for sub-group collective operations.
   bool isSubGroupScope() const { return Scope == ScopeKind::SubGroup; }
   /// @brief Returns true for work-group collective operations.

--- a/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
+++ b/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
@@ -68,117 +68,16 @@ std::optional<compiler::utils::Builtin> isSubGroupFunction(
 /// @return The work-group equivalent of the given builtin.
 Function *lookupWGBuiltin(const compiler::utils::Builtin &SGBuiltin,
                           compiler::utils::BuiltinInfo &BI, Module &M) {
-  compiler::utils::BuiltinID WGBuiltinID = [](compiler::utils::BuiltinID ID) {
-    switch (ID) {
-      default:
-        return compiler::utils::eBuiltinInvalid;
-      case compiler::utils::eMuxBuiltinSubGroupBarrier:
-        return compiler::utils::eMuxBuiltinWorkGroupBarrier;
-      case compiler::utils::eMuxBuiltinSubgroupAny:
-        return compiler::utils::eMuxBuiltinWorkgroupAny;
-      case compiler::utils::eMuxBuiltinSubgroupAll:
-        return compiler::utils::eMuxBuiltinWorkgroupAll;
-      case compiler::utils::eMuxBuiltinSubgroupBroadcast:
-        return compiler::utils::eMuxBuiltinWorkgroupBroadcast;
-      case compiler::utils::eMuxBuiltinSubgroupReduceAdd:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceAdd;
-      case compiler::utils::eMuxBuiltinSubgroupReduceFAdd:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceFAdd;
-      case compiler::utils::eMuxBuiltinSubgroupReduceMul:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceMul;
-      case compiler::utils::eMuxBuiltinSubgroupReduceFMul:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceFMul;
-      case compiler::utils::eMuxBuiltinSubgroupReduceUMax:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceUMax;
-      case compiler::utils::eMuxBuiltinSubgroupReduceSMax:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceSMax;
-      case compiler::utils::eMuxBuiltinSubgroupReduceFMax:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceFMax;
-      case compiler::utils::eMuxBuiltinSubgroupReduceUMin:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceUMin;
-      case compiler::utils::eMuxBuiltinSubgroupReduceSMin:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceSMin;
-      case compiler::utils::eMuxBuiltinSubgroupReduceFMin:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceFMin;
-      case compiler::utils::eMuxBuiltinSubgroupReduceAnd:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceAnd;
-      case compiler::utils::eMuxBuiltinSubgroupReduceOr:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceOr;
-      case compiler::utils::eMuxBuiltinSubgroupReduceXor:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceXor;
-      case compiler::utils::eMuxBuiltinSubgroupReduceLogicalAnd:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceLogicalAnd;
-      case compiler::utils::eMuxBuiltinSubgroupReduceLogicalOr:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceLogicalOr;
-      case compiler::utils::eMuxBuiltinSubgroupReduceLogicalXor:
-        return compiler::utils::eMuxBuiltinWorkgroupReduceLogicalXor;
-      case compiler::utils::eMuxBuiltinSubgroupScanAddInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanAddInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFAddInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFAddInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanMulInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanMulInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMulInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMulInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanUMaxInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanUMaxInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanSMaxInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanSMaxInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMaxInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMaxInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanUMinInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanUMinInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanSMinInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanSMinInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMinInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMinInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanAndInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanAndInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanOrInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanOrInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanXorInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanXorInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalAndInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalAndInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalOrInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalOrInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalXorInclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalXorInclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanAddExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanAddExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFAddExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFAddExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanMulExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanMulExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMulExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMulExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanUMaxExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanUMaxExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanSMaxExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanSMaxExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMaxExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMaxExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanUMinExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanUMinExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanSMinExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanSMinExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanFMinExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanFMinExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanAndExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanAndExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanOrExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanOrExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanXorExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanXorExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalAndExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalAndExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalOrExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalOrExclusive;
-      case compiler::utils::eMuxBuiltinSubgroupScanLogicalXorExclusive:
-        return compiler::utils::eMuxBuiltinWorkgroupScanLogicalXorExclusive;
-    }
-  }(SGBuiltin.ID);
-
+  compiler::utils::BuiltinID WGBuiltinID = compiler::utils::eBuiltinInvalid;
+  if (SGBuiltin.ID == compiler::utils::eMuxBuiltinSubGroupBarrier) {
+    WGBuiltinID = compiler::utils::eMuxBuiltinWorkGroupBarrier;
+  } else {
+    auto SGCollective = BI.isMuxGroupCollective(SGBuiltin.ID);
+    assert(SGCollective.has_value() && "Not a sub-group builtin");
+    auto WGCollective = *SGCollective;
+    WGCollective.Scope = compiler::utils::GroupCollective::ScopeKind::WorkGroup;
+    WGBuiltinID = BI.getMuxGroupCollective(WGCollective);
+  }
   assert(WGBuiltinID != compiler::utils::eBuiltinInvalid &&
          "Missing sub-group -> work-group mapping");
   auto *WGBuiltin =

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_shuffles.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_shuffles.ll
@@ -1,0 +1,79 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -w 4 -vecz-passes=packetizer -S \
+; RUN:   --pass-remarks-missed=vecz < %s 2>&1 | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+; CHECK: Could not packetize sub-group shuffle %shuffle
+define spir_kernel void @kernel1(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %size = call i32 @__mux_get_sub_group_size()
+  %size_minus_1 = sub i32 %size, 1
+  %arrayidx.in = getelementptr inbounds i64, ptr addrspace(1) %in, i64 %gid
+  %val = load i64, ptr addrspace(1) %arrayidx.in, align 8
+  %shuffle = call i64 @__mux_sub_group_shuffle_i64(i64 %val, i32 %size_minus_1)
+  %arrayidx.out = getelementptr inbounds i64, ptr addrspace(1) %out, i64 %gid
+  store i64 %shuffle, ptr addrspace(1) %arrayidx.out, align 8
+  ret void
+}
+
+; CHECK: Could not packetize sub-group shuffle %shuffle_up
+define spir_kernel void @kernel2(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx.in = getelementptr inbounds float, ptr addrspace(1) %in, i64 %gid
+  %val = load float, ptr addrspace(1) %arrayidx.in, align 8
+  %shuffle_up = call float @__mux_sub_group_shuffle_up_f32(float %val, float %val, i32 1)
+  %arrayidx.out = getelementptr inbounds float, ptr addrspace(1) %out, i64 %gid
+  store float %shuffle_up, ptr addrspace(1) %arrayidx.out, align 8
+  ret void
+}
+
+; CHECK: Could not packetize sub-group shuffle %shuffle_down
+define spir_kernel void @kernel3(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx.in = getelementptr inbounds i8, ptr addrspace(1) %in, i64 %gid
+  %val = load i8, ptr addrspace(1) %arrayidx.in, align 8
+  %shuffle_down = call i8 @__mux_sub_group_shuffle_down_i8(i8 %val, i8 %val, i32 1)
+  %arrayidx.out = getelementptr inbounds i8, ptr addrspace(1) %out, i64 %gid
+  store i8 %shuffle_down, ptr addrspace(1) %arrayidx.out, align 8
+  ret void
+}
+
+; CHECK: Could not packetize sub-group shuffle %shuffle_xor
+define spir_kernel void @kernel4(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx.in = getelementptr inbounds half, ptr addrspace(1) %in, i64 %gid
+  %val = load half, ptr addrspace(1) %arrayidx.in, align 8
+  %shuffle_xor = call half @__mux_sub_group_shuffle_xor_f16(half %val, i32 -1)
+  %arrayidx.out = getelementptr inbounds half, ptr addrspace(1) %out, i64 %gid
+  store half %shuffle_xor, ptr addrspace(1) %arrayidx.out, align 8
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)
+
+declare i32 @__mux_get_sub_group_size()
+
+declare i64 @__mux_sub_group_shuffle_i64(i64 %val, i32 %lid)
+
+declare half @__mux_sub_group_shuffle_xor_f16(half %val, i32 %xor_val)
+
+declare i8 @__mux_sub_group_shuffle_down_i8(i8 %curr, i8 %next, i32 %delta)
+
+declare float @__mux_sub_group_shuffle_up_f32(float %prev, float %curr, i32 %delta)

--- a/modules/mux/include/mux/mux.h
+++ b/modules/mux/include/mux/mux.h
@@ -37,7 +37,7 @@ extern "C" {
 /// @brief Mux major version number.
 #define MUX_MAJOR_VERSION 0
 /// @brief Mux minor version number.
-#define MUX_MINOR_VERSION 78
+#define MUX_MINOR_VERSION 79
 /// @brief Mux patch version number.
 #define MUX_PATCH_VERSION 0
 /// @brief Mux combined version number.

--- a/modules/mux/targets/host/include/host/host.h
+++ b/modules/mux/targets/host/include/host/host.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Host major version number.
 #define HOST_MAJOR_VERSION 0
 /// @brief Host minor version number.
-#define HOST_MINOR_VERSION 78
+#define HOST_MINOR_VERSION 79
 /// @brief Host patch version number.
 #define HOST_PATCH_VERSION 0
 /// @brief Host combined version number.

--- a/modules/mux/targets/riscv/include/riscv/riscv.h
+++ b/modules/mux/targets/riscv/include/riscv/riscv.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Riscv major version number.
 #define RISCV_MAJOR_VERSION 0
 /// @brief Riscv minor version number.
-#define RISCV_MINOR_VERSION 78
+#define RISCV_MINOR_VERSION 79
 /// @brief Riscv patch version number.
 #define RISCV_PATCH_VERSION 0
 /// @brief Riscv combined version number.

--- a/modules/mux/tools/api/mux.xml
+++ b/modules/mux/tools/api/mux.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception</comment>
     <block>
       <define priority="high">${FUNCTION_PREFIX}_MAJOR_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} major version number.</brief></doxygen></define>
-      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>78</value>
+      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>79</value>
         <doxygen><brief>${Function_Prefix} minor version number.</brief></doxygen></define>
       <define priority="high">${FUNCTION_PREFIX}_PATCH_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} patch version number.</brief></doxygen></define>

--- a/source/cl/source/binary/source/spirv.cpp
+++ b/source/cl/source/binary/source/spirv.cpp
@@ -28,7 +28,7 @@ namespace binary {
 // TODO: add a proper mechanism for extending spirv-ll and reporting extension
 // support. We don't actually support the generic storage class extension on
 // all core targets. See CA-3067.
-const std::array<const std::string, 10> supported_extensions = {
+const std::array<const std::string, 11> supported_extensions = {
     {
         "SPV_KHR_no_integer_wrap_decoration",
         "SPV_INTEL_kernel_attributes",
@@ -40,6 +40,7 @@ const std::array<const std::string, 10> supported_extensions = {
         "SPV_INTEL_arbitrary_precision_integers",
         "SPV_INTEL_optnone",
         "SPV_INTEL_memory_access_aliasing",
+        "SPV_INTEL_subgroups",
     },
 };
 
@@ -51,7 +52,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
   auto &spvCapabilities = spvDeviceInfo.capabilities;
 
   // A set of capabilities shared between the OpenCL profiles we support.
-  static std::array<spv::Capability, 14> sharedCapabilities = {
+  static std::array<spv::Capability, 15> sharedCapabilities = {
       spv::CapabilityAddresses,
       spv::CapabilityFloat16Buffer,
       spv::CapabilityGroups,
@@ -66,6 +67,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
       spv::CapabilityArbitraryPrecisionIntegersINTEL,
       spv::CapabilityOptNoneINTEL,
       spv::CapabilityMemoryAccessAliasingINTEL,
+      spv::CapabilitySubgroupShuffleINTEL,
   };
 
   if (profile == "FULL_PROFILE") {


### PR DESCRIPTION
These mirror the corresponding builtins in Intel's `SPV_INTEL_subgroups` SPIR-V extension.

This commit also provides support for lowering to these via the SPIR-V `SubgroupShuffleINTEL` capability, as part of the `SPV_INTEL_subgroups` extension.

These builtins are currently not vectorized and thus only implemented for 'trivial' sub-groups of size 1. Support for wider sub-groups will come in later commits.

These builtins also have no work-group equivalents so the `DegenerateSubGroupPass` has been updated to allow kernels to bail out of the process when they must.