### PR TITLE
[spirv-ll] Fix LIT test build with 'make' build system

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2238,6 +2238,7 @@ function(ca_assemble_spirv_ll_lit_test)
     # Generate .spv from .spvasm source.
     file(RELATIVE_PATH spvOut ${CMAKE_BINARY_DIR} ${spv})
     add_custom_command(OUTPUT ${spv}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${dir}
       COMMAND spirv::spirv-as --target-env ${args_TGT_ENV} -o ${spv} ${spvasm}
       DEPENDS spirv::spirv-as ${spvasm}
       COMMENT "Building SPIR-V ${spvOut}")


### PR DESCRIPTION
Certain tests live in sub-directories relative to the current binary dir. On certain build systems, these relative binary sub-directories may not have been created at the time `spirv-as` runs, which (may) then error. This fix adds an extra `COMMAND` to ensure the binary directories are always generated.