### PR TITLE
[compiler] Represent samplers/events internally as size_t

### DIFF
--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_1d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_1d_tgt_tys_32.ll
@@ -17,13 +17,16 @@
 ; REQUIRES: llvm-17+
 ; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
 
-target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
-target triple = "riscv64-unknown-unknown-elf"
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
 
-declare spir_func target("spirv.Event") @__mux_dma_write_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
+declare spir_func target("spirv.Event") @__mux_dma_read_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
 
 
-; CHECK: define spir_func i32 @__refsi_dma_start_seq_write(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i32 [[argEvent:%.*]]) #0 {
+; CHECK: define spir_func i32 @__refsi_dma_start_seq_read(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i32 [[argEvent:%.*]]) #0 {
 ; CHECK:   [[argDstDmaInt:%.*]] = ptrtoint ptr addrspace(3) [[argDstDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[argDstDmaInt]], ptr inttoptr (i64 536879136 to ptr), align 8
 ; CHECK:   [[argSrcDmaInt:%.*]] = ptrtoint ptr addrspace(1) [[argSrcDmaPointer]] to i64

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_1d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_1d_tgt_tys_64.ll
@@ -1,0 +1,34 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_read_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
+
+
+; CHECK: define spir_func i64 @__refsi_dma_start_seq_read(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i64 [[argEvent:%.*]]) #0 {
+; CHECK:   [[argDstDmaInt:%.*]] = ptrtoint ptr addrspace(3) [[argDstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[argDstDmaInt]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[argSrcDmaInt:%.*]] = ptrtoint ptr addrspace(1) [[argSrcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[argSrcDmaInt]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[argWidth]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 17, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   ret i64 [[load]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_2d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_2d_tgt_tys_32.ll
@@ -1,0 +1,41 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_read_2D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, target("spirv.Event"))
+
+
+; CHECK: define spir_func i32 @__refsi_dma_start_2d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstStride:%.*]], i64 [[srcStride:%.*]], i64 [[height:%.*]], i32 [[event:%.*]]) #0 {
+; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[src_int]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[width]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 [[height]], ptr inttoptr (i64 536879152 to ptr), align 8
+; CHECK:   store volatile i64 [[srcStride]], ptr inttoptr (i64 536879168 to ptr), align 8
+; CHECK:   store volatile i64 [[dstStride]], ptr inttoptr (i64 536879184 to ptr), align 8
+; CHECK:   store volatile i64 225, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
+; CHECK:   ret i32 [[trunc]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_2d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_2d_tgt_tys_64.ll
@@ -23,7 +23,7 @@ target triple = "riscv64-unknown-unknown-elf"
 declare spir_func target("spirv.Event") @__mux_dma_read_2D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, target("spirv.Event"))
 
 
-; CHECK: define spir_func i32 @__refsi_dma_start_2d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstStride:%.*]], i64 [[srcStride:%.*]], i64 [[height:%.*]], i32 [[event:%.*]]) #0 {
+; CHECK: define spir_func i64 @__refsi_dma_start_2d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstStride:%.*]], i64 [[srcStride:%.*]], i64 [[height:%.*]], i64 [[event:%.*]]) #0 {
 ; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
 ; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
