### PR TITLE
[spirv-ll] Re-do Builder::create<OpSpecConstant>.

### DIFF
--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.spvasm32
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.spvasm32
@@ -22,7 +22,8 @@
 ; ```openclc
 ;
 ; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
-;                  global int* qInt, global long* qLong, global float* qFloat) {
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble, global half* qHalf) {
 ;   __attribute__((spec_id=0)) constant bool specTrue = true;
 ;   __attribute__((spec_id=1)) constant bool specFalse = false;
 ;   __attribute__((spec_id=2)) constant char specChar = 23;
@@ -30,6 +31,8 @@
 ;   __attribute__((spec_id=4)) constant int specInt = 23;
 ;   __attribute__((spec_id=5)) constant long specLong = 23;
 ;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
 ;
 ;   qBool[0] = specTrue;
 ;   qBool[1] = specFalse;
@@ -38,86 +41,103 @@
 ;   qInt[0] = specInt;
 ;   qLong[0] = specLong;
 ;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+;   qHalf[0] = specHalf;
 ; }
 ; ```
-                  OpCapability Addresses
-                  OpCapability Linkage
-                  OpCapability Kernel
-                  OpCapability Int8
-                  OpCapability Int16
-                  OpCapability Int64
-        %opencl = OpExtInstImport "OpenCL.std"
-                  OpMemoryModel Physical32 OpenCL
-                  OpEntryPoint Kernel %test "test"
- %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
-                  OpSource OpenCL_C 102000
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical32 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
 
 ; Variable names
-                  OpName %pBool "pBool"
-                  OpName %pChar "pChar"
-                  OpName %pShort "pShort"
-                  OpName %pInt "pInt"
-                  OpName %pLong "pLong"
-                  OpName %pFloat "pFloat"
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+                   OpName %pHalf "pHalf"
 
 ; Decorations
-                  OpDecorate %fnParamGroup FuncParamAttr NoCapture
-  %fnParamGroup = OpDecorationGroup
-                  OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble %pHalf
 
 ; Specialization constant decorations
-                  OpDecorate %specBoolTrue SpecId 0
-                  OpDecorate %specBoolFalse SpecId 1
-                  OpDecorate %specChar SpecId 2
-                  OpDecorate %specShort SpecId 3
-                  OpDecorate %specInt SpecId 4
-                  OpDecorate %specLong SpecId 5
-                  OpDecorate %specFloat SpecId 6
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+                   OpDecorate %specHalf SpecId 8
 
 ; Types
-          %void = OpTypeVoid
-          %bool = OpTypeBool
-          %char = OpTypeInt 8 0
-         %short = OpTypeInt 16 0
-           %int = OpTypeInt 32 0
-          %long = OpTypeInt 64 0
-         %float = OpTypeFloat 32
- %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
- %globalCharPtr = OpTypePointer CrossWorkgroup %char
-%gloablShortPtr = OpTypePointer CrossWorkgroup %short
-  %globalIntPtr = OpTypePointer CrossWorkgroup %int
- %globalLongPtr = OpTypePointer CrossWorkgroup %long
-%globalFloatPtr = OpTypePointer CrossWorkgroup %float
-        %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr %globalHalfPtr
 
 ; Specialzation constants
-  %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
- %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
-      %specChar = OpSpecConstant %char 23     ; SpecId: 2
-     %specShort = OpSpecConstant %short 23    ; SpecId: 3
-       %specInt = OpSpecConstant %int 23      ; SpecId: 4
-      %specLong = OpSpecConstant %long 23     ; SpecId: 5
-     %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
 
 ; Constants
-     %constInt1 = OpConstant %int 1
+      %constInt1 = OpConstant %int 1
 
 ; Entry point
-          %test = OpFunction %void None %testFn
-         %pBool = OpFunctionParameter %globalBoolPtr
-         %pChar = OpFunctionParameter %globalCharPtr
-        %pShort = OpFunctionParameter %gloablShortPtr
-          %pInt = OpFunctionParameter %globalIntPtr
-         %pLong = OpFunctionParameter %globalLongPtr
-        %pFloat = OpFunctionParameter %globalFloatPtr
-            %37 = OpLabel
-                  OpStore %pBool %specBoolTrue Aligned 1
-        %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constInt1
-                  OpStore %pBool1 %specBoolFalse Aligned 1
-                  OpStore %pChar %specChar Aligned 1
-                  OpStore %pShort %specShort Aligned 2
-                  OpStore %pInt %specInt Aligned 4
-                  OpStore %pLong %specLong Aligned 8
-                  OpStore %pFloat %specFloat Aligned 4
-                  OpReturn
-                  OpFunctionEnd
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constInt1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.spvasm64
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.spvasm64
@@ -22,7 +22,8 @@
 ; ```openclc
 ;
 ; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
-;                  global int* qInt, global long* qLong, global float* qFloat) {
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble, global half* qHalf) {
 ;   __attribute__((spec_id=0)) constant bool specTrue = true;
 ;   __attribute__((spec_id=1)) constant bool specFalse = false;
 ;   __attribute__((spec_id=2)) constant char specChar = 23;
@@ -30,6 +31,8 @@
 ;   __attribute__((spec_id=4)) constant int specInt = 23;
 ;   __attribute__((spec_id=5)) constant long specLong = 23;
 ;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
 ;
 ;   qBool[0] = specTrue;
 ;   qBool[1] = specFalse;
@@ -38,86 +41,103 @@
 ;   qInt[0] = specInt;
 ;   qLong[0] = specLong;
 ;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+;   qHalf[0] = specHalf;
 ; }
 ; ```
