### PR TITLE
[USM] Accept arbitrary pointers.

### DIFF
--- a/source/cl/include/cl/kernel.h
+++ b/source/cl/include/cl/kernel.h
@@ -262,17 +262,6 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
     /// @param value_size Size of the data.
     argument(compiler::ArgumentType type, const void *value, size_t value_size);
 
-#ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
-    /// @brief Constructor to create an USM allocation argument.
-    ///
-    /// @param type Type of the kernel argument, must be a valid type to use
-    /// with a USM allocation, i.e a global or constant pointer.
-    /// @param usm_alloc USM allocation associated with parameter.
-    /// @param offset Byte offset from the start of the USM allocation.
-    argument(compiler::ArgumentType type,
-             extension::usm::allocation_info *usm_alloc, size_t offset);
-#endif
-
     /// @brief Copy constructor.
     ///
     /// @param other Argument to copy from.
@@ -315,12 +304,6 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
         void *data;
         size_t size;
       } value;
-#ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
-      struct {
-        extension::usm::allocation_info *usm_ptr;
-        size_t offset;
-      } usm;
-#endif
     };
 
     using info = compiler::KernelInfo::ArgumentInfo;
@@ -336,9 +319,6 @@ struct _cl_kernel final : public cl::base<_cl_kernel> {
       memory_buffer,
       sampler,
       value,
-#ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
-      usm,
-#endif
       uninitialized
     };
 

--- a/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
@@ -129,15 +129,6 @@ cl_int createBlockingEventForKernel(cl_command_queue queue, cl_kernel kernel,
   }
   return_event = *new_event;
 
-  // USM allocation set as kernel arguments
-  for (size_t i = 0, e = kernel->info->getNumArguments(); i < e; ++i) {
-    _cl_kernel::argument &arg = kernel->saved_args[i];
-    if (arg.stype == _cl_kernel::argument::storage_type::usm) {
-      auto mux_error = arg.usm.usm_ptr->record_event(return_event);
-      OCL_CHECK(mux_error, return CL_OUT_OF_RESOURCES);
-    }
-  }
-
   // USM allocations which have been set explicitly via clSetKernelExecInfo
   // to be used indirectly in the kernel.
   for (auto indirect_alloc : kernel->indirect_usm_allocs) {

--- a/source/cl/source/extension/source/intel_unified_shared_memory/usm-exports.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/usm-exports.cpp
@@ -474,20 +474,12 @@ cl_int clSetKernelArgMemPointerINTEL(cl_kernel kernel, cl_uint arg_index,
   OCL_CHECK(!(arg_type->address_space == compiler::AddressSpace::GLOBAL ||
               arg_type->address_space == compiler::AddressSpace::CONSTANT),
             return CL_INVALID_ARG_VALUE);
-  if (arg_value) {
-    const cl_context context = kernel->program->context;
 
-    extension::usm::allocation_info *const usm_alloc =
-        extension::usm::findAllocation(context, arg_value);
-    OCL_CHECK(nullptr == usm_alloc, return CL_INVALID_ARG_VALUE);
-
-    const uint64_t offset = getUSMOffset(arg_value, usm_alloc);
-
-    // Will create a mux_descriptor_info_buffer_s descriptor for the argument
-    // using the device specific mux_buffer assigned to the allocation.
-    kernel->saved_args[arg_index] =
-        _cl_kernel::argument(*arg_type, usm_alloc, offset);
-  }
+  // The cl_intel_unified_shared_memory specification has an open question on
+  // whether unknown pointers should be accepted. We accept them since the SYCL
+  // specification and the SYCL CTS imply this must be treated as valid.
+  kernel->saved_args[arg_index] =
+      _cl_kernel::argument(*arg_type, &arg_value, sizeof(void *));
 
   return CL_SUCCESS;
 }

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1168,19 +1168,11 @@ CARGO_NODISCARD cl_int _cl_command_buffer_khr::updateCommandBuffer(
       // Construct Descriptor
       mux_descriptor_info_s descriptor;
       descriptor.type =
-          mux_descriptor_info_type_e::mux_descriptor_info_type_buffer;
-
-      extension::usm::allocation_info *const usm_alloc =
-          extension::usm::findAllocation(command_queue->context, arg_value);
-      OCL_CHECK(nullptr == usm_alloc, return CL_INVALID_ARG_VALUE);
-
-      const uint64_t offset = static_cast<uint64_t>(
-          reinterpret_cast<uintptr_t>(arg_value) -
-          reinterpret_cast<uintptr_t>(usm_alloc->base_ptr));
-
-      auto mux_buffer = usm_alloc->getMuxBufferForDevice(device);
-      descriptor.buffer_descriptor =
-          mux_descriptor_info_buffer_s{mux_buffer, offset};
+          mux_descriptor_info_type_e::mux_descriptor_info_type_plain_old_data;
+      void *data = new char[sizeof arg_value];
+      memcpy(data, &arg_value, sizeof arg_value);
+      descriptor.plain_old_data_descriptor.data = data;
+      descriptor.plain_old_data_descriptor.length = sizeof arg_value;
       update_info.descriptors[update_index] = descriptor;
       update_index++;
     }

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -219,8 +219,6 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
                                               command_buffer, &mutable_config));
 }
 
-// Test clSetKernelMemPointerINTEL error code for CL_INVALID_ARG_VALUE if
-// arg_value is not a valid argument index.
 TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrs[0]));
 
@@ -251,8 +249,11 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
   cl_mutable_base_config_khr mutable_config{
       CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_ARG_VALUE, clUpdateMutableCommandsKHR(
-                                              command_buffer, &mutable_config));
+  // The interaction between cl_intel_unified_shared_memory and
+  // cl_khr_command_buffer_mutable_dispatch is not specified but we assume that
+  // if clSetKernelArgMemPointerINTEL would not report invalid values, neither
+  // will clUpdateMutableCommandsKHR.
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
 }
 
 // Tests for updating USM arguments to a command-buffer kernel command are


### PR DESCRIPTION
# Overview

Remove much special casing for USM pointers

# Reason for change

The SYCL CTS atomic pointer tests are currently failing, and pass with this change.

# Description of change

The SYCL CTS reveals that the logic we had in clSetKernelArgMemPointerINTEL to detect whether the pointer arguments we passed in were valid, while supported by the cl_intel_unified_shared_memory specification, was causing valid SYCL programs to be rejected, and the specification had an open question on whether this is actually desired. This commit implements a change to just accept arbitrary pointer values, which allows us to also remove a bunch of USM special casing.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
