### PR TITLE
[riscv][vecz] Auto-vectorize sub-group kernels to a device-specific sub-group size

### DIFF
--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_pass_machinery.cpp
@@ -124,9 +124,6 @@ llvm::ModulePassManager RefSiM1PassMachinery::getLateTargetPasses() {
     PM.addPass(compiler::utils::LinkBuiltinsPass());
   }
 
-  // TODON'T temporary fix to get subgroup tests passing while we refactor
-  // subgroup support. CA-4712 CA-4679
-  tuner.degenerate_sub_groups = true;
   addPreVeczPasses(PM, tuner);
 
   PM.addPass(vecz::RunVeczPass());

--- a/modules/compiler/vecz/include/vecz/pass.h
+++ b/modules/compiler/vecz/include/vecz/pass.h
@@ -66,7 +66,23 @@ struct VeczPassOptions {
   uint64_t local_size;
 };
 
+/// @brief Returns the vectorization options that would vectorize the provided
+/// function to its required sub-group size.
 std::optional<VeczPassOptions> getReqdSubgroupSizeOpts(llvm::Function &);
+
+/// @brief Returns the vectorization options that would vectorize the provided
+/// function to its required sub-group size (if set) or one of the device's
+/// sub-group sizes.
+///
+/// Only returns options if the function uses sub-group operations, as
+/// determined by the SubGroupAnalysis pass.
+///
+/// Tries to find a good fit that produces one of the device's sub-group sizes,
+/// preferring ones which fit the known local work-group size and powers of
+/// two. The device's sub-group sizes can be sorted such that preferable sizes
+/// are placed towards the front.
+std::optional<VeczPassOptions> getAutoSubgroupSizeOpts(
+    llvm::Function &, llvm::ModuleAnalysisManager &);
 
 /// @brief Analysis pass which determines on which functions @ref RunVeczPass
 /// should operate.

