### PR TITLE
[compiler] Vectorize to any required sub-group size

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
@@ -249,6 +249,11 @@ bool {{cookiecutter.target_name.capitalize()}}VeczPassOpts(
       vecz_mode == compiler::VectorizationMode::NEVER) {
     return false;
   }
+  // Handle required sub-group sizes
+  if (auto reqd_subgroup_vf = vecz::getReqdSubgroupSizeOpts(F)) {
+    PassOpts.assign(1, *reqd_subgroup_vf);
+    return true;
+  }
   auto env_var_opts = processOptimizationOptions(/*env_debug_prefix*/ {});
   if (!env_var_opts.vecz_pass_opts.has_value()) {
     return false;

--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -148,6 +148,11 @@ bool riscvVeczPassOpts(llvm::Function &F, llvm::ModuleAnalysisManager &,
       vecz_mode == compiler::VectorizationMode::NEVER) {
     return false;
   }
+  // Handle required sub-group sizes
+  if (auto reqd_subgroup_vf = vecz::getReqdSubgroupSizeOpts(F)) {
+    PassOpts.assign(1, *reqd_subgroup_vf);
+    return true;
+  }
   auto env_var_opts = RiscvPassMachinery::processOptimizationOptions(
       /*env_debug_prefix*/ {}, vecz_mode);
   if (env_var_opts.vecz_pass_opts.empty()) {

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -67,6 +67,11 @@ bool hostVeczPassOpts(llvm::Function &F, llvm::ModuleAnalysisManager &MAM,
   if (!compiler::utils::isKernelEntryPt(F)) {
     return false;
   }
+  // Handle required sub-group sizes
+  if (auto reqd_subgroup_vf = vecz::getReqdSubgroupSizeOpts(F)) {
+    Opts.assign(1, *reqd_subgroup_vf);
+    return true;
+  }
   const auto &DI =
       MAM.getResult<compiler::utils::DeviceInfoAnalysis>(*F.getParent());
   auto max_work_width = DI.max_work_width;

--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-2.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-2.ll
@@ -1,0 +1,40 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Let vecz pick the right vectorization factor for this kernel check that the
+; verification pass correctly notes we've satisifed the required sub-group
+; size.
+; RUN: env muxc --device "%riscv_device" \
+; RUN:   --passes run-vecz,verify-reqd-sub-group-satisfied < %s \
+; RUN: | FileCheck %s
+
+; CHECK-LABEL: define void @__vecz_v8_bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 !codeplay_ca_vecz.derived !{{[0-9]+}} {
+
+define void @bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 {
+  %id = call i64 @__mux_get_global_id(i32 0)
+  %in.addr = getelementptr i32, ptr addrspace(1) %in, i64 %id
+  %x = load i32, ptr addrspace(1) %in.addr
+  %y = add i32 %x, 1
+  %out.addr = getelementptr i32, ptr addrspace(1) %out, i64 %id
+  store i32 %y, ptr addrspace(1) %out.addr
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+!0 = !{i32 8}

--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-3.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-3.ll
@@ -1,0 +1,32 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Try and forcibly vectorize this no-vecz kernel by 8 and check that the
+; vectorizer does not run, since the required sub-group size is 1. Then check
+; that the verification pass correctly picks up that we have satisfied the
+; kernel's required sub-group size by way of not vectorizing.
+; RUN: env CA_RISCV_VF=8 muxc --device "%riscv_device" \
+; RUN:   --passes run-vecz,verify-reqd-sub-group-satisfied < %s \
+; RUN: | FileCheck %s
+
+; CHECK-NOT: __vecz_
+define void @foo_sg1() #0 !intel_reqd_sub_group_size !2 {
+  ret void
+}
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+!2 = !{i32 1}

--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
@@ -14,19 +14,19 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; Forcibly vectorize this kernel by 8 and check that the verification pass
-; correctly picks up that we haven't satisfied the kernel's required sub-group
-; size.
-; FIXME: This is conflating vecz dimension and sub-group size but that's all we
-; can manage at the moment.
+; Try and forcibly vectorize this no-vecz kernel by 8 and check that the
+; verification pass correctly picks up that we haven't satisfied the kernel's
+; required sub-group size.
 ; RUN: env CA_RISCV_VF=8 not muxc --device "%riscv_device" \
 ; RUN:   --passes "run-vecz,verify-reqd-sub-group-satisfied" %s 2>&1 \
 ; RUN: | FileCheck %s
 
-; CHECK: kernel.cl:10:0: kernel has required sub-group size 7 but the compiler was unable to sastify this constraint
-define void @foo_sg7() #0 !dbg !5 !intel_reqd_sub_group_size !2 {
+; CHECK: kernel.cl:10:0: kernel has required sub-group size 8 but the compiler was unable to sastify this constraint
+define void @foo_sg8() #0 !dbg !5 !intel_reqd_sub_group_size !2 {
   ret void
 }
+
+attributes #0 = { "mux-kernel"="entry-point" "vecz-mode"="never" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!1}
@@ -34,10 +34,7 @@ define void @foo_sg7() #0 !dbg !5 !intel_reqd_sub_group_size !2 {
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !4, runtimeVersion: 0, emissionKind: FullDebug)
 !1 = !{i32 2, !"Debug Info Version", i32 3}
 
-!2 = !{i32 7}
-!3 = !{i32 6}
+!2 = !{i32 8}
 
 !4 = !DIFile(filename: "kernel.cl", directory: "/oneAPI")
 !5 = distinct !DISubprogram(name: "foo_sg7", scope: !4, file: !4, line: 10, scopeLine: 10, flags: DIFlagArtificial | DIFlagPrototyped, unit: !0)
-
-attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning.ll
@@ -34,7 +34,6 @@ entry:
   ret i32 %call
 }
 
-; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
 
 ; CHECK-LABEL: define spir_func i32 @sub_group_reduce_add_test.degenerate-subgroups
 ; CHECK: (i32 [[Y:%.*]]) #[[ATTR0:[0-9]+]]
@@ -42,6 +41,8 @@ entry:
 ; CHECK: [[RESULT:%.*]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[Y]])
 ; CHECK: ret i32 [[RESULT]]
 ; CHECK: }
