### PR TITLE
[spirv-ll] Re-do Builder::create<OpSpecConstant>.

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1004,69 +1004,60 @@ cargo::optional<Error> Builder::create<OpSpecConstant>(
   llvm::Type *type = module.getType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
+  uint64_t value;
+  if (type->getScalarSizeInBits() > 32) {
+    value = op->Value64();
+  } else {
+    value = op->Value32();
+  }
+
   llvm::Constant *spec_constant = nullptr;
 
   if (auto specId = module.getSpecId(op->IdResult())) {
     if (auto specInfo = module.getSpecInfo()) {
       if (specInfo->isSpecialized(*specId)) {
-        // Constant has been specialized, get value and create new constant.
-        switch (type->getTypeID()) {
-          case llvm::Type::IntegerTyID: {
-            switch (type->getScalarSizeInBits()) {
-              case 16: {
-                auto value = specInfo->getValue<uint16_t>(*specId);
-                SPIRV_LL_ASSERT(value, value.error().message.c_str());
-                spec_constant = llvm::ConstantInt::get(type, *value);
-              } break;
-              case 1:
-                if (module.hasCapability(spv::CapabilityKernel)) {
-                  // OpenCL SPIR-V spec constant bool is 8 bits.
-                  auto value = specInfo->getValue<uint8_t>(*specId);
-                  SPIRV_LL_ASSERT(value, value.error().message.c_str());
-                  spec_constant = llvm::ConstantInt::get(type, *value);
-                  break;
-                }
-                // Vulkan SPIR-V spec constant bool is 32 bits.
-                CARGO_FALLTHROUGH;
-              case 32: {
-                auto value = specInfo->getValue<uint32_t>(*specId);
-                SPIRV_LL_ASSERT(value, value.error().message.c_str());
-                spec_constant = llvm::ConstantInt::get(type, *value);
-              } break;
-              case 64: {
-                auto value = specInfo->getValue<uint64_t>(*specId);
-                SPIRV_LL_ASSERT(value, value.error().message.c_str());
-                spec_constant = llvm::ConstantInt::get(type, *value);
-              } break;
-              case 8:
-                if (module.hasCapability(spv::CapabilityKernel)) {
-                  auto value = specInfo->getValue<uint8_t>(*specId);
-                  SPIRV_LL_ASSERT(value, value.error().message.c_str());
-                  spec_constant = llvm::ConstantInt::get(type, *value);
-                  break;
-                }
-                // Vulkan SPIR-V does not support 8 bit integers.
-                CARGO_FALLTHROUGH;
-              default:
-                // The types above encapsulate all those required to be
-                // supported in the SPIR-V core spec for either the Shader or
-                // Kernel capability. It should not be possible to reach this
-                // point as unsupported specialization constant types should
-                // result in an error on definition.
-                llvm_unreachable(
-                    "unsupported int type provided to OpSpecConstant");
+        int size = type->getScalarSizeInBits();
+        switch (size) {
+          case 1:
+            if (module.hasCapability(spv::CapabilityKernel)) {
+              // OpenCL SPIR-V spec constant bool is 8 bits.
+              size = 8;
+            } else {
+              // Vulkan SPIR-V spec constant bool is 32 bits.
+              size = 32;
             }
             break;
-          }
-          case llvm::Type::FloatTyID: {
-            auto value = specInfo->getValue<float>(*specId);
-            SPIRV_LL_ASSERT(value, value.error().message.c_str());
-            spec_constant = llvm::ConstantFP::get(type, *value);
+          case 8:
+            if (!module.hasCapability(spv::CapabilityKernel)) {
+              // Vulkan SPIR-V does not support 8 bit integers.
+              size = -1;
+            }
+            break;
+        }
+        // SpecializationInfo::getValue does not require the type to match, it
+        // merely requires the type to have the correct size. Use integer types
+        // for everything to avoid a need for the host compiler to support
+        // device types.
+        switch (size) {
+          case 8: {
+            auto specValue = specInfo->getValue<uint8_t>(*specId);
+            SPIRV_LL_ASSERT(specValue, specValue.error().message.c_str());
+            value = *specValue;
           } break;
-          case llvm::Type::DoubleTyID: {
-            auto value = specInfo->getValue<double>(*specId);
-            SPIRV_LL_ASSERT(value, value.error().message.c_str());
-            spec_constant = llvm::ConstantFP::get(type, *value);
+          case 16: {
+            auto specValue = specInfo->getValue<uint16_t>(*specId);
+            SPIRV_LL_ASSERT(specValue, specValue.error().message.c_str());
+            value = *specValue;
+          } break;
+          case 32: {
+            auto specValue = specInfo->getValue<uint32_t>(*specId);
+            SPIRV_LL_ASSERT(specValue, specValue.error().message.c_str());
+            value = *specValue;
+          } break;
+          case 64: {
+            auto specValue = specInfo->getValue<uint64_t>(*specId);
+            SPIRV_LL_ASSERT(specValue, specValue.error().message.c_str());
+            value = *specValue;
           } break;
           default:
             llvm_unreachable("Invalid type provided to OpSpecConstant");
@@ -1075,28 +1066,15 @@ cargo::optional<Error> Builder::create<OpSpecConstant>(
       }
     }
   }
-  if (!spec_constant) {
-    uint64_t value = 0;
 
-    if (type->isDoubleTy() || type->isIntegerTy(64)) {
-      value = op->Value64();
-    } else {
-      value = op->Value32();
-    }
-
-    if (type->isFloatingPointTy()) {
-      if (type->isDoubleTy()) {
-        double dval = 0;
-        memcpy(&dval, &value, sizeof(double));
-        spec_constant = llvm::ConstantFP::get(type, dval);
-      } else {
-        float fval = 0;
-        memcpy(&fval, &value, sizeof(float));
-        spec_constant = llvm::ConstantFP::get(type, fval);
-      }
-    } else {
-      spec_constant = llvm::ConstantInt::get(type, value);
-    }
+  if (type->isIntegerTy()) {
+    spec_constant = llvm::ConstantInt::get(type, value);
+  } else if (type->isFloatingPointTy()) {
+    spec_constant = llvm::ConstantFP::get(
+        type, llvm::APFloat(type->getFltSemantics(),
+                            llvm::APInt(type->getScalarSizeInBits(), value)));
+  } else {
+    llvm_unreachable("Invalid type provided to OpSpecConstant");
   }
 
   module.addID(op->IdResult(), op, spec_constant);

--- a/source/cl/test/UnitCL/kernels/CMakeLists.txt
+++ b/source/cl/test/UnitCL/kernels/CMakeLists.txt
@@ -229,6 +229,14 @@ foreach(target ${MUX_TARGET_LIBRARIES})
         continue()
       endif()
 
+      # Skip kernels that don't match capabilities.
+      if((${kernel_name} MATCHES "\.fp64"
+            AND NOT ${target}_CAPABILITIES MATCHES "fp64") OR
+         (${kernel_name} MATCHES "\.fp16"
+            AND NOT ${target}_CAPABILITIES MATCHES "fp16"))
+        continue()
+      endif()
+
       set(kernel_input_name ${kernel})
       set(kernel_output_name "${kernel_name}.bin")
 

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp16.spvasm32
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp16.spvasm32
@@ -1,0 +1,134 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global half* qHalf) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qHalf[0] = specHalf;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical32 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pHalf "pHalf"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pHalf
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specHalf SpecId 8
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalHalfPtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
+
+; Constants
+      %constInt1 = OpConstant %int 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constInt1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp16.spvasm64
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp16.spvasm64
@@ -1,0 +1,134 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global half* qHalf) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qHalf[0] = specHalf;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical64 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pHalf "pHalf"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pHalf
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specHalf SpecId 8
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalHalfPtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
+
+; Constants
+     %constLong1 = OpConstant %long 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constLong1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.fp16.spvasm32
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.fp16.spvasm32
@@ -1,0 +1,143 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble, global half* qHalf) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+;   qHalf[0] = specHalf;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical32 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+                   OpName %pHalf "pHalf"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble %pHalf
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+                   OpDecorate %specHalf SpecId 8
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr %globalHalfPtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
+
+; Constants
+      %constInt1 = OpConstant %int 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constInt1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.fp16.spvasm64
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.fp16.spvasm64
@@ -1,0 +1,143 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble, global half* qHalf) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;   __attribute__((spec_id=8)) constant half specHalf = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+;   qHalf[0] = specHalf;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical64 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+                   OpName %pHalf "pHalf"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble %pHalf
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+                   OpDecorate %specHalf SpecId 8
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+           %half = OpTypeFloat 16
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+  %globalHalfPtr = OpTypePointer CrossWorkgroup %half
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr %globalHalfPtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+       %specHalf = OpSpecConstant %half 23.0   ; SpecId: 8
+
+; Constants
+     %constLong1 = OpConstant %long 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+          %pHalf = OpFunctionParameter %globalHalfPtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constLong1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpStore %pHalf %specHalf Aligned 2
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.spvasm32
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.spvasm32
@@ -1,0 +1,134 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical32 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+
+; Constants
+      %constInt1 = OpConstant %int 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constInt1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.spvasm64
+++ b/source/cl/test/UnitCL/kernels/clSetProgramSpecializationConstant.fp64.spvasm64
@@ -1,0 +1,134 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; This SPIR-V module was hand written to test the
+; clSetProgramSpecialzationConstant() entry point since there is not way to
+; generate specialization constants directly from OpenCL C source code. The
+; following module should be equivalent to:
+;
+; ```openclc
+;
+; kernel void test(global bool* qBool, global char* qChar, global short* qShort,
+;                  global int* qInt, global long* qLong, global float* qFloat,
+;                  global double* qDouble) {
+;   __attribute__((spec_id=0)) constant bool specTrue = true;
+;   __attribute__((spec_id=1)) constant bool specFalse = false;
+;   __attribute__((spec_id=2)) constant char specChar = 23;
+;   __attribute__((spec_id=3)) constant short specShort = 23;
+;   __attribute__((spec_id=4)) constant int specInt = 23;
+;   __attribute__((spec_id=5)) constant long specLong = 23;
+;   __attribute__((spec_id=6)) constant float specFloat = 23;
+;   __attribute__((spec_id=7)) constant double specDouble = 23;
+;
+;   qBool[0] = specTrue;
+;   qBool[1] = specFalse;
+;   qChar[0] = specChar;
+;   qShort[0] = specShort;
+;   qInt[0] = specInt;
+;   qLong[0] = specLong;
+;   qFloat[0] = specFloat;
+;   qDouble[0] = specDouble;
+; }
+; ```
+                   OpCapability Addresses
+                   OpCapability Linkage
+                   OpCapability Kernel
+                   OpCapability Int8
+                   OpCapability Int16
+                   OpCapability Int64
+         %opencl = OpExtInstImport "OpenCL.std"
+                   OpMemoryModel Physical64 OpenCL
+                   OpEntryPoint Kernel %test "test"
+  %kernelArgType = OpString "kernel_arg_type.test.bool*,char*,short*,int*,long*,float*,"
+                   OpSource OpenCL_C 102000
+
+; Variable names
+                   OpName %pBool "pBool"
+                   OpName %pChar "pChar"
+                   OpName %pShort "pShort"
+                   OpName %pInt "pInt"
+                   OpName %pLong "pLong"
+                   OpName %pFloat "pFloat"
+                   OpName %pDouble "pDouble"
+
+; Decorations
+                   OpDecorate %fnParamGroup FuncParamAttr NoCapture
+   %fnParamGroup = OpDecorationGroup
+                   OpGroupDecorate %fnParamGroup %pBool %pChar %pShort %pInt %pLong %pFloat %pDouble
+
+; Specialization constant decorations
+                   OpDecorate %specBoolTrue SpecId 0
+                   OpDecorate %specBoolFalse SpecId 1
+                   OpDecorate %specChar SpecId 2
+                   OpDecorate %specShort SpecId 3
+                   OpDecorate %specInt SpecId 4
+                   OpDecorate %specLong SpecId 5
+                   OpDecorate %specFloat SpecId 6
+                   OpDecorate %specDouble SpecId 7
+
+; Types
+           %void = OpTypeVoid
+           %bool = OpTypeBool
+           %char = OpTypeInt 8 0
+          %short = OpTypeInt 16 0
+            %int = OpTypeInt 32 0
+           %long = OpTypeInt 64 0
+          %float = OpTypeFloat 32
+         %double = OpTypeFloat 64
+  %globalBoolPtr = OpTypePointer CrossWorkgroup %bool
+  %globalCharPtr = OpTypePointer CrossWorkgroup %char
+ %gloablShortPtr = OpTypePointer CrossWorkgroup %short
+   %globalIntPtr = OpTypePointer CrossWorkgroup %int
+  %globalLongPtr = OpTypePointer CrossWorkgroup %long
+ %globalFloatPtr = OpTypePointer CrossWorkgroup %float
+%globalDoublePtr = OpTypePointer CrossWorkgroup %double
+
+         %testFn = OpTypeFunction %void %globalBoolPtr %globalCharPtr %gloablShortPtr %globalIntPtr %globalLongPtr %globalFloatPtr %globalDoublePtr
+
+; Specialzation constants
+   %specBoolTrue = OpSpecConstantTrue %bool    ; SpecId: 0
+  %specBoolFalse = OpSpecConstantFalse %bool   ; SpecId: 1
+       %specChar = OpSpecConstant %char 23     ; SpecId: 2
+      %specShort = OpSpecConstant %short 23    ; SpecId: 3
+        %specInt = OpSpecConstant %int 23      ; SpecId: 4
+       %specLong = OpSpecConstant %long 23     ; SpecId: 5
+      %specFloat = OpSpecConstant %float 23.0  ; SpecId: 6
+     %specDouble = OpSpecConstant %double 23.0 ; SpecId: 7
+
+; Constants
+     %constLong1 = OpConstant %long 1
+
+; Entry point
+           %test = OpFunction %void None %testFn
+          %pBool = OpFunctionParameter %globalBoolPtr
+          %pChar = OpFunctionParameter %globalCharPtr
+         %pShort = OpFunctionParameter %gloablShortPtr
+           %pInt = OpFunctionParameter %globalIntPtr
+          %pLong = OpFunctionParameter %globalLongPtr
+         %pFloat = OpFunctionParameter %globalFloatPtr
+        %pDouble = OpFunctionParameter %globalDoublePtr
+             %37 = OpLabel
+                   OpStore %pBool %specBoolTrue Aligned 1
+         %pBool1 = OpInBoundsPtrAccessChain %globalBoolPtr %pBool %constLong1
+                   OpStore %pBool1 %specBoolFalse Aligned 1
+                   OpStore %pChar %specChar Aligned 1
+                   OpStore %pShort %specShort Aligned 2
+                   OpStore %pInt %specInt Aligned 4
+                   OpStore %pLong %specLong Aligned 8
+                   OpStore %pFloat %specFloat Aligned 4
+                   OpStore %pDouble %specDouble Aligned 8
+                   OpReturn
+                   OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -848,6 +848,12 @@ set(spirv_test
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv.23_memset_kernel.spvasm64
   ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.spvasm32
   ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.spvasm64
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp64.spvasm32
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp64.spvasm64
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp16.spvasm32
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp16.spvasm64
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp64.fp16.spvasm32
+  ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp64.fp16.spvasm64
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_regression.55_float_memcpy.spvasm32
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_regression.55_float_memcpy.spvasm64
   )

--- a/source/cl/test/UnitCL/source/clSetProgramSpecializationConstant.cpp
+++ b/source/cl/test/UnitCL/source/clSetProgramSpecializationConstant.cpp
@@ -27,6 +27,8 @@
 // * SpecId: 4       OpTypeInt       16 bit    Default: 23
 // * SpecId: 5       OpTypeInt       64 bit    Default: 23
 // * SpecId: 6       OpTypeFloat     32 bit    Default: 23.0
+// * SpecId: 7       OpTypeFloat     64 bit    Default: 23.0
+// * SpecId: 8       OpTypeFloat     16 bit    Default: 23.0
 
 struct clSetProgramSpecializationConstantTest : ucl::ContextTest {
   void SetUp() override {
@@ -38,7 +40,14 @@ struct clSetProgramSpecializationConstantTest : ucl::ContextTest {
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
     }
-    auto code = getDeviceSpirvFromFile("clSetProgramSpecializationConstant");
+    std::string kernelName = "clSetProgramSpecializationConstant";
+    if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+      kernelName += ".fp64";
+    }
+    if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+      kernelName += ".fp16";
+    }
+    auto code = getDeviceSpirvFromFile(kernelName);
     cl_int error;
     // TODO: clCreateProgramWithIL has not been implemented yet
     clCreateProgramWithILKHR = reinterpret_cast<clCreateProgramWithILKHR_fn>(
@@ -123,9 +132,21 @@ struct clSetProgramSpecializationConstantSuccessTest
     floatBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_float),
                                  nullptr, &error);
     ASSERT_SUCCESS(error);
+    doubleBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_double),
+                                  nullptr, &error);
+    ASSERT_SUCCESS(error);
+    halfBuffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(cl_half),
+                                nullptr, &error);
+    ASSERT_SUCCESS(error);
   }
 
   void TearDown() final {
+    if (halfBuffer) {
+      ASSERT_SUCCESS(clReleaseMemObject(halfBuffer));
+    }
+    if (doubleBuffer) {
+      ASSERT_SUCCESS(clReleaseMemObject(doubleBuffer));
+    }
     if (floatBuffer) {
       ASSERT_SUCCESS(clReleaseMemObject(floatBuffer));
     }
@@ -154,15 +175,23 @@ struct clSetProgramSpecializationConstantSuccessTest
   }
 
   void getResults() {
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 0, sizeof(cl_mem), &boolBuffer));
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 1, sizeof(cl_mem), &charBuffer));
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &shortBuffer));
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 3, sizeof(cl_mem), &intBuffer));
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 4, sizeof(cl_mem), &longBuffer));
-    ASSERT_SUCCESS(clSetKernelArg(kernel, 5, sizeof(cl_mem), &floatBuffer));
+    int i = 0;
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &boolBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &charBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &shortBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &intBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &longBuffer));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &floatBuffer));
+    if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+      ASSERT_SUCCESS(
+          clSetKernelArg(kernel, i++, sizeof(cl_mem), &doubleBuffer));
+    }
+    if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+      ASSERT_SUCCESS(clSetKernelArg(kernel, i++, sizeof(cl_mem), &halfBuffer));
+    }
     cl_event taskEvent;
     ASSERT_SUCCESS(clEnqueueTask(commandQueue, kernel, 0, nullptr, &taskEvent));
