### PR TITLE
Support SYCL printf.

### DIFF
--- a/source/cl/test/UnitCL/include/kts/printf.h
+++ b/source/cl/test/UnitCL/include/kts/printf.h
@@ -183,6 +183,8 @@ struct PrintfExecution : BasePrintfExecution,
   }
 };
 
+using PrintfExecutionSPIRV = PrintfExecution;
+
 template <class Param>
 struct PrintfExecutionWithParam
     : BasePrintfExecution,

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -997,6 +997,8 @@ set(spirv_test
   ${CMAKE_CURRENT_SOURCE_DIR}/clSetProgramSpecializationConstant.fp64.fp16.spvasm64
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_regression.55_float_memcpy.spvasm32
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_regression.55_float_memcpy.spvasm64
+  ${CMAKE_CURRENT_SOURCE_DIR}/printf.23_string_dpcpp.spvasm32
+  ${CMAKE_CURRENT_SOURCE_DIR}/printf.23_string_dpcpp.spvasm64
   )
 
 if(${OCL_EXTENSION_cl_intel_required_subgroup_size})

--- a/source/cl/test/UnitCL/kernels/printf.23_string_dpcpp.spvasm32
+++ b/source/cl/test/UnitCL/kernels/printf.23_string_dpcpp.spvasm32
@@ -1,0 +1,63 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 39
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %29 "string_dpcpp"
+         %36 = OpString "kernel_arg_type.string."
+               OpSource OpenCL_C 102000
+               OpName %_str ".str"
+               OpName %_str_1 ".str.1"
+               OpName %printf "printf"
+               OpDecorate %37 Constant
+         %37 = OpDecorationGroup
+               OpDecorate %38 Alignment 1
+               OpDecorate %printf LinkageAttributes "printf" Import
+         %38 = OpDecorationGroup
+               OpGroupDecorate %37 %_str %_str_1
+               OpGroupDecorate %38 %_str %_str_1
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+   %uchar_37 = OpConstant %uchar 37
+  %uchar_115 = OpConstant %uchar 115
+    %uchar_0 = OpConstant %uchar 0
+     %uint_3 = OpConstant %uint 3
+   %uchar_72 = OpConstant %uchar 72
+  %uchar_101 = OpConstant %uchar 101
+  %uchar_108 = OpConstant %uchar 108
+  %uchar_111 = OpConstant %uchar 111
+   %uchar_32 = OpConstant %uchar 32
+   %uchar_87 = OpConstant %uchar 87
+  %uchar_114 = OpConstant %uchar 114
+  %uchar_100 = OpConstant %uchar 100
+   %uchar_33 = OpConstant %uchar 33
+   %uchar_10 = OpConstant %uchar 10
+    %uint_14 = OpConstant %uint 14
+     %uint_0 = OpConstant %uint 0
+%_arr_uchar_uint_3 = OpTypeArray %uchar %uint_3
+%_ptr_UniformConstant__arr_uchar_uint_3 = OpTypePointer UniformConstant %_arr_uchar_uint_3
+%_arr_uchar_uint_14 = OpTypeArray %uchar %uint_14
+%_ptr_UniformConstant__arr_uchar_uint_14 = OpTypePointer UniformConstant %_arr_uchar_uint_14
+       %void = OpTypeVoid
+         %28 = OpTypeFunction %void
+%_ptr_UniformConstant_uchar = OpTypePointer UniformConstant %uchar
+   %printf_t = OpTypeFunction %uint %_ptr_UniformConstant_uchar
+          %9 = OpConstantComposite %_arr_uchar_uint_3 %uchar_37 %uchar_115 %uchar_0
+       %_str = OpVariable %_ptr_UniformConstant__arr_uchar_uint_3 UniformConstant %9
+         %24 = OpConstantComposite %_arr_uchar_uint_14 %uchar_72 %uchar_101 %uchar_108 %uchar_108 %uchar_111 %uchar_32 %uchar_87 %uchar_111 %uchar_114 %uchar_108 %uchar_100 %uchar_33 %uchar_10 %uchar_0
+     %_str_1 = OpVariable %_ptr_UniformConstant__arr_uchar_uint_14 UniformConstant %24
+     %printf = OpFunction %uint None %printf_t
+         %39 = OpFunctionParameter %_ptr_UniformConstant_uchar
+               OpFunctionEnd
+         %29 = OpFunction %void DontInline %28
+         %30 = OpLabel
+         %33 = OpInBoundsPtrAccessChain %_ptr_UniformConstant_uchar %_str %uint_0 %uint_0
+         %34 = OpInBoundsPtrAccessChain %_ptr_UniformConstant_uchar %_str_1 %uint_0 %uint_0
+         %35 = OpFunctionCall %uint %printf %33 %34
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/printf.23_string_dpcpp.spvasm64
+++ b/source/cl/test/UnitCL/kernels/printf.23_string_dpcpp.spvasm64
@@ -1,0 +1,65 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 40
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %29 "string_dpcpp"
+         %37 = OpString "kernel_arg_type.string."
+               OpSource OpenCL_C 102000
+               OpName %_str ".str"
+               OpName %_str_1 ".str.1"
+               OpName %printf "printf"
+               OpDecorate %38 Constant
+         %38 = OpDecorationGroup
+               OpDecorate %39 Alignment 1
+               OpDecorate %printf LinkageAttributes "printf" Import
+         %39 = OpDecorationGroup
+               OpGroupDecorate %38 %_str %_str_1
+               OpGroupDecorate %39 %_str %_str_1
+      %uchar = OpTypeInt 8 0
+      %ulong = OpTypeInt 64 0
+       %uint = OpTypeInt 32 0
+   %uchar_37 = OpConstant %uchar 37
+  %uchar_115 = OpConstant %uchar 115
+    %uchar_0 = OpConstant %uchar 0
+    %ulong_3 = OpConstant %ulong 3
+   %uchar_72 = OpConstant %uchar 72
+  %uchar_101 = OpConstant %uchar 101
+  %uchar_108 = OpConstant %uchar 108
+  %uchar_111 = OpConstant %uchar 111
+   %uchar_32 = OpConstant %uchar 32
+   %uchar_87 = OpConstant %uchar 87
+  %uchar_114 = OpConstant %uchar 114
+  %uchar_100 = OpConstant %uchar 100
+   %uchar_33 = OpConstant %uchar 33
+   %uchar_10 = OpConstant %uchar 10
+   %ulong_14 = OpConstant %ulong 14
+     %uint_0 = OpConstant %uint 0
+%_arr_uchar_ulong_3 = OpTypeArray %uchar %ulong_3
+%_ptr_UniformConstant__arr_uchar_ulong_3 = OpTypePointer UniformConstant %_arr_uchar_ulong_3
+%_arr_uchar_ulong_14 = OpTypeArray %uchar %ulong_14
+%_ptr_UniformConstant__arr_uchar_ulong_14 = OpTypePointer UniformConstant %_arr_uchar_ulong_14
+       %void = OpTypeVoid
+         %28 = OpTypeFunction %void
+%_ptr_UniformConstant_uchar = OpTypePointer UniformConstant %uchar
+   %printf_t = OpTypeFunction %uint %_ptr_UniformConstant_uchar
+          %9 = OpConstantComposite %_arr_uchar_ulong_3 %uchar_37 %uchar_115 %uchar_0
+       %_str = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_3 UniformConstant %9
+         %24 = OpConstantComposite %_arr_uchar_ulong_14 %uchar_72 %uchar_101 %uchar_108 %uchar_108 %uchar_111 %uchar_32 %uchar_87 %uchar_111 %uchar_114 %uchar_108 %uchar_100 %uchar_33 %uchar_10 %uchar_0
+     %_str_1 = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_14 UniformConstant %24
+     %printf = OpFunction %uint None %printf_t
+         %40 = OpFunctionParameter %_ptr_UniformConstant_uchar
+               OpFunctionEnd
+         %29 = OpFunction %void DontInline %28
+         %30 = OpLabel
+         %34 = OpInBoundsPtrAccessChain %_ptr_UniformConstant_uchar %_str %uint_0 %uint_0
+         %35 = OpInBoundsPtrAccessChain %_ptr_UniformConstant_uchar %_str_1 %uint_0 %uint_0
+         %36 = OpFunctionCall %uint %printf %34 %35
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/source/ktst_printf.cpp
+++ b/source/cl/test/UnitCL/source/ktst_printf.cpp
@@ -34,6 +34,8 @@
 using namespace kts::ucl;
 
 UCL_EXECUTION_TEST_SUITE(PrintfExecution, testing::ValuesIn(getSourceTypes()));
