### PR TITLE
[spirv-ll] Don't copy test source files to the binary directory

### DIFF
--- a/modules/compiler/spirv-ll/test/glsl/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/glsl/CMakeLists.txt
@@ -812,9 +812,6 @@ foreach(glsl ${GLSL_FILES})
       COMMENT "Building SPIR-V ${spvOut}")
     list(APPEND LitTestFiles ${spv})
   endif()
-
-  add_ca_copy_file(INPUT ${comp} OUTPUT ${test})
-  list(APPEND LitTestFiles ${test})
 endforeach()
 
 add_custom_target(spirv-ll-glsl-lit DEPENDS ${LitTestFiles})

--- a/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/test/spvasm/CMakeLists.txt
@@ -2244,9 +2244,6 @@ function(ca_assemble_spirv_ll_lit_test)
     list(APPEND LitTestFiles ${spv})
   endif()
 
-  add_ca_copy_file(INPUT ${spvasm} OUTPUT ${test})
-  list(APPEND LitTestFiles ${test})
-
   set_property(GLOBAL PROPERTY CA_SPIRV_LL_SPVASM_TEST_FILES ${LitTestFiles})
 endfunction()
 


### PR DESCRIPTION
The LIT test system always runs tests from their source paths, even if the binaries have been offline-assembled and copied into the binary directory.

This appears to be a legacy feature of the old testing system, where all LIT tests were run from the build directory. It's arguably beneficial for the old OCK/ComputeAorta binary releases, but we don't support those any more. None of the other LIT test systems copy source files into the binary directory at configure/build time (see the compiler-lit tests as an example).

This should shave off around 12M from the size of our builds.