### PR TITLE
[spirv-ll] Allow DILocs to span multiple ranges

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -408,12 +408,17 @@ class Module : public ModuleHeader {
       llvm::DILocation *location,
       std::pair<llvm::BasicBlock::iterator, llvm::BasicBlock::iterator> range);
 
+  /// @brief A list of basic block ranges (begin/end).
+  using OpLineRangeVec = std::vector<
+      std::pair<llvm::BasicBlock::iterator, llvm::BasicBlock::iterator>>;
+
+  /// @brief A map from a debug location to the list of ranges it covers.
+  using OpLineRangeMap = llvm::MapVector<llvm::DILocation *, OpLineRangeVec>;
+
   /// @brief Get reference to complete OpLine range list.
   ///
   /// @return Reference to map of `DILocation`/iterator range pairs
-  llvm::MapVector<llvm::DILocation *, std::pair<llvm::BasicBlock::iterator,
-                                                llvm::BasicBlock::iterator>> &
-  getOpLineRanges();
+  OpLineRangeMap &getOpLineRanges();
 
   /// @brief Get `DILocation`/iterator pair for current OpLine range
   ///
@@ -1025,15 +1030,13 @@ class Module : public ModuleHeader {
   llvm::DenseMap<spv::Id, std::string> DebugStrings;
   /// @brief `DIFile` object specified by the module currently being translated.
   llvm::DIFile *File;
-  /// @brief Map of DILocation to basic block iterator range.
+  /// @brief Map of DILocation to sets of basic block iterator ranges.
   ///
-  /// Storing a `std::pair` of iterators instead of `llvm::iterator_range`
+  /// Storing `std::pair`s of iterators instead of `llvm::iterator_range`
   /// because the iterators need to be manipulated after the module has been
   /// translated in its entirety, so we can't construct the `iterator_range`
   /// until that's happened but we still need to store the range.
-  llvm::MapVector<llvm::DILocation *, std::pair<llvm::BasicBlock::iterator,
-                                                llvm::BasicBlock::iterator>>
-      OpLineRanges;
+  OpLineRangeMap OpLineRanges;
   /// @brief DILocation/basic block iterator pair to store current OpLine range.
   std::pair<llvm::DILocation *, llvm::BasicBlock::iterator> CurrentOpLineRange;
   /// @brief Map of BasicBlock to associated `DILexicalBlock`.

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -206,7 +206,6 @@ cargo::optional<Error> Builder::create<OpLine>(const OpLine *op) {
 
   auto *loc = llvm::DILocation::get(block->getContext(), op->Line(),
                                     op->Column(), block);
-
   module.setCurrentOpLineRange(loc, iter);
   return cargo::nullopt;
 }

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -225,12 +225,10 @@ void spirv_ll::Module::setCurrentOpLineRange(llvm::DILocation *block,
 void spirv_ll::Module::addCompleteOpLineRange(
     llvm::DILocation *location,
     std::pair<llvm::BasicBlock::iterator, llvm::BasicBlock::iterator> range) {
-  OpLineRanges.insert({location, range});
+  OpLineRanges[location].push_back(range);
 }
 
-llvm::MapVector<llvm::DILocation *, std::pair<llvm::BasicBlock::iterator,
-                                              llvm::BasicBlock::iterator>> &
-spirv_ll::Module::getOpLineRanges() {
+spirv_ll::Module::OpLineRangeMap &spirv_ll::Module::getOpLineRanges() {
   return OpLineRanges;
 }
 

--- a/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
@@ -44,11 +44,13 @@
                OpLine %file 6 3
           %a = OpVariable %_ptr_Function_bool Function
 ; CHECK: %a = alloca i1{{(, align [0-9])?}}, !dbg [[aLocation:![0-9]+]]
-               OpStore %a %9
-; CHECK: store i1 false, ptr %a{{(, align [0-9])?}}, !dbg [[aLocation]]
                OpLine %file 7 3
           %b = OpVariable %_ptr_Function_int Function
 ; CHECK: %b = alloca i32{{(, align [0-9])?}}, !dbg [[bLocation:![0-9]+]]
+               OpLine %file 6 3
+               OpStore %a %9
+; CHECK: store i1 false, ptr %a{{(, align [0-9])?}}, !dbg [[aLocation]]
+               OpLine %file 7 3
                OpStore %b %13
 ; CHECK: store i32 42, ptr %b{{(, align [0-9])?}}, !dbg [[bLocation]]
                OpLine %file 8 3


### PR DESCRIPTION
The old code wouldn't work correctly when an OpLine was specified multiple times with the same line/column, because we stored only one range for each 'unique' OpLine.

This commit updates the translator to store a list of ranges for each OpLine, meaning multiple distinct ranges can be attached to the same debug location.