### PR TITLE
Fix one more error in test_info.py.

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -123,7 +123,7 @@ class TestList(object):
                 stripped = (line.strip() for line in f)
                 filtered = (line for line in stripped if line and not line.startswith("#"))
                 chunked = csv.reader(filtered)
-                filter_tests.append(json.dumps(chunks) for chunks in chunked)
+                filter_tests.extend(json.dumps(chunks) for chunks in chunked)
 
         with open(list_file_path, "r") as f:
             stripped = (line.strip() for line in f)


### PR DESCRIPTION
# Overview

Fix one more error in test_info.py.

# Reason for change

Currently, while the filter options to run_cities.py no longer cause an error, they do not have the desired effect, filters are ignored.

# Description of change

In #193 I made sure that we would not error out on trying to load filter lists, but did not check that the filter lists worked as intended, and they did not, because list1.append(list2) adds list2 as a single element to list1, whereas the intent was to add each element of list2 to list1, which is what list1.extend(list2) does.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