-    std::array<cl_event, 6> resultEvents;
+    std::array<cl_event, 8> resultEvents;
     ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, boolBuffer, CL_FALSE, 0,
                                        sizeof(bool) * 2, boolResults.data(), 1,
                                        &taskEvent, &resultEvents[0]));
@@ -181,6 +210,12 @@ struct clSetProgramSpecializationConstantSuccessTest
     ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, floatBuffer, CL_FALSE, 0,
                                        sizeof(cl_float), &floatResult, 1,
                                        &taskEvent, &resultEvents[5]));
+    ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, doubleBuffer, CL_FALSE, 0,
+                                       sizeof(cl_double), &doubleResult, 1,
+                                       &taskEvent, &resultEvents[6]));
+    ASSERT_SUCCESS(clEnqueueReadBuffer(commandQueue, halfBuffer, CL_FALSE, 0,
+                                       sizeof(cl_half), &halfResult, 1,
+                                       &taskEvent, &resultEvents[7]));
     ASSERT_SUCCESS(clWaitForEvents(resultEvents.size(), resultEvents.data()));
 
     std::for_each(
@@ -197,12 +232,16 @@ struct clSetProgramSpecializationConstantSuccessTest
   cl_mem intBuffer = nullptr;
   cl_mem longBuffer = nullptr;
   cl_mem floatBuffer = nullptr;
+  cl_mem doubleBuffer = nullptr;
+  cl_mem halfBuffer = nullptr;
   std::array<bool, 2> boolResults;
   cl_char charResult;
   cl_short shortResult;
   cl_int intResult;
   cl_long longResult;
   cl_float floatResult;
+  cl_double doubleResult;
+  cl_half halfResult;
 };
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest, None) {
@@ -219,6 +258,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, None) {
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -239,6 +284,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -259,6 +310,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -279,6 +336,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -299,6 +362,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -319,6 +388,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(value, intResult);              // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -339,6 +414,12 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
   ASSERT_EQ(value, longResult);             // SpecId: 5
   ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest,
@@ -359,6 +440,66 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest,
   ASSERT_EQ(cl_int(23), intResult);      // SpecId: 4
   ASSERT_EQ(cl_long(23), longResult);    // SpecId: 5
   ASSERT_EQ(value, floatResult);         // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
+}
+
+TEST_F(clSetProgramSpecializationConstantSuccessTest,
+       SpecId7OpSpecConstantDouble) {
+  if (!UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    GTEST_SKIP();
+  }
+  cl_double value = 42.0;
+  ASSERT_SUCCESS(
+      clSetProgramSpecializationConstant(program, 7, sizeof(value), &value));
+  ASSERT_SUCCESS(
+      clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
+  cl_int error;
+  kernel = clCreateKernel(program, "test", &error);
+  ASSERT_SUCCESS(error);
+  UCL_RETURN_ON_FATAL_FAILURE(getResults());
+  ASSERT_EQ(true, boolResults[0]);          // SpecId: 0
+  ASSERT_EQ(false, boolResults[1]);         // SpecId: 1
+  ASSERT_EQ(cl_char(23), charResult);       // SpecId: 2
+  ASSERT_EQ(cl_short(23), shortResult);     // SpecId: 3
+  ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
+  ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
+  ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  ASSERT_EQ(value, doubleResult);           // SpecId: 7
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(cl_half(0x4dc0), halfResult);  // SpecId: 8
+  }
+}
+
+TEST_F(clSetProgramSpecializationConstantSuccessTest,
+       SpecId8OpSpecConstantHalf) {
+  if (!UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    GTEST_SKIP();
+  }
+  cl_half value = 0x5140;  // cl_half(42.0f)
+  ASSERT_SUCCESS(
+      clSetProgramSpecializationConstant(program, 8, sizeof(value), &value));
+  ASSERT_SUCCESS(
+      clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
+  cl_int error;
+  kernel = clCreateKernel(program, "test", &error);
+  ASSERT_SUCCESS(error);
+  UCL_RETURN_ON_FATAL_FAILURE(getResults());
+  ASSERT_EQ(true, boolResults[0]);          // SpecId: 0
+  ASSERT_EQ(false, boolResults[1]);         // SpecId: 1
+  ASSERT_EQ(cl_char(23), charResult);       // SpecId: 2
+  ASSERT_EQ(cl_short(23), shortResult);     // SpecId: 3
+  ASSERT_EQ(cl_int(23), intResult);         // SpecId: 4
+  ASSERT_EQ(cl_long(23), longResult);       // SpecId: 5
+  ASSERT_EQ(cl_float(23.0f), floatResult);  // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(cl_double(23.0), doubleResult);  // SpecId: 7
+  }
+  ASSERT_EQ(value, halfResult);  // SpecId: 8
 }
 
 TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
