### PR TITLE
[doc] Update list of tested/supported LLVM versions

### DIFF
--- a/doc/overview/compiler/supported-llvm-versions.rst
+++ b/doc/overview/compiler/supported-llvm-versions.rst
@@ -1,19 +1,12 @@
 Supported LLVM Versions
 =======================
 
-oneAPI Construction Kit depends on LLVM, Clang and LLD.
+The oneAPI Construction Kit depends on LLVM, Clang and (optionally) LLD.
 
-Host
-----
-
-.. rubric:: Supported - tested daily
-
-- 15.0.0 (Any released version)
-- 16.0.6+
-
-RISC-V
-------
+All targets
+-----------
 
 .. rubric:: Supported - tested daily
 
 - 16.0.6+
+- 17.0.3


### PR DESCRIPTION
I've removed the distinction between the two targets, as we nominally support both LLVM versions on each. A bug in either target in either version of LLVM is valid to report, and as such it is more useful for users to be aware of what we *claim* to support than what we actively test. The distinction was more valid in an earlier time when riscv had its own special patched version of LLVM.

Note that this has always been an overly simplified document; it's impossible to convey exactly *what* we test in which configurations on which targets and when, without just providing access to our internal testing infrastructure.