### PR TITLE
[spirv-ll] Rename a couple of getter methods for clarity

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -864,7 +864,7 @@ class Module : public ModuleHeader {
   ///
   /// @return A pointer to the Op or nullptr if not found.
   template <class Op = OpCode>
-  const Op *get(llvm::Type *ty) const {
+  const Op *getFromLLVMTy(llvm::Type *ty) const {
     assert(!ty->isPointerTy() && "can't get the type of a pointer");
     auto found = std::find_if(
         Types.begin(), Types.end(),

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -675,7 +675,7 @@ class Module : public ModuleHeader {
   /// @param[in] id The SPIR-V ID to fetch the value for.
   ///
   /// @return A pointer to the Type or nullptr if not found.
-  llvm::Type *getType(spv::Id id) const;
+  llvm::Type *getLLVMType(spv::Id id) const;
 
   /// @brief Get the `OpType` from the result type of an `OpCode`.
   ///

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -121,7 +121,7 @@ llvm::DIType *spirv_ll::Builder::getDIType(llvm::Type *type) {
         name = "dbg_float_ty";
         break;
       case llvm::Type::PointerTyID: {
-        auto *opTy = module.get<OpType>(type);
+        auto *opTy = module.getFromLLVMTy<OpType>(type);
         SPIRV_LL_ASSERT(opTy && opTy->isPointerType(), "Type is not a pointer");
         llvm::DIType *elem_type =
             getDIType(module.getType(opTy->getTypePointer()->Type()));
@@ -1318,7 +1318,7 @@ void spirv_ll::Builder::checkMemberDecorations(
         nextType = multi_llvm::getVectorElementType(traversed.back());
         break;
       case llvm::Type::PointerTyID: {
-        auto *opTy = module.get<OpType>(traversed.back());
+        auto *opTy = module.getFromLLVMTy<OpType>(traversed.back());
         SPIRV_LL_ASSERT(opTy && opTy->isPointerType(), "Type is not a pointer");
         nextType = module.getType(opTy->getTypePointer()->Type());
         break;
@@ -1364,7 +1364,7 @@ void spirv_ll::Builder::checkMemberDecorations(
   // according to the spec, so this cast is safe.
   uint32_t member =
       cast<llvm::ConstantInt>(indexes[memberIndex])->getZExtValue();
-  auto structType = module.get<OpTypeStruct>(accessedStructType);
+  auto structType = module.getFromLLVMTy<OpTypeStruct>(accessedStructType);
   const auto &memberDecorations =
       module.getMemberDecorations(structType->IdResult(), member);
   for (auto *opMemberDecorate : memberDecorations) {

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -124,7 +124,7 @@ llvm::DIType *spirv_ll::Builder::getDIType(llvm::Type *type) {
         auto *opTy = module.getFromLLVMTy<OpType>(type);
         SPIRV_LL_ASSERT(opTy && opTy->isPointerType(), "Type is not a pointer");
         llvm::DIType *elem_type =
-            getDIType(module.getType(opTy->getTypePointer()->Type()));
+            getDIType(module.getLLVMType(opTy->getTypePointer()->Type()));
         return DIBuilder.createPointerType(elem_type, size, align);
       }
       default:
@@ -663,7 +663,8 @@ llvm::CallInst *spirv_ll::Builder::createImageAccessBuiltinCall(
     llvm::ArrayRef<llvm::Value *> args,
     llvm::ArrayRef<MangleInfo> argMangleInfo,
     const spirv_ll::OpTypeVector *pixelTypeOp) {
-  llvm::Type *pixelElementType = module.getType(pixelTypeOp->ComponentType());
+  llvm::Type *pixelElementType =
+      module.getLLVMType(pixelTypeOp->ComponentType());
   if (pixelElementType->isIntegerTy()) {
     // We need to look up the int type by ID because searching by `llvm::Type`
     // doesn't distinguish between signed and unsigned types, which can cause
@@ -700,7 +701,7 @@ llvm::CallInst *spirv_ll::Builder::createImageAccessBuiltinCall(
 llvm::Value *spirv_ll::Builder::createOCLBuiltinCall(
     OpenCLLIB::Entrypoints opcode, spv::Id resTyId,
     llvm::ArrayRef<spv::Id> args) {
-  llvm::Type *resultType = module.getType(resTyId);
+  llvm::Type *resultType = module.getLLVMType(resTyId);
   SPIRV_LL_ASSERT_PTR(resultType);
 
   llvm::SmallVector<llvm::Value *, 4> argVals;
@@ -1099,7 +1100,7 @@ std::string spirv_ll::Builder::getMangledFunctionName(
         llvm::Type *pointeeTy = nullptr;
         auto *const spvPtrTy = module.get<OpType>(mangleInfo->id);
         if (spvPtrTy->isPointerType()) {
-          pointeeTy = module.getType(spvPtrTy->getTypePointer()->Type());
+          pointeeTy = module.getLLVMType(spvPtrTy->getTypePointer()->Type());
 #if LLVM_VERSION_LESS(17, 0)
         } else if (spvPtrTy->isImageType() || spvPtrTy->isEventType() ||
                    spvPtrTy->isSamplerType()) {
@@ -1230,7 +1231,7 @@ std::string spirv_ll::Builder::getMangledTypeName(
 
     auto const spvPointeeTy =
         module.get<OpType>(mangleInfo->id)->getTypePointer()->Type();
-    auto *const elementTy = module.getType(spvPointeeTy);
+    auto *const elementTy = module.getLLVMType(spvPointeeTy);
     std::string mangled = getMangledPointerPrefix(ty, mangleInfo->typeQuals);
     auto pointeeMangleInfo = *mangleInfo;
     pointeeMangleInfo.typeQuals = 0;
@@ -1320,7 +1321,7 @@ void spirv_ll::Builder::checkMemberDecorations(
       case llvm::Type::PointerTyID: {
         auto *opTy = module.getFromLLVMTy<OpType>(traversed.back());
         SPIRV_LL_ASSERT(opTy && opTy->isPointerType(), "Type is not a pointer");
-        nextType = module.getType(opTy->getTypePointer()->Type());
+        nextType = module.getLLVMType(opTy->getTypePointer()->Type());
         break;
       }
       default:
@@ -1404,7 +1405,7 @@ void spirv_ll::Builder::generateSpecConstantOps() {
 
     switch (op->Opcode()) {
       case spv::OpFMod: {
-        llvm::Type *type = module.getType(op->IdResultType());
+        llvm::Type *type = module.getLLVMType(op->IdResultType());
         SPIRV_LL_ASSERT_PTR(type);
 
         llvm::Value *lhs = module.getValue(op->getValueAtOffset(firstArgIndex));
@@ -1426,7 +1427,7 @@ void spirv_ll::Builder::generateSpecConstantOps() {
                                           {modResult, rhs}, {});
       } break;
       case spv::OpFRem: {
-        llvm::Type *type = module.getType(op->IdResultType());
+        llvm::Type *type = module.getLLVMType(op->IdResultType());
         SPIRV_LL_ASSERT_PTR(type);
 
         llvm::Value *lhs = module.getValue(op->getValueAtOffset(firstArgIndex));

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -2190,7 +2190,7 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
   }
   if (argTy->isVectorTy()) {
     auto *const elemTy = multi_llvm::getVectorElementType(argTy);
-    auto const opElem = module.get<OpCode>(elemTy);
+    auto const opElem = module.getFromLLVMTy<OpCode>(elemTy);
     auto const name = getScalarTypeName(elemTy, opElem);
     auto const numElements =
         std::to_string(multi_llvm::getVectorNumElements(argTy));
@@ -2204,7 +2204,7 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
     return structName;
   }
   if (argTy->isIntegerTy()) {
-    auto argTyOp = module.get<OpType>(argTy);
+    auto argTyOp = module.getFromLLVMTy<OpType>(argTy);
     return getScalarTypeName(argTy, argTyOp);
   }
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
@@ -2238,7 +2238,7 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
     SPIRV_LL_ABORT("Unknown Target Extension Type");
   }
 #endif
-  auto argOp = module.get<OpCode>(argTy);
+  auto argOp = module.getFromLLVMTy<OpCode>(argTy);
   return getScalarTypeName(argTy, argOp);
 }
 }  // namespace

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -49,7 +49,7 @@ cargo::optional<Error> Builder::create<OpNop>(const OpNop *) {
 
 template <>
 cargo::optional<Error> Builder::create<OpUndef>(const OpUndef *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   module.addID(op->IdResult(), op, llvm::UndefValue::get(type));
@@ -396,7 +396,7 @@ cargo::optional<Error> Builder::create<OpTypeFloat>(const OpTypeFloat *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpTypeVector>(const OpTypeVector *op) {
-  llvm::Type *componentType = module.getType(op->ComponentType());
+  llvm::Type *componentType = module.getLLVMType(op->ComponentType());
 
   SPIRV_LL_ASSERT_PTR(componentType);
 
@@ -407,7 +407,7 @@ cargo::optional<Error> Builder::create<OpTypeVector>(const OpTypeVector *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpTypeMatrix>(const OpTypeMatrix *op) {
-  llvm::Type *columnType = module.getType(op->ColumnType());
+  llvm::Type *columnType = module.getLLVMType(op->ColumnType());
 
   SPIRV_LL_ASSERT_PTR(columnType);
 
@@ -546,7 +546,7 @@ cargo::optional<Error> Builder::create<OpTypeSampledImage>(
 
 template <>
 cargo::optional<Error> Builder::create<OpTypeArray>(const OpTypeArray *op) {
-  llvm::Type *elementType = module.getType(op->ElementType());
+  llvm::Type *elementType = module.getLLVMType(op->ElementType());
   llvm::Value *length = module.getValue(op->Length());
 
   SPIRV_LL_ASSERT_PTR(elementType);
@@ -562,7 +562,7 @@ cargo::optional<Error> Builder::create<OpTypeArray>(const OpTypeArray *op) {
 template <>
 cargo::optional<Error> Builder::create<OpTypeRuntimeArray>(
     const OpTypeRuntimeArray *op) {
-  llvm::Type *elementType = module.getType(op->ElementType());
+  llvm::Type *elementType = module.getLLVMType(op->ElementType());
 
   SPIRV_LL_ASSERT_PTR(elementType);
 
@@ -593,7 +593,7 @@ cargo::optional<Error> Builder::create<OpTypeStruct>(const OpTypeStruct *op) {
     llvm::SmallVector<llvm::Type *, 4> memberTypes;
 
     for (auto memberTypeID : memberTypeIDs) {
-      llvm::Type *memberType = module.getType(memberTypeID);
+      llvm::Type *memberType = module.getLLVMType(memberTypeID);
 
       SPIRV_LL_ASSERT_PTR(memberType);
 
@@ -635,7 +635,7 @@ cargo::optional<Error> Builder::create<OpTypePointer>(const OpTypePointer *op) {
 template <>
 cargo::optional<Error> Builder::create<OpTypeFunction>(
     const OpTypeFunction *op) {
-  llvm::Type *returnType = module.getType(op->ReturnType());
+  llvm::Type *returnType = module.getLLVMType(op->ReturnType());
   SPIRV_LL_ASSERT_PTR(returnType);
 
   llvm::SmallVector<llvm::Type *, 4> paramTypes;
@@ -643,7 +643,7 @@ cargo::optional<Error> Builder::create<OpTypeFunction>(
 
   for (int i = 0, n = op->wordCount() - 3; i < n; ++i) {
     auto opTyID = op->ParameterTypes()[i];
-    llvm::Type *paramType = module.getType(opTyID);
+    llvm::Type *paramType = module.getLLVMType(opTyID);
     SPIRV_LL_ASSERT_PTR(paramType);
 
     paramTypes.push_back(paramType);
@@ -720,7 +720,7 @@ cargo::optional<Error> Builder::create<OpTypeForwardPointer>(
 template <>
 cargo::optional<Error> Builder::create<OpConstantTrue>(
     const OpConstantTrue *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -734,7 +734,7 @@ cargo::optional<Error> Builder::create<OpConstantTrue>(
 template <>
 cargo::optional<Error> Builder::create<OpConstantFalse>(
     const OpConstantFalse *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -747,7 +747,7 @@ cargo::optional<Error> Builder::create<OpConstantFalse>(
 
 template <>
 cargo::optional<Error> Builder::create<OpConstant>(const OpConstant *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -800,7 +800,7 @@ cargo::optional<Error> Builder::create<OpConstant>(const OpConstant *op) {
 template <>
 cargo::optional<Error> Builder::create<OpConstantComposite>(
     const OpConstantComposite *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -875,7 +875,7 @@ cargo::optional<Error> Builder::create<OpConstantSampler>(
 template <>
 cargo::optional<Error> Builder::create<OpConstantNull>(
     const OpConstantNull *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -933,7 +933,7 @@ cargo::optional<Error> Builder::create<OpConstantNull>(
 template <>
 cargo::optional<Error> Builder::create<OpSpecConstantTrue>(
     const OpSpecConstantTrue *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Constant *spec_constant = nullptr;
@@ -966,7 +966,7 @@ cargo::optional<Error> Builder::create<OpSpecConstantTrue>(
 template <>
 cargo::optional<Error> Builder::create<OpSpecConstantFalse>(
     const OpSpecConstantFalse *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Constant *spec_constant = nullptr;
@@ -999,7 +999,7 @@ cargo::optional<Error> Builder::create<OpSpecConstantFalse>(
 template <>
 cargo::optional<Error> Builder::create<OpSpecConstant>(
     const OpSpecConstant *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   uint64_t value;
@@ -1082,7 +1082,7 @@ cargo::optional<Error> Builder::create<OpSpecConstant>(
 template <>
 cargo::optional<Error> Builder::create<OpSpecConstantComposite>(
     const OpSpecConstantComposite *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::SmallVector<llvm::Constant *, 4> constituents;
@@ -1133,7 +1133,7 @@ cargo::optional<Error> Builder::create<OpSpecConstantComposite>(
 template <>
 cargo::optional<Error> Builder::create<OpSpecConstantOp>(
     const OpSpecConstantOp *op) {
-  llvm::Type *result_type = module.getType(op->IdResultType());
+  llvm::Type *result_type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(result_type);
 
   llvm::Value *result = nullptr;
@@ -1624,7 +1624,8 @@ cargo::optional<Error> Builder::create<OpSpecConstantOp>(
         indexes.push_back(index);
       }
 
-      auto elementType = module.getType(pointerTy->getTypePointer()->Type());
+      auto elementType =
+          module.getLLVMType(pointerTy->getTypePointer()->Type());
       SPIRV_LL_ASSERT_PTR(elementType);
       if (elementType->isStructTy()) {
         checkMemberDecorations(elementType, indexes, op->IdResult());
@@ -1680,8 +1681,8 @@ static std::optional<std::pair<uint32_t, const char *>> getLinkage(
 template <>
 cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
   // get function type
-  llvm::FunctionType *function_type =
-      llvm::dyn_cast<llvm::FunctionType>(module.getType(op->FunctionType()));
+  auto *function_type = llvm::dyn_cast<llvm::FunctionType>(
+      module.getLLVMType(op->FunctionType()));
 
   SPIRV_LL_ASSERT_PTR(function_type);
 
@@ -2075,7 +2076,7 @@ cargo::optional<Error> Builder::create<OpFunctionParameter>(
       } else if (arg->getType()->isPointerTy()) {
         auto *ty = module.get<OpType>(op->IdResultType());
         SPIRV_LL_ASSERT(ty->isPointerType(), "Parameter is not a pointer");
-        auto *paramTy = module.getType(ty->getTypePointer()->Type());
+        auto *paramTy = module.getLLVMType(ty->getTypePointer()->Type());
         SPIRV_LL_ASSERT_PTR(paramTy);
         switch (funcParamAttr->getValueAtOffset(3)) {
           case spv::FunctionParameterAttributeByVal:
@@ -2177,7 +2178,7 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
     // If we haven't found a known pointer, keep trying.
     auto argTyOp = module.get<OpTypePointer>(argTyID);
     auto pointeeTyID = argTyOp->getTypePointer()->Type();
-    auto *pointeeTy = module.getType(pointeeTyID);
+    auto *pointeeTy = module.getLLVMType(pointeeTyID);
 
     return retrieveArgTyMetadata(module, pointeeTy, pointeeTyID, isBaseTyName) +
            '*';
@@ -2381,11 +2382,11 @@ cargo::optional<Error> Builder::create<OpFunctionCall>(
     //   Note: A forward call is possible because there is no missing type
     //   information: Result Type must match the Return Type of the function,
     //   and the calling argument types must match the formal parameter types.
-    llvm::Type *resultType = module.getType(op->IdResultType());
+    llvm::Type *resultType = module.getLLVMType(op->IdResultType());
     for (unsigned i = 0; i < n_args; ++i) {
       auto *const spv_ty = module.getResultType(op->Arguments()[i]);
       SPIRV_LL_ASSERT_PTR(spv_ty);
-      auto *const llvm_ty = module.getType(spv_ty->IdResult());
+      auto *const llvm_ty = module.getLLVMType(spv_ty->IdResult());
       SPIRV_LL_ASSERT_PTR(llvm_ty);
       paramTypes.push_back(llvm_ty);
     }
@@ -2471,12 +2472,12 @@ cargo::optional<Error> Builder::create<OpFunctionCall>(
 
 template <>
 cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
-  llvm::Type *varPtrTy = module.getType(op->IdResultType());
+  llvm::Type *varPtrTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(varPtrTy);
 
   auto *resultTy = module.get<OpTypePointer>(op->IdResultType());
   SPIRV_LL_ASSERT(resultTy, "Result type is not a pointer");
-  auto varTy = module.getType(resultTy->getTypePointer()->Type());
+  auto varTy = module.getLLVMType(resultTy->getTypePointer()->Type());
 
   llvm::Constant *initializer = nullptr;
   if (op->wordCount() > 4) {
@@ -2750,7 +2751,7 @@ cargo::optional<Error> Builder::create<OpImageTexelPointer>(
 template <>
 cargo::optional<Error> Builder::create<OpLoad>(const OpLoad *op) {
   llvm::Value *ptr = module.getValue(op->Pointer());
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(ptr);
 
@@ -2842,7 +2843,8 @@ cargo::optional<Error> Builder::create<OpCopyMemory>(const OpCopyMemory *op) {
       sourceOpType->isPointerType() && targetOpType->isPointerType(),
       "Source and Target are not pointers");
 
-  auto *pointeeType = module.getType(sourceOpType->getTypePointer()->Type());
+  auto *pointeeType =
+      module.getLLVMType(sourceOpType->getTypePointer()->Type());
 
   SPIRV_LL_ASSERT(sourceOpType->getTypePointer()->Type() ==
                       targetOpType->getTypePointer()->Type(),
@@ -2904,7 +2906,7 @@ cargo::optional<Error> Builder::create<OpCopyMemorySized>(
   SPIRV_LL_ASSERT(targetOpType && targetOpType->isPointerType(),
                   "Target is not a pointer type");
   llvm::Type *targetElementType =
-      module.getType(targetOpType->getTypePointer()->Type());
+      module.getLLVMType(targetOpType->getTypePointer()->Type());
   if (sourceGlobal && sourceGlobal->isConstant() &&
       sourceGlobal->getInitializer() &&
       sourceGlobal->getInitializer()->getType()->isArrayTy() &&
@@ -2956,7 +2958,7 @@ cargo::optional<Error> Builder::create<OpAccessChain>(const OpAccessChain *op) {
   SPIRV_LL_ASSERT(baseTy && baseTy->isPointerType(),
                   "Base is not a pointer type");
 
-  auto *basePointeeTy = module.getType(baseTy->getTypePointer()->Type());
+  auto *basePointeeTy = module.getLLVMType(baseTy->getTypePointer()->Type());
   auto inst = llvm::GetElementPtrInst::Create(basePointeeTy, base, indexes,
                                               module.getName(op->IdResult()),
                                               IRBuilder.GetInsertBlock());
@@ -2985,7 +2987,7 @@ cargo::optional<Error> Builder::create<OpInBoundsAccessChain>(
   SPIRV_LL_ASSERT(baseTy && baseTy->isPointerType(),
                   "Base is not a pointer type");
 
-  auto *basePointeeTy = module.getType(baseTy->getTypePointer()->Type());
+  auto *basePointeeTy = module.getLLVMType(baseTy->getTypePointer()->Type());
   llvm::GetElementPtrInst *inst = llvm::GetElementPtrInst::Create(
       basePointeeTy, base, indexes, module.getName(op->IdResult()),
       IRBuilder.GetInsertBlock());
@@ -3019,7 +3021,7 @@ cargo::optional<Error> Builder::create<OpPtrAccessChain>(
   SPIRV_LL_ASSERT(baseTy && baseTy->isPointerType(),
                   "Base is not a pointer type");
 
-  auto *basePointeeTy = module.getType(baseTy->getTypePointer()->Type());
+  auto *basePointeeTy = module.getLLVMType(baseTy->getTypePointer()->Type());
   llvm::GetElementPtrInst *inst = llvm::GetElementPtrInst::Create(
       basePointeeTy, base, indexes, module.getName(op->IdResult()),
       IRBuilder.GetInsertBlock());
@@ -3132,7 +3134,7 @@ cargo::optional<Error> Builder::create<OpInBoundsPtrAccessChain>(
   SPIRV_LL_ASSERT(baseTy && baseTy->isPointerType(),
                   "Base is not a pointer type");
 
-  auto *basePointeeTy = module.getType(baseTy->getTypePointer()->Type());
+  auto *basePointeeTy = module.getLLVMType(baseTy->getTypePointer()->Type());
   llvm::GetElementPtrInst *inst = llvm::GetElementPtrInst::Create(
       basePointeeTy, base, indexes, module.getName(op->IdResult()),
       IRBuilder.GetInsertBlock());
@@ -3259,7 +3261,7 @@ cargo::optional<Error> Builder::create<OpVectorShuffle>(
 template <>
 cargo::optional<Error> Builder::create<OpCompositeConstruct>(
     const OpCompositeConstruct *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::SmallVector<llvm::Value *, 4> constituents;
@@ -3378,7 +3380,7 @@ cargo::optional<Error> Builder::create<OpCopyObject>(const OpCopyObject *op) {
   auto *opTy = module.getResultType(op->Operand());
   SPIRV_LL_ASSERT_PTR(opTy);
   if (opTy->isPointerType()) {
-    auto *pointeeTy = module.getType(opTy->getTypePointer()->Type());
+    auto *pointeeTy = module.getLLVMType(opTy->getTypePointer()->Type());
     SPIRV_LL_ASSERT_PTR(pointeeTy);
     new_object = IRBuilder.CreateAlloca(pointeeTy);
 
@@ -3418,7 +3420,7 @@ cargo::optional<Error> Builder::create<OpSampledImage>(
     auto *formalSamplerOpTy = module.getResultType(op->Sampler());
     SPIRV_LL_ASSERT_PTR(formalSamplerOpTy);
     auto formalSamplerTyID = formalSamplerOpTy->IdResult();
-    auto *formalSamplerTy = module.getType(formalSamplerTyID);
+    auto *formalSamplerTy = module.getLLVMType(formalSamplerTyID);
     SPIRV_LL_ASSERT(sampler->getType() && sampler->getType()->isIntegerTy(32),
                     "Internal sampler error");
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
@@ -3449,7 +3451,7 @@ cargo::optional<Error> Builder::create<OpImageSampleImplicitLod>(
 template <>
 cargo::optional<Error> Builder::create<OpImageSampleExplicitLod>(
     const OpImageSampleExplicitLod *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   Module::SampledImage sampledImage =
@@ -3544,7 +3546,7 @@ cargo::optional<Error> Builder::create<OpImageDrefGather>(
 
 template <>
 cargo::optional<Error> Builder::create<OpImageRead>(const OpImageRead *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto image = module.getValue(op->Image());
@@ -3594,7 +3596,7 @@ cargo::optional<Error> Builder::create<OpImage>(const OpImage *op) {
 template <>
 cargo::optional<Error> Builder::create<OpImageQueryFormat>(
     const OpImageQueryFormat *op) {
-  llvm::Type *resultType = module.getType(op->IdResultType());
+  llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(resultType);
 
   llvm::Value *image = module.getValue(op->Image());
@@ -3611,7 +3613,7 @@ cargo::optional<Error> Builder::create<OpImageQueryFormat>(
 template <>
 cargo::optional<Error> Builder::create<OpImageQueryOrder>(
     const OpImageQueryOrder *op) {
-  llvm::Type *resultType = module.getType(op->IdResultType());
+  llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(resultType);
 
   llvm::Value *image = module.getValue(op->Image());
@@ -3628,7 +3630,7 @@ cargo::optional<Error> Builder::create<OpImageQueryOrder>(
 template <>
 cargo::optional<Error> Builder::create<OpImageQuerySizeLod>(
     const OpImageQuerySizeLod *op) {
-  llvm::Type *returnType = module.getType(op->IdResultType());
+  llvm::Type *returnType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(returnType);
 
   llvm::Type *returnScalarType = returnType->getScalarType();
@@ -3766,7 +3768,7 @@ cargo::optional<Error> Builder::create<OpImageQuerySamples>(
 
 template <>
 cargo::optional<Error> Builder::create<OpConvertFToU>(const OpConvertFToU *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->FloatValue());
@@ -3782,7 +3784,7 @@ cargo::optional<Error> Builder::create<OpConvertFToU>(const OpConvertFToU *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpConvertFToS>(const OpConvertFToS *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->FloatValue());
@@ -3798,7 +3800,7 @@ cargo::optional<Error> Builder::create<OpConvertFToS>(const OpConvertFToS *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpConvertSToF>(const OpConvertSToF *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->SignedValue());
@@ -3814,7 +3816,7 @@ cargo::optional<Error> Builder::create<OpConvertSToF>(const OpConvertSToF *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpConvertUToF>(const OpConvertUToF *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->UnsignedValue());
@@ -3829,7 +3831,7 @@ cargo::optional<Error> Builder::create<OpConvertUToF>(const OpConvertUToF *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpUConvert>(const OpUConvert *op) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->UnsignedValue());
@@ -3843,7 +3845,7 @@ cargo::optional<Error> Builder::create<OpUConvert>(const OpUConvert *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpSConvert>(const OpSConvert *op) {
-  llvm::Type *retTy = module.getType(op->IdResultType());
+  llvm::Type *retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   llvm::Value *value = module.getValue(op->SignedValue());
@@ -3860,7 +3862,7 @@ cargo::optional<Error> Builder::create<OpFConvert>(const OpFConvert *op) {
   llvm::Value *value = module.getValue(op->FloatValue());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   module.addID(op->IdResult(), op,
@@ -3875,7 +3877,7 @@ cargo::optional<Error> Builder::create<OpQuantizeToF16>(
   llvm::Value *val = module.getValue(op->Value());
   SPIRV_LL_ASSERT_PTR(val);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   module.addID(
@@ -3891,7 +3893,7 @@ cargo::optional<Error> Builder::create<OpConvertPtrToU>(
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreatePtrToInt(value, type);
@@ -3905,7 +3907,7 @@ cargo::optional<Error> Builder::create<OpSatConvertSToU>(
   SPIRV_LL_ASSERT(module.hasCapability(spv::CapabilityKernel),
                   "Kernel capability not enabled");
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->SignedValue());
@@ -3926,7 +3928,7 @@ cargo::optional<Error> Builder::create<OpSatConvertUToS>(
   SPIRV_LL_ASSERT(module.hasCapability(spv::CapabilityKernel),
                   "Kernel capability not enabled");
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto value = module.getValue(op->UnsignedValue());
@@ -3949,7 +3951,7 @@ cargo::optional<Error> Builder::create<OpConvertUToPtr>(
   llvm::Value *value = module.getValue(op->IntegerValue());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreateIntToPtr(value, type);
@@ -3963,7 +3965,7 @@ cargo::optional<Error> Builder::create<OpPtrCastToGeneric>(
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
@@ -3977,7 +3979,7 @@ cargo::optional<Error> Builder::create<OpGenericCastToPtr>(
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
@@ -3991,7 +3993,7 @@ cargo::optional<Error> Builder::create<OpGenericCastToPtrExplicit>(
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
@@ -4004,7 +4006,7 @@ cargo::optional<Error> Builder::create<OpBitcast>(const OpBitcast *op) {
   llvm::Value *value = module.getValue(op->Operand());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = IRBuilder.CreateBitCast(value, type);
@@ -4201,7 +4203,7 @@ cargo::optional<Error> Builder::create<OpSRem>(const OpSRem *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpSMod>(const OpSMod *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *lhs = module.getValue(op->Operand1());
@@ -4234,7 +4236,7 @@ cargo::optional<Error> Builder::create<OpFRem>(const OpFRem *op) {
 
   llvm::Value *result = nullptr;
 
-  llvm::Type *resultType = module.getType(op->IdResultType());
+  llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   result =
       createMangledBuiltinCall("fmod", resultType, op->IdResultType(),
                                {lhs, rhs}, {op->Operand1(), op->Operand2()});
@@ -4244,7 +4246,7 @@ cargo::optional<Error> Builder::create<OpFRem>(const OpFRem *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpFMod>(const OpFMod *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *lhs = module.getValue(op->Operand1());
@@ -4254,7 +4256,7 @@ cargo::optional<Error> Builder::create<OpFMod>(const OpFMod *op) {
   SPIRV_LL_ASSERT_PTR(rhs);
 
   llvm::Value *result = nullptr;
-  llvm::Type *resultType = module.getType(op->IdResultType());
+  llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   result =
       createMangledBuiltinCall("fmod", resultType, op->IdResultType(),
                                {lhs, rhs}, {op->Operand1(), op->Operand2()});
@@ -4276,8 +4278,8 @@ cargo::optional<Error> Builder::create<OpVectorTimesScalar>(
   llvm::Value *vectorValue = module.getValue(op->Vector());
   SPIRV_LL_ASSERT_PTR(vectorValue);
 
-  auto vectorType =
-      llvm::dyn_cast<llvm::FixedVectorType>(module.getType(op->IdResultType()));
+  auto *vectorType = llvm::dyn_cast<llvm::FixedVectorType>(
+      module.getLLVMType(op->IdResultType()));
   SPIRV_LL_ASSERT_PTR(vectorType);
 
   llvm::Value *splatVector =
@@ -4324,7 +4326,7 @@ cargo::optional<Error> Builder::create<OpOuterProduct>(const OpOuterProduct *) {
 
 template <>
 cargo::optional<Error> Builder::create<OpDot>(const OpDot *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *lhs = module.getValue(op->Vector1());
@@ -4352,7 +4354,7 @@ cargo::optional<Error> Builder::create<OpIAddCarry>(const OpIAddCarry *op) {
   llvm::Type *operandType = rhs->getType();
 
   llvm::StructType *resultType =
-      llvm::dyn_cast<llvm::StructType>(module.getType(op->IdResultType()));
+      llvm::dyn_cast<llvm::StructType>(module.getLLVMType(op->IdResultType()));
   SPIRV_LL_ASSERT_PTR(resultType);
 
   std::string functionName;
@@ -4410,7 +4412,7 @@ cargo::optional<Error> Builder::create<OpISubBorrow>(const OpISubBorrow *op) {
   llvm::Type *operandType = rhs->getType();
 
   llvm::StructType *resultType =
-      llvm::dyn_cast<llvm::StructType>(module.getType(op->IdResultType()));
+      llvm::dyn_cast<llvm::StructType>(module.getLLVMType(op->IdResultType()));
   SPIRV_LL_ASSERT_PTR(resultType);
 
   std::string functionName;
@@ -4479,7 +4481,7 @@ cargo::optional<Error> Builder::create<OpUMulExtended>(
   llvm::Value *highOrderBits = IRBuilder.CreateAnd(highOrderBitsMask, mul);
 
   llvm::StructType *type =
-      llvm::dyn_cast<llvm::StructType>(module.getType(op->IdResultType()));
+      llvm::dyn_cast<llvm::StructType>(module.getLLVMType(op->IdResultType()));
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = llvm::ConstantStruct::get(
@@ -4515,7 +4517,7 @@ cargo::optional<Error> Builder::create<OpSMulExtended>(
   llvm::Value *highOrderBits = IRBuilder.CreateAnd(highOrderBitsMask, mul);
 
   llvm::StructType *type =
-      llvm::dyn_cast<llvm::StructType>(module.getType(op->IdResultType()));
+      llvm::dyn_cast<llvm::StructType>(module.getLLVMType(op->IdResultType()));
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *result = llvm::ConstantStruct::get(
@@ -4531,7 +4533,7 @@ cargo::optional<Error> Builder::create<OpSMulExtended>(
 
 template <>
 cargo::optional<Error> Builder::create<OpAny>(const OpAny *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *vector = module.getValue(op->Vector());
@@ -4562,7 +4564,7 @@ cargo::optional<Error> Builder::create<OpAny>(const OpAny *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpAll>(const OpAll *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *vector = module.getValue(op->Vector());
@@ -4593,7 +4595,7 @@ cargo::optional<Error> Builder::create<OpAll>(const OpAll *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpIsNan>(const OpIsNan *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4613,7 +4615,7 @@ cargo::optional<Error> Builder::create<OpIsNan>(const OpIsNan *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpIsInf>(const OpIsInf *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4633,7 +4635,7 @@ cargo::optional<Error> Builder::create<OpIsInf>(const OpIsInf *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpIsFinite>(const OpIsFinite *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4653,7 +4655,7 @@ cargo::optional<Error> Builder::create<OpIsFinite>(const OpIsFinite *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpIsNormal>(const OpIsNormal *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4673,7 +4675,7 @@ cargo::optional<Error> Builder::create<OpIsNormal>(const OpIsNormal *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpSignBitSet>(const OpSignBitSet *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4694,7 +4696,7 @@ cargo::optional<Error> Builder::create<OpSignBitSet>(const OpSignBitSet *op) {
 template <>
 cargo::optional<Error> Builder::create<OpLessOrGreater>(
     const OpLessOrGreater *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4717,7 +4719,7 @@ cargo::optional<Error> Builder::create<OpLessOrGreater>(
 
 template <>
 cargo::optional<Error> Builder::create<OpOrdered>(const OpOrdered *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -4740,7 +4742,7 @@ cargo::optional<Error> Builder::create<OpOrdered>(const OpOrdered *op) {
 
 template <>
 cargo::optional<Error> Builder::create<OpUnordered>(const OpUnordered *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *x = module.getValue(op->x());
@@ -5244,7 +5246,7 @@ cargo::optional<Error> Builder::create<OpNot>(const OpNot *op) {
 template <>
 cargo::optional<Error> Builder::create<OpBitFieldInsert>(
     const OpBitFieldInsert *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *base = module.getValue(op->Base());
@@ -5294,7 +5296,7 @@ cargo::optional<Error> Builder::create<OpBitFieldInsert>(
 template <>
 cargo::optional<Error> Builder::create<OpBitFieldSExtract>(
     const OpBitFieldSExtract *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *base = module.getValue(op->Base());
@@ -5336,7 +5338,7 @@ cargo::optional<Error> Builder::create<OpBitFieldSExtract>(
 template <>
 cargo::optional<Error> Builder::create<OpBitFieldUExtract>(
     const OpBitFieldUExtract *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *base = module.getValue(op->Base());
@@ -5383,7 +5385,7 @@ cargo::optional<Error> Builder::create<OpBitReverse>(const OpBitReverse *) {
 
 template <>
 cargo::optional<Error> Builder::create<OpBitCount>(const OpBitCount *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   llvm::Value *base = module.getValue(op->Base());
@@ -5632,7 +5634,7 @@ cargo::optional<Error> Builder::create<OpAtomicLoad>(const OpAtomicLoad *op) {
   auto semantics = module.getValue(op->Semantics());
   SPIRV_LL_ASSERT_PTR(semantics);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   module.addID(
@@ -5670,7 +5672,7 @@ cargo::optional<Error> Builder::create<OpAtomicExchange>(
     const OpAtomicExchange *op) {
   const auto retOp = op->IdResultType();
   // Atomic exchange can work on floats or integers.
-  const auto *const type = module.getType(retOp);
+  const auto *const type = module.getLLVMType(retOp);
   const auto is_signed =
       !type->isFloatingPointTy() && module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_xchg",
@@ -5687,7 +5689,7 @@ cargo::optional<Error> Builder::create<OpAtomicCompareExchange>(
   // storage class Function is valid but undefined behaviour, so just return the
   // orginal value as the instruction should
   if (pointer->getType()->getPointerAddressSpace() == 0) {
-    auto *resultTy = module.getType(op->IdResultType());
+    auto *resultTy = module.getLLVMType(op->IdResultType());
     module.addID(op->IdResult(), op, IRBuilder.CreateLoad(resultTy, pointer));
     return cargo::nullopt;
   }
@@ -5698,7 +5700,7 @@ cargo::optional<Error> Builder::create<OpAtomicCompareExchange>(
   auto cmp = module.getValue(op->Comparator());
   SPIRV_LL_ASSERT_PTR(cmp);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   module.addID(
@@ -5724,7 +5726,7 @@ cargo::optional<Error> Builder::create<OpAtomicIIncrement>(
   llvm::Value *pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
-  llvm::Type *retTy = module.getType(op->IdResultType());
+  llvm::Type *retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   module.addID(op->IdResult(), op,
@@ -5740,7 +5742,7 @@ cargo::optional<Error> Builder::create<OpAtomicIDecrement>(
   llvm::Value *pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
-  llvm::Type *retTy = module.getType(op->IdResultType());
+  llvm::Type *retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   module.addID(op->IdResult(), op,
@@ -5761,14 +5763,14 @@ void Builder::generateBinaryAtomic(const OpResult *op, spv::Id pointerID,
   if (pointer->getType()->getPointerAddressSpace() == 0) {
     module.addID(
         op->IdResult(), op,
-        IRBuilder.CreateLoad(module.getType(op->IdResultType()), pointer));
+        IRBuilder.CreateLoad(module.getLLVMType(op->IdResultType()), pointer));
     return;
   }
 
   auto value = module.getValue(valueID);
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *retTy = module.getType(op->IdResultType());
+  llvm::Type *retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   llvm::Type *value_type = value->getType();
@@ -5876,7 +5878,7 @@ cargo::optional<Error> Builder::create<OpAtomicXor>(const OpAtomicXor *op) {
 template <>
 cargo::optional<Error> Builder::create<OpPhi>(const OpPhi *op) {
   const unsigned num_values = op->wordCount() - 3;
-  llvm::Type *result_ty = module.getType(op->IdResultType());
+  llvm::Type *result_ty = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(result_ty);
 
   llvm::PHINode *phi = IRBuilder.CreatePHI(result_ty, num_values);
@@ -6137,7 +6139,7 @@ cargo::optional<Error> Builder::create<OpLifetimeStop>(
 template <>
 cargo::optional<Error> Builder::create<OpGroupAsyncCopy>(
     const OpGroupAsyncCopy *op) {
-  llvm::Type *eventTy = module.getType(op->IdResultType());
+  llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(eventTy);
 
   llvm::Value *dst = module.getValue(op->Destination());
@@ -6190,7 +6192,7 @@ cargo::optional<Error> Builder::create<OpGroupWaitEvents>(
 template <typename T>
 void Builder::generateReduction(const T *op, const std::string &opName,
                                 MangleInfo::ForceSignInfo signInfo) {
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   auto *const execution = module.getValue(op->Execution());
@@ -6318,7 +6320,7 @@ void Builder::generateReduction(const T *op, const std::string &opName,
 template <typename T>
 void Builder::generatePredicate(const T *op, const std::string &opName) {
   // Result Type must be a boolean type, which maps to an i1 in LLVM IR.
-  auto *const retTy = module.getType(op->IdResultType());
+  auto *const retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
   SPIRV_LL_ASSERT(retTy == IRBuilder.getInt1Ty(),
                   "return type is not a boolean");
@@ -6441,7 +6443,7 @@ cargo::optional<Error> Builder::create<OpGroupBroadcast>(
     const OpGroupBroadcast *op) {
   // Result Type must be a scalar or vector or floating-point type, integer type
   // or boolean type.
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
   SPIRV_LL_ASSERT(retTy->isIntegerTy() || retTy->isFloatingPointTy(),
                   "return type is not float, integer or boolean");
@@ -6763,7 +6765,7 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffle>(
   auto *invocation_id = module.getValue(op->InvocationId());
   SPIRV_LL_ASSERT_PTR(invocation_id);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
@@ -6788,7 +6790,7 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleUp>(
   auto *delta = module.getValue(op->Delta());
   SPIRV_LL_ASSERT_PTR(delta);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
@@ -6813,7 +6815,7 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleDown>(
   auto *delta = module.getValue(op->Delta());
   SPIRV_LL_ASSERT_PTR(delta);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
@@ -6835,7 +6837,7 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleXor>(
   auto *value = module.getValue(op->Value());
   SPIRV_LL_ASSERT_PTR(value);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   muxBuiltinName += compiler::utils::BuiltinInfo::getMangledTypeStr(retTy);
@@ -7173,7 +7175,7 @@ cargo::optional<Error> Builder::create<OpAtomicFlagTestAndSet>(
   auto semantics = module.getValue(op->Semantics());
   SPIRV_LL_ASSERT_PTR(semantics);
 
-  auto retTy = module.getType(op->IdResultType());
+  auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
   module.addID(
@@ -7224,7 +7226,7 @@ cargo::optional<Error> Builder::create<OpAssumeTrueKHR>(
 
 template <>
 cargo::optional<Error> Builder::create<OpExpectKHR>(const OpExpectKHR *op) {
-  llvm::Type *type = module.getType(op->IdResultType());
+  llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   auto value = module.getValue(op->Value());

--- a/modules/compiler/spirv-ll/source/builder_glsl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_glsl.cpp
@@ -33,7 +33,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -52,7 +52,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(OpExtInst const &opc) {
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -71,7 +71,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -90,7 +90,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -109,7 +109,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -128,7 +128,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -147,7 +147,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   /*
@@ -193,7 +193,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -212,7 +212,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -231,7 +231,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   // The builtin function also returns the whole number part through a
@@ -265,7 +265,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(OpExtInst const &opc) {
   llvm::Value *degrees = module.getValue(op->degrees());
   SPIRV_LL_ASSERT_PTR(degrees);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -284,7 +284,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(OpExtInst const &opc) {
   llvm::Value *radians = module.getValue(op->radians());
   SPIRV_LL_ASSERT_PTR(radians);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -303,7 +303,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -322,7 +322,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -341,7 +341,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -360,7 +360,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -379,7 +379,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -398,7 +398,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
   llvm::Value *yOverX = module.getValue(op->yOverX());
   SPIRV_LL_ASSERT_PTR(yOverX);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -418,7 +418,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -437,7 +437,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -456,7 +456,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -475,7 +475,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -494,7 +494,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -513,7 +513,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -535,7 +535,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -557,7 +557,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -576,7 +576,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -595,7 +595,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -614,7 +614,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -633,7 +633,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -652,7 +652,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -671,7 +671,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(OpExtInst const &opc) {
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -715,7 +715,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
   llvm::Value *i = module.getValue(op->i());
   SPIRV_LL_ASSERT_PTR(i);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -734,7 +734,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(OpExtInst const &opc) {
   auto *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  auto *retType = module.getType(op->IdResultType());
+  auto *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::Value *wholeNo = builder.getIRBuilder().CreateAlloca(x->getType());
@@ -775,7 +775,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -797,7 +797,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -819,7 +819,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -841,7 +841,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -863,7 +863,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -885,7 +885,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -910,7 +910,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(OpExtInst const &opc) {
   llvm::Value *maxVal = module.getValue(op->maxVal());
   SPIRV_LL_ASSERT_PTR(maxVal);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -936,7 +936,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(OpExtInst const &opc) {
   llvm::Value *maxVal = module.getValue(op->maxVal());
   SPIRV_LL_ASSERT_PTR(maxVal);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -962,7 +962,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(OpExtInst const &opc) {
   llvm::Value *maxVal = module.getValue(op->maxVal());
   SPIRV_LL_ASSERT_PTR(maxVal);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -988,7 +988,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
   llvm::Value *a = module.getValue(op->a());
   SPIRV_LL_ASSERT_PTR(a);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result =
@@ -1022,7 +1022,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1047,7 +1047,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(OpExtInst const &opc) {
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1073,7 +1073,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(
   llvm::Value *c = module.getValue(op->c());
   SPIRV_LL_ASSERT_PTR(c);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result =
@@ -1097,7 +1097,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
   llvm::Value *exp = module.getValue(op->exp());
   SPIRV_LL_ASSERT_PTR(exp);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   // We can't automatically mangle frexp with our APIs. For the pointer
@@ -1129,7 +1129,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(OpExtInst const &opc) {
   auto *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  auto *retType = module.getType(op->IdResultType());
+  auto *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::Type *expTy = builder.getIRBuilder().getInt32Ty();
@@ -1176,7 +1176,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
   llvm::Value *exp = module.getValue(op->exp());
   SPIRV_LL_ASSERT_PTR(exp);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   // Don't pass IDs to force signed int mangling. Since CL ldexp can only take
@@ -1199,7 +1199,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1217,7 +1217,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1235,7 +1235,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1253,7 +1253,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1271,7 +1271,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1289,7 +1289,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::Value *result = builder.getIRBuilder().CreateBitCast(v, retType);
@@ -1306,7 +1306,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(OpExtInst const &opc) {
   llvm::Value *p = module.getValue(op->p());
   SPIRV_LL_ASSERT_PTR(p);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   auto result = builder.createMangledBuiltinCall(
@@ -1324,7 +1324,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(OpExtInst const &opc) {
   llvm::Value *p = module.getValue(op->p());
   SPIRV_LL_ASSERT_PTR(p);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   auto result = builder.createMangledBuiltinCall(
@@ -1342,7 +1342,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(OpExtInst const &opc) {
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1360,7 +1360,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(OpExtInst const &opc) {
   llvm::Value *p = module.getValue(op->p());
   SPIRV_LL_ASSERT_PTR(p);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   auto result = builder.createMangledBuiltinCall(
@@ -1378,7 +1378,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(OpExtInst const &opc) {
   llvm::Value *p = module.getValue(op->p());
   SPIRV_LL_ASSERT_PTR(p);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   auto result = builder.createMangledBuiltinCall(
@@ -1397,7 +1397,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
   llvm::Value *v = module.getValue(op->v());
   SPIRV_LL_ASSERT_PTR(v);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::Value *result = builder.getIRBuilder().CreateBitCast(v, retType);
@@ -1414,7 +1414,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Length>(OpExtInst const &opc) {
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1436,7 +1436,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(OpExtInst const &opc) {
   llvm::Value *p1 = module.getValue(op->p1());
   SPIRV_LL_ASSERT_PTR(p1);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1458,7 +1458,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1477,7 +1477,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(OpExtInst const &opc) {
   llvm::Value *x = module.getValue(op->x());
   SPIRV_LL_ASSERT_PTR(x);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1502,7 +1502,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(OpExtInst const &opc) {
   llvm::Value *nRef = module.getValue(op->nRef());
   SPIRV_LL_ASSERT_PTR(nRef);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1526,7 +1526,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(OpExtInst const &opc) {
   llvm::Value *n = module.getValue(op->n());
   SPIRV_LL_ASSERT_PTR(n);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1552,7 +1552,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(OpExtInst const &opc) {
   llvm::Value *eta = module.getValue(op->eta());
   SPIRV_LL_ASSERT_PTR(eta);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1572,7 +1572,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(OpExtInst const &opc) {
   llvm::Value *value = module.getValue(op->value());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1591,7 +1591,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(OpExtInst const &opc) {
   llvm::Value *value = module.getValue(op->value());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1611,7 +1611,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(OpExtInst const &opc) {
   llvm::Value *value = module.getValue(op->value());
   SPIRV_LL_ASSERT_PTR(value);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1669,7 +1669,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1691,7 +1691,7 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
   llvm::Value *y = module.getValue(op->y());
   SPIRV_LL_ASSERT_PTR(y);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(
@@ -1716,7 +1716,7 @@ spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(OpExtInst const &opc) {
   llvm::Value *maxVal = module.getValue(op->maxVal());
   SPIRV_LL_ASSERT_PTR(maxVal);
 
-  llvm::Type *retType = module.getType(op->IdResultType());
+  llvm::Type *retType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retType);
 
   llvm::CallInst *result = builder.createMangledBuiltinCall(

--- a/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
+++ b/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
@@ -55,7 +55,7 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
     OpExtInst const &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy2D2D>(opc);
 
-  llvm::Type *eventTy = module.getType(op->IdResultType());
+  llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(eventTy);
   llvm::Value *dst = module.getValue(op->Destination());
   SPIRV_LL_ASSERT_PTR(dst);
@@ -124,7 +124,7 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
     OpExtInst const &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy3D3D>(opc);
 
-  llvm::Type *eventTy = module.getType(op->IdResultType());
+  llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(eventTy);
   llvm::Value *dst = module.getValue(op->Destination());
   SPIRV_LL_ASSERT_PTR(dst);

--- a/modules/compiler/spirv-ll/source/builder_opencl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_opencl.cpp
@@ -27,7 +27,7 @@ static cargo::optional<spirv_ll::Error> createPrintf(OpExtInst const &opc,
                                                      Builder &builder) {
   auto *op = module.create<OpenCLstd::Printf>(opc);
 
-  llvm::Type *resultType = module.getType(op->IdResultType());
+  llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(resultType);
 
   llvm::Value *format = module.getValue(op->format());

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -489,7 +489,7 @@ bool spirv_ll::Module::addID(spv::Id id, OpCode const *Op, llvm::Value *V) {
   return true;
 }
 
-llvm::Type *spirv_ll::Module::getType(spv::Id id) const {
+llvm::Type *spirv_ll::Module::getLLVMType(spv::Id id) const {
   return Types.lookup(id).Type;
 }
 
@@ -551,10 +551,10 @@ void spirv_ll::Module::updateIncompleteStruct(spv::Id member_id) {
         if (iter.second.empty()) {
           llvm::SmallVector<llvm::Type *, 4> memberTypes;
           for (auto memberType : iter.first->MemberTypes()) {
-            memberTypes.push_back(getType(memberType));
+            memberTypes.push_back(getLLVMType(memberType));
           }
           llvm::StructType *structType =
-              llvm::cast<llvm::StructType>(getType(iter.first->IdResult()));
+              llvm::cast<llvm::StructType>(getLLVMType(iter.first->IdResult()));
           structType->setBody(memberTypes);
           // remove the now fully populated struct from the map
           IncompleteStructs.erase(IncompleteStructs.find(iter.first));
@@ -568,7 +568,7 @@ void spirv_ll::Module::updateIncompleteStruct(spv::Id member_id) {
 void spirv_ll::Module::addCompletePointer(const OpTypePointer *op) {
   spv::Id typeId = op->Type();
   SPIRV_LL_ASSERT(!isForwardPointer(typeId), "typeId is a forward pointer");
-  llvm::Type *type = getType(typeId);
+  llvm::Type *type = getLLVMType(typeId);
   SPIRV_LL_ASSERT_PTR(type);
 
   // Pointer to void type isn't legal in llvm, so substitute char* in such


### PR DESCRIPTION
    [spirv-ll] Rename 'get' method for clarify
    
    There are many overloaded 'get' functions in spirv-ll, and it can be
    confusing whether we're getting an Op from a spv::Id, an Op from a
    llvm::Value, or an Op from a llvm::Type. This is especially because
    there are many variables we call variants of "ty" or "type":
    
    * `spv::Id structType`
    * `OpType *sourceOpType`
    * `llvm::Type *resultType`
    
    Tracking the types of all these variables can be difficult when many
    things are declared with `auto`. One way of combatting this is by better
    naming the functions which declare these types.

Second commit:

    [spirv-ll] Rename 'getType' method for clarity
    
    This is to try to help prevent it getting confused with a method that
    returns a SPIR-V `OpType` value.
