### PR TITLE
Avoid memory leak in _cl_command_buffer_khr::updateCommandBuffer.

### DIFF
--- a/doc/modules/mux/changes.rst
+++ b/doc/modules/mux/changes.rst
@@ -11,6 +11,11 @@ version increases mean backward compatible bug fixes have been applied.
    Versions prior to 1.0.0 may contain breaking changes in minor
    versions as the API is still under development.
 
+0.81.0
+------
+
+* Added ``plain_old_embedded_data`` storage type.
+
 0.80.0
 ------
 

--- a/doc/specifications/mux-compiler-spec.rst
+++ b/doc/specifications/mux-compiler-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Compiler Specification
 =================================
 
-   This is version 0.80.0 of the specification.
+   This is version 0.81.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,

--- a/doc/specifications/mux-runtime-spec.rst
+++ b/doc/specifications/mux-runtime-spec.rst
@@ -1,7 +1,7 @@
 ComputeMux Runtime Specification
 ================================
 
-   This is version 0.80.0 of the specification.
+   This is version 0.81.0 of the specification.
 
 ComputeMux is Codeplay’s proprietary API for executing compute workloads across
 heterogeneous devices. ComputeMux is an extremely lightweight,
@@ -739,6 +739,8 @@ freed.
        struct mux_descriptor_info_image_s image_descriptor;
        struct mux_descriptor_info_sampler_s sampler_descriptor;
        struct mux_descriptor_info_plain_old_data_s plain_old_data_descriptor;
+       struct mux_descriptor_info_plain_old_embedded_data_s
+           plain_old_embedded_data_descriptor;
        struct mux_descriptor_info_shared_local_buffer_s
            shared_local_buffer_descriptor;
        struct mux_descriptor_info_custom_buffer_s custom_buffer_descriptor;
@@ -752,6 +754,8 @@ freed.
 -  ``sampler_descriptor`` - the description of the sampler.
 -  ``plain_old_data_descriptor`` - the description of the plain old
    data.
+-  ``plain_old_embedded_data_descriptor`` - the description of the
+   plain old embedded data.
 -  ``shared_local_buffer_descriptor`` - the description of the shared
    local buffer.
 -  ``custom_buffer_descriptor`` - the description of the custom buffer.
@@ -762,41 +766,60 @@ freed.
 
    -  ``buffer_descriptor`` **must** be initialized.
    -  ``image_descriptor``, ``sampler_descriptor``,
-      ``plain_old_data_descriptor``, ``shared_local_buffer_descriptor``,
-      and ``custom_buffer_descriptor`` **must not** be initialized.
+      ``plain_old_data_descriptor``,
+      ``plain_old_embedded_data_descriptor``,
+      ``shared_local_buffer_descriptor``, and
+      ``custom_buffer_descriptor``
+      **must not** be initialized.
 
 -  If ``type`` is ``mux_descriptor_info_type_image``
 
    -  ``image_descriptor`` **must** be initialized.
    -  ``buffer_descriptor``, ``sampler_descriptor``,
-      ``plain_old_data_descriptor``, ``shared_local_buffer_descriptor``,
-      and ``custom_buffer_descriptor`` **must not** be initialized.
+      ``plain_old_data_descriptor``,
+      ``plain_old_embedded_data_descriptor``,
+      ``shared_local_buffer_descriptor``, and
+      ``custom_buffer_descriptor`` **must not** be initialized.
 
 -  If ``type`` is ``mux_descriptor_info_type_sampler``
 
    -  ``sampler_descriptor`` **must** be initialized.
    -  ``buffer_descriptor``, ``image_descriptor``,
-      ``plain_old_data_descriptor``, ``shared_local_buffer_descriptor``,
-      and ``custom_buffer_descriptor`` **must not** be initialized.
+      ``plain_old_data_descriptor``,
+      ``plain_old_embedded_data_descriptor``,
+      ``shared_local_buffer_descriptor``, and
+      ``custom_buffer_descriptor`` **must not** be initialized.
 
 -  If ``type`` is ``mux_descriptor_info_type_plain_old_data``
 
    -  ``plain_old_data_descriptor`` **must** be initialized.
    -  ``buffer_descriptor``, ``image_descriptor``,
