### PR TITLE
[mux] Advertise a sub-group size of 1

### DIFF
--- a/modules/mux/targets/host/source/device.cpp
+++ b/modules/mux/targets/host/source/device.cpp
@@ -523,6 +523,12 @@ device_info_s::device_info_s(host::arch arch, host::os os, bool native,
   this->sub_groups_support_ifp = false;
   this->supports_work_group_collectives = true;
   this->supports_generic_address_space = true;
+
+  static std::array<size_t, 1> sg_sizes = {
+      1,  // we can always produce a 'trivial' sub-group if asked.
+  };
+  this->sub_group_sizes = sg_sizes.data();
+  this->num_sub_group_sizes = sg_sizes.size();
 }
 
 host::arch device_info_s::detectHostArch() {

--- a/modules/mux/targets/riscv/source/device_info.cpp
+++ b/modules/mux/targets/riscv/source/device_info.cpp
@@ -145,6 +145,12 @@ device_info_s::device_info_s()
   this->max_hardware_counters = std::numeric_limits<int>::max();
   this->supports_work_group_collectives = true;
   this->supports_generic_address_space = true;
+
+  static std::array<size_t, 1> sg_sizes = {
+      1,  // we can always produce a 'trivial' sub-group if asked.
+  };
+  this->sub_group_sizes = sg_sizes.data();
+  this->num_sub_group_sizes = sg_sizes.size();
 }
 
 mux_result_t GetDeviceInfos(uint32_t device_types, uint64_t device_infos_length,


### PR DESCRIPTION
This updates the list of sub-group sizes reported by both the `host` and `riscv` targets to report `1` - the trivial sub-group size.

It appears though we have to report a non-empty list. Ignoring the issues that degenerate sub-groups provide with this system, we should always be able to create a sub-group size of 1, if we don't vectorize.

We won't actually always create kernels with this sub-group size: we'll create degenerate sub-groups and we'll also vectorize, so the user can't rely on this being the *only* sub-group size they'll see if they run a kernel; this requires further work, and ideally some SYCL specification clarifications.