@@ -383,6 +524,16 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
   cl_float floatValue = 42.0f;
   ASSERT_SUCCESS(clSetProgramSpecializationConstant(
       program, 6, sizeof(floatValue), &floatValue));
+  cl_double doubleValue = 42.0f;
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_SUCCESS(clSetProgramSpecializationConstant(
+        program, 7, sizeof(doubleValue), &doubleValue));
+  }
+  cl_half halfValue = 0x5140;  // cl_half(42.0f)
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_SUCCESS(clSetProgramSpecializationConstant(
+        program, 8, sizeof(halfValue), &halfValue));
+  }
   ASSERT_SUCCESS(
       clBuildProgram(program, 1, &device, "", ucl::buildLogCallback, nullptr));
   cl_int error;
@@ -396,4 +547,10 @@ TEST_F(clSetProgramSpecializationConstantSuccessTest, All) {
   ASSERT_EQ(intValue, intResult);         // SpecId: 4
   ASSERT_EQ(longValue, longResult);       // SpecId: 5
   ASSERT_EQ(floatValue, floatResult);     // SpecId: 6
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp64")) {
+    ASSERT_EQ(doubleValue, doubleResult);  // SpecId: 7
+  }
+  if (UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
+    ASSERT_EQ(halfValue, halfResult);  // SpecId: 8
+  }
 }


### PR DESCRIPTION
Builder::create\<OpSpecConstant\> was implemented in a way that duplicated a lot of code, and did not handle sycl::half. This change simplifies things and ensures half is handled correctly.

# Overview

This change re-does Builder::create\<OpSpecConstant\> to remove the duplicated logic for creating constants, and making it more general.

# Reason for change

The code did not support half types, which would result in an llvm_unreachable being reached.

# Description of change

By writing Builder::create\<OpSpecConstant\> in a more general way, half types are implicitly handled without ever needing to specifically handle half types.

I modified the existing clSetProgramSpecializationConstant tests to cover testing of both double (already implemented but missing from the test) and half (not previously implemented).

# Anything else we should know?

The SYCL CTS also tests half support. I specifically looked at the "specialization_constants_defined_various_ways_fp16" test, which succeeds with this change.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
