### PR TITLE
Fix typo in test_info.py.

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -123,7 +123,7 @@ class TestList(object):
                 stripped = (line.strip() for line in f)
                 filtered = (line for line in stripped if line and not line.startswith("#"))
                 chunked = csv.reader(filtered)
-                filtered_tests.append(json.dumps(chunks) for chunks in chunked)
+                filter_tests.append(json.dumps(chunks) for chunks in chunked)
 
         with open(list_file_path, "r") as f:
             stripped = (line.strip() for line in f)


### PR DESCRIPTION
# Overview

Fix variable name.

# Reason for change

One more error in #190 was the spelling of filter_tests as filtered_tests, which went unnoticed during testing as testing had been done without a filter file.

# Description of change

This change refers to the filter_tests variable using its correct name.

Tested by running the OpenCL CTS with both `-i source/cl/scripts/cts-3.0-online-ignore-linux-host.csv` and `-i source/cl/scripts/cts-3.0-online-ignore-linux-riscv.csv` and making sure that tests run.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