+
+; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
 
 declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
 

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-cloning2.ll
@@ -78,7 +78,6 @@ entry:
 }
 
 declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
-; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
 
 ; CHECK: define spir_func i32 @sub_groups.degenerate-subgroups(i32 [[X3:%.+]]) #[[ATTR2:[0-9]+]] {
 ; CHECK: entry:
@@ -93,6 +92,8 @@ declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
 ; CHECK:   [[R1:%.+]] = call spir_func i32 @__mux_work_group_reduce_add_i32(i32 0, i32 [[X1]])
 ; CHECK:   ret i32 [[R1]]
 ; CHECK: }
+
+; CHECK: declare spir_func i32 @__mux_work_group_reduce_add_i32(i32, i32)
 
 !opencl.ocl.version = !{!0}
 

--- a/modules/compiler/test/lit/passes/degenerate-sub-groups-reqd-size.ll
+++ b/modules/compiler/test/lit/passes/degenerate-sub-groups-reqd-size.ll
@@ -1,0 +1,59 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; RUN: muxc --passes degenerate-sub-groups,verify -S %s | FileCheck %s
+
+; Check that the DegenerateSubGroupPass does not clone any kerenels with
+; required sub-group sizes.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-NOT: {{(work_group|foo)}}
+
+define spir_func i32 @clone_this(i32 %x) {
+entry:
+  %call = call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 %x)
+  ret i32 %call
+}
+
+define spir_func i32 @shared(i32 %x) {
+entry:
+  %sqr = mul i32 %x, %x
+  ret i32 %sqr
+}
+
+define spir_func i32 @sub_groups(i32 %x) #0 !intel_reqd_sub_group_size !1 {
+entry:
+  %call1 = call spir_func i32 @clone_this(i32 %x)
+  %call2 = call spir_func i32 @shared(i32 %x)
+  %add = add i32 %call1, %call2
+  ret i32 %add
+}
+
+define spir_func i32 @no_sub_groups(i32 %x) #0 !intel_reqd_sub_group_size !1 {
+entry:
+  %call = call spir_func i32 @shared(i32 %x)
+  ret i32 %call
+}
+
+declare spir_func i32 @__mux_sub_group_reduce_add_i32(i32)
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+!1 = !{i32 4}
+
+attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/utils/include/compiler/utils/attributes.h
+++ b/modules/compiler/utils/include/compiler/utils/attributes.h
@@ -172,6 +172,11 @@ void setHasDegenerateSubgroups(llvm::Function &F);
 /// @param[in] F Function to check.
 bool hasDegenerateSubgroups(const llvm::Function &F);
 