-                  OpCapability Addresses
-                  OpCapability Linkage
-                  OpCapability Kernel
-                  OpCapability Int8
-                  OpCapability Int16
-                  OpCapability Int64
-        %opencl = OpExtInstImport "OpenCL.std"
-                  OpMemoryModel Physical64 OpenCL
-                  OpEntryPoint Kernel %test "test"
- %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
-                  OpSource OpenCL_C 102000
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical64 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
 
 ; Variable names
-                  OpName %pBool "pBool"
-                  OpName %pChar "pChar"
-                  OpName %pShort "pShort"
-                  OpName %pInt "pInt"
-                  OpName %pLong "pLong"
-                  OpName %pFloat "pFloat"
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+                   OpName %pHalf "pHalf"
 
 ; Decorations
-                  OpDecorate %fnParamGroup FuncParamAttr NoCapture
-  %fnParamGroup = OpDecorationGroup
-                  OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble %pHalf
 
 ; Specialization constant decorations
-                  OpDecorate %specBoolTrue SpecId 0
-                  OpDecorate %specBoolFalse SpecId 1
-                  OpDecorate %specChar SpecId 2
-                  OpDecorate %specShort SpecId 3
-                  OpDecorate %specInt SpecId 4
-                  OpDecorate %specLong SpecId 5
-                  OpDecorate %specFloat SpecId 6
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+                   OpDecorate %specHalf SpecId 8
 
 ; Types
-          %void = OpTypeVoid
-          %bool = OpTypeBool
-          %char = OpTypeInt 8 0
-         %short = OpTypeInt 16 0
-           %int = OpTypeInt 32 0
-          %long = OpTypeInt 64 0
-         %float = OpTypeFloat 32
- %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
- %globalCharPtr = OpTypePointer CrossWorkgroup %char
-%gloablShortPtr = OpTypePointer CrossWorkgroup %short
-  %globalIntPtr = OpTypePointer CrossWorkgroup %int
- %globalLongPtr = OpTypePointer CrossWorkgroup %long
-%globalFloatPtr = OpTypePointer CrossWorkgroup %float
-        %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr %globalHalfPtr
 
 ; Specialzation constants
-  %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
- %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
-      %specChar = OpSpecConstant %char 23     ; SpecId: 2
-     %specShort = OpSpecConstant %short 23    ; SpecId: 3
-       %specInt = OpSpecConstant %int 23      ; SpecId: 4
-      %specLong = OpSpecConstant %long 23     ; SpecId: 5
-     %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
 
 ; Constants
-    %constLong1 = OpConstant %long 1
+     %constLong1 = OpConstant %long 1
 
 ; Entry point
-          %test = OpFunction %void None %testFn
-         %pBool = OpFunctionParameter %globalBoolPtr
-         %pChar = OpFunctionParameter %globalCharPtr
-        %pShort = OpFunctionParameter %gloablShortPtr
-          %pInt = OpFunctionParameter %globalIntPtr
-         %pLong = OpFunctionParameter %globalLongPtr
-        %pFloat = OpFunctionParameter %globalFloatPtr
-            %37 = OpLabel
-                  OpStore %pBool %specBoolTrue Aligned 1
-        %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constLong1
-                  OpStore %pBool1 %specBoolFalse Aligned 1
-                  OpStore %pChar %specChar Aligned 1
-                  OpStore %pShort %specShort Aligned 2
-                  OpStore %pInt %specInt Aligned 4
-                  OpStore %pLong %specLong Aligned 8
-                  OpStore %pFloat %specFloat Aligned 4
-                  OpReturn
-                  OpFunctionEnd
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constLong1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/source/clSetProgramSpecializationConstant.cpp
+++ b/source/cl/test/UnitCL/source/clSetProgramSpecializationConstant.cpp
@@ -27,6 +27,8 @@
 // * SpecId: 4       OpTypeInt       16 bit    Default: 23
 // * SpecId: 5       OpTypeInt       64 bit    Default: 23
 // * SpecId: 6       OpTypeFloat     32 bit    Default: 23.0
