### PR TITLE
[compiler] Preserve 'entry point' on vectorized kernels

### DIFF
--- a/doc/modules/compiler/utils.rst
+++ b/doc/modules/compiler/utils.rst
@@ -315,12 +315,12 @@ Attributes>` function attributes for the outermost loops. The logic for the
 dimension unmarshalling lies in
 ``modules/compiler/utils/include/utils/vecz_order.h``.
 
-Preserving debug info is a problem for the barrier pass due to live variables
-getting stored in a struct passed as an argument to each of the generated
-kernels. As a result the memory locations pointed to by the debug info are out
-of date with respect to newly written values. By specifying the ``IsDebug``
-flag when creating the pass we can resolve this problem at the expense of
-performance.
+Preserving debug info is a problem for the ``WorkItemLoopsPass`` due to live
+variables getting stored in a struct passed as an argument to each of the
+generated kernels. As a result the memory locations pointed to by the debug
+info are out of date with respect to newly written values. By specifying the
+``IsDebug`` flag when creating the pass we can resolve this problem at the
+expense of performance.
 
 When the ``IsDebug`` flag is set the pass adds a new ``alloca`` which contains a
 pointer to the live variables struct of the currently executing work-item, since
@@ -428,8 +428,8 @@ function, as appropriate.
 Work-group scheduling (vectorized and scalar loops)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Barrier Pass is responsible for stitching together multiple kernels to make
-a single kernel capable of correctly executing all work-items in the
+The `WorkItemLoopsPass`_ is responsible for stitching together multiple kernels
+to make a single kernel capable of correctly executing all work-items in the
 work-group.
 
 In particular, when a kernel has been vectorized with :doc:`/modules/vecz` it
@@ -438,7 +438,7 @@ vectorized dimension is known to be a multiple of the vectorization factor,
 there exists the possibility that some work-items will not be executed by the
 vectorized loop.
 
-As such, the Barrier Pass is able to stitch together kernels in several
+As such, the `WorkItemLoopsPass`_ is able to stitch together kernels in several
 different configurations:
 
 * Vector + scalar loop
@@ -453,8 +453,8 @@ The vector + scalar kernel combination is considered the default behaviour.
 Most often the work-group size is unknown at compile time and thus it must be
 assumed that the vector loop may not execute all work-items.
 
-This configuration is used if the Barrier Pass is asked to run on a vectorized
-function which has :ref:`\!codeplay_ca_vecz.derived
+This configuration is used if the `WorkItemLoopsPass`_ is asked to run on a
+vectorized function which has :ref:`\!codeplay_ca_vecz.derived
 <specifications/mux-compiler-spec:Metadata>` function metadata linking it back
 to its scalar progenitor. In this case, both the vector and scalar kernel
 functions are identified and are used. The vector work-items are executed
@@ -504,7 +504,7 @@ only" mode:
       :ref:`TransferKernelMetadataPass or EncodeKernelMetadataPass
       <encodekernelmetadatapass>` to encode functions with this information.
 
-* If the Barrier pass has been created with the `ForceNoTail` option.
+* If the `WorkItemLoopsPass`_ has been created with the `ForceNoTail` option.
   * This is a global toggle for *all* kernels in the program.
 * If the kernel has been vectorized with vector predication. In this case the
   vector loop is known to handle scalar iterations itself.
@@ -543,17 +543,17 @@ perform all of the scalar iterations at once.
 Vector only
 ^^^^^^^^^^^
 
-If the Barrier Pass is run on a vectorized kernel for which no `vecz` linking
-metadata is found to identify the scalar kernel, or if a scalar kernel is found
-but one of the conditions listed above hold, then the kernel is emitted using
-the vector kernel only. It is assumed that if no scalar kernel is found it is
-because targets know that one is not required.
+If the `WorkItemLoopsPass`_ is run on a vectorized kernel for which no `vecz`
+linking metadata is found to identify the scalar kernel, or if a scalar kernel
+is found but one of the conditions listed above hold, then the kernel is
+emitted using the vector kernel only. It is assumed that if no scalar kernel is
+found it is because targets know that one is not required.
 
 Scalar only
 ^^^^^^^^^^^
 
