### PR TITLE
[LLVM] Multi_llvm support for current tip changes

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -228,7 +228,7 @@ static llvm::TargetMachine *createTargetMachine(const {{cookiecutter.target_name
   return llvm_target->createTargetMachine(
       target.llvm_triple, target.llvm_cpu, target.llvm_features, options,
       llvm::Reloc::Model::Static, llvm::CodeModel::Small,
-      llvm::CodeGenOpt::Aggressive);
+      multi_llvm::CodeGenOptLevel::Aggressive);
 }
 
 llvm::TargetMachine *{{cookiecutter.target_name.capitalize()}}Module::getTargetMachine() {

--- a/modules/compiler/multi_llvm/include/multi_llvm/enums.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/enums.h
@@ -1,0 +1,46 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef MULTI_LLVM_ENUMS_H_INCLUDED
+#define MULTI_LLVM_ENUMS_H_INCLUDED
+
+#include <llvm/Support/CodeGen.h>
+#include <multi_llvm/llvm_version.h>
+
+namespace multi_llvm {
+#if LLVM_VERSION_MAJOR >= 18
+
+typedef llvm::CodeGenFileType CodeGenFileType;
+typedef llvm::CodeGenOptLevel CodeGenOptLevel;
+
+#else
+
+struct CodeGenFileType {
+  static constexpr auto AssemblyFile = llvm::CGFT_AssemblyFile;
+  static constexpr auto ObjectFile = llvm::CGFT_ObjectFile;
+  static constexpr auto Null = llvm::CGFT_Null;
+};
+
+struct CodeGenOptLevel {
+  static constexpr auto None = llvm::CodeGenOpt::None;
+  static constexpr auto Less = llvm::CodeGenOpt::Less;
+  static constexpr auto Default = llvm::CodeGenOpt::Default;
+  static constexpr auto Aggressive = llvm::CodeGenOpt::Aggressive;
+};
+
+#endif
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_ENUMS_H_INCLUDED

--- a/modules/compiler/multi_llvm/include/multi_llvm/loop_utils.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/loop_utils.h
@@ -13,13 +13,25 @@
 // under the License.
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef MULTI_LLVM_LOOP_UTILS_H_INCLUDED
+#define MULTI_LLVM_LOOP_UTILS_H_INCLUDED
 
-#ifndef MULTI_LLVM_MULTI_LLVM_H_INCLUDED
-#define MULTI_LLVM_MULTI_LLVM_H_INCLUDED
-
-#include <multi_llvm/enums.h>
+#include <llvm/Transforms/Utils/LoopUtils.h>
 #include <multi_llvm/llvm_version.h>
-#include <multi_llvm/loop_utils.h>
-#include <multi_llvm/triple.h>
 
-#endif  // MULTI_LLVM_MULTI_LLVM_H_INCLUDED
+namespace multi_llvm {
+
+inline llvm::Value *createSimpleTargetReduction(
+    llvm::IRBuilderBase &B, const llvm::TargetTransformInfo *TTI,
+    llvm::Value *Src, llvm::RecurKind RdxKind) {
+#if LLVM_VERSION_MAJOR >= 18
+  (void)TTI;
+  return llvm::createSimpleTargetReduction(B, Src, RdxKind);
+#else
+  return llvm::createSimpleTargetReduction(B, TTI, Src, RdxKind);
+#endif
+}
+
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_LOOP_UTILS_H_INCLUDED

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -189,7 +189,7 @@ static llvm::TargetMachine *createTargetMachine(
   return llvm_target->createTargetMachine(
       target.llvm_triple, target.llvm_cpu, target.llvm_features, options,
       llvm::Reloc::Model::Static, llvm::CodeModel::Small,
-      llvm::CodeGenOpt::Aggressive);
+      multi_llvm::CodeGenOptLevel::Aggressive);
 }
 
 llvm::TargetMachine *riscv::RiscvModule::getTargetMachine() {

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1266,7 +1266,7 @@ clang::FrontendInputFile BaseModule::prepareOpenCLInputFile(
 
   auto addIncludeFile = [&](const std::string &name, const void *data,
                             const size_t size) {
-    const auto *entry = instance.getFileManager().getVirtualFile(
+    clang::FileEntryRef entry = instance.getFileManager().getVirtualFileRef(
         "include" PATH_SEPARATOR + name, size, 0);
     std::unique_ptr<llvm::MemoryBuffer> buffer{
         new BakedMemoryBuffer(data, size)};

--- a/modules/compiler/source/base/source/pass_pipelines.cpp
+++ b/modules/compiler/source/base/source/pass_pipelines.cpp
@@ -33,10 +33,12 @@
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/CodeGen.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/IPO/GlobalOpt.h>
 #include <llvm/Transforms/IPO/Inliner.h>
 #include <llvm/Transforms/IPO/Internalize.h>
+#include <multi_llvm/multi_llvm.h>
 
 #include <optional>
 
@@ -128,7 +130,9 @@ void addLLVMDefaultPerModulePipeline(ModulePassManager &PM, PassBuilder &PB,
 Result emitCodeGenFile(llvm::Module &M, TargetMachine *TM,
                        raw_pwrite_stream &ostream, bool create_assembly) {
   legacy::PassManager PM;
-  CodeGenFileType type = !create_assembly ? CGFT_ObjectFile : CGFT_AssemblyFile;
+  CodeGenFileType type = !create_assembly
+                             ? multi_llvm::CodeGenFileType::ObjectFile
+                             : multi_llvm::CodeGenFileType::AssemblyFile;
   if (TM->addPassesToEmitFile(PM, ostream, /*DwoOut*/ nullptr, type,
                               /*DisableVerify*/ false)) {
     return compiler::Result::FAILURE;

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -32,6 +32,7 @@
 #include <llvm/Support/Host.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
+#include <multi_llvm/multi_llvm.h>
 
 #include "host/device.h"
 #include "host/info.h"
@@ -193,7 +194,7 @@ compiler::Result HostTarget::initWithBuiltins(
 
   llvm::orc::JITTargetMachineBuilder TMBuilder(triple);
   TMBuilder.setCPU(CPUName.str());
-  TMBuilder.setCodeGenOptLevel(llvm::CodeGenOpt::Aggressive);
+  TMBuilder.setCodeGenOptLevel(multi_llvm::CodeGenOptLevel::Aggressive);
   for (auto &Feature : FeatureMap) {
     TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
   }

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -27,7 +27,7 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/FormatVariadic.h>
 #include <llvm/Support/ToolOutputFile.h>
-#include <multi_llvm/llvm_version.h>
+#include <multi_llvm/multi_llvm.h>
 
 using namespace llvm;
 
@@ -55,10 +55,13 @@ static cl::opt<bool> WriteTextual(
     cl::init(true));
 
 static cl::opt<CodeGenFileType> FileType(
-    "filetype", cl::init(CGFT_AssemblyFile), cl::desc("Choose a file type:"),
-    cl::values(clEnumValN(CGFT_AssemblyFile, "asm", "Emit a textual file"),
-               clEnumValN(CGFT_ObjectFile, "obj", "Emit a binary object file"),
-               clEnumValN(CGFT_Null, "null",
+    "filetype", cl::init(multi_llvm::CodeGenFileType::AssemblyFile),
+    cl::desc("Choose a file type:"),
+    cl::values(clEnumValN(multi_llvm::CodeGenFileType::AssemblyFile, "asm",
+                          "Emit a textual file"),
+               clEnumValN(multi_llvm::CodeGenFileType::ObjectFile, "obj",
+                          "Emit a binary object file"),
+               clEnumValN(multi_llvm::CodeGenFileType::Null, "null",
                           "Emit nothing, for performance testing")));
 
 static cl::opt<int> DeviceIdx(
@@ -138,14 +141,14 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (FileType == CGFT_Null) {
+  if (FileType == multi_llvm::CodeGenFileType::Null) {
     return 0;
   }
 
   // Open the output file.
   std::error_code EC;
   sys::fs::OpenFlags OpenFlags = sys::fs::OF_None;
-  if (FileType == CGFT_AssemblyFile) {
+  if (FileType == multi_llvm::CodeGenFileType::AssemblyFile) {
     OpenFlags |= sys::fs::OF_Text;
   }
   auto Out = std::make_unique<ToolOutputFile>(OutputFilename, EC, OpenFlags);
@@ -154,7 +157,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (FileType == CGFT_AssemblyFile) {
+  if (FileType == multi_llvm::CodeGenFileType::AssemblyFile) {
     Out->os() << *M.get();
   } else {
     WriteBitcodeToFile(*M.get(), Out->os());

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -255,7 +255,7 @@ Value *createMaybeVPTargetReduction(IRBuilderBase &B,
   assert(isa<VectorType>(Val->getType()) && "Must be vector type");
   // If VL is null, it's not a vector-predicated reduction.
   if (!VL) {
-    return createSimpleTargetReduction(B, &TTI, Val, Kind);
+    return multi_llvm::createSimpleTargetReduction(B, &TTI, Val, Kind);
   }
   auto IntrinsicOp = Intrinsic::not_intrinsic;
   switch (Kind) {

--- a/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
+++ b/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
@@ -120,7 +120,8 @@ unsigned calculateBoolReductionCost(LLVMContext &context, Module *module,
   auto *F = Function::Create(new_fty, Function::InternalLinkage, "tmp", module);
   auto *BB = BasicBlock::Create(context, "reduce", F);
   IRBuilder<> B(BB);
-  createSimpleTargetReduction(B, &TTI, &*F->arg_begin(), RecurKind::And);
+  multi_llvm::createSimpleTargetReduction(B, &TTI, &*F->arg_begin(),
+                                          RecurKind::And);
   unsigned cost = calculateBlockCost(*BB, TTI);
 
   // We don't really need that function in the module anymore because it's


### PR DESCRIPTION
This patch adds multi_llvm support for some changes that have been made in upstream LLVM's main branch. This will not allow the build to succeed at the moment, but it will skip some errors.

Specifically:
* `CodeGenFileType` and `CodeGenOptLevel` are now enum classes and require a struct to "fake" this in LLVM 17 and earlier.
* `createSimpleTargetReduction` no longer accepts the `TargetTransformInfo` parameter. A proxy function has been added which calls the appropriate version.
* Use `getVirtualFileRef` on the file manager. Seems to work in both LLVM 17 and tip.

# Overview

Adds a bit of support for LLVM tip.

# Reason for change

We'd like to test support for LLVM tip sooner rather than later.

# Description of change

This change doesn't allow LLVM tip to build, but it does fix some of the trivial errors encountered while building.

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