-      ``sampler_descriptor``, ``shared_local_buffer_descriptor``, and
+      ``sampler_descriptor``, ``plain_old_embedded_data_descriptor``,
+      ``shared_local_buffer_descriptor``, and
+      ``custom_buffer_descriptor`` **must not** be initialized.
+
+-  If ``type`` is ``mux_descriptor_info_type_plain_old_embedded_data``
+
+   -  ``plain_old_data_descriptor_embedded`` **must** be initialized.
+   -  ``buffer_descriptor``, ``image_descriptor``,
+      ``sampler_descriptor``, ``plain_old_data_descriptor``,
+      ``shared_local_buffer_descriptor``, and
       ``custom_buffer_descriptor`` **must not** be initialized.
 
 -  If ``type`` is ``mux_descriptor_info_type_shared_local_buffer``
 
    -  ``shared_local_buffer_descriptor`` **must** be initialized.
    -  ``buffer_descriptor``, ``image_descriptor``,
-      ``sampler_descriptor``, ``plain_old_data_descriptor``, and
+      ``sampler_descriptor``,
+      ``plain_old_data_descriptor``,
+      ``plain_old_embedded_data_descriptor``, and
       ``custom_buffer_descriptor`` **must not** be initialized.
 
 -  If ``type`` is ``mux_descriptor_info_type_null_buffer``
 
    -  ``buffer_descriptor``, ``image_descriptor``,
       ``sampler_descriptor``, ``plain_old_data_descriptor``,
+      ``plain_old_embedded_data_descriptor``,
       ``shared_local_buffer_descriptor``, and
       ``custom_buffer_descriptor`` **must not** be initialized.
 
@@ -890,7 +913,31 @@ The ``mux_descriptor_info_type_plain_old_data`` enumeration of
    };
 
 -  ``data`` - the data that this descriptor is *describing*.
--  ``offset`` - the length (in bytes) of ``data``.
+-  ``length`` - the length (in bytes) of ``data``.
+
+Plain Old Embedded Data Descriptors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Plain-old-embedded-data descriptors specify that a given
+``mux_descriptor_info_t`` is a
+``mux_descriptor_info_plain_old_embedded_data_s``.
+
+Plain-old-embedded-data descriptors are just like plain-old-data
+descriptors, except they hold the data they refer to internally rather
+than pointing elsewhere. Data is limited in size to 16 bytes.
+
+The ``mux_descriptor_info_type_plain_old_data`` enumeration of
+``mux_descriptor_info_type_e`` is used to specify a buffer descriptor.
+
+.. code:: c
+
+   struct mux_descriptor_info_plain_old_embedded_data_s {
+     size_t length;
+     char data[16];
+   };
+
+-  ``length`` - the length (in bytes) of ``data``.
+-  ``data`` - the data that this descriptor is *describing*.
 
 Shared Local Buffer Descriptors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules/mux/include/mux/mux.h
