### PR TITLE
[vecz] Support vector-predicated reductions natively

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
@@ -43,9 +43,4 @@ if.end:                                           ; preds = %if.then, %entry
 
 ; CHECK: define spir_kernel void @__vecz_nxv2_vp_foo(ptr addrspace(1) nocapture readonly %a, ptr addrspace(1) nocapture %out)
 ; CHECK:  [[CMP:%.*]] = fcmp oeq <vscale x 2 x float> %{{.*}}, zeroinitializer
-; CHECK:  [[INS:%.*]] = insertelement <vscale x 2 x i32> poison, i32 [[VL:%.*]], {{(i32|i64)}} 0
-; CHECK:  [[SPLAT:%.*]] = shufflevector <vscale x 2 x i32> [[INS]], <vscale x 2 x i32> poison, <vscale x 2 x i32> zeroinitializer
-; CHECK:  [[IDX:%.*]] = call <vscale x 2 x i32> @llvm.experimental.stepvector.nxv2i32()
-; CHECK:  [[MASK:%.*]] = icmp ult <vscale x 2 x i32> [[IDX]], [[SPLAT]]
-; CHECK:  [[INP:%.*]] = select <vscale x 2 x i1> [[MASK]], <vscale x 2 x i1> [[CMP]], <vscale x 2 x i1> zeroinitializer
-; CHECK:  %{{.*}} = call i1 @llvm.vector.reduce.or.nxv2i1(<vscale x 2 x i1> [[INP]])
+; CHECK:  %{{.*}} = call i1 @llvm.vp.reduce.or.nxv2i1(i1 false, <vscale x 2 x i1> [[CMP]], {{.*}}, i32 {{.*}})

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/packetize_mask_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/packetize_mask_varying.ll
@@ -39,12 +39,7 @@ if.end:
   ret void
 ; CHECK: define spir_kernel void @__vecz_nxv4_vp_mask_varying
 ; CHECK: [[CMP:%.*]] = icmp slt <vscale x 4 x i64> %{{.*}},
