### PR TITLE
[test] Review use of kts::N and kts::localN.

### DIFF
--- a/source/cl/test/UnitCL/source/C11Atomics.cpp
+++ b/source/cl/test/UnitCL/source/C11Atomics.cpp
@@ -55,15 +55,15 @@ class InitTest : public C11AtomicTestBase {
       return input_data[index];
     };
 
-    // Set up the buffers.
+    // Set up the buffers and run the test.
     AddInputBuffer(kts::N, random_reference);
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::N);
+      AddLocalBuffer(kts::localN * sizeof(T));
+      RunGeneric1D(kts::N, kts::localN);
+    } else {
+      RunGeneric1D(kts::N);
     }
-
-    // Run the test.
-    RunGeneric1D(kts::N);
   }
 };
 
@@ -146,7 +146,7 @@ TEST_P(FenceTest, C11Atomics_08_Fence_Local) {
   // Set up the buffers.
   this->AddInputBuffer(kts::N, kts::Ref_Identity);
   this->AddOutputBuffer(kts::N, kts::Ref_Identity);
-  this->AddLocalBuffer(kts::localN);
+  this->AddLocalBuffer(kts::localN * sizeof(cl_int));
 
   // Run the test.
   this->RunGeneric1D(kts::N, kts::localN);
@@ -166,15 +166,15 @@ class LoadStoreTest : public C11AtomicTestBase {
       return input_data[index];
     };
 
-    // Set up the buffers.
+    // Set up the buffers and run the test.
     AddInputBuffer(kts::N, random_reference);
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::N);
+      AddLocalBuffer(kts::localN * sizeof(T));
+      RunGeneric1D(kts::N, kts::localN);
+    } else {
+      RunGeneric1D(kts::N);
     }
-
-    // Run the test.
-    RunGeneric1D(kts::N);
   }
 };
 
@@ -227,7 +227,7 @@ class ExchangeTest : public C11AtomicTestBase {
       return desired_data[index];
     };
 
-    // Set up the buffers.
+    // Set up the buffers and run the test.
     // The initial values of the atomics are the input.
     // The desired values exchanged into the atomics are the expected output.
     AddInOutBuffer(kts::N, initializer_reference, desired_reference);
@@ -237,11 +237,11 @@ class ExchangeTest : public C11AtomicTestBase {
     // output.
     AddOutputBuffer(kts::N, initializer_reference);
     if (local) {
-      AddLocalBuffer(kts::N);
+      AddLocalBuffer(kts::localN * sizeof(T));
+      RunGeneric1D(kts::N, kts::localN);
+    } else {
+      RunGeneric1D(kts::N);
     }
-
-    // Run the test.
-    RunGeneric1D(kts::N);
   }
 };
 
@@ -289,10 +289,10 @@ TEST_P(FlagTest, C11Atomics_17_Flag_Local_Clear_Set) {
   // The expected output is that the local atomic flags are all unset
   // by the kernel.
   this->AddOutputBuffer(kts::N, false_reference);
-  this->AddLocalBuffer(kts::N);
+  this->AddLocalBuffer(kts::localN * sizeof(cl_bool));
 
   // Run the test.
-  this->RunGeneric1D(kts::N);
+  this->RunGeneric1D(kts::N, kts::localN);
 }
 
 TEST_P(FlagTest, C11Atomics_18_Flag_Local_Set_Twice) {
@@ -308,10 +308,10 @@ TEST_P(FlagTest, C11Atomics_18_Flag_Local_Set_Twice) {
   // The expected output is that the local atomic flags are all set
   // by the kernel.
   this->AddOutputBuffer(kts::N, true_reference);
-  this->AddLocalBuffer(kts::N);
+  this->AddLocalBuffer(kts::localN * sizeof(cl_bool));
 
   // Run the test.
-  this->RunGeneric1D(kts::N);
+  this->RunGeneric1D(kts::N, kts::localN);
 }
 
 TEST_P(FlagTest, C11Atomics_19_Flag_Global_Clear) {
@@ -365,17 +365,17 @@ class FetchTest : public C11AtomicTestBase {
       return input_data[index];
     };
 
-    // Set up the buffers.
+    // Set up the buffers and run the test.
     // The initial values of the atomics are the random input.
     AddInputBuffer(kts::N, random_reference);
     // The expected output values are the initial values loaded atomically.
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::N);
+      AddLocalBuffer(kts::localN * sizeof(T));
+      RunGeneric1D(kts::N, kts::localN);
+    } else {
+      RunGeneric1D(kts::N);
     }
-
-    // Run the test.
-    RunGeneric1D(kts::N);
   }
 
   template <typename T>
