### PR TITLE
Extended the parsing on our test runner to catch "No tests ran"

### DIFF
--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -48,7 +48,7 @@ class CTSTestRun(TestRunBase):
         fail_single_pattern = re.compile(b"^(FAILED .+\.|.+FAILED\.?)$")
         fail_pair_pattern = re.compile(b"^FAILED (\d+) of (\d+) tests\.$")
         skipped_pattern = re.compile(
-            b"(.*Skipping test\.+|skipping|SKIPPED.+)$")
+            b"(.*Skipping test\.+|skipping|SKIPPED.+|No tests ran)$")
         zerorun_pattern = re.compile(b"^Tests completed: 0$")
         doubles_unsupported_pattern = re.compile(b".*Has Double\? NO$")
         extension_unsupported_pattern = re.compile(


### PR DESCRIPTION
# Overview

Updated city runner to catch "No tests ran".

# Reason for change

The test runner we use for running test suites like SYCL CTS does some parsing on the result. We did not catch "No tests ran" to show that all tests were skipped.

# Description of change

Tweaked the regular expression matching in the cts profile of city runner to catch skipped case
