### PR TITLE
[spirv-ll] Improve spirv-as version tracking for test features

### DIFF
--- a/modules/compiler/spirv-ll/test/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/CMakeLists.txt
@@ -35,17 +35,32 @@ if(CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE)
 
   find_package(SpirvTools COMPONENTS spirv-as)
   if(TARGET spirv::spirv-as)
-    # Get the found spirv-as version, takes the form: v<year>.<release>
+    # Get the found spirv-as version, takes the form: v<year>.<point>(-dev)?
+    # We treat 'dev' as the previous point release: see below.
     execute_process(
       COMMAND ${SpirvTools_spirv-as_EXECUTABLE} --version
       OUTPUT_VARIABLE SpirvAsVersionOutput)
-    string(REGEX MATCH "v20[0-9][0-9].[0-9]+"
-      SpirvAsVersion ${SpirvAsVersionOutput})
-    string(REGEX MATCH "20[0-9][0-9]"
-      SpirvAsVersionYear ${SpirvAsVersion})
-    string(REGEX MATCH "[0-9]+$"
-      SpirvAsVersionRelease ${SpirvAsVersion})
-    message(STATUS "spirv-as: v${SpirvAsVersionYear}.${SpirvAsVersionRelease}")
+    string(REGEX MATCH "v(20[0-9][0-9]).([0-9]+)(-dev)?" Tmp ${SpirvAsVersionOutput})
+    set(SpirvAsVersionYear "${CMAKE_MATCH_1}")
+    set(SpirvAsVersionPoint "${CMAKE_MATCH_2}")
+    set(SpirvAsVersionDev "${CMAKE_MATCH_3}")
+    message(STATUS "spirv-as: v${SpirvAsVersionYear}.${SpirvAsVersionPoint}${SpirvAsVersionDev}")
+    # If we have a 'development' version, canonicalize the internal version as
+    # the previous version:
+    # * Decrement the 'point release' by one
+    # * If that would result in a negative number, decrement the year and set
+    #   the 'point release' to 9 (an arbitrarily high version number)
+    if(SpirvAsVersionDev)
+      if(SpirvAsVersionPoint STREQUAL "0")
+        set(SpirvAsVersionPoint "9")
+        MATH(EXPR SpirvAsVersionYear "${SpirvAsVersionYear}-1")
+      else()
+        MATH(EXPR SpirvAsVersionPoint "${SpirvAsVersionPoint}-1")
+      endif()
+      message(STATUS "Detected 'dev' spirv-as version - tracking version "
+        "internally as: v${SpirvAsVersionYear}.${SpirvAsVersionPoint}")
+    endif()
+    set(SpirvAsVersion "${SpirvAsVersionYear}.${SpirvAsVersionPoint}")
   else()
     set(SPVASM_UNSUPPORTED True)
     message(WARNING "${SUITE} spvasm lit tests unsupported: spirv-as not found")
@@ -65,7 +80,8 @@ add_ca_configure_lit_site_cfg(
   CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=${CA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE}
   GLSL_UNSUPPORTED=${GLSL_UNSUPPORTED}
   SPVASM_UNSUPPORTED=${SPVASM_UNSUPPORTED}
-  SPIRV_AS_VERSION_YEAR=${SpirvAsVersionYear})
+  SPIRV_AS_VERSION_YEAR=${SpirvAsVersionYear}
+  SPIRV_AS_VERSION_POINT=${SpirvAsVersionPoint})
 
 add_subdirectory(glsl)
 add_subdirectory(spvasm)

