### PR TITLE
[UnitMux] Fix test tear down

### DIFF
--- a/modules/mux/test/muxCreateFence.cpp
+++ b/modules/mux/test/muxCreateFence.cpp
@@ -40,6 +40,8 @@ TEST_P(muxCreateFenceTest, InvalidDevice) {
 TEST_P(muxCreateFenceTest, InvalidAllocator) {
   mux_fence_t fence;
 
+  const mux_allocator_info_t saved_allocator = allocator;
+
   allocator.alloc = nullptr;
   allocator.free = nullptr;
   ASSERT_ERROR_EQ(mux_error_null_allocator_callback,
@@ -54,6 +56,9 @@ TEST_P(muxCreateFenceTest, InvalidAllocator) {
   allocator.free = nullptr;
   ASSERT_ERROR_EQ(mux_error_null_allocator_callback,
                   muxCreateFence(device, allocator, &fence));
+
+  // Restore allocator to properly tear down test
+  allocator = saved_allocator;
 }
 
 TEST_P(muxCreateFenceTest, NullFence) {


### PR DESCRIPTION
# Overview

This commit restores the allocator info to a valid state before the end of the `InvalidAllocator` test.

# Reason for change

If the allocator info is not restored to a valid state before the end of the test, the device is not destroyed properly as `muxDestroyDevice()` checks for a valid allocator info before doing anything.  If the device object holds any exclusive resources, this makes all following tests fail.
