### PR TITLE
[compiler] Clear retained nodes from artificial sub-programs

### DIFF
--- a/modules/compiler/utils/source/pass_functions.cpp
+++ b/modules/compiler/utils/source/pass_functions.cpp
@@ -659,7 +659,17 @@ static llvm::Function *createKernelWrapperFunctionImpl(
   // copy debug info for function over
   if (auto *SP = F.getSubprogram()) {
     llvm::DIBuilder DIB(*F.getParent());
-    auto *NewSP = DIB.createArtificialSubprogram(SP);
+    llvm::DISubprogram *const NewSP = DIB.createArtificialSubprogram(SP);
+#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+    // Wipe the list of retained nodes, as this new function is a wrapper over
+    // the old one and does not itself contain/retain any of the wrapped
+    // function's nodes.
+    NewSP->replaceRetainedNodes({});
+#else
+    // This does the same as the above, but there's no cleaner API with which
+    // to do it.
+    NewSP->replaceOperandWith(7, nullptr);
+#endif
     NewFunction.setSubprogram(NewSP);
   }
 


### PR DESCRIPTION
Not doing so triggers an assertion in LLVM 17. Unhelpfully, it doesn't
present a verifier error until it reaches the actual machine function
emission stage, right at the end of the compilation process.

Logically I think this makes sense - the wrapper function should not
'retain' any nodes from the wrapped function's sub-program. Those are
retained by the wrapped function itself.

This doesn't seem necessary before LLVM 17 (in that there's no
assertion), and there's no clear API with which to do it, but for
consistency's sake we now do so too.