+// * SpecId: 7       OpTypeFloat     64 bit    Default: 23.0
+// * SpecId: 8       OpTypeFloat     16 bit    Default: 23.0
 
 struct clSetProgramSpecializationConstantTest : ucl::ContextTest {
   void SetUp() override {
@@ -123,9 +125,21 @@ struct clSetProgramSpecializationConstantSuccessTest
     floatBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_float),
                                  nullptr, &error);
     ASSERT_SUCCESS(error);
+    doubleBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_double),
+                                  nullptr, &error);
+    ASSERT_SUCCESS(error);
+    halfBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_half),
+                                nullptr, &error);
+    ASSERT_SUCCESS(error);
   }
 
   void TearDown() final {
+    if (halfBuffer) {
+      ASSERT_SUCCESS(clReleaseMemObject(halfBuffer));
+    }
+    if (doubleBuffer) {
+      ASSERT_SUCCESS(clReleaseMemObject(doubleBuffer));
+    }
     if (floatBuffer) {
       ASSERT_SUCCESS(clReleaseMemObject(floatBuffer));
     }
@@ -160,9 +174,11 @@ struct clSetProgramSpecializationConstantSuccessTest
     ASSERT_SUCCESS(clSetKernelArg(kernel, 3, sizeof(cl_mem), &intBuffer));
     ASSERT_SUCCESS(clSetKernelArg(kernel, 4, sizeof(cl_mem), &longBuffer));
     ASSERT_SUCCESS(clSetKernelArg(kernel, 5, sizeof(cl_mem), &floatBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, 6, sizeof(cl_mem), &doubleBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, 7, sizeof(cl_mem), &halfBuffer));
     cl_event taskEvent;
     ASSERT_SUCCESS(clEnqueueTask(commandQueue, kernel, 0, nullptr, &taskEvent));
-    std::array<cl_event, 6> resultEvents;
+    std::array<cl_event, 8> resultEvents;
     ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, boolBuffer, CL_FALSE, 0,
                                        sizeof(bool) * 2, boolResults.data(), 1,
                                        &taskEvent, &resultEvents[0]));
@@ -181,6 +197,12 @@ struct clSetProgramSpecializationConstantSuccessTest
     ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, floatBuffer, CL_FALSE, 0,
                                        sizeof(cl_float), &floatResult, 1,
                                        &taskEvent, &resultEvents[5]));