@@ -1449,7 +1449,7 @@ class WeakGlobalSingle : public C11AtomicTestBase {
     kts::Reference1D<T> desired_reference = [desired_values](size_t index) {
       return desired_values[index];
     };
-    kts::Reference1D<T> bool_output_reference =
+    kts::Reference1D<cl_int> bool_output_reference =
         [success_index, weak_exchange_failed](size_t index) {
           return index == success_index && !weak_exchange_failed;
         };
@@ -1462,7 +1462,7 @@ class WeakGlobalSingle : public C11AtomicTestBase {
     if (!local) {
       RunGeneric1D(kts::N);
     } else {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer(kts::localN * sizeof(T));
       RunGeneric1D(kts::N, kts::localN);
     }
   }
@@ -1569,7 +1569,7 @@ class WeakLocalSingle : public C11AtomicTestBase {
     kts::Reference1D<T> desired_reference = [desired_values](size_t index) {
       return desired_values[index];
     };
-    kts::Reference1D<T> bool_output_reference =
+    kts::Reference1D<cl_int> bool_output_reference =
         [&success_indices, &weak_exchanges_failed](size_t index) {
           const size_t work_group = index / kts::localN;
           const size_t success_index_of_workgroup = success_indices[work_group];
@@ -1584,7 +1584,7 @@ class WeakLocalSingle : public C11AtomicTestBase {
     AddOutputBuffer(kts::N, bool_output_reference);
     AddLocalBuffer(1);
     if (local_local) {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer(kts::localN * sizeof(T));
     }
 
     // Run the test.

--- a/source/cl/test/UnitCL/source/ktst_compiler_barrier.cpp
+++ b/source/cl/test/UnitCL/source/ktst_compiler_barrier.cpp
@@ -26,6 +26,7 @@ TEST_P(Execution, Compiler_Barrier_02_Group_Divergent_Barriers) {
   const unsigned offset = 5;
   // If `ARRAY_SIZE` changes from `16`, recompile Offline kernels.
   const size_t ARRAY_SIZE = kts::N / kts::localN;
+  ASSERT_EQ(ARRAY_SIZE, 16);
   kts::Reference1D<cl_int> refIn = [&](size_t x) {
     return (x == offset) ? 42 : 0;
   };
@@ -100,6 +101,7 @@ TEST_P(Execution, Compiler_Barrier_04_Mutually_Exclusive_Barriers) {
   const size_t offset = 5;
   // If `ARRAY_SIZE` changes from `16`, recompile Offline kernels.
   const size_t ARRAY_SIZE = kts::N / kts::localN;
+  ASSERT_EQ(ARRAY_SIZE, 16);
   kts::Reference1D<cl_int> refIn = [&](size_t x) {
     return (x == offset) ? 42 : 0;
   };

--- a/source/cl/test/UnitCL/source/ktst_regression_01.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_01.cpp
@@ -33,7 +33,7 @@ using namespace kts::ucl;
 TEST_P(Execution, Regression_01_Pointer_To_Long_Cast) {
   // This test was compiled for SPIRV and Offline with the value of 256. You
   // will need to recompile these targets.
-  ASSERT_TRUE(kts::N == 256);
+  ASSERT_EQ(kts::N, 256);
   AddMacro("N", (unsigned int)kts::N);
   AddInputBuffer(kts::N, kts::Ref_Identity);
   RunGeneric1D(kts::N);

--- a/source/cl/test/UnitCL/source/ktst_regression_02.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_02.cpp
@@ -708,6 +708,9 @@ TEST_P(Execution, Regression_42_Shuffle_Function_Call) {
 }
 
 TEST_P(Execution, Regression_43_Scatter_Gather) {
+  // This test has a kernel that does not handle arbitrary values of N. If its
+  // value is changed, this test will need to be updated manually.
+  ASSERT_EQ(kts::N, 256);
   kts::Reference1D<cl_int> refOut = [](size_t x) { return (cl_int)(x * 7); };
   kts::Reference1D<cl_int> refIn = [](size_t x) {
     return (cl_int)((x + 1) * 7);


### PR DESCRIPTION
# Overview

* C11Atomics.cpp: fix local buffers. We called AddLocalBuffer(kts::N) where kts::N is 256, where we need local_work_size * sizeof(T) which is 64 * 4, which is also 256. This works out but is fragile and breaks if we get larger T, and disregards kts::localN.
* ktst_compiler_barrier.cpp, ktst_regression_02.cpp: add explicit assertions so we fail hard rather than corrupting memory if we change kts::N or kts::localN.
* ktst_regression_01.cpp: change ASSERT_TRUE to ASSERT_EQ to get a better error message if the assertion fails.

# Reason for change

Planned work regarding atomics resulted in test failures due to incorrect use of kts::N. This is split out into a separate MR for easier review.

# Description of change

This change only affects our own tests. Other people see no changes.

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
