### PR TITLE
[compiler] Move IVs into the CreateLoopOpts struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Upgrade guidance:
   `compiler::utils::LowerToMuxBuiltinsPass`.
 * The `compiler::utils::HandleBarriersPass` has been renamed to the
   `compiler::utils::WorkItemLoopsPass`.
+* The `compiler::utils::createLoop` API has moved its list of `IVs` parameter
+  into its `compiler::utils::CreateLoopOpts` parameter. It can now also set the
+  IV names via a second `CreateLoopOpts` field.
 
 ## Version 3.0.0
 

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_wg_loop_pass.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_wg_loop_pass.cpp
@@ -126,7 +126,7 @@ PreservedAnalyses RefSiWGLoopPass::run(Module &M, ModuleAnalysisManager &AM) {
     // looping through num groups in the outermost dimension
     auto *const exitBlock = compiler::utils::createLoop(
         loopPreheaderIR.GetInsertBlock(), nullptr, zero, numGroups[outer_dim],
-        {}, create_loop_opts,
+        create_loop_opts,
         [&](BasicBlock *blockz, Value *z, ArrayRef<Value *>,
             MutableArrayRef<Value *>) -> BasicBlock * {
           IRBuilder<> ir(blockz);
@@ -136,8 +136,7 @@ PreservedAnalyses RefSiWGLoopPass::run(Module &M, ModuleAnalysisManager &AM) {
                                          {i32_0, ir.getInt32(outer_dim)}));
           // looping through num groups in the middle dimension
           return compiler::utils::createLoop(
-              blockz, nullptr, zero, numGroups[middle_dim], {},
-              create_loop_opts,
+              blockz, nullptr, zero, numGroups[middle_dim], create_loop_opts,
               [&](BasicBlock *blocky, Value *y, ArrayRef<Value *>,
                   MutableArrayRef<Value *>) -> BasicBlock * {
                 IRBuilder<> ir(blocky);
@@ -147,7 +146,7 @@ PreservedAnalyses RefSiWGLoopPass::run(Module &M, ModuleAnalysisManager &AM) {
 
                 // looping through num groups in the x dimension
                 return compiler::utils::createLoop(
-                    blocky, nullptr, zero, numGroups[inner_dim], {},
+                    blocky, nullptr, zero, numGroups[inner_dim],
                     create_loop_opts,
                     [&](BasicBlock *blockx, Value *x, ArrayRef<Value *>,
                         MutableArrayRef<Value *>) -> BasicBlock * {

--- a/modules/compiler/targets/host/source/AddEntryHook.cpp
+++ b/modules/compiler/targets/host/source/AddEntryHook.cpp
@@ -177,7 +177,7 @@ PreservedAnalyses AddEntryHookPass::run(Module &M, ModuleAnalysisManager &AM) {
 
     // looping through num groups in the outermost dimension
     auto exitBlock = compiler::utils::createLoop(
-        loopIR.GetInsertBlock(), nullptr, zero, numGroups[outer_dim], {}, opts,
+        loopIR.GetInsertBlock(), nullptr, zero, numGroups[outer_dim], opts,
         [&](BasicBlock *blockz, Value *z, ArrayRef<Value *>,
             MutableArrayRef<Value *>) -> BasicBlock * {
           IRBuilder<> ir(blockz);
@@ -187,7 +187,7 @@ PreservedAnalyses AddEntryHookPass::run(Module &M, ModuleAnalysisManager &AM) {
                                          {i32_0, ir.getInt32(outer_dim)}));
           // looping through num groups in the middle dimension
           return compiler::utils::createLoop(
-              blockz, nullptr, zero, numGroups[middle_dim], {}, opts,
+              blockz, nullptr, zero, numGroups[middle_dim], opts,
               [&](BasicBlock *blocky, Value *y, ArrayRef<Value *>,
                   MutableArrayRef<Value *>) -> BasicBlock * {
                 IRBuilder<> ir(blocky);
@@ -197,7 +197,7 @@ PreservedAnalyses AddEntryHookPass::run(Module &M, ModuleAnalysisManager &AM) {
 
                 // looping through num groups in the x dimension
                 return compiler::utils::createLoop(
-                    blocky, nullptr, sliceStart, clampedSliceEnd, {}, opts,
+                    blocky, nullptr, sliceStart, clampedSliceEnd, opts,
                     [&](BasicBlock *blockx, Value *x, ArrayRef<Value *>,
                         MutableArrayRef<Value *>) -> BasicBlock * {
                       IRBuilder<> ir(blockx);

--- a/modules/compiler/utils/include/compiler/utils/pass_functions.h
+++ b/modules/compiler/utils/include/compiler/utils/pass_functions.h
@@ -182,6 +182,19 @@ struct CreateLoopOpts {
   /// @brief headerName Optional name for the loop header block. Defaults to:
   /// "loopIR".
   llvm::StringRef headerName = "loopIR";
+  /// @brief An optional list of incoming IV values.
+  ///
+  /// Each of these is used as the incoming value to a PHI created by
+  /// createLoop. These PHIs are provided to the 'body' function of createLoop,
+  /// which should in turn set the 'next' version of the IV.
+  std::vector<llvm::Value *> IVs;
+  /// @brief An optional list of IV names, to be set on the PHIs provided by
+  /// 'IVs' field/parameter.
+  ///
+  /// If set, the names are assumed to correlate 1:1 with those IVs. The list
+  /// may be shorter than the list of IVs, in which case the trailing IVs are
+  /// not named.
+  std::vector<std::string> loopIVNames;
 };
 
 /// @brief Create a loop around a body, creating an implicit induction variable
@@ -200,23 +213,22 @@ struct CreateLoopOpts {
 /// @param exit Loop exit block. The new loop will jump to this once it exits.
 /// @param indexStart The start index
 /// @param indexEnd The end index (we compare for <)
-/// @param ivs A list of extra induction variables to create.
 /// @param opts Set of options configuring the generation of this loop.
-/// @param body Body of code to insert into loop. The parameters of this
-/// function are as follows: the loop body BasicBlock; the Value corresponding
-/// to the IV beginning at `indexStart` and incremented each iteration by
-/// `indexInc` while less than `indexEnd`; the list of IVs for this iteration
-/// of the loop (may or may not be PHIs, depending on the loop bounds); the
-/// list of IVs for the next iteration of the loop (the function is required to
-/// fill these in). Both these sets of IVs will be arrays of equal length to
-/// the original list of IVs, in the same order. The function returns the loop
-/// latch/exiting block: this block will be given the branch that decides
-/// between continuing the loop and exiting from it.
+/// @param body Body of code to insert into loop.
+///
+/// The parameters of this function are as follows: the loop body BasicBlock;
+/// the Value corresponding to the IV beginning at `indexStart` and incremented
+/// each iteration by `indexInc` while less than `indexEnd`; the list of IVs
+/// for this iteration of the loop (may or may not be PHIs, depending on the
+/// loop bounds); the list of IVs for the next iteration of the loop (the
+/// function is required to fill these in). Both these sets of IVs will be
+/// arrays of equal length to the original list of IVs, in the same order. The
+/// function returns the loop latch/exiting block: this block will be given the
+/// branch that decides between continuing the loop and exiting from it.
 ///
 /// @return llvm::BasicBlock* The exit block
 llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
                              llvm::Value *indexStart, llvm::Value *indexEnd,
-                             llvm::ArrayRef<llvm::Value *> ivs,
                              const CreateLoopOpts &opts, CreateLoopBodyFn body);
 
 /// @brief Get the last argument of a function.

--- a/modules/compiler/utils/source/pass_functions.cpp
+++ b/modules/compiler/utils/source/pass_functions.cpp
@@ -473,7 +473,6 @@ bool addParamToAllFunctions(llvm::Module &module,
 
 llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
                              llvm::Value *indexStart, llvm::Value *indexEnd,
-                             llvm::ArrayRef<llvm::Value *> ivs,
                              const CreateLoopOpts &opts,
                              CreateLoopBodyFn body) {
   // If the index increment is null, we default to 1 as our index.
@@ -483,8 +482,8 @@ llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
 
   llvm::LLVMContext &ctx = entry->getContext();
 
-  llvm::SmallVector<llvm::Value *, 4> currIVs(ivs.begin(), ivs.end());
-  llvm::SmallVector<llvm::Value *, 4> nextIVs(ivs.size());
+  llvm::SmallVector<llvm::Value *, 4> currIVs(opts.IVs.begin(), opts.IVs.end());
+  llvm::SmallVector<llvm::Value *, 4> nextIVs(opts.IVs.size());
 
   // Check if indexStart, indexEnd, and indexInc are constants.
   if (llvm::isa<llvm::ConstantInt>(indexStart) &&
@@ -564,6 +563,10 @@ llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
     auto *const phi = loopIR.CreatePHI(currIVs[i]->getType(), 2);
     llvm::cast<llvm::PHINode>(phi)->addIncoming(currIVs[i],
                                                 entryIR.GetInsertBlock());
+    // Set IV names if they've been given to us.
+    if (i < opts.loopIVNames.size()) {
+      phi->setName(opts.loopIVNames[i]);
+    }
     currIVs[i] = phi;
   }
 


### PR DESCRIPTION
This deprioritises the IVs parameter of `createLoop`, in the case that users don't wish to set it and are happy with the default of 'none'.

It also allows us to more cohesively provide a second options field which allows users to set the IV names, rather than a) adding an additional parameter to `createLoop` or b) having related values split across `createLoop` and `CreateLoopOpts`.

Split off from #158 