### PR TITLE
Fix dependency on resources.

### DIFF
--- a/cmake/ResourceCompiler.cmake
+++ b/cmake/ResourceCompiler.cmake
@@ -300,10 +300,6 @@ function(target_resources target)
     message(FATAL_ERROR "One or more NAMESPACES must be provided.")
   endif()
 
-  foreach(namespace ${args_NAMESPACES})
-    add_dependencies(${target} resources-${namespace})
-  endforeach()
-
   # Generate the .s/.rc files and add them to the specified target.
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
@@ -316,6 +312,7 @@ function(target_resources target)
 
     foreach(namespace ${args_NAMESPACES})
       get_target_property(resources resources-${namespace} RESOURCES)
+      set_property(SOURCE ${resources_file} APPEND PROPERTY OBJECT_DEPENDS ${resources})
 
       foreach(resource ${resources})
         get_filename_component(name ${resource} NAME)
@@ -377,6 +374,7 @@ ${name}_size:
 
     foreach(namespace ${args_NAMESPACES})
       get_target_property(resources resources-${namespace} RESOURCES)
+      set_property(SOURCE ${resources_file} APPEND PROPERTY OBJECT_DEPENDS ${resources})
 
       foreach(resource ${resources})
         get_filename_component(name ${resource} NAME)
@@ -402,6 +400,8 @@ ${CNAME}_ID RCDATA \"${resource}\"
 
     foreach(namespace ${args_NAMESPACES})
       get_target_property(resources resources-${namespace} RESOURCES)
+      set_property(SOURCE ${resources_file} APPEND PROPERTY OBJECT_DEPENDS ${resources})
+
       foreach(resource ${resources})
         get_filename_component(name ${resource} NAME)
         string(REGEX REPLACE "[-\\.]" "_" name ${name})


### PR DESCRIPTION
# Overview

Fix dependency on resources.

# Reason for change

Currently, when using `target_resources`, if a resource changes and we rebuild, the new resource is built but not included.

# Description of change

It is not the final target that depends on the resources, it is the intermediate object file. The intermediate object file was not getting regenerated when the resources changed.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
