### PR TITLE
[host] Initialize unique_identifier.

### DIFF
--- a/modules/compiler/targets/host/include/host/target.h
+++ b/modules/compiler/targets/host/include/host/target.h
@@ -73,7 +73,7 @@ class HostTarget : public compiler::BaseTarget {
   /// execution engine has a unique name. This identifier will be suffixed onto
   /// the kernel names, and incremented under the context's mutex lock such that
   /// no conflict should occur.
-  uint64_t unique_identifier;
+  uint64_t unique_identifier = 0;
 
   /// @brief LLVM Module containing implementations of the builtin functions
   /// this target provides. May be null for compiler targets without external


### PR DESCRIPTION
This has no directly visible impact since we do not care what unique_identifier's initial value is, we just use it to generate unique names, but valgrind correctly picks up on the fact that we use it without initializing it.

# Overview

This change provides an initial value to `unique_identifier`.

# Reason for change

valgrind reports that we use `unique_identifier` uninitialized.

# Description of change

We use `unique_identifier` only in `HostKernel::lookupOrCreateOptimizedKernel` as follows:

```c++
      if (snprintf(unique_name_data, unique_name_data_length,
                   "__mux_host_%" PRIu64, target.unique_identifier++) < 0) {
```

We do not care what exactly we get as the ID, we just need it to be something we have not seen before. Any initial value will do, so the uninitialized use is mostly harmless and this change should have no visible effect other than to silence valgrind.

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.