+/// @brief Returns the mux sub-group size for the current function.
+///
+/// Currently always returns 1!
+unsigned getMuxSubgroupSize(const llvm::Function &F);
+
 }  // namespace utils
 }  // namespace compiler
 

--- a/modules/compiler/utils/include/compiler/utils/vectorization_factor.h
+++ b/modules/compiler/utils/include/compiler/utils/vectorization_factor.h
@@ -76,9 +76,25 @@ class VectorizationFactor {
   /// factor represents.
   unsigned getKnownMin() const { return KnownMin; }
 
+  VectorizationFactor operator*(unsigned other) const {
+    auto res = *this;
+    res.KnownMin *= other;
+    return res;
+  }
+
   bool operator==(const VectorizationFactor &other) const {
     return KnownMin == other.KnownMin && IsScalable == other.IsScalable;
   }
+
+  bool operator!=(const VectorizationFactor &other) const {
+    return !operator==(other);
+  }
+
+  bool operator==(unsigned other) const {
+    return !IsScalable && KnownMin == other;
+  }
+
+  bool operator!=(unsigned other) const { return !operator==(other); }
 
  private:
   unsigned KnownMin = 1;

--- a/modules/compiler/utils/source/attributes.cpp
+++ b/modules/compiler/utils/source/attributes.cpp
@@ -198,5 +198,11 @@ bool hasDegenerateSubgroups(const Function &F) {
   return Attr.isValid();
 }
 
+unsigned getMuxSubgroupSize(const llvm::Function &) {
+  // FIXME: The mux sub-group size is currently assumed to be 1 for all
+  // functions, kerrnels, and targets. This helper function is just to avoid
+  // hard-coding the constant 1 in places that will eventually need updated.
+  return 1;
+}
 }  // namespace utils
 }  // namespace compiler

--- a/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
+++ b/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
@@ -17,6 +17,7 @@
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/device_info.h>
 #include <compiler/utils/metadata.h>
+#include <compiler/utils/vectorization_factor.h>
 #include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
@@ -94,14 +95,17 @@ PreservedAnalyses VerifyReqdSubGroupSizeSatisfiedPass::run(
     if (!ReqdSGSize) {
       continue;
     }
+
+    auto CurrSGSize = VectorizationFactor::getFixedWidth(
+        compiler::utils::getMuxSubgroupSize(F));
     if (auto VeczInfo = parseVeczToOrigFnLinkMetadata(F)) {
-      if (!VeczInfo->second.vf.isScalable() &&
-          VeczInfo->second.vf.getKnownMin() == *ReqdSGSize) {
-        continue;
-      }
+      CurrSGSize = VeczInfo->second.vf * CurrSGSize.getKnownMin();
     }
-    M.getContext().diagnose(DiagnosticInfoReqdSGSize(
-        F, *ReqdSGSize, DiagnosticInfoReqdSGSize::DK_FailedReqdSGSize));
+
+    if (CurrSGSize != ReqdSGSize) {
+      M.getContext().diagnose(DiagnosticInfoReqdSGSize(
+          F, *ReqdSGSize, DiagnosticInfoReqdSGSize::DK_FailedReqdSGSize));
+    }
   }
 
   return PreservedAnalyses::all();

--- a/modules/compiler/vecz/include/vecz/pass.h
+++ b/modules/compiler/vecz/include/vecz/pass.h
@@ -25,6 +25,7 @@
 #include <llvm/IR/PassManager.h>
 
 #include <cstdint>
+#include <optional>
 
 #include "vecz/vecz_choices.h"
 
@@ -64,6 +65,8 @@ struct VeczPassOptions {
   /// unknown)
   uint64_t local_size;
 };
+
+std::optional<VeczPassOptions> getReqdSubgroupSizeOpts(llvm::Function &);
 
 /// @brief Analysis pass which determines on which functions @ref RunVeczPass
 /// should operate.


### PR DESCRIPTION
This updates users of the vectorizer to set the desired vectorization factor according to the kernel's required sub-group size, if present. It does so using a common method, to ensure consistent behaviour.This helper method assumes that the current underlying 'mux' sub-group size is 1, as we haven't got any in-tree targets that make use of anything larger than that.

All targets consider the required sub-group size less than they do `optnone` or `-cl-wfv=never` options. This can be revisited in the future if users desire different behaviour.