### PR TITLE
Restore handling of blank lines

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -121,13 +121,13 @@ class TestList(object):
 
             with open(path, "r") as f:
                 stripped = (line.strip() for line in f)
-                filtered = (line for line in stripped if not line.startswith("#"))
+                filtered = (line for line in stripped if line and not line.startswith("#"))
                 chunked = csv.reader(filtered)
                 filtered_tests.append(json.dumps(chunks) for chunks in chunked)
 
         with open(list_file_path, "r") as f:
             stripped = (line.strip() for line in f)
-            filtered = (line for line in stripped if not line.startswith("#"))
+            filtered = (line for line in stripped if line and not line.startswith("#"))
             chunked = csv.reader(filtered)
             for chunks in chunked:
                 device_filter = None


### PR DESCRIPTION
# Overview

In #190 I had intended to leave the blank line handling alone, but pushed a version that did change it.

# Reason for change

We error out on blank lines when we shouldn't.

# Description of change

This restores the `if not line` check that we had before and I had wanted to keep intact.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
