### PR TITLE
[compiler] Add work-group scan support in vecz/work-item-loops

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_pass_machinery.cpp
@@ -92,6 +92,10 @@ llvm::ModulePassManager RefSiG1PassMachinery::getLateTargetPasses() {
   auto env_var_opts =
       processOptimizationOptions(env_debug_prefix, /* vecz_mode*/ {});
 
+  // We don't run the WorkItemLoopsPass; we need an implementation of
+  // work-group collective operations.
+  tuner.replace_work_group_collectives = true;
+
   PM.addPass(compiler::utils::TransferKernelMetadataPass());
 
   if (env_debug_prefix) {
@@ -130,8 +134,6 @@ llvm::ModulePassManager RefSiG1PassMachinery::getLateTargetPasses() {
   // addLateBuiltinsPasses, which isn't ideal.
   PM.addPass(compiler::utils::DefineMuxDmaPass());
 
-  // We don't run the WorkItemLoopsPass; make sure that's taken into account.
-  tuner.handling_work_item_loops = false;
   addPreVeczPasses(PM, tuner);
 
   addLateBuiltinsPasses(PM, tuner);

--- a/modules/compiler/source/base/include/base/pass_pipelines.h
+++ b/modules/compiler/source/base/include/base/pass_pipelines.h
@@ -54,8 +54,9 @@ struct BasePassPipelineTuner {
   /// @brief Whether or not to generate code for degenerate sub groups.
   bool degenerate_sub_groups = false;
 
-  /// @brief Whether or not the WorkItemLoopsPass is going to be run.
-  bool handling_work_item_loops = true;
+  /// @brief Whether or not to replace work-group collectives early before
+  /// vectorization.
+  bool replace_work_group_collectives = false;
 
   /// @brief The desired target calling convention, used to configure the
   /// FixupCallingConvention pass.

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -267,11 +267,6 @@ Expected<bool> parseReplaceMuxMathDeclsPassOptions(StringRef Params) {
                                                 "ReplaceMuxMathDeclsPass");
 }
 
-Expected<bool> parseReplaceWGCPassOptions(StringRef Params) {
-  return compiler::utils::parseSinglePassOption(Params, "scans-only",
-                                                "ReplaceWGCPass");
-}
-
 // Lookup table for calling convention enums
 std::unordered_map<std::string, CallingConv::ID> CallConvMap = {
     {"C", CallingConv::C},

--- a/modules/compiler/source/base/source/base_module_pass_registry.def
+++ b/modules/compiler/source/base/source/base_module_pass_registry.def
@@ -42,9 +42,9 @@ MODULE_PASS("rename-builtins", compiler::utils::RenameBuiltinsPass())
 MODULE_PASS("replace-atomic-funcs", compiler::utils::ReplaceAtomicFuncsPass())
 MODULE_PASS("replace-c11-atomic-funcs",
             compiler::utils::ReplaceC11AtomicFuncsPass())
-
 MODULE_PASS("replace-module-scope-vars",
             compiler::utils::ReplaceLocalModuleScopeVariablesPass())
+MODULE_PASS("replace-wgc", compiler::utils::ReplaceWGCPass())
 
 MODULE_PASS("builtin-simplify", compiler::BuiltinSimplificationPass())
 MODULE_PASS("image-arg-subst", compiler::ImageArgumentSubstitutionPass())
@@ -69,14 +69,6 @@ MODULE_PASS("print<vecz-pass-opts>", vecz::VeczPassOptionsPrinterPass(dbgs()))
 #ifndef MODULE_PASS_WITH_PARAMS
 #define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)
 #endif
-
-MODULE_PASS_WITH_PARAMS(
-    "replace-wgc", "compiler::utils::ReplaceWGCPass",
-    [](bool ScansOnly) {
-      return compiler::utils::ReplaceWGCPass(ScansOnly);
-    },
-    parseReplaceWGCPassOptions,
-    "scans-only")
 
 MODULE_PASS_WITH_PARAMS(
     "add-kernel-wrapper", "compiler::utils::AddKernelWrapperPass",

--- a/modules/compiler/source/base/source/pass_pipelines.cpp
+++ b/modules/compiler/source/base/source/pass_pipelines.cpp
@@ -57,12 +57,11 @@ void addPreVeczPasses(ModulePassManager &PM,
     PM.addPass(compiler::utils::DegenerateSubGroupPass());
   }
 
-  // We need to use the software implementation of the work-group collective
-  // builtins. Because ReplaceWGCPass may introduce barrier calls it needs to be
-  // run before PrepareBarriersPass. When using the WorkItemLoopsPass, we can
-  // run the Replace WGC pass in Scans Only mode, since the WorkItemLoopsPass
-  // has its own implementations of reductions and broadcasts.
-  PM.addPass(compiler::utils::ReplaceWGCPass(tuner.handling_work_item_loops));
+  if (tuner.replace_work_group_collectives) {
+    // Because ReplaceWGCPass may introduce barrier calls it needs to be run
+    // before PrepareBarriersPass.
+    PM.addPass(compiler::utils::ReplaceWGCPass());
+  }
 
   // We have to inline all functions containing barriers before running vecz,
   // because the barriers in both the scalar and vector kernels need to be

--- a/modules/compiler/test/lit/passes/work-item-loops-scan-1.ll
+++ b/modules/compiler/test/lit/passes/work-item-loops-scan-1.ll
@@ -1,0 +1,57 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define void @foo(ptr %in, ptr %out) #0 {
+entry:
+  %id = call i64 @__mux_get_local_id(i32 0)
+  %inaddr = getelementptr inbounds i32, ptr %in,  i64 %id
+  %val = load i32, ptr %inaddr
+  %scan = tail call i32 @__mux_work_group_scan_inclusive_mul_i32(i32 0, i32 %val) #4
+  %outaddr = getelementptr inbounds i32, ptr %out,  i64 %id
+  store i32 %scan, ptr %outaddr
+  ret void
+}
+
+; CHECK: define void @foo.mux-barrier-wrapper(ptr %in, ptr %out)
+
+; CHECK-LABEL: loopIR7:
+; CHECK: [[PHIZ:%.*]] = phi i32 [ 1, %sw.bb2 ], [ [[ACC:%.*]], %exitIR11 ]
+
+; CHECK-LABEL: loopIR8:
+; CHECK: [[PHIY:%.*]] = phi i32 [ [[PHIZ]], %loopIR7 ], [ [[ACC]], %exitIR10 ]
+
+; CHECK-LABEL: loopIR9:
+; CHECK: [[PHIX:%.*]] = phi i32 [ [[PHIY]], %loopIR8 ], [ [[ACC]], %loopIR9 ]
+; CHECK: [[VAL:%.*]] = load i32, ptr %live_gep_val, align 4
+; CHECK: [[ACC]] = mul i32 [[PHIX]], [[VAL]]
+; CHECK: call i32 @foo.mux-barrier-region.1(ptr %in, ptr %out, i32 [[ACC]],
+
+declare i32 @__mux_work_group_scan_inclusive_mul_i32(i32, i32) #1
+
+declare i64 @__mux_get_local_id(i32) #2
+
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }
+attributes #1 = { alwaysinline convergent norecurse nounwind }
+attributes #2 = { alwaysinline norecurse nounwind readonly }
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}

--- a/modules/compiler/test/lit/passes/work-item-loops-scan-2.ll
+++ b/modules/compiler/test/lit/passes/work-item-loops-scan-2.ll
@@ -1,0 +1,110 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define void @foo(ptr %in, ptr %out) #0 !codeplay_ca_vecz.base !1 {
+entry:
+  %id = call i64 @__mux_get_local_id(i32 0)
+  %inaddr = getelementptr inbounds i32, ptr %in, i64 %id
+  %val = load i32, ptr %inaddr, align 4
+  %scan = tail call i32 @__mux_work_group_scan_inclusive_mul_i32(i32 0, i32 %val)
+  %outaddr = getelementptr inbounds i32, ptr %out, i64 %id
+  store i32 %scan, ptr %outaddr, align 4
+  ret void
+}
+
+declare i32 @__mux_work_group_scan_inclusive_mul_i32(i32, i32) #1
+
+declare i64 @__mux_get_local_id(i32) #2
+
+define void @__vecz_nxv4_foo(ptr %in, ptr %out) #3 !codeplay_ca_vecz.derived !3 {
+entry:
+  %id = call i64 @__mux_get_local_id(i32 0)
+  %inaddr = getelementptr inbounds i32, ptr %in, i64 %id
+  %0 = load <vscale x 4 x i32>, ptr %inaddr, align 4
+  %1 = call <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_mul_u5nxv4j(<vscale x 4 x i32> %0) #6
+  %2 = call i32 @llvm.vector.reduce.mul.nxv4i32(<vscale x 4 x i32> %0)
+  %3 = call i32 @__mux_work_group_scan_exclusive_mul_i32(i32 0, i32 %2)
+  %.splatinsert = insertelement <vscale x 4 x i32> poison, i32 %3, i64 0
+  %.splat = shufflevector <vscale x 4 x i32> %.splatinsert, <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+  %4 = mul <vscale x 4 x i32> %1, %.splat
+  %outaddr = getelementptr inbounds i32, ptr %out, i64 %id
+  store <vscale x 4 x i32> %4, ptr %outaddr, align 4
+  ret void
+}
+
+; CHECK: define void @__vecz_nxv4_foo.mux-barrier-wrapper(ptr %in, ptr %out)
+
+; Check a linear loop structure, looping over all Zs and Ys, and in the inner
+; loop doing the main and tail X items in sequence.
+; CHECK-LABEL: loopIR11:
+; CHECK: [[PHIZ:%.*]] = phi i32 [ 1, %sw.bb2 ], [ [[TAIL_MERGE:%.*]], %exitIR15 ]
+
+; CHECK-LABEL: loopIR12:
+; CHECK: [[PHIY:%.*]] = phi i32 [ [[PHIZ]], %loopIR11 ], [ [[TAIL_MERGE]], %ca_work_item_x_tail_exit ]
+
+; Main loop
+; CHECK-LABEL: loopIR13:
+; CHECK: [[MPHIX:%.*]] = phi i32 [ [[PHIY]], %ca_work_item_x_main_preheader ], [ [[MACC:%.*]], %loopIR13 ]
+; CHECK: [[MVAL:%.*]] = load i32, ptr %live_gep_, align 4
+; CHECK: [[MACC]] = mul i32 [[MPHIX]], [[MVAL]]
+; This is an exclusive scan, so pass the 'previous' value to the sub-kernel.
+; CHECK: call i32 @__vecz_nxv4_foo.mux-barrier-region.1(ptr %in, ptr %out, i32 [[MPHIX]],
+
+; CHECK-LABEL: ca_work_item_x_main_exit:
+; CHECK: [[MERGE:%.*]] = phi i32 [ [[PHIY]], %loopIR12 ], [ [[MACC]], %loopIR13 ]
+
+; Tail loop
+; CHECK-LABEL: loopIR14:
+; CHECK: [[TPHIX:%.*]] = phi i32 [ [[MERGE]], %ca_work_item_x_tail_preheader ],
+; CHECK-SAME:                    [ [[TACC:%.*]], %loopIR14 ]
+; CHECK: [[TVAL:%.*]] = load i32, ptr %live_gep_val, align 4
+; CHECK: [[TACC]] = mul i32 [[TPHIX]], [[TVAL]]
+; This is an inclusive scan, so pass the 'current' value to the sub-kernel.
+; CHECK: call i32 @foo.mux-barrier-region.2(ptr %in, ptr %out, i32 [[TACC]],
+
+; Note - vecz normally generates the body for this helper, but it's irrelevant
+; for this test
+declare <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_mul_u5nxv4j(<vscale x 4 x i32> %0)
+
+declare i32 @llvm.vector.reduce.mul.nxv4i32(<vscale x 4 x i32>) #4
+
+declare i32 @__mux_work_group_scan_exclusive_mul_i32(i32, i32) #1
+
+declare <vscale x 4 x i32> @llvm.experimental.stepvector.nxv4i32() #4
+
+declare i32 @llvm.vscale.i32() #4
+
+declare <vscale x 4 x i32> @llvm.masked.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr>, i32 immarg, <vscale x 4 x i1>, <vscale x 4 x i32>) #5
+
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }
+attributes #1 = { alwaysinline convergent norecurse nounwind }
+attributes #2 = { alwaysinline norecurse nounwind readonly }
+attributes #3 = { convergent norecurse nounwind "mux-base-fn-name"="__vecz_nxv4_foo" "mux-kernel"="entry-point" }
+attributes #4 = { nocallback nofree nosync nounwind willreturn readnone }
+attributes #5 = { nocallback nofree nosync nounwind willreturn readonly }
+attributes #6 = { nounwind }
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+!1 = !{!2, ptr @__vecz_nxv4_foo}
+!2 = !{i32 4, i32 1, i32 0, i32 0}
+!3 = !{!2, ptr @foo}

--- a/modules/compiler/test/lit/passes/work-item-loops-scan-3.ll
+++ b/modules/compiler/test/lit/passes/work-item-loops-scan-3.ll
@@ -1,0 +1,59 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define void @foo(ptr %in, ptr %out) #0 {
+entry:
+  %id = call i64 @__mux_get_local_id(i32 0)
+  %inaddr = getelementptr inbounds i8, ptr %in,  i64 %id
+  %val = load i8, ptr %inaddr
+  %sext = sext i8 %val to i32
+  %scan = tail call i32 @__mux_work_group_scan_inclusive_mul_i32(i32 0, i32 %sext) #4
+  %outaddr = getelementptr inbounds i32, ptr %out,  i64 %id
+  store i32 %scan, ptr %outaddr
+  ret void
+}
+
+; CHECK: define void @foo.mux-barrier-wrapper(ptr %in, ptr %out)
+
+; CHECK-LABEL: loopIR7:
+; CHECK: [[PHIZ:%.*]] = phi i32 [ 1, %sw.bb2 ], [ [[ACC:%.*]], %exitIR11 ]
+
+; CHECK-LABEL: loopIR8:
+; CHECK: [[PHIY:%.*]] = phi i32 [ [[PHIZ]], %loopIR7 ], [ [[ACC]], %exitIR10 ]
+
+; CHECK-LABEL: loopIR9:
+; CHECK: [[PHIX:%.*]] = phi i32 [ [[PHIY]], %loopIR8 ], [ [[ACC]], %loopIR9 ]
+; CHECK: [[VAL0:%.*]] = load i8, ptr %live_gep_val, align 1
+; CHECK: [[VAL:%.*]] = sext i8 [[VAL0]] to i32
+; CHECK: [[ACC]] = mul i32 [[PHIX]], [[VAL]]
+; CHECK: call i32 @foo.mux-barrier-region.1(ptr %in, ptr %out, i32 [[ACC]],
+
+declare i32 @__mux_work_group_scan_inclusive_mul_i32(i32, i32) #1
+
+declare i64 @__mux_get_local_id(i32) #2
+
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }
+attributes #1 = { alwaysinline convergent norecurse nounwind }
+attributes #2 = { alwaysinline norecurse nounwind readonly }
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}

