### PR TITLE
[compiler] Clarify semantics of SubgroupAnalysis pass

### DIFF
--- a/modules/compiler/test/lit/passes/sub-group-analysis.ll
+++ b/modules/compiler/test/lit/passes/sub-group-analysis.ll
@@ -67,7 +67,22 @@ exit:
   ret void
 }
 
+; We don't consider any of the internal mux 'setters' as uses of sub-group
+; builtins, as they are purely there to support the framework and aren't
+; apparent to the user.
+; CHECK: Function 'function4' uses no sub-group builtins
+define spir_func void @function4() {
+  call void @__mux_set_sub_group_id(i32 0)
+  call void @__mux_set_num_sub_groups(i32 1)
+  call void @__mux_set_max_sub_group_size(i32 2)
+  ret void
+}
+
 declare i32 @__mux_get_sub_group_id()
 declare i32 @__mux_get_sub_group_local_id()
 declare i32 @__mux_sub_group_shuffle_i32(i32, i32)
 declare i32 @__mux_get_max_sub_group_size()
+
+declare void @__mux_set_sub_group_id(i32)
+declare void @__mux_set_num_sub_groups(i32)
+declare void @__mux_set_max_sub_group_size(i32)

--- a/modules/compiler/utils/include/compiler/utils/sub_group_analysis.h
+++ b/modules/compiler/utils/include/compiler/utils/sub_group_analysis.h
@@ -34,6 +34,10 @@ namespace utils {
 /// processed. Thus an external function declaration that uses sub-group
 /// builtins will be missed.
 ///
+/// Internal mux sub-group 'setter' functions are not counted. This is because
+/// they only used internally by the oneAPI Construction Kit as scaffolding for
+/// the sub-group support that the user can observe.
+///
 /// Each function contains the set of mux sub-group builtins it (transitively)
 /// calls.
 class GlobalSubgroupInfo {


### PR DESCRIPTION
This clarifies and tests that the analysis does not consider the use of mux sub-group 'setter' builtins as uses of sub-groups. This was previously under-specified.

This behaviour is because the analysis is primarily to query the use of sub-groups that the user can observe. The effects of the 'setter' builtins are not apparent to the user other than through the 'getter' builtins. They are purely to provide the scaffolding and data for these getters.