+++ b/modules/mux/include/mux/mux.h
@@ -37,7 +37,7 @@ extern "C" {
 /// @brief Mux major version number.
 #define MUX_MAJOR_VERSION 0
 /// @brief Mux minor version number.
-#define MUX_MINOR_VERSION 80
+#define MUX_MINOR_VERSION 81
 /// @brief Mux patch version number.
 #define MUX_PATCH_VERSION 0
 /// @brief Mux combined version number.
@@ -719,7 +719,9 @@ enum mux_descriptor_info_type_e {
   /// @brief Descriptor is a null buffer.
   mux_descriptor_info_type_null_buffer = 5,
   /// @brief Descriptor is a custom buffer.
-  mux_descriptor_info_type_custom_buffer = 6
+  mux_descriptor_info_type_custom_buffer = 6,
+  /// @brief Descriptor is plain-old-embedded-data.
+  mux_descriptor_info_type_plain_old_embedded_data = 7
 };
 
 /// @brief All possible addressing modes describing how to handle out of range
@@ -2709,6 +2711,14 @@ struct mux_descriptor_info_plain_old_data_s {
   size_t length;
 };
 
+/// @brief A Mux descriptor for plain old data.
+struct mux_descriptor_info_plain_old_embedded_data_s {
+  /// @brief Size in bytes of @p data storage.
+  size_t length;
+  /// @brief Buffer for plain old data.
+  char data[16];
+};
+
 /// @brief A Mux descriptor for a shared local buffer.
 struct mux_descriptor_info_shared_local_buffer_s {
   /// @brief Size in bytes of shared local buffer.
@@ -2739,6 +2749,8 @@ struct mux_descriptor_info_s {
     struct mux_descriptor_info_image_s image_descriptor;
     struct mux_descriptor_info_sampler_s sampler_descriptor;
     struct mux_descriptor_info_plain_old_data_s plain_old_data_descriptor;
+    struct mux_descriptor_info_plain_old_embedded_data_s
+        plain_old_embedded_data_descriptor;
     struct mux_descriptor_info_shared_local_buffer_s
         shared_local_buffer_descriptor;
     struct mux_descriptor_info_custom_buffer_s custom_buffer_descriptor;

--- a/modules/mux/targets/host/include/host/host.h
+++ b/modules/mux/targets/host/include/host/host.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Host major version number.
 #define HOST_MAJOR_VERSION 0
 /// @brief Host minor version number.
-#define HOST_MINOR_VERSION 80
+#define HOST_MINOR_VERSION 81
 /// @brief Host patch version number.
 #define HOST_PATCH_VERSION 0
 /// @brief Host combined version number.

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -51,6 +51,9 @@ size_t calcPackedArgsAllocSize(
       case mux_descriptor_info_type_plain_old_data: {
         size = descriptor.plain_old_data_descriptor.length;
       } break;
+      case mux_descriptor_info_type_plain_old_embedded_data: {
+        size = descriptor.plain_old_embedded_data_descriptor.length;
+      } break;
       case mux_descriptor_info_type_shared_local_buffer: {
         size = sizeof(size_t);
       } break;
@@ -138,6 +141,13 @@ void populatePackedArgs(
       case mux_descriptor_info_type_plain_old_data: {
         mux_descriptor_info_plain_old_data_s info =
             descriptor.plain_old_data_descriptor;
+
+        std::memcpy(packed_args_alloc + offset, info.data, info.length);
+        offset += info.length;
+      } break;
+      case mux_descriptor_info_type_plain_old_embedded_data: {
+        mux_descriptor_info_plain_old_embedded_data_s info =
+            descriptor.plain_old_embedded_data_descriptor;
 
         std::memcpy(packed_args_alloc + offset, info.data, info.length);
         offset += info.length;
@@ -1018,6 +1028,12 @@ mux_result_t hostUpdateDescriptors(mux_command_buffer_t command_buffer,
       case mux_descriptor_info_type_plain_old_data: {
         mux_descriptor_info_plain_old_data_s info =
             descriptors[i].plain_old_data_descriptor;
+
+        std::memcpy(arg_address, info.data, info.length);
+      } break;
+      case mux_descriptor_info_type_plain_old_embedded_data: {
+        mux_descriptor_info_plain_old_embedded_data_s info =
+            descriptors[i].plain_old_embedded_data_descriptor;
 
         std::memcpy(arg_address, info.data, info.length);
       } break;

--- a/modules/mux/targets/riscv/include/riscv/riscv.h
+++ b/modules/mux/targets/riscv/include/riscv/riscv.h
@@ -29,7 +29,7 @@ extern "C" {
 /// @brief Riscv major version number.
 #define RISCV_MAJOR_VERSION 0
 /// @brief Riscv minor version number.
-#define RISCV_MINOR_VERSION 80
+#define RISCV_MINOR_VERSION 81
 /// @brief Riscv patch version number.
 #define RISCV_PATCH_VERSION 0
 /// @brief Riscv combined version number.

--- a/modules/mux/tools/api/mux.xml
+++ b/modules/mux/tools/api/mux.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception</comment>
     <block>
       <define priority="high">${FUNCTION_PREFIX}_MAJOR_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} major version number.</brief></doxygen></define>
-      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>80</value>
+      <define priority="high">${FUNCTION_PREFIX}_MINOR_VERSION<value>81</value>
         <doxygen><brief>${Function_Prefix} minor version number.</brief></doxygen></define>
       <define priority="high">${FUNCTION_PREFIX}_PATCH_VERSION<value>0</value>
         <doxygen><brief>${Function_Prefix} patch version number.</brief></doxygen></define>
@@ -710,6 +710,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception</comment>
           <doxygen><brief>Descriptor is a null buffer.</brief></doxygen></constant>
         <constant>${prefix}_descriptor_info_type_custom_buffer<value>6</value>
           <doxygen><brief>Descriptor is a custom buffer.</brief></doxygen></constant>
+        <constant>${prefix}_descriptor_info_type_plain_old_embedded_data<value>7</value>
+          <doxygen><brief>Descriptor is plain-old-embedded-data.</brief></doxygen></constant>
       </scope>
       <doxygen><brief>All possible descriptor types.</brief>
         <see>${prefix}_descriptor_info_s::_type</see>
@@ -2432,6 +2434,16 @@ For OpenCL, this value is used to implement clGetDeviceInfo, when asking for CL_
       <doxygen><brief>An ${Prefix} descriptor for plain old data.</brief></doxygen>
     </struct>
 
+    <struct>${prefix}_descriptor_info_plain_old_embedded_data_s
+      <scope>
+        <member>length<type>size_t</type>
+          <doxygen><brief>Size in bytes of @p data storage.</brief></doxygen></member>
+        <member>data[16]<type>char</type>
+          <doxygen><brief>Buffer for plain old data.</brief></doxygen></member>
+      </scope>
+      <doxygen><brief>An ${Prefix} descriptor for plain old data.</brief></doxygen>
+    </struct>
+
     <struct>${prefix}_descriptor_info_shared_local_buffer_s
       <scope>
         <member>size<type>size_t</type>
@@ -2467,6 +2479,7 @@ For OpenCL, this value is used to implement clGetDeviceInfo, when asking for CL_
         <member>image_descriptor<struct>${prefix}_descriptor_info_image_s</struct></member>
         <member>sampler_descriptor<struct>${prefix}_descriptor_info_sampler_s</struct></member>
         <member>plain_old_data_descriptor<struct>${prefix}_descriptor_info_plain_old_data_s</struct></member>
+        <member>plain_old_embedded_data_descriptor<struct>${prefix}_descriptor_info_plain_old_embedded_data_s</struct></member>
         <member>shared_local_buffer_descriptor<struct>${prefix}_descriptor_info_shared_local_buffer_s</struct></member>
         <member>custom_buffer_descriptor<struct>${prefix}_descriptor_info_custom_buffer_s</struct></member>
         </scope></union></member>

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1167,12 +1167,13 @@ CARGO_NODISCARD cl_int _cl_command_buffer_khr::updateCommandBuffer(
 
       // Construct Descriptor
       mux_descriptor_info_s descriptor;
-      descriptor.type =
-          mux_descriptor_info_type_e::mux_descriptor_info_type_plain_old_data;
-      void *data = new char[sizeof arg_value];
-      memcpy(data, &arg_value, sizeof arg_value);
-      descriptor.plain_old_data_descriptor.data = data;
-      descriptor.plain_old_data_descriptor.length = sizeof arg_value;
+      descriptor.type = mux_descriptor_info_type_e::
+          mux_descriptor_info_type_plain_old_embedded_data;
+      static_assert(sizeof arg_value <=
+                    sizeof descriptor.plain_old_embedded_data_descriptor.data);
+      memcpy(descriptor.plain_old_embedded_data_descriptor.data, &arg_value,
+             sizeof arg_value);
+      descriptor.plain_old_embedded_data_descriptor.length = sizeof arg_value;
       update_info.descriptors[update_index] = descriptor;
       update_index++;
     }


### PR DESCRIPTION
# Overview

Avoid memory leak in _cl_command_buffer_khr::updateCommandBuffer.

# Reason for change

ASAN builds were showing a memory leak when running e.g. MutableDispatchUSMTest_InvalidArgValue_Test.

# Description of change

In _cl_command_buffer_khr::updateCommandBuffer we need to create a plain old data descriptor, which previously required storing the data externally. We have no pre-existing memory which is guaranteed to persist for long enough that we can use it, but the other descriptor storage types meant that mux_descriptor_info_s itself was already more than large enough to hold this data itself, so this change adds a plain_old_embedded_data descriptor storage type and uses it in _cl_command_buffer_khr::updateCommandBuffer.

# Anything else we should know?

This change only adds one trivial use of this new storage type. A future change may add more, but as that is not required to fix the leak that is kept out of this PR.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
