### PR TITLE
Fix for spir-v translation to IR for OpPtrAccessChain

### DIFF
--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1294,6 +1294,13 @@ void spirv_ll::Builder::checkMemberDecorations(
   // the pointer.
   uint64_t memberIndex = 1;
 
+  // If the size of indexes is only one, this means we are not indexing into the
+  // struct itself so exit in this case. This can happen for example if we are
+  // using something like OpPtrAccessChain without an empty indexes input field.
+  if (indexes.size() < 2) {
+    return;
+  }
+
   llvm::SmallVector<llvm::Type *, 4> traversed({accessedStructType});
 
   // Start at one for the reason described above.

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2353,6 +2353,7 @@ set(SPVASM_FILES
   op_expect_assume.spvasm
   op_generic_pointer.spvasm
   op_generic_pointer_builtin.spvasm
+  op_ptr_access_chain.spvasm
   op_spec_constant_generic_pointer.spvasm
   prioritize_function_names.spvasm
   prioritize_function_names_external.spvasm

--- a/modules/compiler/spirv-ll/test/spvasm/op_ptr_access_chain.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_ptr_access_chain.spvasm
@@ -1,0 +1,67 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
+
+    OpCapability Addresses
+    OpCapability Kernel
+    OpCapability Int64
+    OpMemoryModel Physical64 OpenCL
+    OpEntryPoint Kernel %20 "entry_pt"
+
+    %void = OpTypeVoid
+    %ulong = OpTypeInt 64 0
+    %_ptr_Generic_ulong = OpTypePointer Generic %ulong
+
+    %ulong_0 = OpConstant %ulong 0
+    %ulong_3 = OpConstant %ulong 3
+    %float = OpTypeFloat 32
+    %uchar = OpTypeInt 8 0
+    %uint = OpTypeInt 32 0
+    %_ptr_uint = OpTypePointer CrossWorkgroup %uint
+    %ulong_3 = OpConstant %ulong 3
+
+    %struct_user_struct = OpTypeStruct %float %uint %uchar %_ptr_uint
+    %_ptr_CrossWorkgroup_struct_user_struct = OpTypePointer CrossWorkgroup %struct_user_struct
+
+    %19 = OpTypeFunction %void %_ptr_CrossWorkgroup_struct_user_struct %ulong  %ulong
+    %20 = OpFunction %void None %19
+    %_arg_user_struct = OpFunctionParameter %_ptr_CrossWorkgroup_struct_user_struct
+    %_ulong_input = OpFunctionParameter %ulong
+    %_ulong_input2 = OpFunctionParameter %ulong
+   
+; CHECK: define spir_kernel void @entry_pt(ptr addrspace(1) [[PTR:%.*]], i64 {{%[a-zA-Z0-9]+}}, i64 {{%[a-zA-Z0-9]+}}
+    %entry = OpLabel
+
+    ; some maths for the gep input (multiple and an add)
+    %mul = OpIMul %ulong %ulong_3 %_ulong_input
+; CHECK: [[MUL_RES:%[a-zA-Z0-9_]+]] = mul
+    %add = OpIAdd %uint %ulong_0 %_ulong_input2
+; CHECK: [[ADD_RES:%[a-zA-Z0-9_]+]] = add
+
+    ; use two OpPtrAccessChain values to get to the correct index of the user struct array
+    ; we don't gep into the struct
+    %mul_user_struct_ptr = OpPtrAccessChain %_ptr_CrossWorkgroup_struct_user_struct %_arg_user_struct  %mul
+    %add_user_struct_ptr = OpPtrAccessChain %_ptr_CrossWorkgroup_struct_user_struct %mul_user_struct_ptr %add
+
+; CHECK:   [[GEP_MUL:%[a-zA-Z0-9_]+]] = getelementptr %0, ptr addrspace(1) [[PTR]], i64 [[MUL_RES]]
+; CHECK:   [[GEP_ADD:%[a-zA-Z0-9_]+]] = getelementptr %0, ptr addrspace(1) [[GEP_MUL]], i64 [[ADD_RES]]
+; CHECK: store i64 [[ADD_RES]], ptr addrspace(1) [[GEP_ADD]], align 4
+
+    OpStore %add_user_struct_ptr %add Aligned 4
+    OpReturn
+    OpFunctionEnd


### PR DESCRIPTION
# Overview

Fix for spir-v translation to IR for OpPtrAccessChain

# Reason for change

In some cases the indexes field for OpPtrAccessChain can be empty. The translation code currently assumes this not to be the case and checks for element decorations, resulting in a segmentation fault during SYCL CTS testing.

# Description of change

This fixes the empty index case by not checking the decorations in this case. There are some issues with OpMemberDecorate, so testing of the path with additional arguments requiring decorations will not be tested here.

Also some previous clang-format issues have been resolved.

Additional lit tests have been added.
