### PR TITLE
Avoid memory leak in _cl_command_buffer_khr::updateCommandBuffer (alternative)

### DIFF
--- a/source/cl/source/extension/include/extension/khr_command_buffer.h
+++ b/source/cl/source/extension/include/extension/khr_command_buffer.h
@@ -237,6 +237,8 @@ struct _cl_command_buffer_khr final : public cl::base<_cl_command_buffer_khr> {
     cargo::dynamic_array<mux_descriptor_info_s> descriptors;
     // Storage for the indices of each arguments that is getting updated.
     cargo::dynamic_array<uint64_t> indices;
+    // Storage for any pointers referenced by descriptors.
+    cargo::dynamic_array<const void *> pointers;
     // ID of mutable command
     cl_uint id;
   };

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1127,6 +1127,10 @@ CARGO_NODISCARD cl_int _cl_command_buffer_khr::updateCommandBuffer(
       return CL_OUT_OF_HOST_MEMORY;
     }
 
+    if (update_info.pointers.alloc(config.num_svm_args)) {
+      return CL_OUT_OF_HOST_MEMORY;
+    }
+
     const auto mutable_command = config.command;
     update_info.id = mutable_command->id;
     cargo::array_view<const cl_mutable_dispatch_arg_khr> args(config.arg_list,
@@ -1169,10 +1173,10 @@ CARGO_NODISCARD cl_int _cl_command_buffer_khr::updateCommandBuffer(
       mux_descriptor_info_s descriptor;
       descriptor.type =
           mux_descriptor_info_type_e::mux_descriptor_info_type_plain_old_data;
-      void *data = new char[sizeof arg_value];
-      memcpy(data, &arg_value, sizeof arg_value);
-      descriptor.plain_old_data_descriptor.data = data;
-      descriptor.plain_old_data_descriptor.length = sizeof arg_value;
+      descriptor.plain_old_data_descriptor.data = &update_info.pointers[i];
+      descriptor.plain_old_data_descriptor.length =
+          sizeof update_info.pointers[i];
+      update_info.pointers[i] = arg_value;
       update_info.descriptors[update_index] = descriptor;
       update_index++;
     }


### PR DESCRIPTION
# Overview

Avoid memory leak in _cl_command_buffer_khr::updateCommandBuffer.

# Reason for change

ASAN builds were showing a memory leak when running e.g. MutableDispatchUSMTest_InvalidArgValue_Test.

# Description of change

In _cl_command_buffer_khr::updateCommandBuffer we need to create a plain old data descriptor, which requires storing the data externally. We have no pre-existing memory which is guaranteed to persist for long enough that we can use it, but we can add a field to UpdateInfo to hold it.

# Anything else we should know?

This is an alternative to #199. This is a less invasive fix. If this is picked instead of #199, I will close that one. If #199 is picked, I will close this one.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
