### PR TITLE
Bump minimum LLVM version to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Upgrade guidance:
 * The `compiler::utils::createLoop` API has moved its list of `IVs` parameter
   into its `compiler::utils::CreateLoopOpts` parameter. It can now also set the
   IV names via a second `CreateLoopOpts` field.
+* Support for LLVM versions is now limited to LLVM 16 and LLVM 17. Support for
+  earlier LLVM versions has been removed.
 
 ## Version 3.0.0
 

--- a/cmake/ImportLLVM.cmake
+++ b/cmake/ImportLLVM.cmake
@@ -75,7 +75,7 @@ include(DetectLLVMMSVCCRT)
   :cmake:variable:`LLVM_PACKAGE_VERSION` from the imported LLVM install is
   a supported version.
 #]=======================================================================]
-set(CA_LLVM_MINIMUM_VERSION 14.0.0)
+set(CA_LLVM_MINIMUM_VERSION 16.0.0)
 set(CA_LLVM_MAXIMUM_VERSION 17.0.1)
 string(REPLACE ";" "', '" CA_LLVM_VERSIONS_PRETTY "${CA_LLVM_VERSIONS}")
 if("${LLVM_PACKAGE_VERSION}" VERSION_LESS "${CA_LLVM_MINIMUM_VERSION}")

--- a/doc/overview/tutorials/creating-a-new-mux-target/extending-it-further.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/extending-it-further.rst
@@ -42,27 +42,6 @@ Instead, targets may wish to use the following:
 
 This form will preserve ``CA_LLVM_OPTIONS`` in debug builds.
 
-.. warning::
-
-  Targets should be aware that before LLVM 15 it is possible that if a
-  command-line option was set in both ``cl_args`` *and* ``CA_LLVM_OPTIONS``,
-  the process may crash with the following error:
-
-  .. code::
-
-    for the --foo option: may only occur one or more times!
-    for the --bar option: may only occur zero or one times!
-
-  This affected all options not explicitly defined in LLVM as
-  ``llvm::cl::OneOrMore`` or ``llvm::cl::ZeroOrMore``.
-
-  This issue was resolved in LLVM 15 so that this will no longer be an error,
-  but rather the *last* occurrence of an option always wins. The implementation
-  of ``llvm::cl::ParseCommandLineOptions`` parses ``CA_LLVM_OPTIONS`` first,
-  followed by the ``cl_args``. This means that users are unable to override
-  options with ``CA_LLVM_OPTIONS``, with their attempts silently ignored. It is
-  advised that this is documented to users.
-
 Parsing of command-line options could take place in several places.
 
 If options are inherent to a target and not dictated by the specific compilation

--- a/modules/mux/test/muxCloneCommandBuffer.cpp
+++ b/modules/mux/test/muxCloneCommandBuffer.cpp
@@ -237,10 +237,6 @@ struct muxCloneCommandBufferSingleBufferTest
   }
 };
 