-; CHECK: [[INS:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[VL:%.*]], {{(i32|i64)}} 0
-; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[INS]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
-; CHECK: [[IDX:%.*]] = call <vscale x 4 x i32> @llvm.experimental.stepvector.nxv4i32()
-; CHECK: [[MASK:%.*]] = icmp ult <vscale x 4 x i32> [[IDX]], [[SPLAT]]
-; CHECK: [[INP:%.*]] = select <vscale x 4 x i1> [[MASK]], <vscale x 4 x i1> [[CMP]], <vscale x 4 x i1> zeroinitializer
-; CHECK: [[RED:%.*]] = call i1 @llvm.vector.reduce.or.nxv4i1(<vscale x 4 x i1> [[INP]])
+; CHECK: [[RED:%.*]] = call i1 @llvm.vp.reduce.or.nxv4i1(i1 false, <vscale x 4 x i1> [[CMP]], {{.*}}, i32 {{.*}})
 ; CHECK: [[REINS:%.*]] = insertelement <4 x i1> poison, i1 [[RED]], {{(i32|i64)}} 0
 ; CHECK: [[RESPLAT:%.*]] = shufflevector <4 x i1> [[REINS]], <4 x i1> poison, <4 x i32> zeroinitializer
 }

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions.ll
@@ -49,13 +49,8 @@ entry:
   store i32 %2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_all_i32(
-; CHECK: [[T2:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ult <4 x i32> [[S]], <i32 1, i32 2, i32 3, i32 4>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i1> <i1 true, i1 true, i1 true, i1 true>, <4 x i1> [[T2]]
-; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[I]] to i4
-; CHECK: [[R:%.*]] = icmp eq i4 [[T3]], -1
+; CHECK: [[C:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.and.v4i1(i1 true, <4 x i1> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_all_i1(i1 [[R]])
 ; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
@@ -75,13 +70,8 @@ entry:
   store i32 %2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_any_i32(
-; CHECK: [[T2:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i1> [[T2]], <4 x i1> zeroinitializer
-; CHECK: [[T3:%.*]] = bitcast <4 x i1> [[I]] to i4
-; CHECK: [[R:%.*]] = icmp ne i4 [[T3]], 0
+; CHECK: [[C:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.or.v4i1(i1 false, <4 x i1> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_any_i1(i1 [[R]])
 ; CHECK: [[EXT:%.*]] = sext i1 %call2 to i32
 ; CHECK: store i32 [[EXT]], ptr addrspace(1) {{%.*}}, align 4
@@ -99,11 +89,8 @@ entry:
   store i32 %call2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_add_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.add.v4i32(i32 0, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_add_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -120,11 +107,8 @@ entry:
   store i64 %call2, i64 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_add_i64(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> zeroinitializer
-; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i64> @llvm.vp.load.v4i64.p1(
+; CHECK: [[R:%.*]] = call i64 @llvm.vp.reduce.add.v4i64(i64 0, <4 x i64> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_add_i64(i64 [[R]])
 ; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -141,11 +125,8 @@ entry:
   store float %call2, float addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_add_f32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float -0.000000e+00, float -0.000000e+00,
-; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float -0.000000e+00, <4 x float> [[I]])
+; CHECK: [[C:%.*]] = call <4 x float> @llvm.vp.load.v4f32.p1(
+; CHECK: [[R:%.*]] = call float @llvm.vp.reduce.fadd.v4f32(float -0.000000e+00, <4 x float> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fadd_f32(float [[R]])
 ; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -162,11 +143,8 @@ entry:
   store i32 %call2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_smin_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 2147483647, i32 2147483647, 
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smin.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.smin.v4i32(i32 2147483647, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smin_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -183,11 +161,8 @@ entry:
   store i32 %call2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_umin_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.umin.v4i32(i32 -1, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umin_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -204,11 +179,8 @@ entry:
   store i32 %call2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_smax_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -2147483648, i32 -2147483648, 
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.smax.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.smax.v4i32(i32 -2147483648, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_smax_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -225,11 +197,8 @@ entry:
   store i32 %call2, i32 addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_umax_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.umax.v4i32(i32 0, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_umax_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 }
@@ -246,12 +215,9 @@ entry:
   store float %call2, float addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_fmin_f32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 0x7FF8000000000000, float 0x7FF8000000000000,
-; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmin.v4f32(<4 x float> [[I]])
-; CHEKC: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmin_f32(float [[R]])
+; CHECK: [[C:%.*]] = call <4 x float> @llvm.vp.load.v4f32.p1(
+; CHECK: [[R:%.*]] = call float @llvm.vp.reduce.fmin.v4f32(float 0x7FF8000000000000, <4 x float> [[C]], {{.*}})
+; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmin_f32(float [[R]])
 ; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }
 
@@ -267,11 +233,8 @@ entry:
   store float %call2, float addrspace(1)* %arrayidx3, align 4
   ret void
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_fmax_f32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 0xFFF8000000000000, float 0xFFF8000000000000,
-; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmax.v4f32(<4 x float> [[I]])
+; CHECK: [[C:%.*]] = call <4 x float> @llvm.vp.load.v4f32.p1(
+; CHECK: [[R:%.*]] = call float @llvm.vp.reduce.fmax.v4f32(float 0xFFF8000000000000, <4 x float> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmax_f32(float [[R]])
 ; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 }

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -35,11 +35,8 @@ declare spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1)
 declare spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1)
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_mul_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.mul.v4i32(i32 1, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_mul_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -56,11 +53,8 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_mul_i64(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> <i64 1, i64 1, i64 1, i64 1>
-; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.mul.v4i64(<4 x i64> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i64> @llvm.vp.load.v4i64.p1(
+; CHECK: [[R:%.*]] = call i64 @llvm.vp.reduce.mul.v4i64(i64 1, <4 x i64> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_mul_i64(i64 [[R]])
 ; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_i64(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -77,11 +71,8 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_mul_f32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x float> {{%.*}}, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-; CHECK: [[R:%.*]] = call float @llvm.vector.reduce.fmul.v4f32(float 1.000000e+00, <4 x float> [[I]])
+; CHECK: [[C:%.*]] = call <4 x float> @llvm.vp.load.v4f32.p1(
+; CHECK: [[R:%.*]] = call float @llvm.vp.reduce.fmul.v4f32(float 1.000000e+00, <4 x float> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func float @__mux_sub_group_reduce_fmul_f32(float [[R]])
 ; CHECK: store float %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_mul_f32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -98,11 +89,8 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_and_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1> 
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.and.v4i32(i32 -1, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_and_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_and_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -119,11 +107,8 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_or_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i32> {{%.*}}, <4 x i32> zeroinitializer
-; CHECK: [[R:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[I]])
+; CHECK: [[C:%.*]] = call <4 x i32> @llvm.vp.load.v4i32.p1(
+; CHECK: [[R:%.*]] = call i32 @llvm.vp.reduce.or.v4i32(i32 0, <4 x i32> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i32 @__mux_sub_group_reduce_or_i32(i32 [[R]])
 ; CHECK: store i32 %call2, ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_or_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -139,31 +124,28 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: @__vecz_v4_vp_reduce_xor_i32(
-; CHECK: [[SI:%.*]] = insertelement <4 x i32> poison, i32 {{%.*}}, {{(i32|i64)}} 0
-; CHECK: [[S:%.*]] = shufflevector <4 x i32> [[SI]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[C:%.*]] = icmp ugt <4 x i32> [[S]], <i32 0, i32 1, i32 2, i32 3>
-; CHECK: [[I:%.*]] = select <4 x i1> [[C]], <4 x i64> {{%.*}}, <4 x i64> zeroinitializer
-; CHECK: [[R:%.*]] = call i64 @llvm.vector.reduce.xor.v4i64(<4 x i64> [[I]])
+; CHECK-LABEL: @__vecz_v4_vp_reduce_xor_i64(
+; CHECK: [[C:%.*]] = call <4 x i64> @llvm.vp.load.v4i64.p1(
+; CHECK: [[R:%.*]] = call i64 @llvm.vp.reduce.xor.v4i64(i64 0, <4 x i64> [[C]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i64 @__mux_sub_group_reduce_xor_i64(i64 [[R]])
-; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 4
-define spir_kernel void @reduce_xor_i32(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+; CHECK: store i64 %call2, ptr addrspace(1) {{%.*}}, align 8
+define spir_kernel void @reduce_xor_i64(ptr addrspace(1) %in, ptr addrspace(1) %out) {
 entry:
   %call = tail call spir_func i64 @__mux_get_global_id(i32 0)
   %call1 = tail call spir_func i32 @__mux_get_sub_group_id() #6
   %conv = zext i32 %call1 to i64
-  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %in, i64 %call
-  %0 = load i64, ptr addrspace(1) %arrayidx, align 4
+  %arrayidx = getelementptr inbounds i64, ptr addrspace(1) %in, i64 %call
+  %0 = load i64, ptr addrspace(1) %arrayidx, align 8
   %call2 = tail call spir_func i64 @__mux_sub_group_reduce_xor_i64(i64 %0)
   %arrayidx3 = getelementptr inbounds i64, ptr addrspace(1) %out, i64 %conv
-  store i64 %call2, ptr addrspace(1) %arrayidx3, align 4
+  store i64 %call2, ptr addrspace(1) %arrayidx3, align 8
   ret void
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_and(
-; This doesn't generate a reduction intrinsic...
-; CHECK: [[T:%.*]] = icmp eq i4 {{%.*}}, -1
-; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_and_i1(i1 [[T]])
+; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.and.v4i1(i1 true, <4 x i1> [[T]], {{.*}})
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_and_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_and(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -182,8 +164,9 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_or(
-; CHECK: [[T:%.*]] = icmp ne i4 {{%.*}}, 0
-; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1 [[T]])
+; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.or.v4i1(i1 false, <4 x i1> [[T]], {{.*}})
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_or(ptr addrspace(1) %in, ptr addrspace(1) %out) {
@@ -202,10 +185,9 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_xor(
-; CHECK: [[X:%.*]] = call i4 @llvm.ctpop.i4(i4 {{%.*}})
-; CHECK: [[T:%.*]] = and i4 [[X]], 1
-; CHECK: [[C:%.*]] = icmp ne i4 [[T]], 0
-; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[C]])
+; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.xor.v4i1(i1 false, <4 x i1> [[T]], {{.*}})
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_xor(ptr addrspace(1) %in, ptr addrspace(1) %out) {


### PR DESCRIPTION
The initial vecz support for vector-predication was implemented around LLVM 12, before there were intrinsics available for reduction operations. This meant that we had to work around the lack intrinsics by using regular reduction intrinsics and 'sanitizing' the input by masking out the unwanted vector elements with the neutral value.

Vector-predicated reduction intrinsics have been around since LLVM 14 so it's high time we accommodate them natively. This should lead to better code generation when vector-predicating kernels.