### PR TITLE
[host] Fix calculated size of sampler types

### DIFF
--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -41,7 +41,7 @@ size_t calcPackedArgsAllocSize(
     size_t size = 0;
     switch (descriptor.type) {
       case mux_descriptor_info_type_sampler:
-        size = sizeof(uint32_t);
+        size = sizeof(size_t);
         break;
       case mux_descriptor_info_type_buffer:
       case mux_descriptor_info_type_null_buffer:


### PR DESCRIPTION
A recent change makes samplers passed to kernels as size_t types. Unfortunately our pre-commit testing doesn't cover image support very well and it missed that I had forgotten to update the calculated the size of samplers for the purposes of allocating the packed argument struct.