-#if __cplusplus < 201703L
-constexpr size_t muxCloneCommandBufferSingleBufferTest::buffer_size_in_bytes;
-#endif
-
 TEST_P(muxCloneCommandBufferSingleBufferTest, CloneReadBuffer) {
   ASSERT_SUCCESS(muxCommandReadBuffer(command_buffer_to_clone, buffer, 0, data,
                                       buffer_size_in_bytes, 0, nullptr,
@@ -392,10 +388,6 @@ struct muxCloneCommandBufferTwoBufferTest : public muxCloneCommandBufferTest {
     muxCloneCommandBufferTest::TearDown();
   }
 };
-
-#if __cplusplus < 201703L
-constexpr size_t muxCloneCommandBufferTwoBufferTest::buffer_size_in_bytes;
-#endif
 
 TEST_P(muxCloneCommandBufferTwoBufferTest, CloneCopyBuffer) {
   ASSERT_SUCCESS(muxCommandCopyBuffer(command_buffer_to_clone, buffer_one, 0,

--- a/modules/mux/test/muxUpdateDescriptors.cpp
+++ b/modules/mux/test/muxUpdateDescriptors.cpp
@@ -137,14 +137,6 @@ struct muxUpdateDescriptorsTest : public DeviceCompilerTest {
   }
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline.
-constexpr size_t muxUpdateDescriptorsTest::local_size[];
-constexpr size_t muxUpdateDescriptorsTest::global_offset[];
-constexpr size_t muxUpdateDescriptorsTest::global_size[];
-#endif
-
 /// @brief Test fixture for checking we can update the descriptors of an nd
 /// range where the arguments are of the mux_descriptor_info_buffer_s type.
 ///
@@ -298,13 +290,6 @@ struct muxUpdateDescriptorsBufferTest : public muxUpdateDescriptorsTest {
     muxUpdateDescriptorsTest::TearDown();
   }
 };
-
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline.
-constexpr size_t muxUpdateDescriptorsBufferTest::buffer_size;
-constexpr char muxUpdateDescriptorsBufferTest::input_value;
-#endif
 
 // Tests we can successfully update the output argument descriptors to a
 // kernel in an nd range command.
@@ -607,14 +592,6 @@ struct muxUpdateDescriptorsPODTest : public muxUpdateDescriptorsTest {
     muxUpdateDescriptorsTest::TearDown();
   }
 };
-
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline.
-constexpr size_t muxUpdateDescriptorsPODTest::buffer_size;
-constexpr int32_t muxUpdateDescriptorsPODTest::input_value;
-constexpr int32_t muxUpdateDescriptorsPODTest::input_value_updated;
-#endif
 
 // Tests that we can successfully update the descriptors for an input POD
 // argument to a kernel in an nd range command.

--- a/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
@@ -2280,15 +2280,6 @@ class LinearIDTest
   cl_mem output_buffer = nullptr;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-decltype(LinearIDTest::dimensions) LinearIDTest::dimensions;
-decltype(LinearIDTest::global_sizes) LinearIDTest::global_sizes;
-decltype(LinearIDTest::global_offsets) LinearIDTest::global_offsets;
-#endif
-
 TEST_P(LinearIDTest, Local) {
   const size_t work_dim = std::get<0>(GetParam());
   const auto &global_work_size = std::get<1>(GetParam());

--- a/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
+++ b/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
@@ -18,15 +18,6 @@
 
 #include "cl_codeplay_kernel_exec_info.h"
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t USMKernelExecInfoCodeplayTest::elements;
-constexpr cl_uint USMKernelExecInfoCodeplayTest::align;
-constexpr size_t USMKernelExecInfoCodeplayTest::bytes;
-#endif
-
 namespace {
 // Fixture for running kernels where the USM pointers are accessed indirectly,
 // and so must be set in clSetKernelExecInfoCodeplay

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyBufferKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyBufferKHR.cpp
@@ -55,14 +55,6 @@ struct CommandBufferCopyBufferTest : cl_khr_command_buffer_Test {
   static constexpr size_t data_size_in_bytes = elements * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferCopyBufferTest::elements;
-constexpr size_t CommandBufferCopyBufferTest::data_size_in_bytes;
-#endif
-
 TEST_F(CommandBufferCopyBufferTest, Default) {
   std::vector<cl_int> input_data(elements);
 

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyBufferRectKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyBufferRectKHR.cpp
@@ -232,13 +232,6 @@ struct CommandCopyBufferRectTest : cl_khr_command_buffer_Test {
   static constexpr size_t buffer_size = 512;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandCopyBufferRectTest::buffer_size;
-#endif
-
 TEST_F(CommandCopyBufferRectTest, Sync) {
   Position src_origin{0, 0, 0};
   Position dst_origin{0, 0, 0};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyImageKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandCopyImageKHR.cpp
@@ -91,14 +91,6 @@ struct CommandBufferCopyImageTest : cl_khr_command_buffer_Test {
   cl_command_buffer_khr command_buffer = nullptr;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferCopyImageTest::half_dimension;
-constexpr size_t CommandBufferCopyImageTest::dimension_length;
-#endif
-
 TEST_F(CommandBufferCopyImageTest, Sync) {
   const size_t origin[] = {0, 0, 0};
   const size_t region[] = {dimension_length, 1, 1};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandFillBufferKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandFillBufferKHR.cpp
@@ -73,13 +73,6 @@ struct CommandFillBufferKHRTest : cl_khr_command_buffer_Test {
   static constexpr size_t buffer_size = 256;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandFillBufferKHRTest::buffer_size;
-#endif
-
 class CommandFillBufferKHRParamTest
     : public cl_khr_command_buffer_Test,
       public ::testing::WithParamInterface<test_parameters> {};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandFillImageKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandFillImageKHR.cpp
@@ -88,15 +88,6 @@ struct CommandBufferFillImageTest : cl_khr_command_buffer_Test {
   static constexpr size_t dimension_length = half_dimension + half_dimension;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr cl_uint4 CommandBufferFillImageTest::fill_color;
-constexpr size_t CommandBufferFillImageTest::half_dimension;
-constexpr size_t CommandBufferFillImageTest::dimension_length;
-#endif
-
 TEST_F(CommandBufferFillImageTest, Sync) {
   const size_t origin[] = {0, 0, 0};
   const size_t region[] = {dimension_length, 1, 1};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandNDRangeKernelKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandNDRangeKernelKHR.cpp
@@ -180,14 +180,6 @@ class CommandBufferParallelCopyBase : public CommandNDRangeKernelTest {
   constexpr static size_t data_size_in_bytes = global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferParallelCopyBase::global_size;
-constexpr size_t CommandBufferParallelCopyBase::data_size_in_bytes;
-#endif
-
 class ParallelCopyCommandBuffer : public CommandBufferParallelCopyBase {
  protected:
   void SetUp() override {

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
@@ -107,14 +107,6 @@ class CommandBufferMutableBufferArgTest : public MutableDispatchTest {
       global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferMutableBufferArgTest::global_size;
-constexpr const size_t CommandBufferMutableBufferArgTest::data_size_in_bytes;
-#endif
-
 TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferOnce) {
   // Enqueue a mutable dispatch to the command buffer.
   cl_ndrange_kernel_command_properties_khr mutable_properties[3] = {
@@ -1779,14 +1771,6 @@ class CommandBufferMutableLocalBufferArgTest : public MutableDispatchTest {
   static constexpr size_t data_size_in_bytes = global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferMutableLocalBufferArgTest::global_size;
-constexpr size_t CommandBufferMutableLocalBufferArgTest::data_size_in_bytes;
-#endif
-
 TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateOnce) {
   // Enqueue the command buffer.
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
@@ -1964,14 +1948,6 @@ class DISABLED_CommandBufferMutableNullArgTest : public MutableDispatchTest {
   static constexpr size_t global_size = 256;
   static constexpr size_t data_size_in_bytes = global_size * sizeof(cl_int);
 };
-
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t DISABLED_CommandBufferMutableNullArgTest::global_size;
-constexpr size_t DISABLED_CommandBufferMutableNullArgTest::data_size_in_bytes;
-#endif
 
 TEST_F(DISABLED_CommandBufferMutableNullArgTest,
        UpdateInputBufferToNullByValue) {
@@ -2601,14 +2577,6 @@ class CommandBufferMutablePODArgTest : public MutableDispatchTest {
       global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferMutablePODArgTest::global_size;
-constexpr const size_t CommandBufferMutablePODArgTest::data_size_in_bytes;
-#endif
-
 TEST_F(CommandBufferMutablePODArgTest, InvalidArgSize) {
   // Finalize the command buffer.
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
@@ -3178,14 +3146,6 @@ class CommandBufferMutablePODMultiArgTest : public MutableDispatchTest {
   static constexpr const size_t data_size_in_bytes =
       global_size * sizeof(cl_int2);
 };
-
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferMutablePODMultiArgTest::global_size;
-constexpr const size_t CommandBufferMutablePODMultiArgTest::data_size_in_bytes;
-#endif
 
 TEST_F(CommandBufferMutablePODMultiArgTest,
        UpdateTwoInputsSameMutableDispatchConfig) {

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clGetMutableCommandInfoKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clGetMutableCommandInfoKHR.cpp
@@ -71,13 +71,6 @@ struct MutableCommandInfoTest : MutableDispatchTest {
   constexpr static size_t global_size = 8;
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t MutableCommandInfoTest::global_size;
-#endif
-
 TEST_F(MutableCommandInfoTest, InvalidCommandBuffer) {
   ASSERT_EQ_ERRCODE(
       CL_INVALID_MUTABLE_COMMAND_KHR,

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
@@ -108,14 +108,6 @@ class CommandBufferUpdateNDKernel : public MutableDispatchTest {
   constexpr static size_t data_size_in_bytes = global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t CommandBufferUpdateNDKernel::global_size;
-constexpr size_t CommandBufferUpdateNDKernel::data_size_in_bytes;
-#endif
-
 // Return CL_INVALID_COMMAND_BUFFER_KHR if command_buffer is not a valid
 // command-buffer.
 TEST_F(CommandBufferUpdateNDKernel, NullCommandBuffer) {

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -130,14 +130,6 @@ void kernel usm_copy(__global int* in,
   constexpr static size_t data_size_in_bytes = global_size * sizeof(cl_int);
 };
 
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr size_t MutableDispatchUSMTest::global_size;
-constexpr size_t MutableDispatchUSMTest::data_size_in_bytes;
-#endif
-
 // Return CL_INVALID_VALUE if arg_svm_list is NULL and num_svm_args > 0,
 // or arg_svm_list is not NULL and num_svm_args is 0.
 TEST_F(MutableDispatchUSMTest, InvalidArgList) {
@@ -275,13 +267,6 @@ struct MutableDispatchUpdateUSMArgs
       public ::testing::WithParamInterface<usm_pointers> {
   static constexpr std::array<bool, 2> usm_update_pair = {true, false};
 };
-
-#if __cplusplus < 201703L
-// C++14 and below require static member definitions be defined outside the
-// class even if they are initialized inline. TODO: Remove condition once we no
-// longer support earlier than LLVM 15.
-constexpr std::array<bool, 2> MutableDispatchUpdateUSMArgs::usm_update_pair;
-#endif
 
 // Test that a USM pointer argument to the kernel (pointer A) can be updated to
 // another USM pointer (pointer B).


### PR DESCRIPTION
This updates our CMake to only accept LLVM versions 16 and above. We no longer test or support LLVM 15 so leaving CMake support for it may be misleading. It turns out we didn't error on LLVM 14 either, so that was a past mistake.

I've also removed some code that was handling compilation under C++14 and below, which we haven't supported for a wee while. This was just found by grepping for "LLVM 15".

There's still code that ostensibly handles LLVM 15 (such as in `multi_llvm`) but we can remove that gradually over time - those changes may be more intrusive as `multi_llvm` objects may become redundant and need removing (see `multi_llvm::Optional`).