-If the Barrier pass is run on a scalar kernel then only the scalar kernel is
-used.
+If the `WorkItemLoopsPass`_ is run on a scalar kernel then only the scalar
+kernel is used.
 
 OptimalBuiltinReplacementPass
 -----------------------------

--- a/doc/modules/vecz/vecz.md
+++ b/doc/modules/vecz/vecz.md
@@ -52,13 +52,7 @@ requirements.
 
 The `vecz::RunVeczPass` does not delete the original scalar kernel after
 vectorization, nor does it transfer the scalar kernel name to the vectorized
-function. However, the `mux-kernel` attributes will be transferred. This
-attribute is present for a kernel and has the special value `"entry-point"` for
-a "kernel entry point", which latter is a kernel that is intended to be
-directly executed. The barrier pass works only on kernel entry points, so Vecz
-will steal entry point status from the scalar kernel and set entry point status
-on its own output instead. This behaviour is at time of writing still subject
-to change while the details of multiple vectorization are worked out.
+function.
 
 ## Target specialization
 

--- a/doc/overview/example-scenarios/mapping-algorithms-to-vector-hardware.rst
+++ b/doc/overview/example-scenarios/mapping-algorithms-to-vector-hardware.rst
@@ -136,12 +136,13 @@ barriers into no-ops when the kernel scheduling information and hardware
 vectorization capabilities are known when compiling the kernel.
 
 ComputeMux provides an implementation of the compiler-based approach described