--- a/modules/compiler/vecz/source/pass.cpp
+++ b/modules/compiler/vecz/source/pass.cpp
@@ -128,6 +128,14 @@ PreservedAnalyses RunVeczPass::run(Module &M, ModuleAnalysisManager &MAM) {
     ResultTy T;
     Results.insert(std::make_pair(Fn, std::move(T)));
     for (auto &Opts : P.second) {
+      // If we've been given an auto width, try and fit it to any requirements
+      // that the kernel places on its sub-groups.
+      if (Opts.vecz_auto) {
+        if (auto ReqdSGOpts = getReqdSubgroupSizeOpts(*Fn)) {
+          Opts = *ReqdSGOpts;
+        }
+      }
+
       auto *const VU =
           createVectorizationUnit(Ctx, Fn, Opts, Mach.getFAM(), Check);
       if (!VU) {

--- a/modules/compiler/vecz/test/lit/llvm/device-sg-size-auto.ll
+++ b/modules/compiler/vecz/test/lit/llvm/device-sg-size-auto.ll
@@ -1,0 +1,58 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Let vecz pick the right vectorization factor for this kernel
+; RUN: veczc --vecz-auto -k foo -k bar --device-sg-sizes 6,7,8,9 -S < %s | FileCheck %s
+; RUN: veczc --vecz-auto -k foo:4 -k bar:4 --device-sg-sizes 6,7,8,9 -S < %s | FileCheck %s
+
+; Check we auto-vectorize to 8, despite any other options telling us a
+; different vectorization factor. A factor of 8 is 'best' here because it's a
+; power of two.
+; CHECK: define void @__vecz_v8_foo(
+define void @foo(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
+  %id = call i64 @__mux_get_global_id(i32 0)
+  %in.addr = getelementptr i32, ptr addrspace(1) %in, i64 %id
+  %x = load i32, ptr addrspace(1) %in.addr
+  %sglid = call i32 @__mux_get_sub_group_local_id()
+; CHECK: = add <8 x i32>
+  %y = add i32 %x, %sglid
+  %out.addr = getelementptr i32, ptr addrspace(1) %out, i64 %id
+  store i32 %y, ptr addrspace(1) %out.addr
+  ret void
+}
+
+; Check we auto-vectorize to 7, despite any other options telling us a
+; different vectorization factor. A factor of 8 is 'best' here because it's a
+; power of two, but a factor of 7 works well because it won't need a tail.
+; CHECK: define void @__vecz_v7_bar(
+define void @bar(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !reqd_work_group_size !0 {
+  %id = call i64 @__mux_get_global_id(i32 0)
+  %in.addr = getelementptr i32, ptr addrspace(1) %in, i64 %id
+  %x = load i32, ptr addrspace(1) %in.addr
+  %sglid = call i32 @__mux_get_sub_group_local_id()
+; CHECK: = add <7 x i32>
+  %y = add i32 %x, %sglid
+  %out.addr = getelementptr i32, ptr addrspace(1) %out, i64 %id
+  store i32 %y, ptr addrspace(1) %out.addr
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)
+declare i32 @__mux_get_sub_group_local_id()
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+!0 = !{i64 14, i64 1, i64 1}

--- a/modules/compiler/vecz/test/lit/llvm/reqd-sg-size-auto.ll
+++ b/modules/compiler/vecz/test/lit/llvm/reqd-sg-size-auto.ll
@@ -1,0 +1,55 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Let vecz pick the right vectorization factor for this kernel
+; RUN: veczc --vecz-auto -k bar_sg8 -k foo_sg13 -S < %s | FileCheck %s
+; RUN: veczc --vecz-auto -k bar_sg8:4 -k foo_sg13:8 -S < %s | FileCheck %s
+
+; Check we auto-vectorize to 8, despite any other options telling us a
+; different vectorization factor.
+; CHECK: define void @__vecz_v8_bar_sg8
+define void @bar_sg8(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !0 {
+  %id = call i64 @__mux_get_global_id(i32 0)
+  %in.addr = getelementptr i32, ptr addrspace(1) %in, i64 %id
+  %x = load i32, ptr addrspace(1) %in.addr
+; CHECK: = add <8 x i32>
+  %y = add i32 %x, 1
+  %out.addr = getelementptr i32, ptr addrspace(1) %out, i64 %id
+  store i32 %y, ptr addrspace(1) %out.addr
+  ret void
+}
+
+; Check we auto-vectorize to 13, despite any other options telling us a
+; different vectorization factor. This is a silly number but it if we're told
+; to do it we must obey.
+; CHECK: define void @__vecz_v13_foo_sg13
+define void @foo_sg13(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 !intel_reqd_sub_group_size !1 {
+  %id = call i64 @__mux_get_global_id(i32 0)
+  %in.addr = getelementptr i32, ptr addrspace(1) %in, i64 %id
+  %x = load i32, ptr addrspace(1) %in.addr
+; CHECK: = add <13 x i32>
+  %y = add i32 %x, 1
+  %out.addr = getelementptr i32, ptr addrspace(1) %out, i64 %id
+  store i32 %y, ptr addrspace(1) %out.addr
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+!0 = !{i32 8}
+!1 = !{i32 13}

--- a/modules/mux/source/hal/include/mux/hal/kernel.h
+++ b/modules/mux/source/hal/include/mux/hal/kernel.h
@@ -48,8 +48,8 @@ struct kernel_variant_s {
   /// Note that the last sub-group in a work-group may be smaller than this
   /// value.
   /// * If one, denotes a trivial sub-group.
-  /// * If zero, denotes either no sub-groups or a 'degenerate' sub-group
-  /// (i.e., the size of the work-group at enqueue time).
+  /// * If zero, denotes a 'degenerate' sub-group (i.e., the size of the
+  /// work-group at enqueue time).
   uint32_t sub_group_size = 0;
 };
 

--- a/modules/mux/targets/host/include/host/executable.h
+++ b/modules/mux/targets/host/include/host/executable.h
@@ -53,8 +53,8 @@ struct binary_kernel_s {
   /// Note that the last sub-group in a work-group may be smaller than this
   /// value.
   /// * If one, denotes a trivial sub-group.
-  /// * If zero, denotes either no sub-groups or a 'degenerate' sub-group
-  /// (i.e., the size of the work-group at enqueue time).
+  /// * If zero, denotes a 'degenerate' sub-group (i.e., the size of the
+  /// work-group at enqueue time).
   uint32_t sub_group_size;
 };
 

--- a/modules/mux/targets/riscv/source/device_info.cpp
+++ b/modules/mux/targets/riscv/source/device_info.cpp
@@ -146,7 +146,10 @@ device_info_s::device_info_s()
   this->supports_work_group_collectives = true;
   this->supports_generic_address_space = true;
 
-  static std::array<size_t, 1> sg_sizes = {
+  // A list of sub-group sizes we report. Roughly ordered according to
+  // desirability.
+  static std::array<size_t, 4> sg_sizes = {
+      8, 4, 16,
       1,  // we can always produce a 'trivial' sub-group if asked.
   };
   this->sub_group_sizes = sg_sizes.data();

--- a/modules/utils/targets/host/include/host/utils/jit_kernel.h
+++ b/modules/utils/targets/host/include/host/utils/jit_kernel.h
@@ -45,8 +45,8 @@ struct jit_kernel_s {
   /// Note that the last sub-group in a work-group may be smaller than this
   /// value.
   /// * If one, denotes a trivial sub-group.
-  /// * If zero, denotes either no sub-groups or a 'degenerate' sub-group
-  /// (i.e., the size of the work-group at enqueue time).
+  /// * If zero, denotes a 'degenerate' sub-group (i.e., the size of the
+  /// work-group at enqueue time).
   uint32_t sub_group_size;
 };
 


### PR DESCRIPTION
This PR updates the riscv/refsi targets to automatically vectorize kernels/functions containing explicit use of sub-groups to one of the device's advertised sub-group widths.

The rationale for this is as follows: The SYCL 2020 spec has `info::device::sub_group_sizes` which returns "**_the_**" list of sub-group sizes reported by the device. The CTS expects that if it runs a kernel which (for example) returns the kernel's sub-group size to the host, then that size is found in that same device list.

This rules out the use of degenerate sub-groups. We'd have to list all the sub-group (read: work-group) sizes from 1 to 1024, which is useless for users. All of those sub-group sizes could then, in turn, be _required_ by a user, and the compiler would effectively be unable to satisfy. A user requiring a sub-group size of 244 would lead to a very strange situation where the compiler must create a degenerate sub-groups kernel and would then just _hope_ that the user uses a work-group size of 244. Anything else would be invalid. This is another bad user experience.

The vectorizer can be asked to return a suitable vectorization factor for a kernel, given its use of sub-groups and the device's list of sub-group sizes. It is quite rudimentary in its heuristic and doesn't choose between legal powers of two: the first one is taken as the preferred list.

I've filed a ticket for clarification/questions about sub-groups and degenerate sub-groups against the SYCL spec (see https://github.com/KhronosGroup/SYCL-Docs/issues/463), but I think this is a suitable "workaround" for now, or even for the long term. The behaviour is arguably more intuitive for users.

This hasn't been done on `host` due to issues with its compiler framework and its current inability to handle multiple online JIT kernels. That will come later.