+UCL_EXECUTION_TEST_SUITE(PrintfExecutionSPIRV,
+                         testing::Values(SPIRV, OFFLINESPIRV));
 
 BasePrintfExecution::BasePrintfExecution() : BaseExecution() {}
 
@@ -1746,5 +1748,13 @@ TEST_P(PrintfExecution, Printf_22_Half_With_Double_Conversion) {
   AddInputBuffer(1, input);
   this->SetPrintfReference(1, ref);
 
+  this->RunPrintf1D(1);
+}
+
+TEST_P(PrintfExecutionSPIRV, Printf_23_String_DPCPP) {
+  fail_if_not_vectorized_ = false;
+  ReferencePrintfString ref = [](size_t) { return "Hello World!\n"; };
+
+  this->SetPrintfReference(1, ref);
   this->RunPrintf1D(1);
 }


### PR DESCRIPTION
# Overview

Support SYCL printf.

# Reason for change

The way DPC++ translates `printf` is invalid and results in assertion errors when we encounter it. We could diagnose that more clearly, but more useful is to be tolerant and translate it to valid LLVM IR.

# Description of change

DPC++ generates invalid SPIR-V for SYCL code containing calls to __builtin_printf. Be tolerant of this.

* Builder::create<OpFunction>: treat "printf" as a special exception and make it variadic.
* getPointerToStringAsString: recognize address space casts of strings.

# Anything else we should know?

Tested with a local workaround for the out-of-order command queues problem, with the following SYCL program compiled and linked with DPC++ commit 34a06351da0a7581dea472a199f9803be8433868:

```c++
#include <sycl/sycl.hpp>
int main() {
  sycl::queue queue;
  queue.submit([&](sycl::handler &cgh) {
    cgh.single_task([] {
      __builtin_printf("%s, %s!\n", "Hello", "world");
    });
  });
}
```

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
