### PR TITLE
[compiler] Add a sub-group analysis pass

### DIFF
--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -60,6 +60,7 @@
 #include <compiler/utils/replace_target_ext_tys_pass.h>
 #include <compiler/utils/replace_wgc_pass.h>
 #include <compiler/utils/simple_callback_pass.h>
+#include <compiler/utils/sub_group_analysis.h>
 #include <compiler/utils/unique_opaque_structs_pass.h>
 #include <compiler/utils/verify_reqd_sub_group_size_pass.h>
 #include <compiler/utils/work_item_loops_pass.h>

--- a/modules/compiler/source/base/source/base_module_pass_registry.def
+++ b/modules/compiler/source/base/source/base_module_pass_registry.def
@@ -60,6 +60,9 @@ MODULE_PASS("verify-reqd-sub-group-satisfied",
 
 MODULE_PASS("unique-opaque-structs", compiler::utils::UniqueOpaqueStructsPass())
 
+MODULE_PASS("print<sub-groups>",
+            compiler::utils::SubgroupAnalysisPrinterPass(llvm::dbgs()))
+
 MODULE_PASS("run-vecz", vecz::RunVeczPass())
 MODULE_PASS("print<vecz-pass-opts>", vecz::VeczPassOptionsPrinterPass(dbgs()))
 
@@ -149,6 +152,8 @@ MODULE_ANALYSIS("builtin-info",
 MODULE_ANALYSIS("device-info",
                 !Info ? compiler::utils::DeviceInfoAnalysis() :
                         compiler::utils::DeviceInfoAnalysis(*Info))
+
+MODULE_ANALYSIS("sub-groups", compiler::utils::SubgroupAnalysis());
 
 // Note - a default implementation to avoid crashes when retrieving the
 // analysis. Targets will most certainly want to register their own

--- a/modules/compiler/test/lit/passes/sub-group-analysis.ll
+++ b/modules/compiler/test/lit/passes/sub-group-analysis.ll
@@ -1,0 +1,73 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes "print<sub-groups>" < %s 2>&1 | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK: Function 'kernel1' uses 2 sub-group builtins: {{[0-9]+,[0-9]+$}}
+define spir_kernel void @kernel1(i32 %x) {
+entry:
+  %lid = call i32 @__mux_get_sub_group_local_id()
+  %call = call i32 @__mux_sub_group_shuffle_i32(i32 %x, i32 %lid)
+  ret void
+}
+
+; CHECK: Function 'kernel2' uses 2 sub-group builtins: {{[0-9]+,[0-9]+$}}
+define spir_kernel void @kernel2() {
+entry:
+  %lid = call i32 @__mux_get_sub_group_local_id()
+  br label %exit
+exit:
+  %call = call i32 @__mux_get_max_sub_group_size()
+  ret void
+}
+
+; CHECK: Function 'function1' uses 1 sub-group builtin: {{[0-9]+$}}
+define spir_func i32 @function1() {
+  %call = call i32 @__mux_get_max_sub_group_size()
+  ret i32 %call
+}
+
+; CHECK: Function 'function2' uses no sub-group builtins
+define spir_func void @function2() {
+  ret void
+}
+
+; CHECK: Function 'function3' uses 2 sub-group builtins: {{[0-9]+,[0-9]+$}}
+define spir_func i32 @function3() {
+  %call = call i32 @function1()
+  %call2 = call i32 @__mux_get_sub_group_id()
+  ret i32 %call
+}
+
+; CHECK: Function 'kernel3' uses 3 sub-group builtins: {{[0-9]+,[0-9]+,[0-9]+$}}
+define spir_kernel void @kernel3() {
+entry:
+  %lid = call i32 @__mux_get_sub_group_local_id()
+  br label %exit
+exit:
+  %call = call i32 @function3()
+  ; Call this function twice - it shouldn't matter
+  %call2 = call i32 @function3()
+  ret void
+}
+
+declare i32 @__mux_get_sub_group_id()
+declare i32 @__mux_get_sub_group_local_id()
+declare i32 @__mux_sub_group_shuffle_i32(i32, i32)
+declare i32 @__mux_get_max_sub_group_size()

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -64,6 +64,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/replace_wgc_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/scheduling.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/simple_callback_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/sub_group_analysis.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/target_extension_types.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/unique_opaque_structs_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/vectorization_factor.h
@@ -112,6 +113,7 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_target_ext_tys_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/replace_wgc_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/scheduling.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/sub_group_analysis.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/target_extension_types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/unique_opaque_structs_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp

--- a/modules/compiler/utils/include/compiler/utils/sub_group_analysis.h
+++ b/modules/compiler/utils/include/compiler/utils/sub_group_analysis.h
@@ -1,0 +1,111 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef COMPILER_UTILS_SUB_GROUP_ANALYSIS_H_INCLUDED
+#define COMPILER_UTILS_SUB_GROUP_ANALYSIS_H_INCLUDED
+
+#include <compiler/utils/builtin_info.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/IR/PassManager.h>
+
+#include <map>
+#include <set>
+
+namespace compiler {
+namespace utils {
+
+/// @brief Provides module-level information about the sub-group usage of each
+/// function contained within.
+///
+/// The results for each function are cached in a map. Declarations are not
+/// processed. Thus an external function declaration that uses sub-group
+/// builtins will be missed.
+///
+/// Each function contains the set of mux sub-group builtins it (transitively)
+/// calls.
+class GlobalSubgroupInfo {
+  struct SubgroupInfo {
+    std::set<BuiltinID> UsedSubgroupBuiltins;
+  };
+
+  using FunctionMapTy =
+      std::map<const llvm::Function *, std::unique_ptr<SubgroupInfo>>;
+
+  FunctionMapTy FunctionMap;
+
+  compiler::utils::BuiltinInfo &BI;
+
+ public:
+  GlobalSubgroupInfo(llvm::Module &M, BuiltinInfo &);
+
+  compiler::utils::BuiltinInfo &getBuiltinInfo() { return BI; }
+
+  using iterator = FunctionMapTy::iterator;
+  using const_iterator = FunctionMapTy::const_iterator;
+
+  /// @brief Returns the SubgroupInfo for the provided function.
+  ///
+  /// The function must already exist in the map.
+  inline const SubgroupInfo *operator[](const llvm::Function *F) const {
+    const_iterator I = FunctionMap.find(F);
+    assert(I != FunctionMap.end() && "Function not in sub-group info!");
+    return I->second.get();
+  }
+
+  bool usesSubgroups(const llvm::Function &F) const;
+
+  /// @brief Returns true if the provided function is a mux sub-group
+  /// collective builtin or sub-group barrier.
+  std::optional<compiler::utils::Builtin> isMuxSubgroupBuiltin(
+      const llvm::Function *F) const;
+};
+
+/// @brief Computes and returns the GlobalSubgroupInfo for a Module.
+class SubgroupAnalysis : public llvm::AnalysisInfoMixin<SubgroupAnalysis> {
+  friend AnalysisInfoMixin<SubgroupAnalysis>;
+
+ public:
+  using Result = GlobalSubgroupInfo;
+
+  explicit SubgroupAnalysis() {}
+
+  /// @brief Retrieve the GlobalSubgroupInfo for the module.
+  Result run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+
+  /// @brief Return the name of the pass.
+  static llvm::StringRef name() { return "Sub-group analysis"; }
+
+ private:
+  /// @brief Unique pass identifier.
+  static llvm::AnalysisKey Key;
+};
+
+/// @brief Helper pass to print out the contents of the SubgroupAnalysis
+/// analysis.
+class SubgroupAnalysisPrinterPass
+    : public llvm::PassInfoMixin<SubgroupAnalysisPrinterPass> {
+  llvm::raw_ostream &OS;
+
+ public:
+  explicit SubgroupAnalysisPrinterPass(llvm::raw_ostream &OS) : OS(OS) {}
+
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+};
+
+}  // namespace utils
+}  // namespace compiler
+
+#endif  // COMPILER_UTILS_SUB_GROUP_ANALYSIS_H_INCLUDED

--- a/modules/compiler/utils/source/sub_group_analysis.cpp
+++ b/modules/compiler/utils/source/sub_group_analysis.cpp
@@ -1,0 +1,159 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/builtin_info.h>
+#include <compiler/utils/sub_group_analysis.h>
+#include <llvm/ADT/PriorityWorklist.h>
+#include <llvm/ADT/SetOperations.h>
+
+using namespace llvm;
+
+namespace compiler {
+namespace utils {
+
+GlobalSubgroupInfo::GlobalSubgroupInfo(Module &M, BuiltinInfo &BI) : BI(BI) {
+  SmallPtrSet<Function *, 8> UsesSubgroups;
+  SmallPriorityWorklist<Function *, 4> Worklist;
+
+  for (auto &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    auto SGI = std::make_unique<SubgroupInfo>();
+    for (auto &BB : F) {
+      for (const auto &I : BB) {
+        if (auto *const CI = dyn_cast<CallInst>(&I)) {
+          if (auto SGBuiltin = isMuxSubgroupBuiltin(CI->getCalledFunction())) {
+            // Only add each function to the worklist once
+            if (UsesSubgroups.insert(&F).second) {
+              Worklist.insert(&F);
+            }
+            // Track this function's use of this builtin
+            SGI->UsedSubgroupBuiltins.insert(SGBuiltin->ID);
+          }
+        }
+      }
+    }
+    FunctionMap.insert({&F, std::move(SGI)});
+  }
+
+  // Collect all functions that contain sub-group calls, including calls to
+  // other functions in the module that contain sub-group calls.
+  while (!Worklist.empty()) {
+    auto *const F = Worklist.pop_back_val();
+    const auto &FSubgroups = FunctionMap[F]->UsedSubgroupBuiltins;
+    // Track which unique call-graph edges we've traversed, in case F ends up
+    // calling the same function multiple times. The set of builtins used by
+    // this item isn't going to change while we're working on it.
+    SmallPtrSet<Function *, 4> AlreadyUnioned;
+    for (auto *const U : F->users()) {
+      if (auto *const CI = dyn_cast<CallInst>(U)) {
+        auto *const CallerF = CI->getFunction();
+        // If we haven't seen this function before, we need to process it and
+        // propagate its users.
+        if (UsesSubgroups.insert(CallerF).second) {
+          Worklist.insert(CallerF);
+        }
+        // If we've recorded that CallerF calls F for the first time in this
+        // loop, CallerF's set of used builtins gains all the builtins used by
+        // F.
+        if (AlreadyUnioned.insert(CallerF).second) {
+          auto &CallerSubgroups = FunctionMap[CallerF]->UsedSubgroupBuiltins;
+          // If the set union produces a new set...
+          if (set_union(CallerSubgroups, FSubgroups)) {
+            // ... we might have previously visited CallerF when it had fewer
+            // registered uses of sub-groups. Thus we need to stick it back on
+            // the worklist to propagate these to its users.
+            Worklist.insert(CallerF);
+          }
+        }
+      }
+    }
+  }
+}
+
+bool GlobalSubgroupInfo::usesSubgroups(const llvm::Function &F) const {
+  auto I = FunctionMap.find(&F);
+  assert(I != FunctionMap.end() && "Missing entry for function");
+  return !I->second->UsedSubgroupBuiltins.empty();
+}
+
+std::optional<Builtin> GlobalSubgroupInfo::isMuxSubgroupBuiltin(
+    const Function *F) const {
+  if (!F) {
+    return std::nullopt;
+  }
+  auto SGBuiltin = BI.analyzeBuiltin(*F);
+
+  switch (SGBuiltin.ID) {
+    default:
+      break;
+    case eMuxBuiltinSubGroupBarrier:
+    case eMuxBuiltinGetSubGroupSize:
+    case eMuxBuiltinGetMaxSubGroupSize:
+    case eMuxBuiltinGetNumSubGroups:
+    case eMuxBuiltinGetSubGroupId:
+    case eMuxBuiltinGetSubGroupLocalId:
+      return SGBuiltin;
+  }
+
+  if (auto GroupOp = BI.isMuxGroupCollective(SGBuiltin.ID);
+      GroupOp && GroupOp->isSubGroupScope()) {
+    return SGBuiltin;
+  }
+
+  return std::nullopt;
+}
+
+AnalysisKey SubgroupAnalysis::Key;
+
+SubgroupAnalysis::Result SubgroupAnalysis::run(Module &M,
+                                               ModuleAnalysisManager &AM) {
+  return GlobalSubgroupInfo(M, AM.getResult<BuiltinInfoAnalysis>(M));
+}
+
+PreservedAnalyses SubgroupAnalysisPrinterPass::run(Module &M,
+                                                   ModuleAnalysisManager &AM) {
+  const auto &Info = AM.getResult<SubgroupAnalysis>(M);
+
+  for (auto &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    OS << "Function '" << F.getName() << "' uses";
+    if (!Info.usesSubgroups(F)) {
+      OS << " no sub-group builtins\n";
+      continue;
+    }
+    auto *FInfo = Info[&F];
+    assert(FInfo && "Missing function info");
+    const auto &UsedBuiltins = FInfo->UsedSubgroupBuiltins;
+    // Note: this output isn't stable and shouldn't be relied upon. It's mostly
+    // for developer analysis.
+    OS << " " << UsedBuiltins.size() << " sub-group builtin"
+       << (UsedBuiltins.size() == 1 ? "" : "s") << ": "
+       << static_cast<unsigned>(*UsedBuiltins.begin());
+    for (auto B :
+         make_range(std::next(UsedBuiltins.begin()), UsedBuiltins.end())) {
+      OS << "," << static_cast<unsigned>(B);
+    }
+    OS << "\n";
+  }
+
+  return PreservedAnalyses::all();
+}
+}  // namespace utils
+}  // namespace compiler


### PR DESCRIPTION
This pass analyses a module's use of mux sub-group builtins. It returns
a map with info about every function *definition*, whether or not that
function uses mux sub-group builtins, as well as the set of mux builtin
IDs it uses.

It is unable to glean anything about function declarations, therefore
in such a case, this analysis should not be relied on for 100%
correctness; however, this is not generally a use-case that the oneAPI
construction kit supports.

The degenerate sub-groups pass can use this analysis to reduce some of
its own computations.

In the future the vectorizer will use this to automatically vectorize
kernels using sub-groups to a device-specific sub-group size.