@@ -34,5 +34,4 @@ declare spir_func target("spirv.Event") @__mux_dma_read_2D(i8 addrspace(3)*, i8 
 ; CHECK:   store volatile i64 [[dstStride]], ptr inttoptr (i64 536879184 to ptr), align 8
 ; CHECK:   store volatile i64 225, ptr inttoptr (i64 536879104 to ptr), align 8
 ; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
-; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
-; CHECK:   ret i32 [[trunc]]
+; CHECK:   ret i64 [[load]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_3d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_3d_tgt_tys_32.ll
@@ -1,0 +1,44 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_read_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
+
+
+; CHECK: define spir_func i32 @__refsi_dma_start_3d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i32 [[xxxx:%.*]]) #0 {
+; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[src_int]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[width]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 [[height]], ptr inttoptr (i64 536879152 to ptr), align 8
+; CHECK:   store volatile i64 [[numPlanes]], ptr inttoptr (i64 536879160 to ptr), align 8
+; CHECK:   store volatile i64 [[srcLineStride]], ptr inttoptr (i64 536879168 to ptr), align 8
+; CHECK:   store volatile i64 [[srcPlaneStride]], ptr inttoptr (i64 536879176 to ptr), align 8
+; CHECK:   store volatile i64 [[dstLineStride]], ptr inttoptr (i64 536879184 to ptr), align 8
+; CHECK:   store volatile i64 [[dstPlaneStride]], ptr inttoptr (i64 536879192 to ptr), align 8
+; CHECK:   store volatile i64 241, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
+; CHECK:   ret i32 [[trunc]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_3d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_read_3d_tgt_tys_64.ll
@@ -1,0 +1,40 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_read_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
+
+
+; CHECK: define spir_func i64 @__refsi_dma_start_3d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i64 [[xxxx:%.*]]) #0 {
+; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[src_int]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[width]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 [[height]], ptr inttoptr (i64 536879152 to ptr), align 8
+; CHECK:   store volatile i64 [[numPlanes]], ptr inttoptr (i64 536879160 to ptr), align 8
+; CHECK:   store volatile i64 [[srcLineStride]], ptr inttoptr (i64 536879168 to ptr), align 8
+; CHECK:   store volatile i64 [[srcPlaneStride]], ptr inttoptr (i64 536879176 to ptr), align 8
+; CHECK:   store volatile i64 [[dstLineStride]], ptr inttoptr (i64 536879184 to ptr), align 8
+; CHECK:   store volatile i64 [[dstPlaneStride]], ptr inttoptr (i64 536879192 to ptr), align 8
+; CHECK:   store volatile i64 241, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   ret i64 [[load]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_32.ll
@@ -14,19 +14,24 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; REQUIRES: llvm-17+
-; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+; UNSUPPORTED: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes define-mux-dma,verify -S | FileCheck %s
 
-target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
-target triple = "riscv64-unknown-unknown-elf"
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
 
-declare spir_func void @__mux_dma_wait(i32, ptr)
+%__mux_dma_event_t = type opaque
+declare spir_func void @__mux_dma_wait(i32, %__mux_dma_event_t**)
 
 ; CHECK: define spir_func void @__refsi_dma_wait(i32 [[numEvents:%.*]], ptr [[eventList:%.*]]) #0 {
 ; CHECK:   %loop_iv = phi i32 [ 0, %entry ], [ %new_iv, %body ]
 ; CHECK:   %max_xfer_id = phi i32 [ 0, %entry ], [ %new_max_xfer_id, %body ]
-; CHECK:   [[eventGep:%.*]] = getelementptr i32, ptr [[eventList]], i32 %loop_iv
-; CHECK:   %xfer_id = load i32, ptr [[eventGep]], align 4
+; CHECK:   [[eventGep:%.*]] = getelementptr ptr, ptr [[eventList]], i32 %loop_iv
+; CHECK:   [[event:%.*]] = load ptr, ptr [[eventGep]], align 4
+; CHECK:   %xfer_id = ptrtoint ptr [[event]] to i32
 ; CHECK:   %new_iv = add i32 %loop_iv, 1
 ; CHECK:   [[higher:%.*]] = icmp ugt i32 %xfer_id, %max_xfer_id
 ; CHECK:   %new_max_xfer_id = select i1 [[higher]], i32 %xfer_id, i32 %max_xfer_id

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_64.ll
@@ -26,15 +26,14 @@ declare spir_func void @__mux_dma_wait(i32, %__mux_dma_event_t**)
 
 ; CHECK: define spir_func void @__refsi_dma_wait(i32 [[numEvents:%.*]], ptr [[eventList:%.*]]) #0 {
 ; CHECK:   %loop_iv = phi i32 [ 0, %entry ], [ %new_iv, %body ]
-; CHECK:   %max_xfer_id = phi i32 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   %max_xfer_id = phi i64 [ 0, %entry ], [ %new_max_xfer_id, %body ]
 ; CHECK:   [[eventGep:%.*]] = getelementptr ptr, ptr [[eventList]], i32 %loop_iv
 ; CHECK:   [[event:%.*]] = load ptr, ptr [[eventGep]], align 8
-; CHECK:   %xfer_id = ptrtoint ptr [[event]] to i32
+; CHECK:   %xfer_id = ptrtoint ptr [[event]] to i64
 ; CHECK:   %new_iv = add i32 %loop_iv, 1
-; CHECK:   [[higher:%.*]] = icmp ugt i32 %xfer_id, %max_xfer_id
-; CHECK:   %new_max_xfer_id = select i1 [[higher]], i32 %xfer_id, i32 %max_xfer_id
+; CHECK:   [[higher:%.*]] = icmp ugt i64 %xfer_id, %max_xfer_id
+; CHECK:   %new_max_xfer_id = select i1 [[higher]], i64 %xfer_id, i64 %max_xfer_id
 ; CHECK:   %exit_cond = icmp ult i32 %new_iv, [[numEvents]]
 ; CHECK:   br i1 %exit_cond, label %body, label %epilog
-; CHECK:   %event_id_to_wait = phi i32 [ 0, %entry ], [ %new_max_xfer_id, %body ]
-; CHECK:   [[store:%.*]] = zext i32 %event_id_to_wait to i64
-; CHECK:   store volatile i64 [[store]], ptr inttoptr (i64 536879120 to ptr), align 8
+; CHECK:   %event_id_to_wait = phi i64 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   store volatile i64 %event_id_to_wait, ptr inttoptr (i64 536879120 to ptr), align 8

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_tgt_tys_32.ll
@@ -1,0 +1,40 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
+
+declare spir_func void @__mux_dma_wait(i32, ptr)
+
+; CHECK: define spir_func void @__refsi_dma_wait(i32 [[numEvents:%.*]], ptr [[eventList:%.*]]) #0 {
+; CHECK:   %loop_iv = phi i32 [ 0, %entry ], [ %new_iv, %body ]
+; CHECK:   %max_xfer_id = phi i32 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   [[eventGep:%.*]] = getelementptr i32, ptr [[eventList]], i32 %loop_iv
+; CHECK:   %xfer_id = load i32, ptr [[eventGep]], align 4
+; CHECK:   %new_iv = add i32 %loop_iv, 1
+; CHECK:   [[higher:%.*]] = icmp ugt i32 %xfer_id, %max_xfer_id
+; CHECK:   %new_max_xfer_id = select i1 [[higher]], i32 %xfer_id, i32 %max_xfer_id
+; CHECK:   %exit_cond = icmp ult i32 %new_iv, [[numEvents]]
+; CHECK:   br i1 %exit_cond, label %body, label %epilog
+; CHECK:   %event_id_to_wait = phi i32 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   [[store:%.*]] = zext i32 %event_id_to_wait to i64
+; CHECK:   store volatile i64 [[store]], ptr inttoptr (i64 536879120 to ptr), align 8

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_wait_tgt_tys_64.ll
@@ -1,0 +1,36 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-unknown-elf"
+
+declare spir_func void @__mux_dma_wait(i32, ptr)
+
+; CHECK: define spir_func void @__refsi_dma_wait(i32 [[numEvents:%.*]], ptr [[eventList:%.*]]) #0 {
+; CHECK:   %loop_iv = phi i32 [ 0, %entry ], [ %new_iv, %body ]
+; CHECK:   %max_xfer_id = phi i64 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   [[eventGep:%.*]] = getelementptr i64, ptr [[eventList]], i32 %loop_iv
+; CHECK:   %xfer_id = load i64, ptr [[eventGep]], align 8
+; CHECK:   %new_iv = add i32 %loop_iv, 1
+; CHECK:   [[higher:%.*]] = icmp ugt i64 %xfer_id, %max_xfer_id
+; CHECK:   %new_max_xfer_id = select i1 [[higher]], i64 %xfer_id, i64 %max_xfer_id
+; CHECK:   %exit_cond = icmp ult i32 %new_iv, [[numEvents]]
+; CHECK:   br i1 %exit_cond, label %body, label %epilog
+; CHECK:   %event_id_to_wait = phi i64 [ 0, %entry ], [ %new_max_xfer_id, %body ]
+; CHECK:   store volatile i64 %event_id_to_wait, ptr inttoptr (i64 536879120 to ptr), align 8

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_1d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_1d_tgt_tys_32.ll
@@ -17,13 +17,15 @@
 ; REQUIRES: llvm-17+
 ; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
 
-target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
-target triple = "riscv64-unknown-unknown-elf"
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
 
-declare spir_func target("spirv.Event") @__mux_dma_read_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
+declare spir_func target("spirv.Event") @__mux_dma_write_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
 
-
-; CHECK: define spir_func i32 @__refsi_dma_start_seq_read(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i32 [[argEvent:%.*]]) #0 {
+; CHECK: define spir_func i32 @__refsi_dma_start_seq_write(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i32 [[argEvent:%.*]]) #0 {
 ; CHECK:   [[argDstDmaInt:%.*]] = ptrtoint ptr addrspace(3) [[argDstDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[argDstDmaInt]], ptr inttoptr (i64 536879136 to ptr), align 8
 ; CHECK:   [[argSrcDmaInt:%.*]] = ptrtoint ptr addrspace(1) [[argSrcDmaPointer]] to i64

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_1d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_1d_tgt_tys_64.ll
@@ -1,0 +1,34 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_write_1D(i8 addrspace(3)*, i8 addrspace(1)*, i64, target("spirv.Event"))
+
+
+; CHECK: define spir_func i64 @__refsi_dma_start_seq_write(ptr addrspace(3) [[argDstDmaPointer:%.*]], ptr addrspace(1) [[argSrcDmaPointer:%.*]], i64 [[argWidth:%.*]], i64 [[argEvent:%.*]]) #0 {
+; CHECK:   [[argDstDmaInt:%.*]] = ptrtoint ptr addrspace(3) [[argDstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[argDstDmaInt]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[argSrcDmaInt:%.*]] = ptrtoint ptr addrspace(1) [[argSrcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[argSrcDmaInt]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[argWidth]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 17, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   ret i64 [[load]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_2d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_2d_tgt_tys_32.ll
@@ -17,8 +17,11 @@
 ; REQUIRES: llvm-17+
 ; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
 
-target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
-target triple = "riscv64-unknown-unknown-elf"
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
 
 declare spir_func target("spirv.Event") @__mux_dma_write_2D(i8 addrspace(1)*, i8 addrspace(3)*, i64, i64, i64, i64, target("spirv.Event"))
 

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_2d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_2d_tgt_tys_64.ll
@@ -20,23 +20,17 @@
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
 target triple = "riscv64-unknown-unknown-elf"
 
-declare spir_func target("spirv.Event") @__mux_dma_write_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
+declare spir_func target("spirv.Event") @__mux_dma_write_2D(i8 addrspace(1)*, i8 addrspace(3)*, i64, i64, i64, i64, target("spirv.Event"))
 
-
-
-; CHECK: define spir_func i32 @__refsi_dma_start_3d_write(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i64 [[xxxx:%.*]], i32 [[event:%.*]]) #0 {
-; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
+; CHECK: define spir_func i64 @__refsi_dma_start_2d_write(ptr addrspace(1) [[dstDmaPointer:%.*]], ptr addrspace(3) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstStride:%.*]], i64 [[srcStride:%.*]], i64 [[height:%.*]], i64 [[event:%.*]]) #0 {
+; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(1) [[dstDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
-; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
+; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(3) [[srcDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[src_int]], ptr inttoptr (i64 536879128 to ptr), align 8
 ; CHECK:   store volatile i64 [[width]], ptr inttoptr (i64 536879144 to ptr), align 8
 ; CHECK:   store volatile i64 [[height]], ptr inttoptr (i64 536879152 to ptr), align 8
-; CHECK:   store volatile i64 [[numPlanes]], ptr inttoptr (i64 536879160 to ptr), align 8
-; CHECK:   store volatile i64 [[srcLineStride]], ptr inttoptr (i64 536879168 to ptr), align 8
-; CHECK:   store volatile i64 [[srcPlaneStride]], ptr inttoptr (i64 536879176 to ptr), align 8
-; CHECK:   store volatile i64 [[dstLineStride]], ptr inttoptr (i64 536879184 to ptr), align 8
-; CHECK:   store volatile i64 [[dstPlaneStride]], ptr inttoptr (i64 536879192 to ptr), align 8
-; CHECK:   store volatile i64 241, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   store volatile i64 [[srcStride]], ptr inttoptr (i64 536879168 to ptr), align 8
+; CHECK:   store volatile i64 [[dstStride]], ptr inttoptr (i64 536879184 to ptr), align 8
+; CHECK:   store volatile i64 225, ptr inttoptr (i64 536879104 to ptr), align 8
 ; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
-; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
-; CHECK:   ret i32 [[trunc]]
+; CHECK:   ret i64 [[load]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_3d_tgt_tys_32.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_3d_tgt_tys_32.ll
@@ -1,0 +1,43 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; REQUIRES: llvm-17+
+; RUN: muxc --device "%riscv_device" %s --passes replace-target-ext-tys,define-mux-dma,verify -S | FileCheck %s
+
+; Note - RefSi M1 is a 64-bit architecture. This test tests that the compiler
+; passes would correctly generate code for a theoretical 32-bit version of this
+; architecture.
+target datalayout = "e-m:e-p:32:32-i64:64-i128:128-n64-S128"
+target triple = "riscv32-unknown-unknown-elf"
+
+declare spir_func target("spirv.Event") @__mux_dma_write_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
+
+; CHECK: define spir_func i32 @__refsi_dma_start_3d_write(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i64 [[xxxx:%.*]], i32 [[event:%.*]]) #0 {
+; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
+; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
+; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
+; CHECK:   store volatile i64 [[src_int]], ptr inttoptr (i64 536879128 to ptr), align 8
+; CHECK:   store volatile i64 [[width]], ptr inttoptr (i64 536879144 to ptr), align 8
+; CHECK:   store volatile i64 [[height]], ptr inttoptr (i64 536879152 to ptr), align 8
+; CHECK:   store volatile i64 [[numPlanes]], ptr inttoptr (i64 536879160 to ptr), align 8
+; CHECK:   store volatile i64 [[srcLineStride]], ptr inttoptr (i64 536879168 to ptr), align 8
+; CHECK:   store volatile i64 [[srcPlaneStride]], ptr inttoptr (i64 536879176 to ptr), align 8
+; CHECK:   store volatile i64 [[dstLineStride]], ptr inttoptr (i64 536879184 to ptr), align 8
+; CHECK:   store volatile i64 [[dstPlaneStride]], ptr inttoptr (i64 536879192 to ptr), align 8
+; CHECK:   store volatile i64 241, ptr inttoptr (i64 536879104 to ptr), align 8
+; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
+; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
+; CHECK:   ret i32 [[trunc]]

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_3d_tgt_tys_64.ll
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/test/passes/refsi_define_mux_dma_pass_write_3d_tgt_tys_64.ll
@@ -20,10 +20,11 @@
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
 target triple = "riscv64-unknown-unknown-elf"
 
-declare spir_func target("spirv.Event") @__mux_dma_read_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
+declare spir_func target("spirv.Event") @__mux_dma_write_3D(i8 addrspace(3)*, i8 addrspace(1)*, i64, i64, i64, i64, i64, i64, i64, i64, target("spirv.Event"))
 
 
-; CHECK: define spir_func i32 @__refsi_dma_start_3d_read(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i32 [[xxxx:%.*]]) #0 {
+
+; CHECK: define spir_func i64 @__refsi_dma_start_3d_write(ptr addrspace(3) [[dstDmaPointer:%.*]], ptr addrspace(1) [[srcDmaPointer:%.*]], i64 [[width:%.*]], i64 [[dstLineStride:%.*]], i64 [[srcLineStride:%.*]], i64 [[height:%.*]], i64 [[dstPlaneStride:%.*]], i64 [[srcPlaneStride:%.*]], i64 [[numPlanes:%.*]], i64 [[xxxx:%.*]], i64 [[event:%.*]]) #0 {
 ; CHECK:   [[dst_int:%.*]] = ptrtoint ptr addrspace(3) [[dstDmaPointer]] to i64
 ; CHECK:   store volatile i64 [[dst_int]], ptr inttoptr (i64 536879136 to ptr), align 8
 ; CHECK:   [[src_int:%.*]] = ptrtoint ptr addrspace(1) [[srcDmaPointer]] to i64
@@ -37,5 +38,4 @@ declare spir_func target("spirv.Event") @__mux_dma_read_3D(i8 addrspace(3)*, i8 
 ; CHECK:   store volatile i64 [[dstPlaneStride]], ptr inttoptr (i64 536879192 to ptr), align 8
 ; CHECK:   store volatile i64 241, ptr inttoptr (i64 536879104 to ptr), align 8
 ; CHECK:   [[load:%.*]] = load volatile i64, ptr inttoptr (i64 536879112 to ptr), align 8
-; CHECK:   [[trunc:%.*]] = trunc i64 [[load]] to i32
-; CHECK:   ret i32 [[trunc]]
+; CHECK:   ret i64 [[load]]

--- a/modules/compiler/test/lit/passes/image-arg-subst-64.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst-64.ll
@@ -20,7 +20,7 @@
 ; RUN: muxc --passes image-arg-subst,verify %s | FileCheck %s
 
 target triple = "spir64-unknown-unknown"
-target datalayout = "e-p:32:32:32-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK: define internal spir_kernel void @image_sampler.old(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, ptr addrspace(2) %sampler1, ptr addrspace(2) %sampler2) [[OLD_ATTRS:#[0-9]+]] {
 define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, ptr addrspace(2) %sampler1, ptr addrspace(2) %sampler2) #0 {
@@ -56,9 +56,9 @@ entry:
 }
 
 ; We've updated the old kernel to pass samplers as i32
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, i32 %sampler1, i32 %sampler2) [[NEW_ATTRS:#[0-9]+]] {
-; CHECK:   %sampler1.ptrcast = inttoptr i32 %sampler1 to ptr addrspace(2)
-; CHECK:   %sampler2.ptrcast = inttoptr i32 %sampler2 to ptr addrspace(2)
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img, i64 %sampler1, i64 %sampler2) [[NEW_ATTRS:#[0-9]+]] {
+; CHECK:   %sampler1.ptrcast = inttoptr i64 %sampler1 to ptr addrspace(2)
+; CHECK:   %sampler2.ptrcast = inttoptr i64 %sampler2 to ptr addrspace(2)
 ; CHECK:   call spir_kernel void @image_sampler.old(
 ; CHECK-SAME:  ptr addrspace(1) nocapture writeonly align 4 %out, ptr addrspace(1) %img,
 ; CHECK-SAME:  ptr addrspace(2) %sampler1.ptrcast, ptr addrspace(2) %sampler2.ptrcast) #0

--- a/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
@@ -17,8 +17,9 @@
 ; REQUIRES: llvm-17+
 ; RUN: muxc --passes replace-target-ext-tys,image-arg-subst,verify %s | FileCheck %s
 
-target triple = "spir64-unknown-unknown"
-target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
+target datalayout = "e-p:32:32:32-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
 
 ; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr %img, i32 %sampler1, i32 %sampler2) {{#[0-9]+}} {
 define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {

--- a/modules/compiler/test/lit/passes/lower-async-copies-tgt-tys.ll
+++ b/modules/compiler/test/lit/passes/lower-async-copies-tgt-tys.ll
@@ -20,7 +20,7 @@
 ;
 ; For this we usually run the replace-target-ext-tys-pass beforehand, to
 ; replace the target extension type with the default event type in ComputeMux
-; (i32). A target would also have control over this process.
+; (size_t). A target would also have control over this process.
 ;
 ; We also run the pass on the target extension types directly, to simulate a
 ; target using their own target extension types. This is perfectly valid from a
@@ -32,7 +32,7 @@
 ; RUN: muxc --passes lower-to-mux-builtins,early-cse,verify %s \
 ; RUN:  | FileCheck %s -DEVENT_TY='target("spirv.Event")' -DNULLEVENT=zeroinitializer
 ; RUN: muxc --passes replace-target-ext-tys,lower-to-mux-builtins,early-cse,verify %s \
-; RUN:  | FileCheck %s -DEVENT_TY=i32 -DNULLEVENT=0
+; RUN:  | FileCheck %s -DEVENT_TY=i64 -DNULLEVENT=0
 
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/modules/compiler/test/lit/passes/replace-event-tys-64.ll
+++ b/modules/compiler/test/lit/passes/replace-event-tys-64.ll
@@ -17,19 +17,19 @@
 ; REQUIRES: llvm-17+
 ; RUN: muxc --passes replace-target-ext-tys,verify %s | FileCheck %s 
 
-target triple = "spir-unknown-unknown"
-target datalayout = "e-p:32:32:32-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 
-; CHECK-DAG: [[NEW_STRUCTA:.*]] = type { i64, i32, i64 }
+; CHECK-DAG: [[NEW_STRUCTA:.*]] = type { i64, i64, i64 }
 %structTyA = type { i64, target("spirv.Event"), i64 }
-; CHECK-DAG: [[NEW_STRUCTB:.*]] = type <{ i8, [4 x i32], [2 x [[NEW_STRUCTA]]] }>
+; CHECK-DAG: [[NEW_STRUCTB:.*]] = type <{ i8, [4 x i64], [2 x [[NEW_STRUCTA]]] }>
 %structTyB = type <{ i8, [4 x target("spirv.Event")], [2 x %structTyA] }>
 ; Don't remap this type - expect the exact same name
 ; CHECK-DAG: %structTyC = type { i64, i64, i64 }
 %structTyC = type { i64, i64, i64 }
 
 ; CHECK-LABEL: define spir_kernel void @my_func
-; CHECK-SAME:    [2 x i32] %array_param,
+; CHECK-SAME:    [2 x i64] %array_param,
 ; CHECK-SAME:    [[NEW_STRUCTA]] %named_s_a,
 ; CHECK-SAME:    { [[NEW_STRUCTA]], i8 } %literal_s,
 ; CHECK-SAME:    [[NEW_STRUCTB]] %named_s_b,
@@ -38,18 +38,18 @@ define spir_kernel void @my_func([2 x target("spirv.Event")] %array_param,
                                  %structTyA %named_s_a, { %structTyA, i8 } %literal_s,
                                  %structTyB %named_s_b,
                                  %structTyC %named_s_c) #0 {
-; CHECK: event_array = alloca [2 x i32]
+; CHECK: event_array = alloca [2 x i64]
   %event_array = alloca [2 x target("spirv.Event")]
 ; CHECK: %an_event = extractvalue [[NEW_STRUCTA]] %named_s_a, 1
   %an_event = extractvalue %structTyA %named_s_a, 1
 ; CHECK: %another_event = extractvalue { [[NEW_STRUCTA]], i8 } %literal_s, 0, 1
   %another_event = extractvalue { %structTyA, i8 } %literal_s, 0, 1
-; CHECK: call void @some_function(i32 %an_event)
+; CHECK: call void @some_function(i64 %an_event)
   call void @some_function(target("spirv.Event") %an_event)
-; CHECK: call void @some_function(i32 %another_event)
+; CHECK: call void @some_function(i64 %another_event)
   call void @some_function(target("spirv.Event") %another_event)
   %a_third_event = extractvalue %structTyB %named_s_b, 1, 3
-; CHECK: call void @some_function(i32 %a_third_event)
+; CHECK: call void @some_function(i64 %a_third_event)
   call void @some_function(target("spirv.Event") %a_third_event)
   ret void
 }

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -629,9 +629,10 @@ class BuiltinInfo {
   /// that the type is a target extension type.
   ///
   /// @param Ty The target extension type to remap
+  /// @param M The Module in which to replace the type
   /// @return The remapped type, or nullptr if the type does not require
   /// remapping
-  llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty);
+  llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty, llvm::Module &M);
 
   /// Handle the invalidation of this information.
   ///
@@ -709,7 +710,7 @@ class BIMuxInfoConcept {
   ///   * spirv.Event -> i32
   ///   * spirv.Sampler -> i32
   ///   * spirv.Image -> MuxImage* (regardless of image parameters)
-  virtual llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty);
+  virtual llvm::Type *getRemappedTargetExtTy(llvm::Type *Ty, llvm::Module &M);
 
   /// @see BuiltinInfo::getBuiltinRange
   virtual std::optional<llvm::ConstantRange> getBuiltinRange(

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -599,9 +599,9 @@ bool BuiltinInfo::requiresSchedulingParameters(BuiltinID ID) {
   return MuxImpl->requiresSchedulingParameters(ID);
 }
 
-Type *BuiltinInfo::getRemappedTargetExtTy(Type *Ty) {
+Type *BuiltinInfo::getRemappedTargetExtTy(Type *Ty, Module &M) {
   // Defer to mux for the scheduling parameters.
-  return MuxImpl->getRemappedTargetExtTy(Ty);
+  return MuxImpl->getRemappedTargetExtTy(Ty, M);
 }
 
 SmallVector<BuiltinInfo::SchedParamInfo, 4>

--- a/modules/compiler/utils/source/mux_builtin_info.cpp
+++ b/modules/compiler/utils/source/mux_builtin_info.cpp
@@ -22,6 +22,7 @@
 #include <compiler/utils/pass_functions.h>
 #include <compiler/utils/scheduling.h>
 #include <compiler/utils/target_extension_types.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/multi_llvm.h>
 
@@ -876,8 +877,9 @@ bool BIMuxInfoConcept::requiresSchedulingParameters(BuiltinID ID) {
   }
 }
 
-Type *BIMuxInfoConcept::getRemappedTargetExtTy(Type *Ty) {
+Type *BIMuxInfoConcept::getRemappedTargetExtTy(Type *Ty, Module &M) {
 #if LLVM_VERSION_LESS(17, 0)
+  (void)M;
   (void)Ty;
 #else
   // We only map target extension types
@@ -885,14 +887,14 @@ Type *BIMuxInfoConcept::getRemappedTargetExtTy(Type *Ty) {
   auto &Ctx = Ty->getContext();
   auto *TgtExtTy = cast<TargetExtType>(Ty);
 
-  // Samplers are replaced by default with i32s
+  // Samplers are replaced by default with size_t.
   if (TgtExtTy == compiler::utils::tgtext::getSamplerTy(Ctx)) {
-    return IntegerType::getInt32Ty(Ctx);
+    return getSizeType(M);
   }
 
-  // Events are replaced by default with i32s
+  // Events are replaced by default with size_t.
   if (TgtExtTy == compiler::utils::tgtext::getEventTy(Ctx)) {
-    return IntegerType::getInt32Ty(Ctx);
+    return getSizeType(M);
   }
 
   // *All* images are replaced by default with a pointer in the default address

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -129,10 +129,10 @@ void populatePackedArgs(
             break;
         }
 
-        uint32_t sampler_ptr = libimg::HostCreateSampler(
+        uint64_t sampler_ptr = libimg::HostCreateSampler(
             info.sampler.normalize_coords, addressing_mode, filter_mode);
-        std::memcpy(packed_args_alloc + offset, &sampler_ptr, sizeof(uint32_t));
-        offset += sizeof(uint32_t);
+        std::memcpy(packed_args_alloc + offset, &sampler_ptr, sizeof(size_t));
+        offset += sizeof(size_t);
 #endif
       } break;
       case mux_descriptor_info_type_plain_old_data: {


### PR DESCRIPTION
This fixes a bug in LLVM 17 where, on 64-bit targets, the `target` types used to represent samplers and events have an implicit size/alignment of 8 bytes (as their underlying "layout type" is `ptr`). This means that it is generally invalid to replace them with `i32`, as this may break existing alignment/size assumptions that the rest of the module has made on the access of the 'old' types.

Instead, we choose to replace `target` types with `size_t` (in practice `i32` or `i64` depending on the SPIR triple). This works more or less the same way on 32-bit targets.

On 64-bit targets, however, the runtime passes samplers to kernels as 8-byte values. These values follow the existing munging via pointers on LLVM 16, but are eventually zero-extended or truncated to `i32` when they interface with existing APIs that expect `i32` - such as `libimg`.