### PR TITLE
Handle ConstantArray in WorkItemLoopPass

### DIFF
--- a/modules/compiler/test/lit/passes/work-item-loop-array.ll
+++ b/modules/compiler/test/lit/passes/work-item-loop-array.ll
@@ -1,0 +1,29 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+
+; CHECK: @llvm.used = appending global [1 x ptr] [ptr @foo.mux-barrier-wrapper], section "llvm.metadata" 
+@llvm.used = appending global [1 x ptr] [ptr @foo], section "llvm.metadata"
+
+
+define void @foo() #0 {
+  ret void
+}
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }

--- a/modules/compiler/utils/include/compiler/utils/pass_functions.h
+++ b/modules/compiler/utils/include/compiler/utils/pass_functions.h
@@ -23,6 +23,7 @@
 
 #include <cargo/optional.h>
 #include <llvm/ADT/Twine.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
 
@@ -74,6 +75,18 @@ void replaceConstantExpressionWithInstruction(llvm::Constant *const constant);
 /// @param[in] to Constant which will replace any operands which are `from`
 void remapConstantExpr(llvm::ConstantExpr *expr, llvm::Constant *from,
                        llvm::Constant *to);
+
+/// @brief remap operands of a constant array
+///
+/// @note This will create a new constant array and replace references to
+/// the original constant with the new one
+///
+/// @param[in] arr Constant array to be remapped
+/// @param[in] from Constant which if found in array will be
+/// replaced
+/// @param[in] to Constant which will replace any operands which are `from`
+void remapConstantArray(llvm::ConstantArray *arr, llvm::Constant *from,
+                        llvm::Constant *to);
 
 /// @brief Discover if input function references debug info metadata nodes
 ///

--- a/modules/compiler/utils/source/work_item_loops_pass.cpp
+++ b/modules/compiler/utils/source/work_item_loops_pass.cpp
@@ -1716,10 +1716,12 @@ Function *compiler::utils::WorkItemLoopsPass::makeWrapperFunction(
   for (auto *user : refF.users()) {
     if (ConstantExpr *constant = dyn_cast<ConstantExpr>(user)) {
       remapConstantExpr(constant, &refF, new_wrapper);
+    } else if (ConstantArray *ca = dyn_cast<ConstantArray>(user)) {
+      remapConstantArray(ca, &refF, new_wrapper);
     } else if (!isa<CallInst>(user)) {
       llvm_unreachable(
           "Cannot handle user of function being anything other than a "
-          "ConstantExpr or CallInst");
+          "ConstantExpr, ConstantArray or CallInst");
     }
   }
 


### PR DESCRIPTION
# Overview

Handle case where the kernel function is used by an LLVM ConstantArray.

# Reason for change

An llvm_unreachable was being hit.

# Description of change

Handle similarly to `llvm::ConstantExpression`.

Added test `modules/compiler/test/lit/passes/work-item-loop-array.ll `

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
