### PR TITLE
Fix stdout usage in city runner python script

### DIFF
--- a/scripts/testing/city_runner/profiles/sycl_cts.py
+++ b/scripts/testing/city_runner/profiles/sycl_cts.py
@@ -17,6 +17,7 @@
 import os
 import io
 import re
+from sys import stdout
 from city_runner.profiles.default import DefaultProfile
 from city_runner.profiles.default import DefaultTestRun
 from city_runner.execution import TestRunBase


### PR DESCRIPTION
# Overview

Fixed sycl_cts profile when no output

# Reason for change

The sycl_cts profile was using stdout without importing it.

# Description of change

Added import for stdout