### PR TITLE
[test] More reviews, rework AddLocalBuffer.

### DIFF
--- a/source/cl/test/UnitCL/include/kts/execution.h
+++ b/source/cl/test/UnitCL/include/kts/execution.h
@@ -105,7 +105,12 @@ struct BaseExecution : ::ucl::CommandQueueTest, SharedExecution {
   void AddInOutBuffer(size_t size, Reference1DPtr<T> refIn,
                       Reference1D<T> refOut);
 
-  void AddLocalBuffer(size_t size);
+  void AddLocalBuffer(size_t nelm, size_t elmsize);
+
+  template <typename T>
+  void AddLocalBuffer(size_t size) {
+    AddLocalBuffer(size, sizeof(T));
+  }
 
   template <typename T>
   void AddInputImage(const cl_image_format &format, const cl_image_desc &desc,

--- a/source/cl/test/UnitCL/source/C11Atomics.cpp
+++ b/source/cl/test/UnitCL/source/C11Atomics.cpp
@@ -59,7 +59,7 @@ class InitTest : public C11AtomicTestBase {
     AddInputBuffer(kts::N, random_reference);
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
       RunGeneric1D(kts::N, kts::localN);
     } else {
       RunGeneric1D(kts::N);
@@ -182,7 +182,7 @@ TEST_P(FenceTest, C11Atomics_08_Fence_Local) {
   // Set up the buffers.
   this->AddInputBuffer(kts::N, kts::Ref_Identity);
   this->AddOutputBuffer(kts::N, kts::Ref_Identity);
-  this->AddLocalBuffer(kts::localN * sizeof(cl_int));
+  this->AddLocalBuffer<cl_int>(kts::localN);
 
   // Run the test.
   this->RunGeneric1D(kts::N, kts::localN);
@@ -206,7 +206,7 @@ class LoadStoreTest : public C11AtomicTestBase {
     AddInputBuffer(kts::N, random_reference);
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
       RunGeneric1D(kts::N, kts::localN);
     } else {
       RunGeneric1D(kts::N);
@@ -345,7 +345,7 @@ class ExchangeTest : public C11AtomicTestBase {
     // output.
     AddOutputBuffer(kts::N, initializer_reference);
     if (local) {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
       RunGeneric1D(kts::N, kts::localN);
     } else {
       RunGeneric1D(kts::N);
@@ -433,7 +433,7 @@ TEST_P(FlagTest, C11Atomics_17_Flag_Local_Clear_Set) {
   // The expected output is that the local atomic flags are all unset
   // by the kernel.
   this->AddOutputBuffer(kts::N, false_reference);
-  this->AddLocalBuffer(kts::localN * sizeof(cl_bool));
+  this->AddLocalBuffer<cl_bool>(kts::localN);
 
   // Run the test.
   this->RunGeneric1D(kts::N, kts::localN);
@@ -452,7 +452,7 @@ TEST_P(FlagTest, C11Atomics_18_Flag_Local_Set_Twice) {
   // The expected output is that the local atomic flags are all set
   // by the kernel.
   this->AddOutputBuffer(kts::N, true_reference);
-  this->AddLocalBuffer(kts::localN * sizeof(cl_bool));
+  this->AddLocalBuffer<cl_bool>(kts::localN);
 
   // Run the test.
   this->RunGeneric1D(kts::N, kts::localN);
@@ -515,7 +515,7 @@ class FetchTest : public C11AtomicTestBase {
     // The expected output values are the initial values loaded atomically.
     AddOutputBuffer(kts::N, random_reference);
     if (local) {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
       RunGeneric1D(kts::N, kts::localN);
     } else {
       RunGeneric1D(kts::N);
@@ -609,7 +609,7 @@ class FetchTest : public C11AtomicTestBase {
       AddInputBuffer(kts::N / kts::localN, init_reference);
     }
 
-    AddLocalBuffer(kts::N / kts::localN);
+    AddLocalBuffer<T>(kts::localN);
 
     // Run the test.
     RunGeneric1D(kts::N, kts::localN);
@@ -1521,10 +1521,10 @@ class FetchTruthTableTest
     this->AddInputBuffer(2, input_reference);
     // Expected output is the result of the binary operation.
     this->AddOutputBuffer(1, output_reference);
-    this->AddLocalBuffer(2);
+    this->AddLocalBuffer<T>(2);
 
     // Run the test.
-    this->RunGeneric1D(2);
+    this->RunGeneric1D(2, 2);
   }
 };
 
@@ -1714,9 +1714,9 @@ class Strong : public C11AtomicTestBase {
     if (!local) {
       RunGeneric1D(kts::N);
     } else {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer<T>(kts::localN);
       if (local_local) {
-        AddLocalBuffer(kts::localN);
+        AddLocalBuffer<T>(kts::localN);
       }
       RunGeneric1D(kts::N, kts::localN);
     }
@@ -1900,7 +1900,7 @@ class StrongGlobalSingle : public C11AtomicTestBase {
     if (!local) {
       RunGeneric1D(kts::N);
     } else {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer<T>(kts::localN);
 
       // Run the test.
       RunGeneric1D(kts::N, kts::localN);
@@ -2059,9 +2059,9 @@ class StrongLocalSingle : public C11AtomicTestBase {
     AddInOutBuffer(kts::N, expected_in_reference, expected_output_reference);
     AddInputBuffer(kts::N, desired_reference);
     AddOutputBuffer(kts::N, bool_output_reference);
-    AddLocalBuffer(1);
+    AddLocalBuffer<T>(1);
     if (local_local) {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer<T>(kts::localN);
     }
 
     // Run the test.
@@ -2208,9 +2208,9 @@ class Weak : public C11AtomicTestBase {
     if (!local) {
       RunGeneric1D(kts::N);
     } else {
-      AddLocalBuffer(kts::localN);
+      AddLocalBuffer<T>(kts::localN);
       if (local_local) {
-        AddLocalBuffer(kts::localN);
+        AddLocalBuffer<T>(kts::localN);
       }
       RunGeneric1D(kts::N, kts::localN);
     }
@@ -2401,7 +2401,7 @@ class WeakGlobalSingle : public C11AtomicTestBase {
     if (!local) {
       RunGeneric1D(kts::N);
     } else {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
       RunGeneric1D(kts::N, kts::localN);
     }
   }
@@ -2563,9 +2563,9 @@ class WeakLocalSingle : public C11AtomicTestBase {
     AddInOutBuffer(kts::N, expected_in_reference, expected_output_reference);
     AddInputBuffer(kts::N, desired_reference);
     AddOutputBuffer(kts::N, bool_output_reference);
-    AddLocalBuffer(1);
+    AddLocalBuffer<T>(1);
     if (local_local) {
-      AddLocalBuffer(kts::localN * sizeof(T));
+      AddLocalBuffer<T>(kts::localN);
     }
 
     // Run the test.

--- a/source/cl/test/UnitCL/source/cl_khr_extended_async_copies/extended_async.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_extended_async_copies/extended_async.cpp
@@ -44,9 +44,9 @@ TEST_P(Execution, Ext_Async_01_Simple_2D) {
   if (!isSourceTypeIn({OPENCL_C, OFFLINE})) {
     GTEST_SKIP();
   }
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, vaddOutC);
@@ -58,9 +58,9 @@ TEST_P(Execution, Ext_Async_02_Simple_3D) {
   if (!isSourceTypeIn({OPENCL_C, OFFLINE})) {
     GTEST_SKIP();
   }
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, vaddOutC);

--- a/source/cl/test/UnitCL/source/kts/execution.cpp
+++ b/source/cl/test/UnitCL/source/kts/execution.cpp
@@ -380,10 +380,13 @@ void kts::ucl::BaseExecution::AddInOutBuffer(BufferDesc &&desc) {
   args_->AddInOutBuffer(desc);
 }
 
-void kts::ucl::BaseExecution::AddLocalBuffer(size_t size) {
+void kts::ucl::BaseExecution::AddLocalBuffer(size_t nelm, size_t elmsize) {
+  assert(elmsize != 0 && "cannot allocate zero-sized elements");
+  size_t bytesize = nelm * elmsize;
+  assert(bytesize / elmsize == nelm && "overflow in size computation");
   // UnitCL AddLocalBuffer requires this to be allocated with cargo::alloc.
   void *raw = cargo::alloc(sizeof(PointerPrimitive), alignof(PointerPrimitive));
-  PointerPrimitive *pointer_primitive = new (raw) PointerPrimitive(size);
+  PointerPrimitive *pointer_primitive = new (raw) PointerPrimitive(bytesize);
   args_->AddLocalBuffer(pointer_primitive);
 }
 

--- a/source/cl/test/UnitCL/source/ktst_barrier.cpp
+++ b/source/cl/test/UnitCL/source/ktst_barrier.cpp
@@ -364,7 +364,7 @@ TEST_P(Execution, Barrier_14_Barrier_In_Reduce) {
 
   AddInputBuffer(kts::N, refIn);
   AddOutputBuffer(kts::N / kts::localN, refOut);
-  AddLocalBuffer(kts::localN * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(kts::localN);
   RunGeneric1D(kts::N, kts::localN);
 }
 
@@ -397,7 +397,7 @@ TEST_P(MemFenceTests, Barrier_16_Memory_Fence_Global) {
 TEST_P(MemFenceTests, Barrier_16_Memory_Fence_Local) {
   AddMacro("FENCE_OP", getParam());
   AddInputBuffer(kts::N, kts::Ref_Identity);
-  AddLocalBuffer(kts::localN);
+  AddLocalBuffer<cl_int>(kts::localN);
   AddOutputBuffer(kts::N, kts::Ref_Identity);
   RunGeneric1D(kts::N, kts::localN);
 }

--- a/source/cl/test/UnitCL/source/ktst_dma.cpp
+++ b/source/cl/test/UnitCL/source/ktst_dma.cpp
@@ -124,8 +124,8 @@ TEST_P(Execution, Dma_01_Direct) {
 }
 
 TEST_P(Execution, Dma_02_Explicit_Copy) {
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, vaddOutC);
@@ -133,8 +133,8 @@ TEST_P(Execution, Dma_02_Explicit_Copy) {
 }
 
 TEST_P(Execution, Dma_03_Explicit_Copy_Rotate) {
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, vaddOutC);
@@ -142,9 +142,9 @@ TEST_P(Execution, Dma_03_Explicit_Copy_Rotate) {
 }
 
 TEST_P(Execution, Dma_04_async_copy) {
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, vaddOutC);
@@ -156,12 +156,12 @@ TEST_P(Execution, Dma_04_async_copy) {
 // size of the local buffers.
 TEST_P(Execution, Dma_05_async_double_buffer) {
   const cl_int iterations = 16;
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N * iterations, vaddInA);
   AddInputBuffer(kts::N * iterations, vaddInB);
   AddOutputBuffer(kts::N * iterations, vaddOutC);
@@ -267,10 +267,9 @@ TEST_P(AsyncCopyTests, Dma_10_half_async_copy) {
   const auto param = getParam();
   AddMacro("TYPE", param.type_str);
 
-  const size_t local_buffer_len = local_wg_size * param.type_size;
-  AddLocalBuffer(local_buffer_len);
-  AddLocalBuffer(local_buffer_len);
-  AddLocalBuffer(local_buffer_len);
+  AddLocalBuffer(local_wg_size, param.type_size);
+  AddLocalBuffer(local_wg_size, param.type_size);
+  AddLocalBuffer(local_wg_size, param.type_size);
 
   if (3 == param.vec_width) {
     AddInputBuffer(kts::N, makeHalf3Streamer(HalfTypeParam::InA));
@@ -299,10 +298,9 @@ TEST_P(AsyncCopyTests, Dma_11_half_async_strided_copy) {
   const auto param = getParam();
   AddMacro("TYPE", param.type_str);
 
-  const size_t local_buffer_len = local_wg_size * param.type_size;
-  AddLocalBuffer(local_buffer_len);
-  AddLocalBuffer(local_buffer_len);
-  AddLocalBuffer(local_buffer_len);
+  AddLocalBuffer(local_wg_size, param.type_size);
+  AddLocalBuffer(local_wg_size, param.type_size);
+  AddLocalBuffer(local_wg_size, param.type_size);
 
   if (3 == param.vec_width) {
     AddInputBuffer(kts::N * 2, makeHalf3Streamer(HalfTypeParam::InA));
@@ -376,8 +374,8 @@ TEST_P(Execution, Dma_13_wait_event_is_barrier) {
                    (((x % local_wg_size) + 1) % local_wg_size));
   };
 
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, rotateB);
@@ -389,7 +387,7 @@ TEST_P(Execution, Dma_14_wait_event_is_barrier_overwrite) {
     return vaddInA(x) + 1;
   };
 
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddOutputBuffer(kts::N, vaddInAPlusOne);
   RunGeneric1D(kts::N, local_wg_size);
@@ -408,10 +406,10 @@ TEST_P(Execution, DISABLED_Dma_15_wait_event_is_execution_barrier) {
                    (((x % local_wg_size) + 1) % local_wg_size));
   };
 
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddInputBuffer(kts::N, vaddInB);
   AddOutputBuffer(kts::N, rotateA);
@@ -424,7 +422,7 @@ TEST_P(Execution, Dma_16_wait_event_is_barrier_strided) {
     return vaddInA(x) + 1;
   };
 
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, vaddInA);
   AddOutputBuffer(kts::N, vaddInAPlusOne);
   RunGeneric1D(kts::N, local_wg_size);

--- a/source/cl/test/UnitCL/source/ktst_regression_03.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_03.cpp
@@ -130,7 +130,7 @@ TEST_P(Execution, Regression_56_Local_Vec_Mem) {
 
   // Only want one thread
   AddOutputBuffer(1, refOut);
-  AddLocalBuffer(sizeof(cl_float4));
+  AddLocalBuffer<cl_float4>(1);
   AddInputBuffer(1, refIn);
   RunGeneric1D(1, 1);
 }
@@ -322,7 +322,7 @@ TEST_P(Execution, Regression_61_Sycl_Barrier) {
   };
 
   AddInOutBuffer(kts::N, kts::Ref_Identity, refOut);
-  AddLocalBuffer(sizeof(cl_int) * 2);
+  AddLocalBuffer<cl_int>(2);
   RunGeneric1D(kts::N, 2);
 }
 
@@ -334,13 +334,13 @@ TEST_P(Execution, Regression_62_Sycl_Barrier) {
   };
 
   AddInOutBuffer(kts::N, kts::Ref_Identity, refOut);
-  AddLocalBuffer(sizeof(cl_int) * 2);
+  AddLocalBuffer<cl_int>(2);
   AddInOutBuffer(kts::N, kts::Ref_Identity, refOut);
-  AddLocalBuffer(sizeof(cl_int) * 2);
+  AddLocalBuffer<cl_int>(2);
   AddInOutBuffer(kts::N, kts::Ref_Identity, refOut);
-  AddLocalBuffer(sizeof(cl_int) * 2);
+  AddLocalBuffer<cl_int>(2);
   AddInOutBuffer(kts::N, kts::Ref_Identity, refOut);
-  AddLocalBuffer(sizeof(cl_int) * 2);
+  AddLocalBuffer<cl_int>(2);
   RunGeneric1D(kts::N, 2);
 }
 
@@ -373,8 +373,8 @@ TEST_P(MultipleLocalDimensionsTests,
 
   kts::Reference1D<cl_int> refOut = [](size_t) { return 1; };
 
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
-  AddLocalBuffer(local_wg_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_wg_size);
+  AddLocalBuffer<cl_int>(local_wg_size);
   AddInputBuffer(kts::N, refIn);
   AddInputBuffer(kts::N, refIn);
   AddOutputBuffer(kts::N, refOut);

--- a/source/cl/test/UnitCL/source/ktst_regression_04.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_04.cpp
@@ -536,7 +536,7 @@ TEST_P(Execution, Regression_89_Multiple_Local_Memory_Kernels) {
 }
 
 TEST_P(Execution, Regression_90_Offline_Local_Memcpy) {
-  AddLocalBuffer(kts::localN * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(kts::localN);
   AddOutputBuffer(kts::localN, kts::Ref_Identity);
   RunGeneric1D(kts::localN, kts::localN);  // Only the first WG is valid.
 }
@@ -544,7 +544,7 @@ TEST_P(Execution, Regression_90_Offline_Local_Memcpy) {
 TEST_P(Execution, Regression_90_Offline_Local_Memcpy_Fixed) {
   fail_if_not_vectorized_ = false;
   const size_t local_size = 17;  // Kernel uses reqd_work_group_size(17,1,1);
-  AddLocalBuffer(local_size * sizeof(cl_int));
+  AddLocalBuffer<cl_int>(local_size);
   AddOutputBuffer(local_size, kts::Ref_Identity);
   RunGeneric1D(local_size, local_size);  // Only the first WG is valid.
 }

--- a/source/cl/test/UnitCL/source/ktst_regression_05.cpp
+++ b/source/cl/test/UnitCL/source/ktst_regression_05.cpp
@@ -89,7 +89,7 @@ TEST_P(Execution, Regression_104_async_work_group_copy_int3) {
   auto refIn = kts::BuildVec3Reference1D<cl_int3>(kts::Ref_A);
   AddInputBuffer(kts::N, refIn);
   AddOutputBuffer(kts::N, refIn);
-  AddLocalBuffer(kts::localN * sizeof(cl_int3));
+  AddLocalBuffer<cl_int3>(kts::localN);
   RunGeneric1D(kts::N, kts::localN);
 }
 

--- a/source/cl/test/UnitCL/source/ktst_spirv.cpp
+++ b/source/cl/test/UnitCL/source/ktst_spirv.cpp
@@ -32,7 +32,7 @@ TEST_P(Execution, Spirv_01_Copy) {
 
 TEST_P(Execution, Spirv_02_Async_Copy) {
   AddInputBuffer(kts::N, kts::Ref_A);
-  AddLocalBuffer(kts::localN * sizeof(cl_uint));
+  AddLocalBuffer<cl_uint>(kts::localN);
   AddOutputBuffer(kts::N, kts::Ref_A);
 
   RunGeneric1D(kts::N, kts::localN);

--- a/source/cl/test/UnitCL/source/ktst_vload_vstore.cpp
+++ b/source/cl/test/UnitCL/source/ktst_vload_vstore.cpp
@@ -86,7 +86,7 @@ TEST_P(HalfVloadVstoreTests, Vloadvstore_02_Half_Local) {
   const size_t elements = N * vec_width;
 
   AddInputBuffer(elements, refIn);
-  AddLocalBuffer(elements * sizeof(cl_half));
+  AddLocalBuffer<cl_half>(elements);
   AddOutputBuffer(elements, refOut);
   RunGeneric1D(N, N);
 }


### PR DESCRIPTION
# Overview

More reviews, rework AddLocalBuffer.

# Reason for change

We have UnitCL tests where we under-allocate buffers and access local memory out of bounds.

# Description of change

AddLocalBuffer was error-prone as it was used in conjunction with AddInputBuffer and AddOutputBuffer, which take a number of elements, whereas AddLocalBuffer takes a number of bytes. This commit changes AddLocalBuffer so that it takes a number of elements, and either an element type as a template parameter, or an element size as a function parameter. Updating the tests to use this new API revealed a number of cases where we were still under-allocating buffers.

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