--- a/modules/compiler/utils/include/compiler/utils/replace_wgc_pass.h
+++ b/modules/compiler/utils/include/compiler/utils/replace_wgc_pass.h
@@ -37,23 +37,10 @@ namespace utils {
 /// introduces global variables into the module in the __local address space
 /// and therefore must be run before the ReplaceLocalModuleScopeVariablesPass
 /// on any target making use of that pass.
-///
-/// The constructor for this pass takes a boolean value indicating whether or
-/// not only Work Group Collective Scan operations should be processed. This is
-/// because the vectorizer and the Handle Barriers Pass are now able to work
-/// with reductions and broadcasts *as-is*. Pass false here if you do not intend
-/// to use the Handle Barriers Pass, so working implementations of these
-/// builtins are still generated. Pass true if you are using the Handle Barriers
-/// Pass, since its own implementations are more efficient.
 class ReplaceWGCPass final : public llvm::PassInfoMixin<ReplaceWGCPass> {
  public:
-  ReplaceWGCPass(bool scansOnly = false) : scans_only(scansOnly) {}
+  ReplaceWGCPass() {}
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
-
- private:
-  /// @brief when set to true, only work group collective scans will be
-  /// replaced.
-  bool scans_only = false;
 };
 }  // namespace utils
 }  // namespace compiler