--- a/modules/compiler/spirv-ll/test/lit.cfg
+++ b/modules/compiler/spirv-ll/test/lit.cfg
@@ -72,9 +72,19 @@ if (config.explicitly_online_offline == True
             subst_path = config.substitutions[idx][1]
             output = str(check_output([subst_path, '--version']))
 
-            m = re.search(r'SPIRV-Tools v(20\d{2,})\.(\d+)', output)
+            m = re.search(r'SPIRV-Tools v(20\d{2,})\.(\d+)(-dev)?', output)
             if m:
                 config.spirv_as_version_year = int(m.group(1))
+                config.spirv_as_version_point = int(m.group(2))
+                if m.group(3):
+                    # If decrementing the point would result in a negative
+                    # point release, decrement the year instead, and set the
+                    # point at 9.
+                    if config.spirv_as_version_point != 0:
+                        config.spirv_as_version_point -= 1
+                    else:
+                        config.spirv_as_version_point = 9
+                        config.spirv_as_version_year -= 1
 
     if not extra_tools[1].was_resolved:
         config.available_features.add('no-glsl')
@@ -86,5 +96,12 @@ if 'spirv_as_version_year' not in vars(config) or not config.spirv_as_version_ye
     lit_config.note("spirv-as version could not be determined: some tests may be disabled")
 else:
     config.available_features.add(f'spirv-as-v{config.spirv_as_version_year}-only')
-    for year in range(2016, config.spirv_as_version_year + 1):
-        config.available_features.add(f'spirv-as-v{year}+')
+    # Add all of the previous years maj.point releases. We arbitrarily assume 9
+    # as the max point release. We have to include them all as these are LIT
+    # features, not actual version strings that can be programatically checked.
+    for year in range(2016, config.spirv_as_version_year):
+        for point in range(0, 10):
+            config.available_features.add(f'spirv-as-v{year}.{point}+')
+    # Add all of this year's maj.point releases
+    for point in range(0, config.spirv_as_version_point + 1):
+        config.available_features.add(f'spirv-as-v{config.spirv_as_version_year}.{point}+')

--- a/modules/compiler/spirv-ll/test/lit.site.cfg.in
+++ b/modules/compiler/spirv-ll/test/lit.site.cfg.in
@@ -52,6 +52,8 @@ if @SPVASM_UNSUPPORTED@ and (config.offline and config.explicitly_online_offline
 
 if '@SPIRV_AS_VERSION_YEAR@' and (config.offline and config.explicitly_online_offline != True):
     config.spirv_as_version_year = int(@SPIRV_AS_VERSION_YEAR@)
+if '@SPIRV_AS_VERSION_POINT@' and (config.offline and config.explicitly_online_offline != True):
+    config.spirv_as_version_point = int(@SPIRV_AS_VERSION_POINT@)
 
 # Defer to the common lit configuration to set up the bulk of the config.
 common_lit_cfg_path = os.path.join('@CA_COMMON_LIT_BINARY_PATH@', 'lit.common.cfg')

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2365,14 +2365,14 @@ set(SPVASM_FILES
   invalid_storage_class.spvasm
   )
 
-if(SpirvAsVersionYear GREATER 2019)
+if(SpirvAsVersion VERSION_GREATER_EQUAL "2020.0")
   list(APPEND SPVASM_FILES
     op_execution_mode_max_work_dim.spvasm
     opencl_group_async_copy_2d2d.spvasm
     opencl_group_async_copy_3d3d.spvasm)
 endif()
 
-if (SpirvAsVersionYear GREATER_EQUAL 2022)
+if (SpirvAsVersion VERSION_GREATER_EQUAL "2021.3")
   list(APPEND SPVASM_FILES
     intel_opt_none.spvasm
     subgroup_shuffle_intel.spvasm
@@ -2382,12 +2382,11 @@ if (SpirvAsVersionYear GREATER_EQUAL 2022)
   )
 endif()
 
-if (SpirvAsVersionYear GREATER 2022)
-  list(APPEND SPVASM_FILES
-    intel_memory_access_aliasing.spvasm)
+if (SpirvAsVersion VERSION_GREATER_EQUAL "2022.2")
+  list(APPEND SPVASM_FILES intel_memory_access_aliasing.spvasm)
 endif()
 
-if (SpirvAsVersionYear GREATER 2023)
+if (SpirvAsVersion VERSION_GREATER_EQUAL "2023.5")
   list(APPEND SPVASM_FILES op_group_f_mul.spvasm)
 endif()
 

--- a/modules/compiler/spirv-ll/test/spvasm/intel_memory_access_aliasing.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_memory_access_aliasing.spvasm
@@ -13,7 +13,7 @@
 ; under the License.
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-; REQUIRES: spirv-as-v2023+
+; REQUIRES: spirv-as-v2022.2+
 ; RUN: spirv-as --version
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -e SPV_INTEL_memory_access_aliasing %spv_file_s

--- a/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_opt_none.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2022+
+; REQUIRES: spirv-as-v2021.3+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                OpCapability Addresses

--- a/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_max_work_dim.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_execution_mode_max_work_dim.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2020+
+; REQUIRES: spirv-as-v2020.0+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_mul.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_mul.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2024+
+; REQUIRES: spirv-as-v2023.5+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c GroupUniformArithmeticKHR %spv_file_s | FileCheck %s
 

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_2d2d.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2020+
+; REQUIRES: spirv-as-v2020.0+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_group_async_copy_3d3d.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2020+
+; REQUIRES: spirv-as-v2020.0+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
 ; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_down_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_down_intel.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2022+
+; REQUIRES: spirv-as-v2021.3+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
 ; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_intel.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2022+
+; REQUIRES: spirv-as-v2021.3+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
 ; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_up_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_up_intel.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2022+
+; REQUIRES: spirv-as-v2021.3+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 -c SubgroupShuffleINTEL \
 ; RUN:   -e SPV_INTEL_subgroups %spv_file_s | FileCheck %s

--- a/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_xor_intel.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/subgroup_shuffle_xor_intel.spvasm
@@ -14,7 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: spirv-as-v2022+
+; REQUIRES: spirv-as-v2021.3+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: spirv-ll-tool -a OpenCL -b 64 -c Float64 -c Int64 \
 ; RUN:   -c GenericPointer -c SubgroupShuffleINTEL \


### PR DESCRIPTION
This improves our previous tracking of `spirv-as` versions which was based soley on their release year, ignoring the point release. This coarse grained system meant that we had to conditionally enable spirv-ll tests on versions far newer than the oldest version which supports them, e.g., a feature introduce in `v2022.1` couldn't be tested until `v2022.0` was released.

It also now tracks `-dev` versions, which are packaged on some distributions as the 'official' `spirv-as` binary. We treat these as the previous point release, as in testing we have discovered that `v2022.1-dev` doesn't have some features present in `v2022.1`. Thus a `dev` version decrements the point release by 1, and if that would result in a negative version, we decrement the year instead, and set the point to 9. We choose 9 somewhat arbitrarily: the tools have never released such a high point number. For example, we internally track versions thus:

    v2022.1-dev -> v2022.0
    v2022.0-dev -> v2021.9

We also print this to the console during CMake configuration, for better clarity.

Note that we must do this both in CMake (for offline configurations) and in LIT (for online configurations), but the logic is the same.

With this internal information in place, we now add LIT features for point releases. We add all point releases 0..9 for previous years, so v2022.1 would add the following features:

    v2021.0+, v2021.1+, ..., v2021.9+, v2022.0+, v2022.1+

It similarily adds the same ten 'point' features 0..9 for all years from 2016 until the 'current' year. This is another reason for choosing 9 as the highest point release: we don't want to add an unreasonably high number of features (e.g., 99 per year) as it bloats the feature list and makes more improtant features harder to spot during development.

With these new features, we can retroactively enables some LIT tests for older `spirv-as` versions.