+    ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, doubleBuffer, CL_FALSE, 0,
+                                       sizeof(cl_double), &doubleResult, 1,
+                                       &taskEvent, &resultEvents[6]));
+    ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, halfBuffer, CL_FALSE, 0,
+                                       sizeof(cl_half), &halfResult, 1,
+                                       &taskEvent, &resultEvents[7]));
     ASSERT_SUCCESS(clWaitForEvents(resultEvents.size(), resultEvents.data()));
 
     std::for_each(
@@ -197,12 +219,16 @@ struct clSetProgramSpecializationConstantSuccessTest
   cl_mem intBuffer = nullptr;
   cl_mem longBuffer = nullptr;
   cl_mem floatBuffer = nullptr;
+  cl_mem doubleBuffer = nullptr;
+  cl_mem halfBuffer = nullptr;
   std::array<bool, 2> boolResults;
   cl_char charResult;
   cl_short shortResult;
   cl_int intResult;
   cl_long longResult;
   cl_float floatResult;
+  cl_double doubleResult;
+  cl_half halfResult;
 };
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest, None) {
@@ -219,6 +245,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, None) {
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -239,6 +267,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -259,6 +289,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -279,6 +311,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -299,6 +333,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -319,6 +355,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(value, intResult);              // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -339,6 +377,8 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(value, longResult);             // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -352,13 +392,59 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   kernel = clCreateKernel(program, "test", &error);
   ASSERT_SUCCESS(error);
   UCL_RETURN_ON_FATAL_FAILURE(getResults());
-  ASSERT_EQ(true, boolResults[0]);       // SpecId: 0
-  ASSERT_EQ(false, boolResults[1]);      // SpecId: 1
-  ASSERT_EQ(cl_char(23), charResult);    // SpecId: 2
-  ASSERT_EQ(cl_short(23), shortResult);  // SpecId: 3
-  ASSERT_EQ(cl_int(23), intResult);      // SpecId: 4
-  ASSERT_EQ(cl_long(23), longResult);    // SpecId: 5
-  ASSERT_EQ(value, floatResult);         // SpecId: 6
+  ASSERT_EQ(true, boolResults[0]);           // SpecId: 0
+  ASSERT_EQ(false, boolResults[1]);          // SpecId: 1
+  ASSERT_EQ(cl_char(23), charResult);        // SpecId: 2
+  ASSERT_EQ(cl_short(23), shortResult);      // SpecId: 3
+  ASSERT_EQ(cl_int(23), intResult);          // SpecId: 4
+  ASSERT_EQ(cl_long(23), longResult);        // SpecId: 5
+  ASSERT_EQ(value, floatResult);             // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);    // SpecId: 8
+}
+
+TEST_F(clSetProgramSpecializationConstantSuccessTest,
+       SpecId7OpSpecConstantDouble) {
+  cl_double value = 42.0;
+  ASSERT_SUCCESS(
+      clSetProgramSpecializationConstant(program, 7, sizeof(value), &value));
+  ASSERT_SUCCESS(
+      clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
+  cl_int error;
+  kernel = clCreateKernel(program, "test", &error);
+  ASSERT_SUCCESS(error);
+  UCL_RETURN_ON_FATAL_FAILURE(getResults());
+  ASSERT_EQ(true, boolResults[0]);          // SpecId: 0
+  ASSERT_EQ(false, boolResults[1]);         // SpecId: 1
+  ASSERT_EQ(cl_char(23), charResult);       // SpecId: 2
+  ASSERT_EQ(cl_short(23), shortResult);     // SpecId: 3
+  ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
+  ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
+  ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(value, doubleResult);           // SpecId: 7
+  ASSERT_EQ(cl_half(0x4dc0), halfResult);   // SpecId: 8
+}
+
+TEST_F(clSetProgramSpecializationConstantSuccessTest,
+       SpecId6OpSpecConstantHalf) {
+  cl_half value = 0x5140;  // cl_half(42.0f)
+  ASSERT_SUCCESS(
+      clSetProgramSpecializationConstant(program, 8, sizeof(value), &value));
+  ASSERT_SUCCESS(
+      clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
+  cl_int error;
+  kernel = clCreateKernel(program, "test", &error);
+  ASSERT_SUCCESS(error);
+  UCL_RETURN_ON_FATAL_FAILURE(getResults());
+  ASSERT_EQ(true, boolResults[0]);           // SpecId: 0
+  ASSERT_EQ(false, boolResults[1]);          // SpecId: 1
+  ASSERT_EQ(cl_char(23), charResult);        // SpecId: 2
+  ASSERT_EQ(cl_short(23), shortResult);      // SpecId: 3
+  ASSERT_EQ(cl_int(23), intResult);          // SpecId: 4
+  ASSERT_EQ(cl_long(23), longResult);        // SpecId: 5
+  ASSERT_EQ(cl_float(23.0f), floatResult);   // SpecId: 6
+  ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  ASSERT_EQ(value, halfResult);              // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
@@ -383,6 +469,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
   cl_float floatValue = 42.0f;
   ASSERT_SUCCESS(clSetProgramSpecializationConstant(
       program, 6, sizeof(floatValue), &floatValue));
+  cl_double doubleValue = 42.0f;
+  ASSERT_SUCCESS(clSetProgramSpecializationConstant(
+      program, 7, sizeof(doubleValue), &doubleValue));
+  cl_half halfValue = 0x5140;  // cl_half(42.0f)
+  ASSERT_SUCCESS(clSetProgramSpecializationConstant(
+      program, 8, sizeof(halfValue), &halfValue));
   ASSERT_SUCCESS(
       clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
   cl_int error;
@@ -396,4 +488,6 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
   ASSERT_EQ(intValue, intResult);         // SpecId: 4
   ASSERT_EQ(longValue, longResult);       // SpecId: 5
   ASSERT_EQ(floatValue, floatResult);     // SpecId: 6
+  ASSERT_EQ(doubleValue, doubleResult);   // SpecId: 7
+  ASSERT_EQ(halfValue, halfResult);       // SpecId: 8
 }


### PR DESCRIPTION
Builder::create<OpSpecConstant> was implemented in a way that duplicated a lot of code, and did not handle sycl::half. This change simplifies things and ensures half is handled correctly.

# Overview

This change re-does Builder::create<OpSpecConstant> to remove the duplicated logic for creating constants, and making it more general.

# Reason for change

The code did not support half types, which would result in an llvm_unreachable being reached.

# Description of change

By writing Builder::create<OpSpecConstant> in a more general way, half types are implicitly handled without ever needing to specifically handle half types.

I modified the existing clSetProgramSpecializationConstant tests to cover testing of both double (already implemented but missing from the test) and half (not previously implemented).

# Anything else we should know?

The SYCL CTS also tests half support. I specifically looked at the "specialization_constants_defined_various_ways_fp16" test, which succeeds with this change.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