--- a/modules/compiler/utils/source/replace_wgc_pass.cpp
+++ b/modules/compiler/utils/source/replace_wgc_pass.cpp
@@ -615,9 +615,6 @@ PreservedAnalyses compiler::utils::ReplaceWGCPass::run(
     auto Builtin = BI.analyzeBuiltin(F);
     if (auto WGC = BI.isMuxGroupCollective(Builtin.ID);
         WGC && WGC->isWorkGroupScope()) {
-      if (scans_only && !WGC->isScan()) {
-        continue;
-      }
       WGCollectives.push_back({&F, *WGC});
     }
   }

--- a/modules/compiler/vecz/test/lit/llvm/workgroup_scans.ll
+++ b/modules/compiler/vecz/test/lit/llvm/workgroup_scans.ll
@@ -1,0 +1,204 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -w 4 -S -vecz-passes=packetizer < %s | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+declare i64 @__mux_get_global_id(i32)
+
+declare i32 @__mux_work_group_scan_inclusive_add_i32(i32, i32)
+declare i64 @__mux_work_group_scan_inclusive_add_i64(i32, i64)
+declare float @__mux_work_group_scan_inclusive_fadd_f32(i32, float)
+
+declare i32 @__mux_work_group_scan_inclusive_smin_i32(i32, i32)
+declare i32 @__mux_work_group_scan_inclusive_umin_i32(i32, i32)
+declare i32 @__mux_work_group_scan_inclusive_smax_i32(i32, i32)
+declare i32 @__mux_work_group_scan_inclusive_umax_i32(i32, i32)
+declare float @__mux_work_group_scan_inclusive_fmin_f32(i32, float)
+declare float @__mux_work_group_scan_inclusive_fmax_f32(i32, float)
+
+define spir_kernel void @reduce_scan_incl_add_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
+  %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i32 @__mux_work_group_scan_inclusive_add_i32(i32 0, i32 %0)
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
+  store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_i32(
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_add_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_work_group_scan_exclusive_add_i32(i32 0, i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <4 x i32> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x i32> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_add_i64(i64 addrspace(1)* %in, i64 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i64, i64 addrspace(1)* %in, i64 %call
+  %0 = load i64, i64 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i64 @__mux_work_group_scan_inclusive_add_i64(i32 0, i64 %0)
+  %arrayidx2 = getelementptr inbounds i64, i64 addrspace(1)* %out, i64 %call
+  store i64 %call1, i64 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_i64(
+; CHECK: [[SCAN:%.*]] = call <4 x i64> @__vecz_b_sub_group_scan_inclusive_add_Dv4_m(<4 x i64> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i64 @__mux_work_group_scan_exclusive_add_i64(i32 0, i64 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i64> poison, i64 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i64> [[HEAD]], <4 x i64> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = add <4 x i64> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x i64> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_add_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
+  %0 = load float, float addrspace(1)* %arrayidx, align 4
+  %call1 = tail call float @__mux_work_group_scan_inclusive_fadd_f32(i32 0, float %0)
+  %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
+  store float %call1, float addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_add_f32(
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_add_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float -0.0{{.*}}, <4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_work_group_scan_exclusive_fadd_f32(i32 0, float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = fadd <4 x float> [[SCAN]], [[SPLAT]]
+; CHECK: store <4 x float> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_smin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
+  %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i32 @__mux_work_group_scan_inclusive_smin_i32(i32 0, i32 %0)
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
+  store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_smin_i32(
+; CHECK: call <4 x i32> @__vecz_b_sub_group_scan_inclusive_smin_Dv4_i(<4 x i32> %{{.*}})
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smin.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_work_group_scan_exclusive_smin_i32(i32 0, i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_umin_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
+  %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i32 @__mux_work_group_scan_inclusive_umin_i32(i32 0, i32 %0)
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
+  store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_umin_i32(
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umin_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_work_group_scan_exclusive_umin_i32(i32 0, i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.umin.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_smax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
+  %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i32 @__mux_work_group_scan_inclusive_smax_i32(i32 0, i32 %0)
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
+  store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_smax_i32(
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_smax_Dv4_i(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.smax.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_work_group_scan_exclusive_smax_i32(i32 0, i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_umax_i32(i32 addrspace(1)* %in, i32 addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %in, i64 %call
+  %0 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %call1 = tail call i32 @__mux_work_group_scan_inclusive_umax_i32(i32 0, i32 %0)
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %out, i64 %call
+  store i32 %call1, i32 addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_umax_i32(
+; CHECK: [[SCAN:%.*]] = call <4 x i32> @__vecz_b_sub_group_scan_inclusive_umax_Dv4_j(<4 x i32> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call i32 @__mux_work_group_scan_exclusive_umax_i32(i32 0, i32 [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x i32> poison, i32 [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[HEAD]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x i32> @llvm.umax.v4i32(<4 x i32> [[SCAN]], <4 x i32> [[SPLAT]])
+; CHECK: store <4 x i32> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_fmin_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
+  %0 = load float, float addrspace(1)* %arrayidx, align 4
+  %call1 = tail call float @__mux_work_group_scan_inclusive_fmin_f32(i32 0, float %0)
+  %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
+  store float %call1, float addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_fmin_f32(
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_min_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmin.v4f32(<4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_work_group_scan_exclusive_fmin_f32(i32 0, float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x float> @llvm.minnum.v4f32(<4 x float> [[SCAN]], <4 x float> [[SPLAT]])
+; CHECK: store <4 x float> [[FINAL]],
+}
+
+define spir_kernel void @reduce_scan_incl_fmax_f32(float addrspace(1)* %in, float addrspace(1)* %out) {
+entry:
+  %call = tail call i64 @__mux_get_global_id(i32 0)
+  %arrayidx = getelementptr inbounds float, float addrspace(1)* %in, i64 %call
+  %0 = load float, float addrspace(1)* %arrayidx, align 4
+  %call1 = tail call float @__mux_work_group_scan_inclusive_fmax_f32(i32 0, float %0)
+  %arrayidx2 = getelementptr inbounds float, float addrspace(1)* %out, i64 %call
+  store float %call1, float addrspace(1)* %arrayidx2, align 4
+  ret void
+; CHECK-LABEL: @__vecz_v4_reduce_scan_incl_fmax_f32(
+; CHECK: [[SCAN:%.*]] = call <4 x float> @__vecz_b_sub_group_scan_inclusive_max_Dv4_f(<4 x float> [[INPUT:%.*]])
+; CHECK: [[SUM:%.*]] = call float @llvm.vector.reduce.fmax.v4f32(<4 x float> [[INPUT]])
+; CHECK: [[EXCL_SCAN:%.*]] = call float @__mux_work_group_scan_exclusive_fmax_f32(i32 0, float [[SUM]])
+; CHECK: [[HEAD:%.*]] = insertelement <4 x float> poison, float [[EXCL_SCAN]], {{(i32|i64)}} 0
+; CHECK: [[SPLAT:%.*]] = shufflevector <4 x float> [[HEAD]], <4 x float> poison, <4 x i32> zeroinitializer
+; CHECK: [[FINAL:%.*]] = call <4 x float> @llvm.maxnum.v4f32(<4 x float> [[SCAN]], <4 x float> [[SPLAT]])
+; CHECK: store <4 x float> [[FINAL]],
+}


### PR DESCRIPTION
This completes the set of work-group collective functions we can support
via the 'alternative' pathway through the vectorizer and the
work-item-loops pass. They join broadcasts and reductions, which were
added a while back.

The scans are implemented using a linear work-item loop, accumulating
with each iteration of the 'X' loop. The vectorizer vectorizes them like
the sub-group scans, so the accumulator used is just the
current/previous value of scan operation so far. The vectorized
work-group merges this with the partial scan over the vector group.

The 'scans-only' parameter to the replace-wgc pass has been removed. The
pass is either run or it isn't run, depending on what the target wants
to do to support the work-group collective operations. Only the RefSi G1
WIPT example uses the old pass, though it should still be tested in LIT.

In unofficial local testing, these scans appear to be around 10% faster
to complete the associated SYCL-CTS tests. This requires more
investigation, however.