-above in the form of a 'barrier pass' that can be used by any ComputeMux
-target. With this pass it is possible to easily execute compute kernels that
-make use of barriers without requiring any synchronization capabilities from
-the hardware other than what is already needed to execute barrier-less kernels.
-The Host ComputeMux target that executes kernels on the CPU is an example of a
-target that uses this barrier pass to support kernels with barriers.
+above in the form of a 'work-item loops pass' that can be used by any
+ComputeMux target. With this pass it is possible to easily execute compute
+kernels that make use of barriers without requiring any synchronization
+capabilities from the hardware other than what is already needed to execute
+barrier-less kernels. The Host ComputeMux target that executes kernels on the
+CPU is an example of a target that uses this work-item loops pass to support
+kernels with barriers.
 
 The Vecz Whole-Function Vectorizer
 ----------------------------------

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
@@ -131,15 +131,15 @@ llvm::ModulePassManager RefSiM1PassMachinery::getLateTargetPasses() {
 
   PM.addPass(vecz::RunVeczPass());
 
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
   addLateBuiltinsPasses(PM, tuner);
 
   compiler::utils::WorkItemLoopsPassOptions WIOpts;
   WIOpts.IsDebug = options.opt_disable;
   WIOpts.ForceNoTail = env_var_opts.force_no_tail;
   PM.addPass(compiler::utils::WorkItemLoopsPass(WIOpts));
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   compiler::addPrepareWorkGroupSchedulingPasses(PM);
 

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
@@ -191,15 +191,15 @@ llvm::ModulePassManager {{cookiecutter.target_name.capitalize()}}PassMachinery::
 
   PM.addPass(vecz::RunVeczPass());
 
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
   addLateBuiltinsPasses(PM, tuner);
 
   compiler::utils::WorkItemLoopsPassOptions WIOpts;
   WIOpts.IsDebug = options.opt_disable;
   WIOpts.ForceNoTail = env_var_opts.force_no_tail;
   PM.addPass(compiler::utils::WorkItemLoopsPass(WIOpts));
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   compiler::addPrepareWorkGroupSchedulingPasses(PM);
 

--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -231,15 +231,15 @@ llvm::ModulePassManager RiscvPassMachinery::getLateTargetPasses() {
 
   PM.addPass(vecz::RunVeczPass());
 
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
   addLateBuiltinsPasses(PM, tuner);
 
   compiler::utils::WorkItemLoopsPassOptions WIOpts;
   WIOpts.IsDebug = options.opt_disable;
   WIOpts.ForceNoTail = env_var_opts.force_no_tail;
   PM.addPass(compiler::utils::WorkItemLoopsPass(WIOpts));
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   compiler::addPrepareWorkGroupSchedulingPasses(PM);
 

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -261,15 +261,15 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
 
   PM.addPass(vecz::RunVeczPass());
 
-  // Verify that any required sub-group size was met.
-  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
-
   addLateBuiltinsPasses(PM, tuner);
 
   compiler::utils::WorkItemLoopsPassOptions WIOpts;
   WIOpts.IsDebug = options.opt_disable;
 
   PM.addPass(compiler::utils::WorkItemLoopsPass(WIOpts));
+
+  // Verify that any required sub-group size was met.
+  PM.addPass(compiler::utils::VerifyReqdSubGroupSizeSatisfiedPass());
 
   PM.addPass(compiler::utils::AddSchedulingParametersPass());
 

--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-2.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size-2.ll
@@ -14,14 +14,16 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; Let vecz pick the right vectorization factor for this kernel check that the
-; verification pass correctly notes we've satisifed the required sub-group
-; size.
-; RUN: env muxc --device "%riscv_device" \
-; RUN:   --passes run-vecz,verify-reqd-sub-group-satisfied < %s \
+; Let vecz pick the right vectorization factor for this kernel, wrap the kernel
+; up in a loop, and check that the verification pass correctly notes we've
+; satisfied the required sub-group size. This implies that we haven't generated
+; a separate work-item loop wrapper for the original kernel, as the constraint
+; wouldn't have been satisfied on that.
+; RUN: muxc --device "%riscv_device" \
+; RUN:   --passes run-vecz,work-item-loops,verify-reqd-sub-group-satisfied < %s \
 ; RUN: | FileCheck %s
 
-; CHECK-LABEL: define void @__vecz_v8_bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 !codeplay_ca_vecz.derived !{{[0-9]+}} {
+; CHECK-LABEL: define{{( internal)?}} void @__vecz_v8_bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 !codeplay_ca_vecz.derived !{{[0-9]+}} {
 
 define void @bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 {
   %id = call i64 @__mux_get_global_id(i32 0)

--- a/modules/compiler/test/lit/passes/barriers-v-vp.ll
+++ b/modules/compiler/test/lit/passes/barriers-v-vp.ll
@@ -23,6 +23,9 @@ define internal void @foo() !codeplay_ca_vecz.base !2 !codeplay_ca_vecz.base !3 
   ret void
 }
 
+; Check we've stripped this VP kernel of its 'entry point' status, as it hasn't
+; been given work-item loops. Check this by checking there aren't any attributes.
+; CHECK: define internal void @__vecz_v2_vp_foo() !codeplay_ca_vecz.derived {{\![0-9]+}} {
 define void @__vecz_v2_vp_foo() #0 !codeplay_ca_vecz.derived !5 {
   ret void
 }

--- a/modules/compiler/test/lit/passes/work-item-loops-entry-points.ll
+++ b/modules/compiler/test/lit/passes/work-item-loops-entry-points.ll
@@ -1,0 +1,148 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+; CHECK: define internal void @foo() [[OLD_ATTRS:#[0-9]+]] {
+define void @foo() #0 {
+  ret void
+}
+
+; CHECK: define internal void @nosg_main() [[OLD_ATTRS]] !codeplay_ca_vecz.derived {{\![0-9]+}} {
+define void @nosg_main() #0 !codeplay_ca_vecz.derived !1 {
+  ret void
+}
+
+; CHECK: define internal void @nosg_tail() [[OLD_NOSG_ATTRS:#[0-9]+]] !codeplay_ca_vecz.base {{\![0-9]+}} {
+define void @nosg_tail() #0 !codeplay_ca_vecz.base !0 {
+  ret void
+}
+
+; CHECK: define internal void @degensg_main() [[OLD_DEGENSG_MAIN_ATTRS:#[0-9]+]] !codeplay_ca_vecz.derived {{\![0-9]+}} {
+define void @degensg_main() #1 !codeplay_ca_vecz.derived !4 {
+  ret void
+}
+
+; CHECK: define internal void @degensg_tail() [[OLD_DEGENSG_TAIL_ATTRS:#[0-9]+]] !codeplay_ca_vecz.base {{\![0-9]+}} {
+define void @degensg_tail() #1 !codeplay_ca_vecz.base !3 {
+  ret void
+}
+
+; CHECK: define internal void @uses_sg_main() [[OLD_ATTRS]] !codeplay_ca_vecz.derived {{\![0-9]+}} {
+define void @uses_sg_main() #0 !codeplay_ca_vecz.derived !6 {
+  %x = call i32 @__mux_get_sub_group_local_id()
+  ret void
+}
+
+; CHECK: define internal void @uses_sg_tail() [[OLD_ATTRS]] !codeplay_ca_vecz.base {{\![0-9]+}} {
+define void @uses_sg_tail() #0 !codeplay_ca_vecz.base !5 {
+  ret void
+}
+
+; CHECK: define internal void @reqd_sg_main() [[OLD_ATTRS]] !codeplay_ca_vecz.derived {{\![0-9]+}} !intel_reqd_sub_group_size {{\![0-9]+}} {
+define void @reqd_sg_main() #0 !codeplay_ca_vecz.derived !8 !intel_reqd_sub_group_size !9 {
+  ret void
+}
+
+; CHECK: define internal void @reqd_sg_tail() [[OLD_NOSG_ATTRS]] !codeplay_ca_vecz.base {{\![0-9]+}} !intel_reqd_sub_group_size {{\![0-9]+}} {
+define void @reqd_sg_tail() #0 !codeplay_ca_vecz.base !7 !intel_reqd_sub_group_size !9 {
+  ret void
+}
+
+; CHECK: define internal void @reqd_wg_main() [[OLD_ATTRS]] !codeplay_ca_vecz.derived {{\![0-9]+}} !reqd_work_group_size {{\![0-9]+}} {
+define void @reqd_wg_main() #0 !codeplay_ca_vecz.derived !11 !reqd_work_group_size !12 {
+  ret void
+}
+
+; CHECK: define internal void @reqd_wg_tail() [[OLD_NOSG_ATTRS]] !codeplay_ca_vecz.base {{\![0-9]+}} !reqd_work_group_size {{\![0-9]+}} {
+define void @reqd_wg_tail() #0 !codeplay_ca_vecz.base !10 !reqd_work_group_size !12 {
+  ret void
+}
+
+declare i32 @__mux_get_sub_group_local_id()
+
+; Check we've defined a wrapper for 'foo' (because it was marked an entry
+; point).
+; CHECK: define void @foo.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we've defined a wrapper for nosg's 'main' kernel (because it was marked
+; an entry point).
+; CHECK: define void @nosg_main.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we haven't defined another separate wrapper for nosg's 'tail' kernel.
+; Even though it was marked an entry point, it's redundant as it's not used for
+; a fallback sub-group kernel.
+; CHECK-NOT: @nosg_tail.mux-barrier-wrapper()
+
+; Check we've defined a wrapper for degensg's 'main' kernel (because it was marked
+; an entry point).
+; CHECK: define void @degensg_main.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we haven't defined another separate wrapper for degensg's 'tail' kernel.
+; Even though it was marked an entry point, it's redundant as the 'main'
+; wrapper is degenerate, so no fallback is needed.
+; CHECK-NOT: @degensg_tail.mux-barrier-wrapper()
+
+; Check we've defined a wrapper for uses_sg's 'main' kernel (because it was
+; marked an entry point).
+; CHECK: define void @uses_sg_main.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we've defined a wrapper for uses_sg's 'tail' kernel (because it is
+; required as a fallback kernel).
+; CHECK: define void @uses_sg_tail.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we've defined a wrapper for reqd_sg's 'main' kernel.
+; CHECK: define void @reqd_sg_main.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we haven't defined another separate wrapper for reqd_sg's 'tail' kernel.
+; Even though it was marked an entry point, it's redundant as it has a required
+; sub-group size that isn't 1. So no fallback is needed.
+; CHECK-NOT: @reqd_sg_tail.mux-barrier-wrapper()
+
+; Check we've defined a wrapper for reqd_wg's 'main' kernel
+; CHECK: define void @reqd_wg_main.mux-barrier-wrapper() {{#[0-9]+}}
+
+; Check we haven't defined another separate wrapper for reqd_wg's 'tail' kernel.
+; Even though it was marked an entry point, it's redundant as it the main has a
+; required work-group size and so covers the whole work-group without needing a
+; tail.
+; CHECK-NOT: @reqd_wg_tail.mux-barrier-wrapper()
+
+; Check we've stripped the old functions of their 'entry-point' status
+; CHECK-DAG: attributes [[OLD_ATTRS]] = { alwaysinline convergent norecurse nounwind }
+; CHECK-DAG: attributes [[OLD_NOSG_ATTRS]] = { convergent norecurse nounwind }
+; CHECK-DAG: attributes [[OLD_DEGENSG_MAIN_ATTRS]] = { alwaysinline convergent norecurse nounwind "mux-degenerate-subgroups" }
+; CHECK-DAG: attributes [[OLD_DEGENSG_TAIL_ATTRS]] = { convergent norecurse nounwind "mux-degenerate-subgroups" }
+
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }
+attributes #1 = { convergent norecurse nounwind "mux-kernel"="entry-point" "mux-degenerate-subgroups" }
+
+!0 = !{!2, ptr @nosg_main}
+!1 = !{!2, ptr @nosg_tail}
+!2 = !{i32 4, i32 0, i32 0, i32 0}
+!3 = !{!2, ptr @degensg_main}
+!4 = !{!2, ptr @degensg_tail}
+!5 = !{!2, ptr @uses_sg_main}
+!6 = !{!2, ptr @uses_sg_tail}
+!7 = !{!2, ptr @reqd_sg_main}
+!8 = !{!2, ptr @reqd_sg_tail}
+!9 = !{i32 4}
+!10 = !{!2, ptr @reqd_wg_main}
+!11 = !{!2, ptr @reqd_wg_tail}
+!12 = !{i32 4, i32 1, i32 1}

--- a/modules/compiler/vecz/source/pass.cpp
+++ b/modules/compiler/vecz/source/pass.cpp
@@ -168,23 +168,14 @@ PreservedAnalyses RunVeczPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
   // Fix up the metadata and clean out any dead kernels
   for (auto &P : Results) {
-    Function *Fn = P.first;
     auto &Result = P.second;
-    bool const IsKernel = compiler::utils::isKernel(*Fn);
-    bool DropScalarMDs = IsKernel && !Result.empty();
     for (auto &R : Result) {
       VectorizationUnit *VU = R.first;
       trackVeczSuccessFailure(*VU);
       if (!createVectorizedFunctionMetadata(*VU)) {
-        // We only drop the metadata from the scalar kernel when the number of
-        // Results is non-zero and they all succeeded
-        DropScalarMDs = false;
-        LLVM_DEBUG(dbgs() << Fn->getName() << " failed to vectorize\n");
+        LLVM_DEBUG(dbgs() << P.first->getName() << " failed to vectorize\n");
         eraseFailed(VU);
       }
-    }
-    if (DropScalarMDs) {
-      compiler::utils::dropIsKernel(*Fn);
     }
   }
   return PreservedAnalyses::none();


### PR DESCRIPTION
This fixes a long-standing hack in the vectorizer where it would strip
the vectorized kernels of their 'kernel' status.

This wasn't anything to do with vectorization but was a legacy behaviour
owing to the fact that the vectorizer used to replace the old functions.
The `WorkItemLoopsPass` would in turn wrap every kernel it came across,
and we didn't want it wrapping up the old 'scalar' kernel since we'd
never call it: this would negatively impact compile time for no reason.

However, with the revised sub-groups model and to handle the case where
the target is not using degenerate sub-groups, we *do* want to wrap up
the unvectorized scalar kernel as it is useful as a fallback in the same
way the degenerate sub-group kernel is.

To avoid compiling unnecessary kernel wrappers, the `WorkItemLoopsPass`
has been taught to avoid wrapping scalar kernels if they don't use
sub-group builtins, or if they're degenerate, or if the kernel has a
required sub-group size. This should preserve the old behaviour in the
vast majority of cases.

The `VerifyReqdSubGroupSizeSatisfiedPass` must now be run later in the
pipeline, after the `WorkItemLoopsPass` has run. This is because
immediately after vectorization the old 'scalar' kernel appears as
though the required sub-group size has not been met. It is only once the
`WorkItemLoopsPass` has run and vectorized and unvectorized kernels have
been merged that we have our 'final' kernel forms, and we can glean
whether the compiler correctly satisfied the constraints.

We could alternatively make the pass look at all the vectorized forms of
each kernel and verify that *at least one* form of each kernel has met
the requirement, but this ties its behaviour more closely with the
vectorizer's output, whereas currently it's fairly agnostic: it runs
over all kernel entry points.