### PR TITLE
[spirv-ll] Replace most internal uses of cargo types

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -49,6 +49,12 @@ static constexpr const char SAMPLER_INIT_FN[] =
 
 class Builder;
 
+/// Wrap a string into an llvm::StringError.
+static inline llvm::Error makeStringError(const llvm::Twine &message) {
+  return llvm::make_error<llvm::StringError>(message.str(),
+                                             llvm::inconvertibleErrorCode());
+}
+
 class OpenCLBuilder {
  public:
   /// @brief Constructor.
@@ -63,10 +69,10 @@ class OpenCLBuilder {
   /// @tparam T The OpenCL extended instruction class template to create.
   /// @param opc The OpCode object to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <typename T>
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  llvm::Error create(OpExtInst const &opc);
 
   /// @brief Create a vector OpenCL extended instruction transformation to LLVM
   /// IR.
@@ -74,10 +80,10 @@ class OpenCLBuilder {
   /// @tparam inst The OpenCL extended instruction to create.
   /// @param opc The OpCode object to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <OpenCLLIB::Entrypoints inst>
-  cargo::optional<spirv_ll::Error> createVec(OpExtInst const &opc);
+  llvm::Error createVec(OpExtInst const &opc);
 
   /// @brief Create an OpenCL extended instruction transformation to LLVM IR.
   ///
@@ -86,9 +92,9 @@ class OpenCLBuilder {
   ///
   /// @param opc The OpCode object to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  llvm::Error create(OpExtInst const &opc);
 
  private:
   /// @brief `spirv_ll::Builder` that owns this object.
@@ -112,10 +118,10 @@ class GLSLBuilder {
   /// @tparam inst The GLSL extended instruction to create.
   /// @param opc The OpCode object to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <enum GLSLstd450 inst>
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  llvm::Error create(OpExtInst const &opc);
 
   /// @brief Create a GLSL extended instruction transformation to LLVM IR.
   ///
@@ -124,9 +130,9 @@ class GLSLBuilder {
   ///
   /// @param opc The OpCode object to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  llvm::Error create(OpExtInst const &opc);
 
  private:
   /// @brief `spirv_ll::Builder` that owns this object.
@@ -162,10 +168,10 @@ class GroupAsyncCopiesBuilder {
   /// create.
   /// @param opc The spirv_ll::OpCode object to translate.
   ///
-  /// @return Returns an optional where cargo::nullopt represents success,
-  /// otherwise returns a spirv_ll::Error object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <Instruction inst>
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  llvm::Error create(OpExtInst const &opc);
 
   /// @brief Create a Codeplay.GroupAsyncCopies extended instruction
   /// transformation to LLVM IR.
@@ -175,9 +181,9 @@ class GroupAsyncCopiesBuilder {
   ///
   /// @param opc The spirv_ll::OpCode object to translate.
   ///
-  /// @return Returns an optional where cargo::nullopt represents success,
-  /// otherwise returns a spirv_ll::Error object containing a diagnostic.
-  cargo::optional<spirv_ll::Error> create(OpExtInst const &opc);
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  llvm::Error create(OpExtInst const &opc);
 
  private:
   /// @brief Reference to the spirv_ll::Builder that owns this object.
@@ -298,10 +304,10 @@ class Builder {
   /// @tparam Op The type of OpCode to create.
   /// @param op The base object to create the derived OpCode from.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <class Op>
-  cargo::optional<spirv_ll::Error> create(const OpCode &op) {
+  llvm::Error create(const OpCode &op) {
     return create<Op>(module.create<Op>(op));
   }
 
@@ -310,10 +316,10 @@ class Builder {
   /// @tparam Op The type of OpCode to create.
   /// @param op The OpCode to translate.
   ///
-  /// @return Returns an optional where `cargo::nullopt` represents success,
-  /// otherwise returns a `spirv_ll::Error` object containing a diagnostic.
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
   template <class Op>
-  cargo::optional<spirv_ll::Error> create(const Op *op);
+  llvm::Error create(const Op *op);
 
   /// @brief Populate the incoming edges/values for the given Phi node
   /// @param op The SpirV Op for the Phi node

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -678,7 +678,7 @@ class Module : public ModuleHeader {
   /// @param[in] argno the zero-indexed argument number
   /// @return SPIR-V SSA ID referring to the parameter type or nullopt on
   /// failure
-  cargo::optional<spv::Id> getParamTypeID(spv::Id func, unsigned argno) const;
+  std::optional<spv::Id> getParamTypeID(spv::Id func, unsigned argno) const;
 
   /// @brief Get the LLVM Type for the given SPIR-V ID.
   ///
@@ -909,8 +909,8 @@ class Module : public ModuleHeader {
   /// @param id ID of the spec constant.
   ///
   /// @return Return the specialization ID of the spec constant if present,
-  /// `cargo::nullopt` otherwise.
-  cargo::optional<uint32_t> getSpecId(spv::Id id) const;
+  /// `std::nullopt` otherwise.
+  std::optional<uint32_t> getSpecId(spv::Id id) const;
 
   /// @brief Get a pointer to the push constant struct type defined in the
   /// module.

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -43,37 +43,35 @@
 namespace spirv_ll {
 
 template <>
-cargo::optional<Error> Builder::create<OpNop>(const OpNop *) {
+llvm::Error Builder::create<OpNop>(const OpNop *) {
   // Intentional no-op
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUndef>(const OpUndef *op) {
+llvm::Error Builder::create<OpUndef>(const OpUndef *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
   module.addID(op->IdResult(), op, llvm::UndefValue::get(type));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSourceContinued>(
-    const OpSourceContinued *op) {
+llvm::Error Builder::create<OpSourceContinued>(const OpSourceContinued *op) {
   module.appendSourceMetadataString(op->ContinuedSource().str());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSourceExtension>(
-    const OpSourceExtension *) {
+llvm::Error Builder::create<OpSourceExtension>(const OpSourceExtension *) {
   // This instruction has no semantic impact and doesn't represent any
   // information that is currently relevant to us.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSource>(const OpSource *op) {
+llvm::Error Builder::create<OpSource>(const OpSource *op) {
   module.setSourceLanguage(op->SourceLanguage());
 
   if (module.getSourceMetadataString().size() > 0) {
@@ -112,24 +110,24 @@ cargo::optional<Error> Builder::create<OpSource>(const OpSource *op) {
     }
   }
   module.setSourceMetadataString(source);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpName>(const OpName *op) {
+llvm::Error Builder::create<OpName>(const OpName *op) {
   module.addName(op->Target(), op->Name().str());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMemberName>(const OpMemberName *) {
-  return cargo::nullopt;
+llvm::Error Builder::create<OpMemberName>(const OpMemberName *) {
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpString>(const OpString *op) {
+llvm::Error Builder::create<OpString>(const OpString *op) {
   module.addDebugString(op->IdResult(), op->String().str());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 llvm::DIFile *Builder::getOrCreateDIFile(const OpLine *op_line) {
@@ -225,7 +223,7 @@ Module::LineRangeBeginTy Builder::createLineRangeBegin(const OpLine *op_line,
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLine>(const OpLine *op) {
+llvm::Error Builder::create<OpLine>(const OpLine *op) {
   // Close the current range, if applicable.
   checkEndOpLineRange();
 
@@ -239,7 +237,7 @@ cargo::optional<Error> Builder::create<OpLine>(const OpLine *op) {
                                       op->Column(), module.getDIFile());
     module.setCurrentOpLineRange(Module::LineRangeBeginTy{op, loc});
 
-    return cargo::nullopt;
+    return llvm::Error::success();
   }
 
   llvm::DISubprogram *function_scope =
@@ -255,12 +253,12 @@ cargo::optional<Error> Builder::create<OpLine>(const OpLine *op) {
                                       op->Column(), function_scope);
     module.setCurrentOpLineRange(Module::LineRangeBeginTy{op, loc});
 
-    return cargo::nullopt;
+    return llvm::Error::success();
   }
 
   module.setCurrentOpLineRange(createLineRangeBegin(op, *current_block));
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 void Builder::checkEndOpLineRange() {
@@ -288,21 +286,21 @@ void Builder::checkEndOpLineRange() {
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpExtension>(const OpExtension *op) {
+llvm::Error Builder::create<OpExtension>(const OpExtension *op) {
   auto extension = op->Name();
   if (std::none_of(deviceInfo.extensions.begin(), deviceInfo.extensions.end(),
                    [&](const std::string &deviceExtension) {
                      return extension == deviceExtension;
                    })) {
-    return Error{"OpExtension " + extension.str() + " not supported by device"};
+    return makeStringError("OpExtension " + extension.str() +
+                           " not supported by device");
   }
   module.declareExtension(extension);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpExtInstImport>(
-    const OpExtInstImport *op) {
+llvm::Error Builder::create<OpExtInstImport>(const OpExtInstImport *op) {
   auto name = op->Name();
   if (name == "GLSL.std.450") {
     module.associateExtendedInstrSet(op->IdResult(), ExtendedInstrSet::GLSL450);
@@ -317,11 +315,11 @@ cargo::optional<Error> Builder::create<OpExtInstImport>(
             static_cast<int>(name.size()), name.data());
     abort();
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpExtInst>(const OpExtInst *op) {
+llvm::Error Builder::create<OpExtInst>(const OpExtInst *op) {
   switch (module.getExtendedInstrSet(op->Set())) {
     case ExtendedInstrSet::GLSL450:
       return GLSLBuilder.create(*op);
@@ -330,18 +328,18 @@ cargo::optional<Error> Builder::create<OpExtInst>(const OpExtInst *op) {
     case ExtendedInstrSet::GroupAsyncCopies:
       return GroupAsyncCopiesBuilder.create(*op);
     default: {
-      return Error("Could not find extended instruction set for ID " +
-                   std::to_string(op->Set()));
+      return makeStringError("Could not find extended instruction set for ID " +
+                             std::to_string(op->Set()));
     }
   }
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMemoryModel>(const OpMemoryModel *op) {
+llvm::Error Builder::create<OpMemoryModel>(const OpMemoryModel *op) {
   if (deviceInfo.addressingModel != op->AddressingModel()) {
-    return Error{"OpMemoryModel AddressingModel " +
-                 std::to_string(op->AddressingModel()) +
-                 " not supported by device"};
+    return makeStringError("OpMemoryModel AddressingModel " +
+                           std::to_string(op->AddressingModel()) +
+                           " not supported by device");
   }
   switch (op->AddressingModel()) {
     case spv::AddressingModel::AddressingModelLogical:
@@ -376,19 +374,18 @@ cargo::optional<Error> Builder::create<OpMemoryModel>(const OpMemoryModel *op) {
               deviceInfo.addressBits == 64)) {
     module.llvmModule->setDataLayout(dataLayout64);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEntryPoint>(const OpEntryPoint *op) {
+llvm::Error Builder::create<OpEntryPoint>(const OpEntryPoint *op) {
   module.addName(op->EntryPoint(), op->Name().str());
   module.addEntryPoint(op);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpExecutionMode>(
-    const OpExecutionMode *op) {
+llvm::Error Builder::create<OpExecutionMode>(const OpExecutionMode *op) {
   module.addExecutionMode(op);
   switch (op->Mode()) {
     case spv::ExecutionMode::ExecutionModeLocalSize: {
@@ -402,44 +399,44 @@ cargo::optional<Error> Builder::create<OpExecutionMode>(
     default:
       break;
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCapability>(const OpCapability *op) {
+llvm::Error Builder::create<OpCapability>(const OpCapability *op) {
   auto capability = op->Capability();
   if (std::none_of(deviceInfo.capabilities.begin(),
                    deviceInfo.capabilities.end(),
                    [&](spv::Capability deviceCapability) {
                      return capability == deviceCapability;
                    })) {
-    return Error{"OpCapability " + getCapabilityName(capability) +
-                 " not supported by device"};
+    return makeStringError("OpCapability " + getCapabilityName(capability) +
+                           " not supported by device");
   }
   module.enableCapability(capability);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeVoid>(const OpTypeVoid *op) {
+llvm::Error Builder::create<OpTypeVoid>(const OpTypeVoid *op) {
   module.addID(op->IdResult(), op, IRBuilder.getVoidTy());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeBool>(const OpTypeBool *op) {
+llvm::Error Builder::create<OpTypeBool>(const OpTypeBool *op) {
   module.addID(op->IdResult(), op, IRBuilder.getInt1Ty());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeInt>(const OpTypeInt *op) {
+llvm::Error Builder::create<OpTypeInt>(const OpTypeInt *op) {
   module.addID(op->IdResult(), op, IRBuilder.getIntNTy(op->Width()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeFloat>(const OpTypeFloat *op) {
+llvm::Error Builder::create<OpTypeFloat>(const OpTypeFloat *op) {
   if (op->Width() == 16) {
     module.addID(op->IdResult(), op, IRBuilder.getHalfTy());
   } else if (op->Width() == 32) {
@@ -447,33 +444,33 @@ cargo::optional<Error> Builder::create<OpTypeFloat>(const OpTypeFloat *op) {
   } else if (op->Width() == 64) {
     module.addID(op->IdResult(), op, IRBuilder.getDoubleTy());
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeVector>(const OpTypeVector *op) {
+llvm::Error Builder::create<OpTypeVector>(const OpTypeVector *op) {
   llvm::Type *componentType = module.getLLVMType(op->ComponentType());
 
   SPIRV_LL_ASSERT_PTR(componentType);
 
   module.addID(op->IdResult(), op,
                llvm::FixedVectorType::get(componentType, op->ComponentCount()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeMatrix>(const OpTypeMatrix *op) {
+llvm::Error Builder::create<OpTypeMatrix>(const OpTypeMatrix *op) {
   llvm::Type *columnType = module.getLLVMType(op->ColumnType());
 
   SPIRV_LL_ASSERT_PTR(columnType);
 
   module.addID(op->IdResult(), op,
                llvm::ArrayType::get(columnType, op->ColumnCount()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeImage>(const OpTypeImage *op) {
+llvm::Error Builder::create<OpTypeImage>(const OpTypeImage *op) {
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
   llvm::Type *imageType = nullptr;
   auto &ctx = *context.llvmContext;
@@ -568,11 +565,11 @@ cargo::optional<Error> Builder::create<OpTypeImage>(const OpTypeImage *op) {
   // need to know the underlying type (e.g., for mangling)
   module.addInternalStructType(op->IdResult(), structTy);
 #endif
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeSampler>(const OpTypeSampler *op) {
+llvm::Error Builder::create<OpTypeSampler>(const OpTypeSampler *op) {
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
   module.addID(op->IdResult(), op,
                compiler::utils::tgtext::getSamplerTy(*context.llvmContext));
@@ -591,17 +588,16 @@ cargo::optional<Error> Builder::create<OpTypeSampler>(const OpTypeSampler *op) {
   // need to know the underlying type (e.g., for mangling)
   module.addInternalStructType(op->IdResult(), sampler_struct);
 #endif
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeSampledImage>(
-    const OpTypeSampledImage *) {
-  return cargo::nullopt;
+llvm::Error Builder::create<OpTypeSampledImage>(const OpTypeSampledImage *) {
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeArray>(const OpTypeArray *op) {
+llvm::Error Builder::create<OpTypeArray>(const OpTypeArray *op) {
   llvm::Type *elementType = module.getLLVMType(op->ElementType());
   llvm::Value *length = module.getValue(op->Length());
 
@@ -612,22 +608,21 @@ cargo::optional<Error> Builder::create<OpTypeArray>(const OpTypeArray *op) {
 
   module.addID(op->IdResult(), op,
                llvm::ArrayType::get(elementType, lengthCst->getZExtValue()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeRuntimeArray>(
-    const OpTypeRuntimeArray *op) {
+llvm::Error Builder::create<OpTypeRuntimeArray>(const OpTypeRuntimeArray *op) {
   llvm::Type *elementType = module.getLLVMType(op->ElementType());
 
   SPIRV_LL_ASSERT_PTR(elementType);
 
   module.addID(op->IdResult(), op, llvm::ArrayType::get(elementType, 0));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeStruct>(const OpTypeStruct *op) {
+llvm::Error Builder::create<OpTypeStruct>(const OpTypeStruct *op) {
   bool forwardDeclared = false;
   llvm::SmallVector<spv::Id, 4> memberTypeIDs;
   llvm::SmallVector<spv::Id, 2> forwardPointerIDs;
@@ -667,30 +662,29 @@ cargo::optional<Error> Builder::create<OpTypeStruct>(const OpTypeStruct *op) {
 
     module.addID(op->IdResult(), op, structTy);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeOpaque>(const OpTypeOpaque *op) {
+llvm::Error Builder::create<OpTypeOpaque>(const OpTypeOpaque *op) {
   module.addID(op->IdResult(), op,
                llvm::StructType::create(*context.llvmContext, op->Name()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypePointer>(const OpTypePointer *op) {
+llvm::Error Builder::create<OpTypePointer>(const OpTypePointer *op) {
   spv::Id typeId = op->Type();
   if (module.isForwardPointer(typeId)) {
     module.addIncompletePointer(op, typeId);
   } else {
     module.addCompletePointer(op);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeFunction>(
-    const OpTypeFunction *op) {
+llvm::Error Builder::create<OpTypeFunction>(const OpTypeFunction *op) {
   llvm::Type *returnType = module.getLLVMType(op->ReturnType());
   SPIRV_LL_ASSERT_PTR(returnType);
 
@@ -712,11 +706,11 @@ cargo::optional<Error> Builder::create<OpTypeFunction>(
 
   module.setParamTypeIDs(id, paramTypeIds);
   module.addID(id, op, functionType);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeEvent>(const OpTypeEvent *op) {
+llvm::Error Builder::create<OpTypeEvent>(const OpTypeEvent *op) {
 #if LLVM_VERSION_GREATER_EQUAL(17, 0)
   module.addID(op->IdResult(), op,
                compiler::utils::tgtext::getEventTy(*context.llvmContext));
@@ -728,54 +722,51 @@ cargo::optional<Error> Builder::create<OpTypeEvent>(const OpTypeEvent *op) {
   // need to know the underlying type (e.g., for mangling)
   module.addInternalStructType(op->IdResult(), event_struct);
 #endif
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
-static Error errorUnsupportedDeviceEnqueueOp(const std::string &opName) {
+static llvm::Error errorUnsupportedDeviceEnqueueOp(const std::string &opName) {
   // Capability DeviceEnqueue isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 3.1 for supported capabilities.
   // It is, however, implicitly declared by SPIR-V 1.1 modules which declare the
   // SubgroupDispatch capability for CL 3.0 devices supporting subgroups. This
   // is highly dubious, and appears like a spec bug of some kind.
-  return Error(opName + " is not supported.");
+  return makeStringError(opName + " is not supported.");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeDeviceEvent>(
-    const OpTypeDeviceEvent *) {
+llvm::Error Builder::create<OpTypeDeviceEvent>(const OpTypeDeviceEvent *) {
   return errorUnsupportedDeviceEnqueueOp("OpTypeDeviceEvent");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeReserveId>(
-    const OpTypeReserveId *) {
+llvm::Error Builder::create<OpTypeReserveId>(const OpTypeReserveId *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeQueue>(const OpTypeQueue *) {
+llvm::Error Builder::create<OpTypeQueue>(const OpTypeQueue *) {
   return errorUnsupportedDeviceEnqueueOp("OpTypeQueue");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypePipe>(const OpTypePipe *) {
+llvm::Error Builder::create<OpTypePipe>(const OpTypePipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTypeForwardPointer>(
+llvm::Error Builder::create<OpTypeForwardPointer>(
     const OpTypeForwardPointer *op) {
   module.addForwardPointer(op->PointerType());
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstantTrue>(
-    const OpConstantTrue *op) {
+llvm::Error Builder::create<OpConstantTrue>(const OpConstantTrue *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
@@ -784,12 +775,11 @@ cargo::optional<Error> Builder::create<OpConstantTrue>(
   constant->setName(module.getName(op->IdResult()));
 
   module.addID(op->IdResult(), op, constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstantFalse>(
-    const OpConstantFalse *op) {
+llvm::Error Builder::create<OpConstantFalse>(const OpConstantFalse *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
@@ -798,11 +788,11 @@ cargo::optional<Error> Builder::create<OpConstantFalse>(
   constant->setName(module.getName(op->IdResult()));
 
   module.addID(op->IdResult(), op, constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstant>(const OpConstant *op) {
+llvm::Error Builder::create<OpConstant>(const OpConstant *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
@@ -850,11 +840,11 @@ cargo::optional<Error> Builder::create<OpConstant>(const OpConstant *op) {
 
   constant->setName(module.getName(op->IdResult()));
   module.addID(op->IdResult(), op, constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstantComposite>(
+llvm::Error Builder::create<OpConstantComposite>(
     const OpConstantComposite *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
@@ -888,12 +878,11 @@ cargo::optional<Error> Builder::create<OpConstantComposite>(
 
   constant->setName(module.getName(op->IdResult()));
   module.addID(op->IdResult(), op, constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstantSampler>(
-    const OpConstantSampler *op) {
+llvm::Error Builder::create<OpConstantSampler>(const OpConstantSampler *op) {
   // Translate SPIR-V enums into values from SPIR 1.2 spec Table 4
   // https://www.khronos.org/registry/SPIR/specs/spir_spec-1.2.pdf
   static const uint32_t addressingModes[] = {
@@ -925,12 +914,11 @@ cargo::optional<Error> Builder::create<OpConstantSampler>(
   SPIRV_LL_ASSERT_PTR(constSampler);
 
   module.addID(op->IdResult(), op, constSampler);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConstantNull>(
-    const OpConstantNull *op) {
+llvm::Error Builder::create<OpConstantNull>(const OpConstantNull *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
   SPIRV_LL_ASSERT_PTR(type);
@@ -983,12 +971,11 @@ cargo::optional<Error> Builder::create<OpConstantNull>(
   }
   constant->setName(module.getName(op->IdResult()));
   module.addID(op->IdResult(), op, constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSpecConstantTrue>(
-    const OpSpecConstantTrue *op) {
+llvm::Error Builder::create<OpSpecConstantTrue>(const OpSpecConstantTrue *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -1016,11 +1003,11 @@ cargo::optional<Error> Builder::create<OpSpecConstantTrue>(
   }
 
   module.addID(op->IdResult(), op, spec_constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSpecConstantFalse>(
+llvm::Error Builder::create<OpSpecConstantFalse>(
     const OpSpecConstantFalse *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
@@ -1049,12 +1036,11 @@ cargo::optional<Error> Builder::create<OpSpecConstantFalse>(
   }
 
   module.addID(op->IdResult(), op, spec_constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSpecConstant>(
-    const OpSpecConstant *op) {
+llvm::Error Builder::create<OpSpecConstant>(const OpSpecConstant *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -1132,11 +1118,11 @@ cargo::optional<Error> Builder::create<OpSpecConstant>(
   }
 
   module.addID(op->IdResult(), op, spec_constant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSpecConstantComposite>(
+llvm::Error Builder::create<OpSpecConstantComposite>(
     const OpSpecConstantComposite *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
@@ -1183,12 +1169,11 @@ cargo::optional<Error> Builder::create<OpSpecConstantComposite>(
   }
 
   module.addID(op->IdResult(), op, spec_constant_composite);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSpecConstantOp>(
-    const OpSpecConstantOp *op) {
+llvm::Error Builder::create<OpSpecConstantOp>(const OpSpecConstantOp *op) {
   llvm::Type *result_type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(result_type);
 
@@ -1652,7 +1637,7 @@ cargo::optional<Error> Builder::create<OpSpecConstantOp>(
       // Defer the op so we can call the fmod builtin.
       module.deferSpecConstantOp(op);
 
-      return cargo::nullopt;
+      return llvm::Error::success();
       break;
     }
     case spv::OpAccessChain:
@@ -1702,13 +1687,13 @@ cargo::optional<Error> Builder::create<OpSpecConstantOp>(
     // function, so defer the translation.
     case spv::OpFMod: {
       module.deferSpecConstantOp(op);
-      return cargo::nullopt;
+      return llvm::Error::success();
     }
     default:
       llvm_unreachable("Invalid OpCode given to OpSpecConstantOp");
   }
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 namespace {
@@ -1735,7 +1720,7 @@ static std::optional<std::pair<uint32_t, const char *>> getLinkage(
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
+llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
   // get function type
   auto *function_type = llvm::dyn_cast<llvm::FunctionType>(
       module.getLLVMType(op->FunctionType()));
@@ -2021,12 +2006,12 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
             case spv::ExecutionModeSubgroupsPerWorkgroup:
               // We declare we support SubgroupDispatch but really we only do so
               // to handle SubgroupSize.
-              return Error(
+              return makeStringError(
                   "Execution Mode SubgroupsPerWorkgroup is not supported.");
             case spv::ExecutionModeSubgroupsPerWorkgroupId:
               // We declare we support SubgroupDispatch but really we only do so
               // to handle SubgroupSize.
-              return Error(
+              return makeStringError(
                   "Execution Mode SubgroupsPerWorkgroupId is not supported.");
             default:
               break;
@@ -2100,7 +2085,7 @@ cargo::optional<Error> Builder::create<OpFunction>(const OpFunction *op) {
     getOrCreateDebugFunctionScope(function, current_range->op_line);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 namespace {
@@ -2113,7 +2098,7 @@ inline void addTypeAttr(llvm::Argument *arg, llvm::Type *ty,
 }  // namespace
 
 template <>
-cargo::optional<Error> Builder::create<OpFunctionParameter>(
+llvm::Error Builder::create<OpFunctionParameter>(
     const OpFunctionParameter *op) {
   SPIRV_LL_ASSERT_PTR(getCurrentFunction());
   auto param = popFunctionArg();
@@ -2136,7 +2121,7 @@ cargo::optional<Error> Builder::create<OpFunctionParameter>(
             arg->addAttr(llvm::Attribute::SExt);
             break;
           default:
-            return Error(
+            return makeStringError(
                 "Invalid function parameter attribute for integer type.");
         }
       } else if (arg->getType()->isPointerTy()) {
@@ -2164,7 +2149,7 @@ cargo::optional<Error> Builder::create<OpFunctionParameter>(
             arg->addAttr(llvm::Attribute::WriteOnly);
             break;
           default:
-            return Error(
+            return makeStringError(
                 "Invalid function parameter attribute for pointer type.");
         }
       }
@@ -2196,7 +2181,7 @@ cargo::optional<Error> Builder::create<OpFunctionParameter>(
   }
 
   module.addID(op->IdResult(), op, param);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 namespace {
@@ -2311,7 +2296,7 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
 }  // namespace
 
 template <>
-cargo::optional<Error> Builder::create<OpFunctionEnd>(const OpFunctionEnd *) {
+llvm::Error Builder::create<OpFunctionEnd>(const OpFunctionEnd *) {
   llvm::Function *function = getCurrentFunction();
   SPIRV_LL_ASSERT_PTR(function);
 
@@ -2334,7 +2319,8 @@ cargo::optional<Error> Builder::create<OpFunctionEnd>(const OpFunctionEnd *) {
       const unsigned argNo = arg.getArgNo();
       auto argTyOr = module.getParamTypeID(opTypeFunction->IdResult(), argNo);
       if (!argTyOr.has_value()) {
-        return Error("failed to lookup pointer type for formal parameter");
+        return makeStringError(
+            "failed to lookup pointer type for formal parameter");
       }
       const spv::Id typeID = argTyOr.value();
 
@@ -2418,7 +2404,7 @@ cargo::optional<Error> Builder::create<OpFunctionEnd>(const OpFunctionEnd *) {
 
   setCurrentFunction(nullptr);
   checkEndOpLineRange();
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 static inline llvm::Attribute getTypedAttr(llvm::LLVMContext &c,
@@ -2431,8 +2417,7 @@ static inline llvm::Attribute getTypedAttr(llvm::LLVMContext &c,
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFunctionCall>(
-    const OpFunctionCall *op) {
+llvm::Error Builder::create<OpFunctionCall>(const OpFunctionCall *op) {
   llvm::Function *callee;
   const unsigned n_args = op->wordCount() - 4;
 
@@ -2533,11 +2518,11 @@ cargo::optional<Error> Builder::create<OpFunctionCall>(
     }
   }
   module.addID(op->IdResult(), op, call);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
+llvm::Error Builder::create<OpVariable>(const OpVariable *op) {
   llvm::Type *varPtrTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(varPtrTy);
 
@@ -2644,9 +2629,9 @@ cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
           // Visible only within the declaring function of the current
           // invocation. Regular function memory.
           if (!IRBuilder.GetInsertBlock()) {
-            return Error{
+            return makeStringError(
                 "invalid SPIR-V: variables can not have a function[7] "
-                "storage class outside of a function"};
+                "storage class outside of a function");
           }
           value = IRBuilder.CreateAlloca(varTy);
           value->setName(name);
@@ -2765,14 +2750,14 @@ cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
                 *module.llvmModule, varPtrTy, false,
                 llvm::GlobalValue::LinkageTypes::PrivateLinkage,
                 llvm::UndefValue::get(varPtrTy)));
-        return cargo::nullopt;
+        return llvm::Error::success();
       case spv::StorageClassPushConstant:
         module.setPushConstantStructVariable(
             op->IdResult(), new llvm::GlobalVariable(
                                 *module.llvmModule, varPtrTy, false,
                                 llvm::GlobalValue::LinkageTypes::PrivateLinkage,
                                 llvm::UndefValue::get(varPtrTy)));
-        return cargo::nullopt;
+        return llvm::Error::success();
       case spv::StorageClassOutput:
       case spv::StorageClassAtomicCounter:
       case spv::StorageClassImage:
@@ -2800,22 +2785,21 @@ cargo::optional<Error> Builder::create<OpVariable>(const OpVariable *op) {
   }
 
   module.addID(op->IdResult(), op, value);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageTexelPointer>(
-    const OpImageTexelPointer *) {
+llvm::Error Builder::create<OpImageTexelPointer>(const OpImageTexelPointer *) {
   // This instruction is only useful to Vulkan, as it produces a pointer with
   // storage class Image which is only to be used for atomic operations, but the
   // OpenCL SPIR-V environment spec forbids storage class Image for atomic
   // operations (see section 2.1). It will remain unimplemented until VK gets
   // image support.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLoad>(const OpLoad *op) {
+llvm::Error Builder::create<OpLoad>(const OpLoad *op) {
   llvm::Value *ptr = module.getValue(op->Pointer());
   llvm::Type *type = module.getLLVMType(op->IdResultType());
 
@@ -2850,11 +2834,11 @@ cargo::optional<Error> Builder::create<OpLoad>(const OpLoad *op) {
   }
 
   module.addID(op->IdResult(), op, load);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpStore>(const OpStore *op) {
+llvm::Error Builder::create<OpStore>(const OpStore *op) {
   llvm::Value *ptr = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(ptr);
 
@@ -2887,11 +2871,11 @@ cargo::optional<Error> Builder::create<OpStore>(const OpStore *op) {
   if (module.getFirstDecoration(op->Pointer(), spv::DecorationVolatile)) {
     store->setVolatile(true);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCopyMemory>(const OpCopyMemory *op) {
+llvm::Error Builder::create<OpCopyMemory>(const OpCopyMemory *op) {
   llvm::Value *source = module.getValue(op->Source());
   SPIRV_LL_ASSERT_PTR(source);
   SPIRV_LL_ASSERT(source->getType()->isPointerTy(), "Source is not a pointer");
@@ -2935,12 +2919,11 @@ cargo::optional<Error> Builder::create<OpCopyMemory>(const OpCopyMemory *op) {
 
   IRBuilder.CreateMemCpy(target, llvm::MaybeAlign(alignment), source,
                          llvm::MaybeAlign(alignment), size, isVolatile);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCopyMemorySized>(
-    const OpCopyMemorySized *op) {
+llvm::Error Builder::create<OpCopyMemorySized>(const OpCopyMemorySized *op) {
   llvm::Value *source = module.getValue(op->Source());
   SPIRV_LL_ASSERT_PTR(source);
 
@@ -2993,7 +2976,7 @@ cargo::optional<Error> Builder::create<OpCopyMemorySized>(
           // really strange copy operation after all.
           IRBuilder.CreateMemCpy(target, llvm::MaybeAlign(alignment), source,
                                  llvm::MaybeAlign(alignment), size, isVolatile);
-          return cargo::nullopt;
+          return llvm::Error::success();
         }
       }
       // If we made it this far we now know that the whole intializer array
@@ -3006,11 +2989,11 @@ cargo::optional<Error> Builder::create<OpCopyMemorySized>(
     IRBuilder.CreateMemCpy(target, llvm::MaybeAlign(alignment), source,
                            llvm::MaybeAlign(alignment), size, isVolatile);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAccessChain>(const OpAccessChain *op) {
+llvm::Error Builder::create<OpAccessChain>(const OpAccessChain *op) {
   llvm::Value *base = module.getValue(op->Base());
   SPIRV_LL_ASSERT_PTR(base);
 
@@ -3034,11 +3017,11 @@ cargo::optional<Error> Builder::create<OpAccessChain>(const OpAccessChain *op) {
   }
 
   module.addID(op->IdResult(), op, inst);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpInBoundsAccessChain>(
+llvm::Error Builder::create<OpInBoundsAccessChain>(
     const OpInBoundsAccessChain *op) {
   auto base = module.getValue(op->Base());
   SPIRV_LL_ASSERT_PTR(base);
@@ -3059,18 +3042,16 @@ cargo::optional<Error> Builder::create<OpInBoundsAccessChain>(
       IRBuilder.GetInsertBlock());
   inst->setIsInBounds();
 
-
   if (basePointeeTy->isStructTy()) {
     checkMemberDecorations(basePointeeTy, indexes, op->IdResult());
   }
 
   module.addID(op->IdResult(), op, inst);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpPtrAccessChain>(
-    const OpPtrAccessChain *op) {
+llvm::Error Builder::create<OpPtrAccessChain>(const OpPtrAccessChain *op) {
   auto base = module.getValue(op->Base());
   SPIRV_LL_ASSERT_PTR(base);
 
@@ -3097,11 +3078,11 @@ cargo::optional<Error> Builder::create<OpPtrAccessChain>(
   }
 
   module.addID(op->IdResult(), op, inst);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpArrayLength>(const OpArrayLength *op) {
+llvm::Error Builder::create<OpArrayLength>(const OpArrayLength *op) {
   llvm::Type *blockType = module.getBlockType(op->Structure());
 
   if (blockType) {
@@ -3169,20 +3150,20 @@ cargo::optional<Error> Builder::create<OpArrayLength>(const OpArrayLength *op) {
                  IRBuilder.CreateUDiv(arraySizeInBytes,
                                       IRBuilder.getInt32(arrayElementSize)));
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGenericPtrMemSemantics>(
+llvm::Error Builder::create<OpGenericPtrMemSemantics>(
     const OpGenericPtrMemSemantics *) {
   // The generic storage class requires the GenericPointer capability, which is
   // not supported by OpenCL 1.2, see the OpenCL SPIR-V environment spec section
   // 6.1.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpInBoundsPtrAccessChain>(
+llvm::Error Builder::create<OpInBoundsPtrAccessChain>(
     const OpInBoundsPtrAccessChain *op) {
   auto base = module.getValue(op->Base());
   SPIRV_LL_ASSERT_PTR(base);
@@ -3207,33 +3188,30 @@ cargo::optional<Error> Builder::create<OpInBoundsPtrAccessChain>(
   inst->setIsInBounds();
 
   module.addID(op->IdResult(), op, inst);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDecorate>(const OpDecorate *op) {
+llvm::Error Builder::create<OpDecorate>(const OpDecorate *op) {
   module.addDecoration(op->Target(), op);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMemberDecorate>(
-    const OpMemberDecorate *op) {
+llvm::Error Builder::create<OpMemberDecorate>(const OpMemberDecorate *op) {
   module.addMemberDecoration(op->StructureType(), op->Member(), op);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDecorationGroup>(
-    const OpDecorationGroup *) {
+llvm::Error Builder::create<OpDecorationGroup>(const OpDecorationGroup *) {
   // the way we track decorations means that we don't actually have to do
   // anything here
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupDecorate>(
-    const OpGroupDecorate *op) {
+llvm::Error Builder::create<OpGroupDecorate>(const OpGroupDecorate *op) {
   auto groupDecorations = module.getDecorations(op->DecorationGroup());
 
   for (auto decorateOp : groupDecorations) {
@@ -3241,11 +3219,11 @@ cargo::optional<Error> Builder::create<OpGroupDecorate>(
       module.addDecoration(targetID, decorateOp);
     }
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupMemberDecorate>(
+llvm::Error Builder::create<OpGroupMemberDecorate>(
     const OpGroupMemberDecorate *op) {
   auto groupDecorations = module.getDecorations(op->DecorationGroup());
 
@@ -3255,11 +3233,11 @@ cargo::optional<Error> Builder::create<OpGroupMemberDecorate>(
       module.addMemberDecoration(target.Id, target.Literal, memberDecorate);
     }
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVectorExtractDynamic>(
+llvm::Error Builder::create<OpVectorExtractDynamic>(
     const OpVectorExtractDynamic *op) {
   llvm::Value *vector = module.getValue(op->Vector());
   SPIRV_LL_ASSERT_PTR(vector);
@@ -3271,11 +3249,11 @@ cargo::optional<Error> Builder::create<OpVectorExtractDynamic>(
   element->setName(module.getName(op->IdResult()));
 
   module.addID(op->IdResult(), op, element);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVectorInsertDynamic>(
+llvm::Error Builder::create<OpVectorInsertDynamic>(
     const OpVectorInsertDynamic *op) {
   llvm::Value *component = module.getValue(op->Component());
   SPIRV_LL_ASSERT_PTR(component);
@@ -3291,12 +3269,11 @@ cargo::optional<Error> Builder::create<OpVectorInsertDynamic>(
   new_vec->setName(module.getName(op->IdResult()));
 
   module.addID(op->IdResult(), op, new_vec);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVectorShuffle>(
-    const OpVectorShuffle *op) {
+llvm::Error Builder::create<OpVectorShuffle>(const OpVectorShuffle *op) {
   llvm::Value *v1 = module.getValue(op->Vector1());
   SPIRV_LL_ASSERT_PTR(v1);
 
@@ -3321,11 +3298,11 @@ cargo::optional<Error> Builder::create<OpVectorShuffle>(
   new_vec->setName(module.getName(op->IdResult()));
 
   module.addID(op->IdResult(), op, new_vec);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCompositeConstruct>(
+llvm::Error Builder::create<OpCompositeConstruct>(
     const OpCompositeConstruct *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
@@ -3369,12 +3346,11 @@ cargo::optional<Error> Builder::create<OpCompositeConstruct>(
 
     module.addID(op->IdResult(), op, new_composite);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCompositeExtract>(
-    const OpCompositeExtract *op) {
+llvm::Error Builder::create<OpCompositeExtract>(const OpCompositeExtract *op) {
   llvm::Value *composite = module.getValue(op->Composite());
   SPIRV_LL_ASSERT_PTR(composite);
 
@@ -3398,12 +3374,11 @@ cargo::optional<Error> Builder::create<OpCompositeExtract>(
 
     module.addID(op->IdResult(), op, element);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCompositeInsert>(
-    const OpCompositeInsert *op) {
+llvm::Error Builder::create<OpCompositeInsert>(const OpCompositeInsert *op) {
   llvm::Value *composite = module.getValue(op->Composite());
   SPIRV_LL_ASSERT_PTR(composite);
 
@@ -3431,11 +3406,11 @@ cargo::optional<Error> Builder::create<OpCompositeInsert>(
 
     module.addID(op->IdResult(), op, new_composite);
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCopyObject>(const OpCopyObject *op) {
+llvm::Error Builder::create<OpCopyObject>(const OpCopyObject *op) {
   llvm::Value *object = module.getValue(op->Operand());
   SPIRV_LL_ASSERT_PTR(object);
 
@@ -3461,18 +3436,17 @@ cargo::optional<Error> Builder::create<OpCopyObject>(const OpCopyObject *op) {
   }
 
   module.addID(op->IdResult(), op, new_object);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpTranspose>(const OpTranspose *) {
+llvm::Error Builder::create<OpTranspose>(const OpTranspose *) {
   // TODO: transpose builtin
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSampledImage>(
-    const OpSampledImage *op) {
+llvm::Error Builder::create<OpSampledImage>(const OpSampledImage *op) {
   llvm::Value *image = module.getValue(op->Image());
   SPIRV_LL_ASSERT_PTR(image);
 
@@ -3503,19 +3477,19 @@ cargo::optional<Error> Builder::create<OpSampledImage>(
   }
 
   module.addSampledImage(op->IdResult(), image, sampler);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleImplicitLod>(
+llvm::Error Builder::create<OpImageSampleImplicitLod>(
     const OpImageSampleImplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleExplicitLod>(
+llvm::Error Builder::create<OpImageSampleExplicitLod>(
     const OpImageSampleExplicitLod *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
@@ -3536,82 +3510,81 @@ cargo::optional<Error> Builder::create<OpImageSampleExplicitLod>(
       module.get<OpTypeVector>(op->IdResultType()));
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleDrefImplicitLod>(
+llvm::Error Builder::create<OpImageSampleDrefImplicitLod>(
     const OpImageSampleDrefImplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleDrefExplicitLod>(
+llvm::Error Builder::create<OpImageSampleDrefExplicitLod>(
     const OpImageSampleDrefExplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleProjImplicitLod>(
+llvm::Error Builder::create<OpImageSampleProjImplicitLod>(
     const OpImageSampleProjImplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleProjExplicitLod>(
+llvm::Error Builder::create<OpImageSampleProjExplicitLod>(
     const OpImageSampleProjExplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleProjDrefImplicitLod>(
+llvm::Error Builder::create<OpImageSampleProjDrefImplicitLod>(
     const OpImageSampleProjDrefImplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSampleProjDrefExplicitLod>(
+llvm::Error Builder::create<OpImageSampleProjDrefExplicitLod>(
     const OpImageSampleProjDrefExplicitLod *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageFetch>(const OpImageFetch *) {
+llvm::Error Builder::create<OpImageFetch>(const OpImageFetch *) {
   // This instruction is Vulkan exclusive as it requires the OpTypeImage to have
   // sampled set to 1, which the OpenCL SPIR-V environment spec forbids. For
   // this reason it will remain unimplemented until VK gets image support.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageGather>(const OpImageGather *) {
+llvm::Error Builder::create<OpImageGather>(const OpImageGather *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageDrefGather>(
-    const OpImageDrefGather *) {
+llvm::Error Builder::create<OpImageDrefGather>(const OpImageDrefGather *) {
   // This instruction is Shader capability so it will remain unimplemented until
   // VK has image support
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageRead>(const OpImageRead *op) {
+llvm::Error Builder::create<OpImageRead>(const OpImageRead *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3627,11 +3600,11 @@ cargo::optional<Error> Builder::create<OpImageRead>(const OpImageRead *op) {
       {op->Image(), op->Coordinate()}, pixelTypeOp);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageWrite>(const OpImageWrite *op) {
+llvm::Error Builder::create<OpImageWrite>(const OpImageWrite *op) {
   auto image = module.getValue(op->Image());
   SPIRV_LL_ASSERT_PTR(image);
 
@@ -3649,19 +3622,18 @@ cargo::optional<Error> Builder::create<OpImageWrite>(const OpImageWrite *op) {
       "write_image", voidTy, MangleInfo(0), {image, coord, texel},
       {op->Image(), op->Coordinate(), op->Texel()}, pixelTypeOp);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImage>(const OpImage *op) {
+llvm::Error Builder::create<OpImage>(const OpImage *op) {
   auto sampledImage = module.getSampledImage(op->SampledImage());
   module.addID(op->IdResult(), op, sampledImage.image);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQueryFormat>(
-    const OpImageQueryFormat *op) {
+llvm::Error Builder::create<OpImageQueryFormat>(const OpImageQueryFormat *op) {
   llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(resultType);
 
@@ -3673,12 +3645,11 @@ cargo::optional<Error> Builder::create<OpImageQueryFormat>(
       {image}, {op->Image()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQueryOrder>(
-    const OpImageQueryOrder *op) {
+llvm::Error Builder::create<OpImageQueryOrder>(const OpImageQueryOrder *op) {
   llvm::Type *resultType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(resultType);
 
@@ -3690,11 +3661,11 @@ cargo::optional<Error> Builder::create<OpImageQueryOrder>(
       {image}, {op->Image()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQuerySizeLod>(
+llvm::Error Builder::create<OpImageQuerySizeLod>(
     const OpImageQuerySizeLod *op) {
   llvm::Type *returnType = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(returnType);
@@ -3797,43 +3768,39 @@ cargo::optional<Error> Builder::create<OpImageQuerySizeLod>(
     }
   }
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQuerySize>(
-    const OpImageQuerySize *) {
+llvm::Error Builder::create<OpImageQuerySize>(const OpImageQuerySize *) {
   // This instruction requires the ImageQuery capability which is not supported
   // by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQueryLod>(
-    const OpImageQueryLod *) {
+llvm::Error Builder::create<OpImageQueryLod>(const OpImageQueryLod *) {
   // This instruction requires the ImageQuery capability which is not supported
   // by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQueryLevels>(
-    const OpImageQueryLevels *) {
+llvm::Error Builder::create<OpImageQueryLevels>(const OpImageQueryLevels *) {
   // This instruction requires the ImageQuery capability which is not supported
   // by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageQuerySamples>(
-    const OpImageQuerySamples *) {
+llvm::Error Builder::create<OpImageQuerySamples>(const OpImageQuerySamples *) {
   // This instruction requires the ImageQuery capability which is not supported
   // by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertFToU>(const OpConvertFToU *op) {
+llvm::Error Builder::create<OpConvertFToU>(const OpConvertFToU *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3845,11 +3812,11 @@ cargo::optional<Error> Builder::create<OpConvertFToU>(const OpConvertFToU *op) {
       createConversionBuiltinCall(value, MangleInfo(op->FloatValue()), retTy,
                                   op->IdResultType(), op->IdResult()));
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertFToS>(const OpConvertFToS *op) {
+llvm::Error Builder::create<OpConvertFToS>(const OpConvertFToS *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3861,11 +3828,11 @@ cargo::optional<Error> Builder::create<OpConvertFToS>(const OpConvertFToS *op) {
                createConversionBuiltinCall(
                    value, MangleInfo(op->FloatValue()), retTy,
                    MangleInfo::getSigned(op->IdResultType()), op->IdResult()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertSToF>(const OpConvertSToF *op) {
+llvm::Error Builder::create<OpConvertSToF>(const OpConvertSToF *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3877,11 +3844,11 @@ cargo::optional<Error> Builder::create<OpConvertSToF>(const OpConvertSToF *op) {
   module.addID(op->IdResult(), op,
                createConversionBuiltinCall(value, {}, retTy, op->IdResultType(),
                                            op->IdResult()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertUToF>(const OpConvertUToF *op) {
+llvm::Error Builder::create<OpConvertUToF>(const OpConvertUToF *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3892,11 +3859,11 @@ cargo::optional<Error> Builder::create<OpConvertUToF>(const OpConvertUToF *op) {
       op->IdResult(), op,
       createConversionBuiltinCall(value, MangleInfo(op->UnsignedValue()), retTy,
                                   op->IdResultType(), op->IdResult()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUConvert>(const OpUConvert *op) {
+llvm::Error Builder::create<OpUConvert>(const OpUConvert *op) {
   auto retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3906,11 +3873,11 @@ cargo::optional<Error> Builder::create<OpUConvert>(const OpUConvert *op) {
   auto *const result = IRBuilder.CreateZExtOrTrunc(value, retTy);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSConvert>(const OpSConvert *op) {
+llvm::Error Builder::create<OpSConvert>(const OpSConvert *op) {
   llvm::Type *retTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(retTy);
 
@@ -3920,11 +3887,11 @@ cargo::optional<Error> Builder::create<OpSConvert>(const OpSConvert *op) {
   auto *const result = IRBuilder.CreateSExtOrTrunc(value, retTy);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFConvert>(const OpFConvert *op) {
+llvm::Error Builder::create<OpFConvert>(const OpFConvert *op) {
   llvm::Value *value = module.getValue(op->FloatValue());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -3934,12 +3901,11 @@ cargo::optional<Error> Builder::create<OpFConvert>(const OpFConvert *op) {
   module.addID(op->IdResult(), op,
                createConversionBuiltinCall(value, {}, type, op->IdResult(),
                                            op->IdResult()));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpQuantizeToF16>(
-    const OpQuantizeToF16 *op) {
+llvm::Error Builder::create<OpQuantizeToF16>(const OpQuantizeToF16 *op) {
   llvm::Value *val = module.getValue(op->Value());
   SPIRV_LL_ASSERT_PTR(val);
 
@@ -3950,12 +3916,11 @@ cargo::optional<Error> Builder::create<OpQuantizeToF16>(
       op->IdResult(), op,
       createMangledBuiltinCall("quantizeToF16", type, op->IdResultType(), {val},
                                MangleInfo(op->Value())));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertPtrToU>(
-    const OpConvertPtrToU *op) {
+llvm::Error Builder::create<OpConvertPtrToU>(const OpConvertPtrToU *op) {
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -3964,12 +3929,11 @@ cargo::optional<Error> Builder::create<OpConvertPtrToU>(
 
   llvm::Value *result = IRBuilder.CreatePtrToInt(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSatConvertSToU>(
-    const OpSatConvertSToU *op) {
+llvm::Error Builder::create<OpSatConvertSToU>(const OpSatConvertSToU *op) {
   SPIRV_LL_ASSERT(module.hasCapability(spv::CapabilityKernel),
                   "Kernel capability not enabled");
 
@@ -3985,12 +3949,11 @@ cargo::optional<Error> Builder::create<OpSatConvertSToU>(
       value, {}, retTy, op->IdResultType(), op->IdResult(), true);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSatConvertUToS>(
-    const OpSatConvertUToS *op) {
+llvm::Error Builder::create<OpSatConvertUToS>(const OpSatConvertUToS *op) {
   SPIRV_LL_ASSERT(module.hasCapability(spv::CapabilityKernel),
                   "Kernel capability not enabled");
 
@@ -4008,12 +3971,11 @@ cargo::optional<Error> Builder::create<OpSatConvertUToS>(
       op->IdResult(), true);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpConvertUToPtr>(
-    const OpConvertUToPtr *op) {
+llvm::Error Builder::create<OpConvertUToPtr>(const OpConvertUToPtr *op) {
   llvm::Value *value = module.getValue(op->IntegerValue());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -4022,12 +3984,11 @@ cargo::optional<Error> Builder::create<OpConvertUToPtr>(
 
   llvm::Value *result = IRBuilder.CreateIntToPtr(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpPtrCastToGeneric>(
-    const OpPtrCastToGeneric *op) {
+llvm::Error Builder::create<OpPtrCastToGeneric>(const OpPtrCastToGeneric *op) {
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -4036,12 +3997,11 @@ cargo::optional<Error> Builder::create<OpPtrCastToGeneric>(
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGenericCastToPtr>(
-    const OpGenericCastToPtr *op) {
+llvm::Error Builder::create<OpGenericCastToPtr>(const OpGenericCastToPtr *op) {
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -4050,11 +4010,11 @@ cargo::optional<Error> Builder::create<OpGenericCastToPtr>(
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGenericCastToPtrExplicit>(
+llvm::Error Builder::create<OpGenericCastToPtrExplicit>(
     const OpGenericCastToPtrExplicit *op) {
   llvm::Value *value = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(value);
@@ -4064,11 +4024,11 @@ cargo::optional<Error> Builder::create<OpGenericCastToPtrExplicit>(
 
   llvm::Value *result = IRBuilder.CreatePointerCast(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitcast>(const OpBitcast *op) {
+llvm::Error Builder::create<OpBitcast>(const OpBitcast *op) {
   llvm::Value *value = module.getValue(op->Operand());
   SPIRV_LL_ASSERT_PTR(value);
 
@@ -4077,31 +4037,31 @@ cargo::optional<Error> Builder::create<OpBitcast>(const OpBitcast *op) {
 
   llvm::Value *result = IRBuilder.CreateBitCast(value, type);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSNegate>(const OpSNegate *op) {
+llvm::Error Builder::create<OpSNegate>(const OpSNegate *op) {
   llvm::Value *value = module.getValue(op->Operand());
 
   SPIRV_LL_ASSERT_PTR(value);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateNeg(value));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFNegate>(const OpFNegate *op) {
+llvm::Error Builder::create<OpFNegate>(const OpFNegate *op) {
   llvm::Value *value = module.getValue(op->Operand());
 
   SPIRV_LL_ASSERT_PTR(value);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateFNeg(value));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIAdd>(const OpIAdd *op) {
+llvm::Error Builder::create<OpIAdd>(const OpIAdd *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4118,11 +4078,11 @@ cargo::optional<Error> Builder::create<OpIAdd>(const OpIAdd *op) {
     llvm::cast<llvm::Instruction>(result)->setHasNoUnsignedWrap(true);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFAdd>(const OpFAdd *op) {
+llvm::Error Builder::create<OpFAdd>(const OpFAdd *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4131,11 +4091,11 @@ cargo::optional<Error> Builder::create<OpFAdd>(const OpFAdd *op) {
 
   llvm::Value *result = IRBuilder.CreateFAdd(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpISub>(const OpISub *op) {
+llvm::Error Builder::create<OpISub>(const OpISub *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4152,11 +4112,11 @@ cargo::optional<Error> Builder::create<OpISub>(const OpISub *op) {
     llvm::cast<llvm::Instruction>(result)->setHasNoUnsignedWrap(true);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFSub>(const OpFSub *op) {
+llvm::Error Builder::create<OpFSub>(const OpFSub *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4165,11 +4125,11 @@ cargo::optional<Error> Builder::create<OpFSub>(const OpFSub *op) {
 
   llvm::Value *result = IRBuilder.CreateFSub(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIMul>(const OpIMul *op) {
+llvm::Error Builder::create<OpIMul>(const OpIMul *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4186,11 +4146,11 @@ cargo::optional<Error> Builder::create<OpIMul>(const OpIMul *op) {
     llvm::cast<llvm::Instruction>(result)->setHasNoUnsignedWrap(true);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFMul>(const OpFMul *op) {
+llvm::Error Builder::create<OpFMul>(const OpFMul *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4199,11 +4159,11 @@ cargo::optional<Error> Builder::create<OpFMul>(const OpFMul *op) {
 
   llvm::Value *result = IRBuilder.CreateFMul(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUDiv>(const OpUDiv *op) {
+llvm::Error Builder::create<OpUDiv>(const OpUDiv *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4212,11 +4172,11 @@ cargo::optional<Error> Builder::create<OpUDiv>(const OpUDiv *op) {
 
   llvm::Value *result = IRBuilder.CreateUDiv(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSDiv>(const OpSDiv *op) {
+llvm::Error Builder::create<OpSDiv>(const OpSDiv *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4225,11 +4185,11 @@ cargo::optional<Error> Builder::create<OpSDiv>(const OpSDiv *op) {
 
   llvm::Value *result = IRBuilder.CreateSDiv(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFDiv>(const OpFDiv *op) {
+llvm::Error Builder::create<OpFDiv>(const OpFDiv *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4238,11 +4198,11 @@ cargo::optional<Error> Builder::create<OpFDiv>(const OpFDiv *op) {
 
   llvm::Value *result = IRBuilder.CreateFDiv(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUMod>(const OpUMod *op) {
+llvm::Error Builder::create<OpUMod>(const OpUMod *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4251,11 +4211,11 @@ cargo::optional<Error> Builder::create<OpUMod>(const OpUMod *op) {
 
   llvm::Value *result = IRBuilder.CreateURem(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSRem>(const OpSRem *op) {
+llvm::Error Builder::create<OpSRem>(const OpSRem *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4264,11 +4224,11 @@ cargo::optional<Error> Builder::create<OpSRem>(const OpSRem *op) {
 
   llvm::Value *result = IRBuilder.CreateSRem(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSMod>(const OpSMod *op) {
+llvm::Error Builder::create<OpSMod>(const OpSMod *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4289,11 +4249,11 @@ cargo::optional<Error> Builder::create<OpSMod>(const OpSMod *op) {
   result = IRBuilder.CreateSelect(cmp, IRBuilder.CreateAdd(sRem, absRhs), sRem);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFRem>(const OpFRem *op) {
+llvm::Error Builder::create<OpFRem>(const OpFRem *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4307,11 +4267,11 @@ cargo::optional<Error> Builder::create<OpFRem>(const OpFRem *op) {
       createMangledBuiltinCall("fmod", resultType, op->IdResultType(),
                                {lhs, rhs}, {op->Operand1(), op->Operand2()});
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFMod>(const OpFMod *op) {
+llvm::Error Builder::create<OpFMod>(const OpFMod *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4332,11 +4292,11 @@ cargo::optional<Error> Builder::create<OpFMod>(const OpFMod *op) {
       "copysign", type, op->IdResultType(), {result, rhs}, {});
 
   module.addID(op->IdResult(), op, signCorrectedResult);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVectorTimesScalar>(
+llvm::Error Builder::create<OpVectorTimesScalar>(
     const OpVectorTimesScalar *op) {
   llvm::Value *scalarValue = module.getValue(op->Scalar());
   SPIRV_LL_ASSERT_PTR(scalarValue);
@@ -4353,45 +4313,41 @@ cargo::optional<Error> Builder::create<OpVectorTimesScalar>(
 
   llvm::Value *result = IRBuilder.CreateFMul(splatVector, vectorValue);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMatrixTimesScalar>(
-    const OpMatrixTimesScalar *) {
+llvm::Error Builder::create<OpMatrixTimesScalar>(const OpMatrixTimesScalar *) {
   // TODO: To implement with abacus. See CA-341
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpVectorTimesMatrix>(
-    const OpVectorTimesMatrix *) {
+llvm::Error Builder::create<OpVectorTimesMatrix>(const OpVectorTimesMatrix *) {
   // TODO: To implement with abacus. See CA-341
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMatrixTimesVector>(
-    const OpMatrixTimesVector *) {
+llvm::Error Builder::create<OpMatrixTimesVector>(const OpMatrixTimesVector *) {
   // TODO: To implement with abacus. See CA-341
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMatrixTimesMatrix>(
-    const OpMatrixTimesMatrix *) {
+llvm::Error Builder::create<OpMatrixTimesMatrix>(const OpMatrixTimesMatrix *) {
   // TODO: To implement with abacus. See CA-341
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpOuterProduct>(const OpOuterProduct *) {
+llvm::Error Builder::create<OpOuterProduct>(const OpOuterProduct *) {
   // TODO: To implement with abacus. See CA-341
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDot>(const OpDot *op) {
+llvm::Error Builder::create<OpDot>(const OpDot *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4406,11 +4362,11 @@ cargo::optional<Error> Builder::create<OpDot>(const OpDot *op) {
                                {op->Vector1(), op->Vector2()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIAddCarry>(const OpIAddCarry *op) {
+llvm::Error Builder::create<OpIAddCarry>(const OpIAddCarry *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4464,11 +4420,11 @@ cargo::optional<Error> Builder::create<OpIAddCarry>(const OpIAddCarry *op) {
   result = IRBuilder.CreateInsertValue(result, extBool, 1);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpISubBorrow>(const OpISubBorrow *op) {
+llvm::Error Builder::create<OpISubBorrow>(const OpISubBorrow *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4522,12 +4478,11 @@ cargo::optional<Error> Builder::create<OpISubBorrow>(const OpISubBorrow *op) {
   result = IRBuilder.CreateInsertValue(result, extBool, 1);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUMulExtended>(
-    const OpUMulExtended *op) {
+llvm::Error Builder::create<OpUMulExtended>(const OpUMulExtended *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4558,12 +4513,11 @@ cargo::optional<Error> Builder::create<OpUMulExtended>(
   result = IRBuilder.CreateInsertValue(result, highOrderBits, 1);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSMulExtended>(
-    const OpSMulExtended *op) {
+llvm::Error Builder::create<OpSMulExtended>(const OpSMulExtended *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4594,11 +4548,11 @@ cargo::optional<Error> Builder::create<OpSMulExtended>(
   result = IRBuilder.CreateInsertValue(result, highOrderBits, 1);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAny>(const OpAny *op) {
+llvm::Error Builder::create<OpAny>(const OpAny *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4625,11 +4579,11 @@ cargo::optional<Error> Builder::create<OpAny>(const OpAny *op) {
   llvm::Value *truncResult = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, truncResult);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAll>(const OpAll *op) {
+llvm::Error Builder::create<OpAll>(const OpAll *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4656,11 +4610,11 @@ cargo::optional<Error> Builder::create<OpAll>(const OpAll *op) {
   llvm::Value *truncResult = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, truncResult);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsNan>(const OpIsNan *op) {
+llvm::Error Builder::create<OpIsNan>(const OpIsNan *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4676,11 +4630,11 @@ cargo::optional<Error> Builder::create<OpIsNan>(const OpIsNan *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsInf>(const OpIsInf *op) {
+llvm::Error Builder::create<OpIsInf>(const OpIsInf *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4696,11 +4650,11 @@ cargo::optional<Error> Builder::create<OpIsInf>(const OpIsInf *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsFinite>(const OpIsFinite *op) {
+llvm::Error Builder::create<OpIsFinite>(const OpIsFinite *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4716,11 +4670,11 @@ cargo::optional<Error> Builder::create<OpIsFinite>(const OpIsFinite *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsNormal>(const OpIsNormal *op) {
+llvm::Error Builder::create<OpIsNormal>(const OpIsNormal *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4736,11 +4690,11 @@ cargo::optional<Error> Builder::create<OpIsNormal>(const OpIsNormal *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSignBitSet>(const OpSignBitSet *op) {
+llvm::Error Builder::create<OpSignBitSet>(const OpSignBitSet *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4756,12 +4710,11 @@ cargo::optional<Error> Builder::create<OpSignBitSet>(const OpSignBitSet *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLessOrGreater>(
-    const OpLessOrGreater *op) {
+llvm::Error Builder::create<OpLessOrGreater>(const OpLessOrGreater *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4780,11 +4733,11 @@ cargo::optional<Error> Builder::create<OpLessOrGreater>(
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpOrdered>(const OpOrdered *op) {
+llvm::Error Builder::create<OpOrdered>(const OpOrdered *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4803,11 +4756,11 @@ cargo::optional<Error> Builder::create<OpOrdered>(const OpOrdered *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUnordered>(const OpUnordered *op) {
+llvm::Error Builder::create<OpUnordered>(const OpUnordered *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -4826,12 +4779,11 @@ cargo::optional<Error> Builder::create<OpUnordered>(const OpUnordered *op) {
   result = IRBuilder.CreateTrunc(result, type);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLogicalEqual>(
-    const OpLogicalEqual *op) {
+llvm::Error Builder::create<OpLogicalEqual>(const OpLogicalEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4840,12 +4792,11 @@ cargo::optional<Error> Builder::create<OpLogicalEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpEQ(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLogicalNotEqual>(
-    const OpLogicalNotEqual *op) {
+llvm::Error Builder::create<OpLogicalNotEqual>(const OpLogicalNotEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4854,11 +4805,11 @@ cargo::optional<Error> Builder::create<OpLogicalNotEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpNE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLogicalOr>(const OpLogicalOr *op) {
+llvm::Error Builder::create<OpLogicalOr>(const OpLogicalOr *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4867,11 +4818,11 @@ cargo::optional<Error> Builder::create<OpLogicalOr>(const OpLogicalOr *op) {
 
   llvm::Value *result = IRBuilder.CreateOr(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLogicalAnd>(const OpLogicalAnd *op) {
+llvm::Error Builder::create<OpLogicalAnd>(const OpLogicalAnd *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4880,21 +4831,21 @@ cargo::optional<Error> Builder::create<OpLogicalAnd>(const OpLogicalAnd *op) {
 
   llvm::Value *result = IRBuilder.CreateAnd(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLogicalNot>(const OpLogicalNot *op) {
+llvm::Error Builder::create<OpLogicalNot>(const OpLogicalNot *op) {
   llvm::Value *value = module.getValue(op->Operand());
   SPIRV_LL_ASSERT_PTR(value);
 
   llvm::Value *result = IRBuilder.CreateNot(value);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSelect>(const OpSelect *op) {
+llvm::Error Builder::create<OpSelect>(const OpSelect *op) {
   llvm::Value *condition = module.getValue(op->Condition());
   SPIRV_LL_ASSERT_PTR(condition);
 
@@ -4906,11 +4857,11 @@ cargo::optional<Error> Builder::create<OpSelect>(const OpSelect *op) {
 
   llvm::Value *result = IRBuilder.CreateSelect(condition, obj1, obj2);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIEqual>(const OpIEqual *op) {
+llvm::Error Builder::create<OpIEqual>(const OpIEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4919,11 +4870,11 @@ cargo::optional<Error> Builder::create<OpIEqual>(const OpIEqual *op) {
 
   llvm::Value *result = IRBuilder.CreateICmpEQ(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpINotEqual>(const OpINotEqual *op) {
+llvm::Error Builder::create<OpINotEqual>(const OpINotEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4932,12 +4883,11 @@ cargo::optional<Error> Builder::create<OpINotEqual>(const OpINotEqual *op) {
 
   llvm::Value *result = IRBuilder.CreateICmpNE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUGreaterThan>(
-    const OpUGreaterThan *op) {
+llvm::Error Builder::create<OpUGreaterThan>(const OpUGreaterThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4946,12 +4896,11 @@ cargo::optional<Error> Builder::create<OpUGreaterThan>(
 
   llvm::Value *result = IRBuilder.CreateICmpUGT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSGreaterThan>(
-    const OpSGreaterThan *op) {
+llvm::Error Builder::create<OpSGreaterThan>(const OpSGreaterThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -4960,11 +4909,11 @@ cargo::optional<Error> Builder::create<OpSGreaterThan>(
 
   llvm::Value *result = IRBuilder.CreateICmpSGT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUGreaterThanEqual>(
+llvm::Error Builder::create<OpUGreaterThanEqual>(
     const OpUGreaterThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -4974,11 +4923,11 @@ cargo::optional<Error> Builder::create<OpUGreaterThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpUGE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSGreaterThanEqual>(
+llvm::Error Builder::create<OpSGreaterThanEqual>(
     const OpSGreaterThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -4988,11 +4937,11 @@ cargo::optional<Error> Builder::create<OpSGreaterThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpSGE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpULessThan>(const OpULessThan *op) {
+llvm::Error Builder::create<OpULessThan>(const OpULessThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5001,11 +4950,11 @@ cargo::optional<Error> Builder::create<OpULessThan>(const OpULessThan *op) {
 
   llvm::Value *result = IRBuilder.CreateICmpULT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSLessThan>(const OpSLessThan *op) {
+llvm::Error Builder::create<OpSLessThan>(const OpSLessThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5014,12 +4963,11 @@ cargo::optional<Error> Builder::create<OpSLessThan>(const OpSLessThan *op) {
 
   llvm::Value *result = IRBuilder.CreateICmpSLT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpULessThanEqual>(
-    const OpULessThanEqual *op) {
+llvm::Error Builder::create<OpULessThanEqual>(const OpULessThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5028,12 +4976,11 @@ cargo::optional<Error> Builder::create<OpULessThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpULE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSLessThanEqual>(
-    const OpSLessThanEqual *op) {
+llvm::Error Builder::create<OpSLessThanEqual>(const OpSLessThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5042,11 +4989,11 @@ cargo::optional<Error> Builder::create<OpSLessThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateICmpSLE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdEqual>(const OpFOrdEqual *op) {
+llvm::Error Builder::create<OpFOrdEqual>(const OpFOrdEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5055,11 +5002,11 @@ cargo::optional<Error> Builder::create<OpFOrdEqual>(const OpFOrdEqual *op) {
 
   llvm::Value *result = IRBuilder.CreateFCmpOEQ(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordEqual>(const OpFUnordEqual *op) {
+llvm::Error Builder::create<OpFUnordEqual>(const OpFUnordEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5068,12 +5015,11 @@ cargo::optional<Error> Builder::create<OpFUnordEqual>(const OpFUnordEqual *op) {
 
   llvm::Value *result = IRBuilder.CreateFCmpUEQ(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdNotEqual>(
-    const OpFOrdNotEqual *op) {
+llvm::Error Builder::create<OpFOrdNotEqual>(const OpFOrdNotEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5082,12 +5028,11 @@ cargo::optional<Error> Builder::create<OpFOrdNotEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpONE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordNotEqual>(
-    const OpFUnordNotEqual *op) {
+llvm::Error Builder::create<OpFUnordNotEqual>(const OpFUnordNotEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5096,12 +5041,11 @@ cargo::optional<Error> Builder::create<OpFUnordNotEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpUNE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdLessThan>(
-    const OpFOrdLessThan *op) {
+llvm::Error Builder::create<OpFOrdLessThan>(const OpFOrdLessThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5110,12 +5054,11 @@ cargo::optional<Error> Builder::create<OpFOrdLessThan>(
 
   llvm::Value *result = IRBuilder.CreateFCmpOLT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordLessThan>(
-    const OpFUnordLessThan *op) {
+llvm::Error Builder::create<OpFUnordLessThan>(const OpFUnordLessThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5124,12 +5067,11 @@ cargo::optional<Error> Builder::create<OpFUnordLessThan>(
 
   llvm::Value *result = IRBuilder.CreateFCmpULT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdGreaterThan>(
-    const OpFOrdGreaterThan *op) {
+llvm::Error Builder::create<OpFOrdGreaterThan>(const OpFOrdGreaterThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5138,11 +5080,11 @@ cargo::optional<Error> Builder::create<OpFOrdGreaterThan>(
 
   llvm::Value *result = IRBuilder.CreateFCmpOGT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordGreaterThan>(
+llvm::Error Builder::create<OpFUnordGreaterThan>(
     const OpFUnordGreaterThan *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -5152,11 +5094,11 @@ cargo::optional<Error> Builder::create<OpFUnordGreaterThan>(
 
   llvm::Value *result = IRBuilder.CreateFCmpUGT(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdLessThanEqual>(
+llvm::Error Builder::create<OpFOrdLessThanEqual>(
     const OpFOrdLessThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -5166,11 +5108,11 @@ cargo::optional<Error> Builder::create<OpFOrdLessThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpOLE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordLessThanEqual>(
+llvm::Error Builder::create<OpFUnordLessThanEqual>(
     const OpFUnordLessThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -5180,11 +5122,11 @@ cargo::optional<Error> Builder::create<OpFUnordLessThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpULE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFOrdGreaterThanEqual>(
+llvm::Error Builder::create<OpFOrdGreaterThanEqual>(
     const OpFOrdGreaterThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -5194,11 +5136,11 @@ cargo::optional<Error> Builder::create<OpFOrdGreaterThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpOGE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFUnordGreaterThanEqual>(
+llvm::Error Builder::create<OpFUnordGreaterThanEqual>(
     const OpFUnordGreaterThanEqual *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
@@ -5208,11 +5150,11 @@ cargo::optional<Error> Builder::create<OpFUnordGreaterThanEqual>(
 
   llvm::Value *result = IRBuilder.CreateFCmpUGE(lhs, rhs);
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpShiftRightLogical>(
+llvm::Error Builder::create<OpShiftRightLogical>(
     const OpShiftRightLogical *op) {
   llvm::Value *base = module.getValue(op->Base());
 
@@ -5223,11 +5165,11 @@ cargo::optional<Error> Builder::create<OpShiftRightLogical>(
   SPIRV_LL_ASSERT_PTR(shift);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateLShr(base, shift));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpShiftRightArithmetic>(
+llvm::Error Builder::create<OpShiftRightArithmetic>(
     const OpShiftRightArithmetic *op) {
   llvm::Value *base = module.getValue(op->Base());
 
@@ -5238,12 +5180,11 @@ cargo::optional<Error> Builder::create<OpShiftRightArithmetic>(
   SPIRV_LL_ASSERT_PTR(shift);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateAShr(base, shift));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpShiftLeftLogical>(
-    const OpShiftLeftLogical *op) {
+llvm::Error Builder::create<OpShiftLeftLogical>(const OpShiftLeftLogical *op) {
   llvm::Value *base = module.getValue(op->Base());
   SPIRV_LL_ASSERT_PTR(base);
 
@@ -5261,11 +5202,11 @@ cargo::optional<Error> Builder::create<OpShiftLeftLogical>(
     llvm::cast<llvm::Instruction>(result)->setHasNoUnsignedWrap(true);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitwiseOr>(const OpBitwiseOr *op) {
+llvm::Error Builder::create<OpBitwiseOr>(const OpBitwiseOr *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5273,11 +5214,11 @@ cargo::optional<Error> Builder::create<OpBitwiseOr>(const OpBitwiseOr *op) {
   SPIRV_LL_ASSERT_PTR(rhs);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateOr(lhs, rhs));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitwiseXor>(const OpBitwiseXor *op) {
+llvm::Error Builder::create<OpBitwiseXor>(const OpBitwiseXor *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5285,11 +5226,11 @@ cargo::optional<Error> Builder::create<OpBitwiseXor>(const OpBitwiseXor *op) {
   SPIRV_LL_ASSERT_PTR(rhs);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateXor(lhs, rhs));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitwiseAnd>(const OpBitwiseAnd *op) {
+llvm::Error Builder::create<OpBitwiseAnd>(const OpBitwiseAnd *op) {
   llvm::Value *lhs = module.getValue(op->Operand1());
   SPIRV_LL_ASSERT_PTR(lhs);
 
@@ -5297,21 +5238,20 @@ cargo::optional<Error> Builder::create<OpBitwiseAnd>(const OpBitwiseAnd *op) {
   SPIRV_LL_ASSERT_PTR(rhs);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateAnd(lhs, rhs));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpNot>(const OpNot *op) {
+llvm::Error Builder::create<OpNot>(const OpNot *op) {
   llvm::Value *operand = module.getValue(op->Operand());
   SPIRV_LL_ASSERT_PTR(operand);
 
   module.addID(op->IdResult(), op, IRBuilder.CreateNot(operand));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitFieldInsert>(
-    const OpBitFieldInsert *op) {
+llvm::Error Builder::create<OpBitFieldInsert>(const OpBitFieldInsert *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -5356,12 +5296,11 @@ cargo::optional<Error> Builder::create<OpBitFieldInsert>(
   base = IRBuilder.CreateAnd(base, base_mask);
   // or the base and the insert to arrive at the resultant combined bit field
   module.addID(op->IdResult(), op, IRBuilder.CreateOr(base, insert));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitFieldSExtract>(
-    const OpBitFieldSExtract *op) {
+llvm::Error Builder::create<OpBitFieldSExtract>(const OpBitFieldSExtract *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -5398,12 +5337,11 @@ cargo::optional<Error> Builder::create<OpBitFieldSExtract>(
     base = IRBuilder.CreateAShr(base, offset_vec);
     module.addID(op->IdResult(), op, IRBuilder.CreateAnd(base, mask_vec));
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitFieldUExtract>(
-    const OpBitFieldUExtract *op) {
+llvm::Error Builder::create<OpBitFieldUExtract>(const OpBitFieldUExtract *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -5440,17 +5378,17 @@ cargo::optional<Error> Builder::create<OpBitFieldUExtract>(
     base = IRBuilder.CreateLShr(base, offset_vec);
     module.addID(op->IdResult(), op, IRBuilder.CreateAnd(base, mask_vec));
   }
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitReverse>(const OpBitReverse *) {
+llvm::Error Builder::create<OpBitReverse>(const OpBitReverse *) {
   // TODO: implement this as a builtin
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBitCount>(const OpBitCount *op) {
+llvm::Error Builder::create<OpBitCount>(const OpBitCount *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -5461,98 +5399,97 @@ cargo::optional<Error> Builder::create<OpBitCount>(const OpBitCount *op) {
       "popcount", type, op->IdResultType(), {base}, {op->Base()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdx>(const OpDPdx *) {
+llvm::Error Builder::create<OpDPdx>(const OpDPdx *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdy>(const OpDPdy *) {
+llvm::Error Builder::create<OpDPdy>(const OpDPdy *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFwidth>(const OpFwidth *) {
+llvm::Error Builder::create<OpFwidth>(const OpFwidth *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdxFine>(const OpDPdxFine *) {
+llvm::Error Builder::create<OpDPdxFine>(const OpDPdxFine *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdyFine>(const OpDPdyFine *) {
+llvm::Error Builder::create<OpDPdyFine>(const OpDPdyFine *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFwidthFine>(const OpFwidthFine *) {
+llvm::Error Builder::create<OpFwidthFine>(const OpFwidthFine *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdxCoarse>(const OpDPdxCoarse *) {
+llvm::Error Builder::create<OpDPdxCoarse>(const OpDPdxCoarse *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpDPdyCoarse>(const OpDPdyCoarse *) {
+llvm::Error Builder::create<OpDPdyCoarse>(const OpDPdyCoarse *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpFwidthCoarse>(const OpFwidthCoarse *) {
+llvm::Error Builder::create<OpFwidthCoarse>(const OpFwidthCoarse *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEmitVertex>(const OpEmitVertex *) {
+llvm::Error Builder::create<OpEmitVertex>(const OpEmitVertex *) {
   // This instruction requires the Geometry capability, which is not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEndPrimitive>(const OpEndPrimitive *) {
+llvm::Error Builder::create<OpEndPrimitive>(const OpEndPrimitive *) {
   // This instruction requires the Geometry capability, which is not supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEmitStreamVertex>(
-    const OpEmitStreamVertex *) {
+llvm::Error Builder::create<OpEmitStreamVertex>(const OpEmitStreamVertex *) {
   // This instruction requires the GeometryStreams capability, which is not
   // supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEndStreamPrimitive>(
+llvm::Error Builder::create<OpEndStreamPrimitive>(
     const OpEndStreamPrimitive *) {
   // This instruction requires the GeometryStreams capability, which is not
   // supported.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 static llvm::AttributeList getMuxBarrierAttrs(llvm::LLVMContext &ctx) {
@@ -5565,8 +5502,7 @@ static llvm::AttributeList getMuxBarrierAttrs(llvm::LLVMContext &ctx) {
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpControlBarrier>(
-    const OpControlBarrier *op) {
+llvm::Error Builder::create<OpControlBarrier>(const OpControlBarrier *op) {
   auto *execution = module.getValue(op->Execution());
   SPIRV_LL_ASSERT_PTR(execution);
 
@@ -5599,7 +5535,7 @@ cargo::optional<Error> Builder::create<OpControlBarrier>(
                                        {defaultID, memory, semantics});
     ci->getCalledFunction()->setAttributes(
         getMuxBarrierAttrs(*context.llvmContext));
-    return cargo::nullopt;
+    return llvm::Error::success();
   }
 
   // If it's not a constant, emit a wrapper function which dynamically chooses
@@ -5669,12 +5605,11 @@ cargo::optional<Error> Builder::create<OpControlBarrier>(
   // Now we just have a regular function call in our original function.
   IRBuilder.CreateCall(module.barrierWrapperFcn,
                        {execution, memory, semantics});
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpMemoryBarrier>(
-    const OpMemoryBarrier *op) {
+llvm::Error Builder::create<OpMemoryBarrier>(const OpMemoryBarrier *op) {
   llvm::Value *semantics = module.getValue(op->Semantics());
   SPIRV_LL_ASSERT_PTR(semantics);
 
@@ -5686,11 +5621,11 @@ cargo::optional<Error> Builder::create<OpMemoryBarrier>(
   ci->getCalledFunction()->setAttributes(
       getMuxBarrierAttrs(*context.llvmContext));
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicLoad>(const OpAtomicLoad *op) {
+llvm::Error Builder::create<OpAtomicLoad>(const OpAtomicLoad *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -5709,11 +5644,11 @@ cargo::optional<Error> Builder::create<OpAtomicLoad>(const OpAtomicLoad *op) {
                                op->IdResultType(), {pointer, semantics, scope},
                                {MangleInfo(op->Pointer(), MangleInfo::VOLATILE),
                                 op->Semantics(), op->Scope()}));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicStore>(const OpAtomicStore *op) {
+llvm::Error Builder::create<OpAtomicStore>(const OpAtomicStore *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -5730,12 +5665,11 @@ cargo::optional<Error> Builder::create<OpAtomicStore>(const OpAtomicStore *op) {
                            spv::OpTypeVoid, {pointer, value, semantics, scope},
                            {MangleInfo(op->Pointer(), MangleInfo::VOLATILE),
                             op->Value(), op->Semantics(), op->Scope()});
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicExchange>(
-    const OpAtomicExchange *op) {
+llvm::Error Builder::create<OpAtomicExchange>(const OpAtomicExchange *op) {
   const auto retOp = op->IdResultType();
   // Atomic exchange can work on floats or integers.
   const auto *const type = module.getLLVMType(retOp);
@@ -5743,11 +5677,11 @@ cargo::optional<Error> Builder::create<OpAtomicExchange>(
       !type->isFloatingPointTy() && module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_xchg",
                        is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicCompareExchange>(
+llvm::Error Builder::create<OpAtomicCompareExchange>(
     const OpAtomicCompareExchange *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
@@ -5757,7 +5691,7 @@ cargo::optional<Error> Builder::create<OpAtomicCompareExchange>(
   if (pointer->getType()->getPointerAddressSpace() == 0) {
     auto *resultTy = module.getLLVMType(op->IdResultType());
     module.addID(op->IdResult(), op, IRBuilder.CreateLoad(resultTy, pointer));
-    return cargo::nullopt;
+    return llvm::Error::success();
   }
 
   auto value = module.getValue(op->Value());
@@ -5775,20 +5709,18 @@ cargo::optional<Error> Builder::create<OpAtomicCompareExchange>(
                                {pointer, cmp, value},
                                {MangleInfo(op->Pointer(), MangleInfo::VOLATILE),
                                 op->Comparator(), op->Value()}));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicCompareExchangeWeak>(
+llvm::Error Builder::create<OpAtomicCompareExchangeWeak>(
     const OpAtomicCompareExchangeWeak *op) {
   // Has the same semantics as OpAtomicCompareExchange.
-  Builder::create<OpAtomicCompareExchange>(*op);
-  return cargo::nullopt;
+  return Builder::create<OpAtomicCompareExchange>(*op);
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicIIncrement>(
-    const OpAtomicIIncrement *op) {
+llvm::Error Builder::create<OpAtomicIIncrement>(const OpAtomicIIncrement *op) {
   llvm::Value *pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -5799,12 +5731,11 @@ cargo::optional<Error> Builder::create<OpAtomicIIncrement>(
                createMangledBuiltinCall(
                    "atomic_inc", retTy, op->IdResultType(), pointer,
                    MangleInfo(op->Pointer(), MangleInfo::VOLATILE)));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicIDecrement>(
-    const OpAtomicIDecrement *op) {
+llvm::Error Builder::create<OpAtomicIDecrement>(const OpAtomicIDecrement *op) {
   llvm::Value *pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -5815,7 +5746,7 @@ cargo::optional<Error> Builder::create<OpAtomicIDecrement>(
                createMangledBuiltinCall(
                    "atomic_dec", retTy, op->IdResultType(), pointer,
                    MangleInfo(op->Pointer(), MangleInfo::VOLATILE)));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 void Builder::generateBinaryAtomic(const OpResult *op, spv::Id pointerID,
@@ -5854,95 +5785,92 @@ void Builder::generateBinaryAtomic(const OpResult *op, spv::Id pointerID,
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicIAdd>(const OpAtomicIAdd *op) {
+llvm::Error Builder::create<OpAtomicIAdd>(const OpAtomicIAdd *op) {
   const auto retOp = op->IdResultType();
   const auto is_signed = module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_add", is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicISub>(const OpAtomicISub *op) {
+llvm::Error Builder::create<OpAtomicISub>(const OpAtomicISub *op) {
   const auto retOp = op->IdResultType();
   const auto is_signed = module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_sub", is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicSMin>(const OpAtomicSMin *op) {
+llvm::Error Builder::create<OpAtomicSMin>(const OpAtomicSMin *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_min", true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicUMin>(const OpAtomicUMin *op) {
+llvm::Error Builder::create<OpAtomicUMin>(const OpAtomicUMin *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_min", false);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicSMax>(const OpAtomicSMax *op) {
+llvm::Error Builder::create<OpAtomicSMax>(const OpAtomicSMax *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_max", true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicUMax>(const OpAtomicUMax *op) {
+llvm::Error Builder::create<OpAtomicUMax>(const OpAtomicUMax *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_max", false);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicFAddEXT>(
-    const OpAtomicFAddEXT *op) {
+llvm::Error Builder::create<OpAtomicFAddEXT>(const OpAtomicFAddEXT *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(),
                        "atomic_fetch_add_explicit", true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicFMinEXT>(
-    const OpAtomicFMinEXT *op) {
+llvm::Error Builder::create<OpAtomicFMinEXT>(const OpAtomicFMinEXT *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(),
                        "atomic_fetch_min_explicit", true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicFMaxEXT>(
-    const OpAtomicFMaxEXT *op) {
+llvm::Error Builder::create<OpAtomicFMaxEXT>(const OpAtomicFMaxEXT *op) {
   generateBinaryAtomic(op, op->Pointer(), op->Value(),
                        "atomic_fetch_max_explicit", true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicAnd>(const OpAtomicAnd *op) {
+llvm::Error Builder::create<OpAtomicAnd>(const OpAtomicAnd *op) {
   const auto retOp = op->IdResultType();
   const auto is_signed = module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_and", is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicOr>(const OpAtomicOr *op) {
+llvm::Error Builder::create<OpAtomicOr>(const OpAtomicOr *op) {
   const auto retOp = op->IdResultType();
   const auto is_signed = module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_or", is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicXor>(const OpAtomicXor *op) {
+llvm::Error Builder::create<OpAtomicXor>(const OpAtomicXor *op) {
   const auto retOp = op->IdResultType();
   const auto is_signed = module.get<OpTypeInt>(retOp)->Signedness();
   generateBinaryAtomic(op, op->Pointer(), op->Value(), "atomic_xor", is_signed);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpPhi>(const OpPhi *op) {
+llvm::Error Builder::create<OpPhi>(const OpPhi *op) {
   const unsigned num_values = op->wordCount() - 3;
   llvm::Type *result_ty = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(result_ty);
@@ -5954,7 +5882,7 @@ cargo::optional<Error> Builder::create<OpPhi>(const OpPhi *op) {
   // populatePhi()
 
   module.addID(op->IdResult(), op, phi);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 void Builder::populatePhi(OpPhi const &op) {
@@ -5975,7 +5903,7 @@ void Builder::populatePhi(OpPhi const &op) {
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLoopMerge>(const OpLoopMerge *op) {
+llvm::Error Builder::create<OpLoopMerge>(const OpLoopMerge *op) {
   llvm::MDNode *loop_control = nullptr;
 
   // account for the technically legal combination of Unroll and DontUnroll
@@ -6008,16 +5936,15 @@ cargo::optional<Error> Builder::create<OpLoopMerge>(const OpLoopMerge *op) {
     module.setLoopControl(op->ContinueTarget(), loop_control);
   }
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSelectionMerge>(
-    const OpSelectionMerge *) {
+llvm::Error Builder::create<OpSelectionMerge>(const OpSelectionMerge *) {
   // This instruction does not have any semantic impact on the module, and
   // unlike what we can do with loop unrolling above there is no llvm mapping
   // for control flow flattening.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 llvm::BasicBlock *Builder::getOrCreateBasicBlock(spv::Id label) {
@@ -6036,7 +5963,7 @@ llvm::BasicBlock *Builder::getOrCreateBasicBlock(spv::Id label) {
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLabel>(const OpLabel *op) {
+llvm::Error Builder::create<OpLabel>(const OpLabel *op) {
   llvm::Function *current_function = getCurrentFunction();
   SPIRV_LL_ASSERT_PTR(current_function);
 
@@ -6070,11 +5997,11 @@ cargo::optional<Error> Builder::create<OpLabel>(const OpLabel *op) {
   }
 
   module.addID(op->IdResult(), op, bb);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBranch>(const OpBranch *op) {
+llvm::Error Builder::create<OpBranch>(const OpBranch *op) {
   llvm::BasicBlock *bb = getOrCreateBasicBlock(op->TargetLabel());
   SPIRV_LL_ASSERT_PTR(bb);
 
@@ -6083,11 +6010,11 @@ cargo::optional<Error> Builder::create<OpBranch>(const OpBranch *op) {
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBranchConditional>(
+llvm::Error Builder::create<OpBranchConditional>(
     const OpBranchConditional *op) {
   llvm::BasicBlock *true_bb = getOrCreateBasicBlock(op->TrueLabel());
   SPIRV_LL_ASSERT_PTR(true_bb);
@@ -6131,11 +6058,11 @@ cargo::optional<Error> Builder::create<OpBranchConditional>(
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSwitch>(const OpSwitch *op) {
+llvm::Error Builder::create<OpSwitch>(const OpSwitch *op) {
   llvm::Value *selector = module.getValue(op->Selector());
   SPIRV_LL_ASSERT_PTR(selector);
 
@@ -6160,33 +6087,33 @@ cargo::optional<Error> Builder::create<OpSwitch>(const OpSwitch *op) {
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpKill>(const OpKill *) {
+llvm::Error Builder::create<OpKill>(const OpKill *) {
   // This instruction is only valid in the Fragment execuction model, which is
   // not supported.
 
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReturn>(const OpReturn *) {
+llvm::Error Builder::create<OpReturn>(const OpReturn *) {
   SPIRV_LL_ASSERT_PTR(getCurrentFunction());
   IRBuilder.CreateRetVoid();
 
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReturnValue>(const OpReturnValue *op) {
+llvm::Error Builder::create<OpReturnValue>(const OpReturnValue *op) {
   SPIRV_LL_ASSERT_PTR(getCurrentFunction());
 
   llvm::Value *value = module.getValue(op->Value());
@@ -6197,22 +6124,21 @@ cargo::optional<Error> Builder::create<OpReturnValue>(const OpReturnValue *op) {
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpUnreachable>(const OpUnreachable *) {
+llvm::Error Builder::create<OpUnreachable>(const OpUnreachable *) {
   IRBuilder.CreateUnreachable();
 
   // This instruction ends a block.
   checkEndOpLineRange();
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLifetimeStart>(
-    const OpLifetimeStart *op) {
+llvm::Error Builder::create<OpLifetimeStart>(const OpLifetimeStart *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -6225,12 +6151,11 @@ cargo::optional<Error> Builder::create<OpLifetimeStart>(
   }
 
   IRBuilder.CreateLifetimeStart(pointer, sizeConstant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpLifetimeStop>(
-    const OpLifetimeStop *op) {
+llvm::Error Builder::create<OpLifetimeStop>(const OpLifetimeStop *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -6243,12 +6168,11 @@ cargo::optional<Error> Builder::create<OpLifetimeStop>(
   }
 
   IRBuilder.CreateLifetimeEnd(pointer, sizeConstant);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupAsyncCopy>(
-    const OpGroupAsyncCopy *op) {
+llvm::Error Builder::create<OpGroupAsyncCopy>(const OpGroupAsyncCopy *op) {
   llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(eventTy);
 
@@ -6275,12 +6199,11 @@ cargo::optional<Error> Builder::create<OpGroupAsyncCopy>(
           {op->Destination(), MangleInfo(op->Source(), MangleInfo::CONST),
            op->NumElements(), op->Stride(), op->Event()},
           /*convergent*/ true));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupWaitEvents>(
-    const OpGroupWaitEvents *op) {
+llvm::Error Builder::create<OpGroupWaitEvents>(const OpGroupWaitEvents *op) {
   llvm::Value *numEvents = module.getValue(op->NumEvents());
   SPIRV_LL_ASSERT_PTR(numEvents);
 
@@ -6296,7 +6219,7 @@ cargo::optional<Error> Builder::create<OpGroupWaitEvents>(
                             : "_Z17wait_group_eventsiPU3AS49ocl_event",
                     IRBuilder.getVoidTy(), {numEvents, eventsList},
                     /*convergent*/ true);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <typename T>
@@ -6537,20 +6460,19 @@ void Builder::generatePredicate(const T *op, const std::string &opName) {
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupAll>(const OpGroupAll *op) {
+llvm::Error Builder::create<OpGroupAll>(const OpGroupAll *op) {
   generatePredicate(op, "all");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupAny>(const OpGroupAny *op) {
+llvm::Error Builder::create<OpGroupAny>(const OpGroupAny *op) {
   generatePredicate(op, "any");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupBroadcast>(
-    const OpGroupBroadcast *op) {
+llvm::Error Builder::create<OpGroupBroadcast>(const OpGroupBroadcast *op) {
   // Result Type must be a scalar or vector or floating-point type, integer type
   // or boolean type.
   auto retTy = module.getLLVMType(op->IdResultType());
@@ -6756,117 +6678,114 @@ cargo::optional<Error> Builder::create<OpGroupBroadcast>(
       IRBuilder.CreateCall(broadcastWrapper, {execution, value, localId});
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupIAdd>(const OpGroupIAdd *op) {
+llvm::Error Builder::create<OpGroupIAdd>(const OpGroupIAdd *op) {
   generateReduction(op, "add");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupFAdd>(const OpGroupFAdd *op) {
+llvm::Error Builder::create<OpGroupFAdd>(const OpGroupFAdd *op) {
   generateReduction(op, "add");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupFMin>(const OpGroupFMin *op) {
+llvm::Error Builder::create<OpGroupFMin>(const OpGroupFMin *op) {
   generateReduction(op, "min");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupUMin>(const OpGroupUMin *op) {
+llvm::Error Builder::create<OpGroupUMin>(const OpGroupUMin *op) {
   generateReduction(op, "min", MangleInfo::ForceSignInfo::ForceUnsigned);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupSMin>(const OpGroupSMin *op) {
+llvm::Error Builder::create<OpGroupSMin>(const OpGroupSMin *op) {
   generateReduction(op, "min", MangleInfo::ForceSignInfo::ForceSigned);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupFMax>(const OpGroupFMax *op) {
+llvm::Error Builder::create<OpGroupFMax>(const OpGroupFMax *op) {
   generateReduction(op, "max");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupUMax>(const OpGroupUMax *op) {
+llvm::Error Builder::create<OpGroupUMax>(const OpGroupUMax *op) {
   generateReduction(op, "max", MangleInfo::ForceSignInfo::ForceUnsigned);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupSMax>(const OpGroupSMax *op) {
+llvm::Error Builder::create<OpGroupSMax>(const OpGroupSMax *op) {
   generateReduction(op, "max", MangleInfo::ForceSignInfo::ForceSigned);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 // SPV_KHR_uniform_group_instructions
 template <>
-cargo::optional<Error> Builder::create<OpGroupIMulKHR>(
-    const OpGroupIMulKHR *op) {
+llvm::Error Builder::create<OpGroupIMulKHR>(const OpGroupIMulKHR *op) {
   generateReduction(op, "mul");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupFMulKHR>(
-    const OpGroupFMulKHR *op) {
+llvm::Error Builder::create<OpGroupFMulKHR>(const OpGroupFMulKHR *op) {
   generateReduction(op, "mul");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupBitwiseAndKHR>(
+llvm::Error Builder::create<OpGroupBitwiseAndKHR>(
     const OpGroupBitwiseAndKHR *op) {
   generateReduction(op, "and");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupBitwiseOrKHR>(
+llvm::Error Builder::create<OpGroupBitwiseOrKHR>(
     const OpGroupBitwiseOrKHR *op) {
   generateReduction(op, "or");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupBitwiseXorKHR>(
+llvm::Error Builder::create<OpGroupBitwiseXorKHR>(
     const OpGroupBitwiseXorKHR *op) {
   generateReduction(op, "xor");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupLogicalAndKHR>(
+llvm::Error Builder::create<OpGroupLogicalAndKHR>(
     const OpGroupLogicalAndKHR *op) {
   generateReduction(op, "logical_and");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupLogicalOrKHR>(
+llvm::Error Builder::create<OpGroupLogicalOrKHR>(
     const OpGroupLogicalOrKHR *op) {
   generateReduction(op, "logical_or");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupLogicalXorKHR>(
+llvm::Error Builder::create<OpGroupLogicalXorKHR>(
     const OpGroupLogicalXorKHR *op) {
   generateReduction(op, "logical_xor");
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSubgroupShuffle>(
-    const OpSubgroupShuffle *op) {
+llvm::Error Builder::create<OpSubgroupShuffle>(const OpSubgroupShuffle *op) {
   std::string muxBuiltinName = "__mux_sub_group_shuffle_";
 
   auto *data = module.getValue(op->Data());
@@ -6883,11 +6802,11 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffle>(
   auto *const ci = createBuiltinCall(
       muxBuiltinName, retTy, {data, invocation_id}, /*convergent*/ true);
   module.addID(op->IdResult(), op, ci);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSubgroupShuffleUp>(
+llvm::Error Builder::create<OpSubgroupShuffleUp>(
     const OpSubgroupShuffleUp *op) {
   std::string muxBuiltinName = "__mux_sub_group_shuffle_up_";
 
@@ -6908,11 +6827,11 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleUp>(
   auto *const ci = createBuiltinCall(
       muxBuiltinName, retTy, {previous, current, delta}, /*convergent*/ true);
   module.addID(op->IdResult(), op, ci);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSubgroupShuffleDown>(
+llvm::Error Builder::create<OpSubgroupShuffleDown>(
     const OpSubgroupShuffleDown *op) {
   std::string muxBuiltinName = "__mux_sub_group_shuffle_down_";
 
@@ -6933,11 +6852,11 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleDown>(
   auto *const ci = createBuiltinCall(
       muxBuiltinName, retTy, {current, next, delta}, /*convergent*/ true);
   module.addID(op->IdResult(), op, ci);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSubgroupShuffleXor>(
+llvm::Error Builder::create<OpSubgroupShuffleXor>(
     const OpSubgroupShuffleXor *op) {
   std::string muxBuiltinName = "__mux_sub_group_shuffle_xor_";
 
@@ -6955,326 +6874,312 @@ cargo::optional<Error> Builder::create<OpSubgroupShuffleXor>(
   auto *const ci = createBuiltinCall(muxBuiltinName, retTy, {data, value},
                                      /*convergent*/ true);
   module.addID(op->IdResult(), op, ci);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReadPipe>(const OpReadPipe *) {
+llvm::Error Builder::create<OpReadPipe>(const OpReadPipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpWritePipe>(const OpWritePipe *) {
+llvm::Error Builder::create<OpWritePipe>(const OpWritePipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReservedReadPipe>(
-    const OpReservedReadPipe *) {
+llvm::Error Builder::create<OpReservedReadPipe>(const OpReservedReadPipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReservedWritePipe>(
-    const OpReservedWritePipe *) {
+llvm::Error Builder::create<OpReservedWritePipe>(const OpReservedWritePipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReserveReadPipePackets>(
+llvm::Error Builder::create<OpReserveReadPipePackets>(
     const OpReserveReadPipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReserveWritePipePackets>(
+llvm::Error Builder::create<OpReserveWritePipePackets>(
     const OpReserveWritePipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCommitReadPipe>(
-    const OpCommitReadPipe *) {
+llvm::Error Builder::create<OpCommitReadPipe>(const OpCommitReadPipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCommitWritePipe>(
-    const OpCommitWritePipe *) {
+llvm::Error Builder::create<OpCommitWritePipe>(const OpCommitWritePipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsValidReserveId>(
-    const OpIsValidReserveId *) {
+llvm::Error Builder::create<OpIsValidReserveId>(const OpIsValidReserveId *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetNumPipePackets>(
-    const OpGetNumPipePackets *) {
+llvm::Error Builder::create<OpGetNumPipePackets>(const OpGetNumPipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetMaxPipePackets>(
-    const OpGetMaxPipePackets *) {
+llvm::Error Builder::create<OpGetMaxPipePackets>(const OpGetMaxPipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupReserveReadPipePackets>(
+llvm::Error Builder::create<OpGroupReserveReadPipePackets>(
     const OpGroupReserveReadPipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupReserveWritePipePackets>(
+llvm::Error Builder::create<OpGroupReserveWritePipePackets>(
     const OpGroupReserveWritePipePackets *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupCommitReadPipe>(
+llvm::Error Builder::create<OpGroupCommitReadPipe>(
     const OpGroupCommitReadPipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGroupCommitWritePipe>(
+llvm::Error Builder::create<OpGroupCommitWritePipe>(
     const OpGroupCommitWritePipe *) {
   // Capability Pipes isn't supported by CL 1.2, see OpenCL SPIR-V
   // environment spec section 6.1 for supported capabilities.
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEnqueueMarker>(
-    const OpEnqueueMarker *) {
+llvm::Error Builder::create<OpEnqueueMarker>(const OpEnqueueMarker *) {
   return errorUnsupportedDeviceEnqueueOp("OpEnqueueMarker");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpEnqueueKernel>(
-    const OpEnqueueKernel *) {
+llvm::Error Builder::create<OpEnqueueKernel>(const OpEnqueueKernel *) {
   return errorUnsupportedDeviceEnqueueOp("OpEnqueueKernel");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetKernelNDrangeSubGroupCount>(
+llvm::Error Builder::create<OpGetKernelNDrangeSubGroupCount>(
     const OpGetKernelNDrangeSubGroupCount *) {
   return errorUnsupportedDeviceEnqueueOp("OpGetKernelNDrangeSubGroupCount");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetKernelNDrangeMaxSubGroupSize>(
+llvm::Error Builder::create<OpGetKernelNDrangeMaxSubGroupSize>(
     const OpGetKernelNDrangeMaxSubGroupSize *) {
   return errorUnsupportedDeviceEnqueueOp("OpGetKernelNDrangeMaxSubGroupSize");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetKernelWorkGroupSize>(
+llvm::Error Builder::create<OpGetKernelWorkGroupSize>(
     const OpGetKernelWorkGroupSize *) {
   return errorUnsupportedDeviceEnqueueOp("OpGetKernelWorkGroupSize");
 }
 
 template <>
-cargo::optional<Error>
-Builder::create<OpGetKernelPreferredWorkGroupSizeMultiple>(
+llvm::Error Builder::create<OpGetKernelPreferredWorkGroupSizeMultiple>(
     const OpGetKernelPreferredWorkGroupSizeMultiple *) {
   return errorUnsupportedDeviceEnqueueOp(
       "OpGetKernelPreferredWorkGroupSizeMultiple");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpRetainEvent>(const OpRetainEvent *) {
+llvm::Error Builder::create<OpRetainEvent>(const OpRetainEvent *) {
   return errorUnsupportedDeviceEnqueueOp("OpRetainEvent");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpReleaseEvent>(const OpReleaseEvent *) {
+llvm::Error Builder::create<OpReleaseEvent>(const OpReleaseEvent *) {
   return errorUnsupportedDeviceEnqueueOp("OpReleaseEvent");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCreateUserEvent>(
-    const OpCreateUserEvent *) {
+llvm::Error Builder::create<OpCreateUserEvent>(const OpCreateUserEvent *) {
   return errorUnsupportedDeviceEnqueueOp("OpCreateUserEvent");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpIsValidEvent>(const OpIsValidEvent *) {
+llvm::Error Builder::create<OpIsValidEvent>(const OpIsValidEvent *) {
   return errorUnsupportedDeviceEnqueueOp("OpIsValidEvent");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpSetUserEventStatus>(
+llvm::Error Builder::create<OpSetUserEventStatus>(
     const OpSetUserEventStatus *) {
   return errorUnsupportedDeviceEnqueueOp("OpSetUserEventStatus");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpCaptureEventProfilingInfo>(
+llvm::Error Builder::create<OpCaptureEventProfilingInfo>(
     const OpCaptureEventProfilingInfo *) {
   return errorUnsupportedDeviceEnqueueOp("OpCaptureEventProfilingInfo");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetDefaultQueue>(
-    const OpGetDefaultQueue *) {
+llvm::Error Builder::create<OpGetDefaultQueue>(const OpGetDefaultQueue *) {
   return errorUnsupportedDeviceEnqueueOp("OpGetDefaultQueue");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpBuildNDRange>(const OpBuildNDRange *) {
+llvm::Error Builder::create<OpBuildNDRange>(const OpBuildNDRange *) {
   return errorUnsupportedDeviceEnqueueOp("OpBuildNDRange");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetKernelLocalSizeForSubgroupCount>(
+llvm::Error Builder::create<OpGetKernelLocalSizeForSubgroupCount>(
     const OpGetKernelLocalSizeForSubgroupCount *) {
   return errorUnsupportedDeviceEnqueueOp(
       "OpGetKernelLocalSizeForSubgroupCount");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpGetKernelMaxNumSubgroups>(
+llvm::Error Builder::create<OpGetKernelMaxNumSubgroups>(
     const OpGetKernelMaxNumSubgroups *) {
   return errorUnsupportedDeviceEnqueueOp("OpGetKernelMaxNumSubgroups");
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleImplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleImplicitLod>(
     const OpImageSparseSampleImplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleExplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleExplicitLod>(
     const OpImageSparseSampleExplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleDrefImplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleDrefImplicitLod>(
     const OpImageSparseSampleDrefImplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleDrefExplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleDrefExplicitLod>(
     const OpImageSparseSampleDrefExplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleProjImplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleProjImplicitLod>(
     const OpImageSparseSampleProjImplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleProjExplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleProjExplicitLod>(
     const OpImageSparseSampleProjExplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleProjDrefImplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleProjDrefImplicitLod>(
     const OpImageSparseSampleProjDrefImplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseSampleProjDrefExplicitLod>(
+llvm::Error Builder::create<OpImageSparseSampleProjDrefExplicitLod>(
     const OpImageSparseSampleProjDrefExplicitLod *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseFetch>(
-    const OpImageSparseFetch *) {
+llvm::Error Builder::create<OpImageSparseFetch>(const OpImageSparseFetch *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseGather>(
-    const OpImageSparseGather *) {
+llvm::Error Builder::create<OpImageSparseGather>(const OpImageSparseGather *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseDrefGather>(
+llvm::Error Builder::create<OpImageSparseDrefGather>(
     const OpImageSparseDrefGather *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseTexelsResident>(
+llvm::Error Builder::create<OpImageSparseTexelsResident>(
     const OpImageSparseTexelsResident *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpNoLine>(const OpNoLine *) {
+llvm::Error Builder::create<OpNoLine>(const OpNoLine *) {
   checkEndOpLineRange();
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicFlagTestAndSet>(
+llvm::Error Builder::create<OpAtomicFlagTestAndSet>(
     const OpAtomicFlagTestAndSet *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
@@ -7294,12 +7199,11 @@ cargo::optional<Error> Builder::create<OpAtomicFlagTestAndSet>(
                                op->IdResultType(), {pointer, semantics, scope},
                                {MangleInfo(op->Pointer(), MangleInfo::VOLATILE),
                                 op->Semantics(), op->Scope()}));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAtomicFlagClear>(
-    const OpAtomicFlagClear *op) {
+llvm::Error Builder::create<OpAtomicFlagClear>(const OpAtomicFlagClear *op) {
   auto pointer = module.getValue(op->Pointer());
   SPIRV_LL_ASSERT_PTR(pointer);
 
@@ -7313,29 +7217,27 @@ cargo::optional<Error> Builder::create<OpAtomicFlagClear>(
                            spv::OpTypeVoid, {pointer, semantics, scope},
                            {MangleInfo(op->Pointer(), MangleInfo::VOLATILE),
                             op->Semantics(), op->Scope()});
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpImageSparseRead>(
-    const OpImageSparseRead *) {
+llvm::Error Builder::create<OpImageSparseRead>(const OpImageSparseRead *) {
   // This instruction requires the SparseResidency capability which is not
   // supported by OpenCL 1.2 (see OpenCL SPIR-V environment spec section 6.1)
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpAssumeTrueKHR>(
-    const OpAssumeTrueKHR *op) {
+llvm::Error Builder::create<OpAssumeTrueKHR>(const OpAssumeTrueKHR *op) {
   auto condition = module.getValue(op->Condition());
   SPIRV_LL_ASSERT_PTR(condition);
 
   IRBuilder.CreateAssumption(condition);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<Error> Builder::create<OpExpectKHR>(const OpExpectKHR *op) {
+llvm::Error Builder::create<OpExpectKHR>(const OpExpectKHR *op) {
   llvm::Type *type = module.getLLVMType(op->IdResultType());
   SPIRV_LL_ASSERT_PTR(type);
 
@@ -7354,7 +7256,7 @@ cargo::optional<Error> Builder::create<OpExpectKHR>(const OpExpectKHR *op) {
   module.addID(op->IdResult(), op,
                IRBuilder.CreateIntrinsic(llvm::Intrinsic::expect, type,
                                          {value, expectedValue}));
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 }  // namespace spirv_ll

--- a/modules/compiler/spirv-ll/source/builder_glsl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_glsl.cpp
@@ -26,7 +26,7 @@
 namespace spirv_ll {
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Round>(opc);
 
@@ -41,12 +41,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::RoundEven>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -60,11 +60,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Trunc>(opc);
 
@@ -79,11 +79,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FAbs>(opc);
 
@@ -98,11 +98,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SAbs>(opc);
 
@@ -117,11 +117,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FSign>(opc);
 
@@ -136,11 +136,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SSign>(opc);
 
@@ -182,11 +182,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Floor>(opc);
 
@@ -201,11 +201,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Ceil>(opc);
 
@@ -220,11 +220,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Fract>(opc);
 
@@ -254,12 +254,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Radians>(opc);
 
   llvm::Value *degrees = module.getValue(op->degrees());
@@ -273,12 +273,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Degrees>(opc);
 
   llvm::Value *radians = module.getValue(op->radians());
@@ -292,12 +292,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Sin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -311,12 +310,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Cos>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -330,12 +328,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Tan>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -349,11 +346,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Asin>(opc);
 
@@ -368,11 +365,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Acos>(opc);
 
@@ -387,11 +384,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Atan>(opc);
 
@@ -407,11 +404,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Sinh>(opc);
 
@@ -426,11 +423,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Cosh>(opc);
 
@@ -445,11 +442,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Tanh>(opc);
 
@@ -464,11 +461,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Asinh>(opc);
 
@@ -483,11 +480,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Acosh>(opc);
 
@@ -502,11 +499,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Atanh>(opc);
 
@@ -521,11 +518,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Atan2>(opc);
 
@@ -543,12 +540,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Pow>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -565,12 +561,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Exp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -584,12 +579,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Log>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -603,11 +597,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Exp2>(opc);
 
@@ -622,11 +616,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Log2>(opc);
 
@@ -641,11 +635,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Sqrt>(opc);
 
@@ -660,12 +654,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::InverseSqrt>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -679,33 +673,33 @@ spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Determinant>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Determinant>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Determinant>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450MatrixInverse>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450MatrixInverse>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::MatrixInverse>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Modf>(opc);
 
@@ -723,12 +717,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FrexpStruct>(opc);
 
   auto *x = module.getValue(op->x());
@@ -761,11 +755,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FMin>(opc);
 
@@ -783,11 +777,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UMin>(opc);
 
@@ -805,11 +799,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SMin>(opc);
 
@@ -827,11 +821,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FMax>(opc);
 
@@ -849,11 +843,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UMax>(opc);
 
@@ -871,11 +865,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SMax>(opc);
 
@@ -893,12 +887,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -919,12 +913,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -945,12 +939,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -971,11 +965,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FMix>(opc);
 
@@ -997,22 +991,22 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450IMix>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450IMix>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::IMix>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Step>(opc);
 
@@ -1030,12 +1024,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::SmoothStep>(opc);
 
   llvm::Value *edge0 = module.getValue(op->edge0());
@@ -1056,12 +1050,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Fma>(opc);
 
   llvm::Value *a = module.getValue(op->a());
@@ -1083,11 +1076,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Frexp>(opc);
 
@@ -1118,12 +1111,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FrexpStruct>(opc);
 
   auto *x = module.getValue(op->x());
@@ -1162,11 +1155,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Ldexp>(opc);
 
@@ -1188,12 +1181,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackSnorm4x8>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1206,12 +1199,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(OpExtInst const &opc) {
       "packSnorm4x8", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackUnorm4x8>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1224,12 +1217,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(OpExtInst const &opc) {
       "packUnorm4x8", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackSnorm2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1242,12 +1235,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(OpExtInst const &opc) {
       "packSnorm2x16", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackUnorm2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1260,12 +1253,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(OpExtInst const &opc) {
       "packUnorm2x16", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackHalf2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1278,12 +1271,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(OpExtInst const &opc) {
       "packHalf2x16", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::PackDouble2x32>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1295,12 +1288,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(OpExtInst const &opc) {
   llvm::Value *result = builder.getIRBuilder().CreateBitCast(v, retType);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackSnorm2x16>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1313,12 +1306,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(OpExtInst const &opc) {
       "unpackSnorm2x16", retType, op->IdResultType(), {p}, {op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackUnorm2x16>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1331,12 +1324,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(OpExtInst const &opc) {
       "unpackUnorm2x16", retType, op->IdResultType(), {p}, {op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackHalf2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1349,12 +1342,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(OpExtInst const &opc) {
       "unpackHalf2x16", retType, op->IdResultType(), {v}, {op->v()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackSnorm4x8>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1367,12 +1360,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(OpExtInst const &opc) {
       "unpackSnorm4x8", retType, op->IdResultType(), {p}, {op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackUnorm4x8>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1385,12 +1378,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(OpExtInst const &opc) {
       "unpackUnorm4x8", retType, op->IdResultType(), {p}, {op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::UnpackDouble2x32>(opc);
 
@@ -1403,12 +1395,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
   llvm::Value *result = builder.getIRBuilder().CreateBitCast(v, retType);
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Length>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Length>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Length>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1422,12 +1414,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Length>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Distance>(opc);
 
   llvm::Value *p0 = module.getValue(op->p0());
@@ -1444,11 +1436,11 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Cross>(opc);
 
@@ -1466,12 +1458,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Normalize>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1485,12 +1477,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FaceForward>(opc);
 
   llvm::Value *n = module.getValue(op->n());
@@ -1512,12 +1504,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Reflect>(opc);
 
   llvm::Value *i = module.getValue(op->i());
@@ -1535,12 +1527,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::Refract>(opc);
 
   llvm::Value *i = module.getValue(op->i());
@@ -1561,12 +1553,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FindILsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1580,12 +1572,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FindSMsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1600,12 +1592,12 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::FindUMsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1619,47 +1611,44 @@ spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtCentroid>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtCentroid>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtCentroid>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtSample>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtSample>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtSample>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtOffset>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtOffset>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtOffset>(opc);
 
   // Builtin not yet implemented!
   // Update and rerun generate_glsl_builder_calls once implemented.
   (void)op;
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::NMin>(opc);
 
@@ -1677,11 +1666,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
     OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::NMax>(opc);
 
@@ -1699,12 +1688,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(
+    OpExtInst const &opc) {
   auto *op = module.create<GLSLstd450::NClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1725,15 +1714,14 @@ spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(OpExtInst const &opc) {
 
   module.addID(op->IdResult(), op, result);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 #define CASE(ExtInst) \
   case ExtInst:       \
     return create<ExtInst>(opc);
 
-cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create(OpExtInst const &opc) {
   switch (opc.Instruction()) {
     CASE(GLSLstd450Round)
     CASE(GLSLstd450RoundEven)
@@ -1817,8 +1805,8 @@ cargo::optional<spirv_ll::Error> spirv_ll::GLSLBuilder::create(
     CASE(GLSLstd450NMax)
     CASE(GLSLstd450NClamp)
     default:
-      return Error("Unrecognized extended instruction " +
-                   std::to_string(opc.Instruction()));
+      return makeStringError(llvm::Twine("Unrecognized extended instruction ") +
+                             std::to_string(opc.Instruction()));
   }
 }
 

--- a/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
+++ b/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
@@ -50,7 +50,7 @@ struct GroupAsyncCopy3D3D : OpExtInst {
 };
 
 template <>
-cargo::optional<spirv_ll::Error>
+llvm::Error
 GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
     OpExtInst const &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy2D2D>(opc);
@@ -89,9 +89,9 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
     mangledName =
         "_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event";
   } else {
-    return Error{
+    return makeStringError(
         "GroupAsyncCopy2D2D invalid storage class for Source and/or "
-        "Destination"};
+        "Destination");
   }
 
   llvm::Type *i8Ty = llvm::IntegerType::getInt8Ty(*module.context.llvmContext);
@@ -115,11 +115,11 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
       /* convergent = */ true);
   module.addID(op->IdResult(), op, call);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
+llvm::Error
 GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
     OpExtInst const &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy3D3D>(opc);
@@ -164,9 +164,9 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
     mangledName =
         "_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event";
   } else {
-    return Error{
+    return makeStringError(
         "GroupAsyncCopy3D3D invalid storage class for Source and/or "
-        "Destination"};
+        "Destination");
   }
 
   llvm::Type *i8Ty = llvm::IntegerType::getInt8Ty(*module.context.llvmContext);
@@ -193,20 +193,19 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
       /* convergent = */ true);
   module.addID(op->IdResult(), op, call);
 
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
-cargo::optional<spirv_ll::Error> GroupAsyncCopiesBuilder::create(
-    OpExtInst const &opc) {
+llvm::Error GroupAsyncCopiesBuilder::create(OpExtInst const &opc) {
   switch (opc.Instruction()) {
     case GroupAsyncCopy2D2D:
       return create<GroupAsyncCopy2D2D>(opc);
     case GroupAsyncCopy3D3D:
       return create<GroupAsyncCopy3D3D>(opc);
     default:
-      return Error{
+      return makeStringError(
           "Unrecognized Codeplay.GroupAsyncCopies extended instruction " +
-          std::to_string(opc.Instruction())};
+          std::to_string(opc.Instruction()));
   }
 }
 }  // namespace spirv_ll

--- a/modules/compiler/spirv-ll/source/builder_opencl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_opencl.cpp
@@ -22,9 +22,8 @@
 
 namespace spirv_ll {
 
-static cargo::optional<spirv_ll::Error> createPrintf(OpExtInst const &opc,
-                                                     Module &module,
-                                                     Builder &builder) {
+static llvm::Error createPrintf(OpExtInst const &opc, Module &module,
+                                Builder &builder) {
   auto *op = module.create<OpenCLstd::Printf>(opc);
 
   llvm::Type *resultType = module.getLLVMType(op->IdResultType());
@@ -62,12 +61,11 @@ static cargo::optional<spirv_ll::Error> createPrintf(OpExtInst const &opc,
   call->setTailCallKind(llvm::CallInst::TCK_Tail);
 
   module.addID(op->IdResult(), op, call);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X>>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X>>(OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -75,11 +73,11 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X>>(
       op->IdResultType(), {op->x()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X, Y>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, Y>>(opc);
 
@@ -88,12 +86,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X, Y>>(
       op->IdResultType(), {op->x(), op->y()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, Z>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, Z>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, Y, Z>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -101,12 +99,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, Z>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->y(), op->z()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, PTR>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, PTR>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, PTR>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -114,12 +112,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, PTR>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->ptr()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, EXP>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, EXP>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, EXP>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -127,11 +125,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, EXP>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->exp()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X, K>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, K>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, K>>(opc);
 
@@ -140,12 +138,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<X, K>>(
       op->IdResultType(), {op->x(), op->k()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, SIGNP>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SIGNP>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, SIGNP>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -153,11 +151,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, SIGNP>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->signp()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<Y, X>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<Y, X>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<Y, X>>(opc);
 
@@ -166,12 +164,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<Y, X>>(
       op->IdResultType(), {op->y(), op->x()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<A, B, C>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<A, B, C>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<A, B, C>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -179,12 +177,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<A, B, C>>(OpExtInst const &opc) {
       op->IdResultType(), {op->a(), op->b(), op->c()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, IPTR>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, IPTR>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, IPTR>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -192,12 +190,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, IPTR>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->iPtr()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<NANCODE>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<NANCODE>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<NANCODE>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -205,12 +203,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<NANCODE>>(OpExtInst const &opc) {
       op->IdResultType(), {op->nanCode()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, QUO>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, QUO>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, Y, QUO>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -218,12 +216,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, QUO>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->y(), op->quo()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, COSVAL>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, COSVAL>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, COSVAL>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -231,12 +229,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, COSVAL>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->cosVal()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, MINVAL, MAXVAL>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, MINVAL, MAXVAL>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, MINVAL, MAXVAL>>(opc);
 
@@ -245,11 +242,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, MINVAL, MAXVAL>>(
       op->IdResultType(), {op->x(), op->minVal(), op->maxVal()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<V, I>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<V, I>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<V, I>>(opc);
 
@@ -258,12 +255,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<V, I>>(
       op->IdResultType(), {op->v(), op->i()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<HI, LO>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<HI, LO>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<HI, LO>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -271,12 +268,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<HI, LO>>(OpExtInst const &opc) {
       op->IdResultType(), {op->hi(), op->lo()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<DEGREES>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DEGREES>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<DEGREES>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -284,12 +281,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<DEGREES>>(OpExtInst const &opc) {
       op->IdResultType(), {op->degrees()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<RADIANS>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<RADIANS>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<RADIANS>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -297,12 +294,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<RADIANS>>(OpExtInst const &opc) {
       op->IdResultType(), {op->radians()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, A>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, A>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, Y, A>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -310,12 +307,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, A>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->y(), op->a()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<P>>(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P>>(OpExtInst const &opc) {
   auto *op = module.create<ExtInst<P>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -323,12 +319,12 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create<ExtInst<P>>(
       op->IdResultType(), {op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<P0, P1>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P0, P1>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<P0, P1>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -336,12 +332,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<P0, P1>>(OpExtInst const &opc) {
       op->IdResultType(), {op->p0(), op->p1()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<EDGE, X>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE, X>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<EDGE, X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -349,12 +345,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<EDGE, X>>(OpExtInst const &opc) {
       op->IdResultType(), {op->edge(), op->x()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<EDGE0, EDGE1, X>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE0, EDGE1, X>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<EDGE0, EDGE1, X>>(opc);
 
@@ -363,12 +358,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<EDGE0, EDGE1, X>>(
       op->IdResultType(), {op->edge0(), op->edge1(), op->x()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, SHUFFLEMASK>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SHUFFLEMASK>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, SHUFFLEMASK>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -376,12 +371,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, SHUFFLEMASK>>(OpExtInst const &opc) {
       op->IdResultType(), {op->x(), op->shuffleMask()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, SHUFFLEMASK>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, SHUFFLEMASK>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<X, Y, SHUFFLEMASK>>(opc);
 
@@ -390,12 +384,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, SHUFFLEMASK>>(
       op->IdResultType(), {op->x(), op->y(), op->shuffleMask()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<PTR, NUM_ELEMENTS>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<PTR, NUM_ELEMENTS>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<PTR, NUM_ELEMENTS>>(opc);
 
@@ -404,12 +397,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<PTR, NUM_ELEMENTS>>(
       op->IdResultType(), {op->ptr(), op->numElements()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<OFFSET, P, N>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -417,12 +410,12 @@ spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P>>(OpExtInst const &opc) {
       op->IdResultType(), {op->offset(), op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P, N>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P, N>>(
+    OpExtInst const &opc) {
   auto *op = module.create<ExtInst<OFFSET, P, N>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -430,12 +423,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P, N>>(OpExtInst const &opc) {
       op->IdResultType(), {op->offset(), op->p(), op->n()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<DATA, OFFSET, P>>(opc);
 
@@ -444,12 +436,11 @@ spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P>>(
       op->IdResultType(), {op->data(), op->offset(), op->p()});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 template <>
-cargo::optional<spirv_ll::Error>
-spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P, MODE>>(
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P, MODE>>(
     OpExtInst const &opc) {
   auto *op = module.create<ExtInst<DATA, OFFSET, P, MODE>>(opc);
 
@@ -459,15 +450,14 @@ spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P, MODE>>(
       {op->data(), op->offset(), op->p(), static_cast<spv::Id>(op->mode())});
 
   module.addID(op->IdResult(), op, result);
-  return cargo::nullopt;
+  return llvm::Error::success();
 }
 
 #define CASE(Opcode, ExtInst) \
   case Opcode:                \
     return create<ExtInst>(opc);
 
-cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create(
-    OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create(OpExtInst const &opc) {
   switch (opc.Instruction()) {
     CASE(OpenCLLIB::Acos, OpenCLstd::Acos)
     CASE(OpenCLLIB::Acosh, OpenCLstd::Acosh)
@@ -635,8 +625,8 @@ cargo::optional<spirv_ll::Error> spirv_ll::OpenCLBuilder::create(
       return createPrintf(opc, module, builder);
 
     default:
-      return Error("Unrecognized extended instruction " +
-                   std::to_string(opc.Instruction()));
+      return makeStringError("Unrecognized extended instruction " +
+                             std::to_string(opc.Instruction()));
   }
 }
 

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -147,7 +147,7 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
   llvm::SmallVector<OpIRLocTy, 8> Phis;
 
   for (auto op : module) {
-    cargo::optional<Error> error;
+    std::optional<llvm::Error> error;
     switch (op.code) {
         // Unsupported opcodes are ignored.
       default:
@@ -157,7 +157,8 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
         // SPIR-V which contains unsupported opcodes intentionally by the user
         // with the intent that the SPIR-V consumer simply ignores them, as is
         // allowed by the SPIR-V spec, then this abort should be removed.
-        error = Error{"unsupported opcode: " + std::to_string(op.code)};
+        error =
+            makeStringError("unsupported opcode: " + std::to_string(op.code));
 #endif
         break;
       case spv::OpNop:
@@ -1112,8 +1113,8 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
         error = builder.create<OpExpectKHR>(op);
         break;
     }
-    if (error) {
-      return cargo::make_unexpected(std::move(error.value()));
+    if (error && *error) {
+      return cargo::make_unexpected(llvm::toString(std::move(*error)));
     }
   }
 

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -673,17 +673,17 @@ void spirv_ll::Module::setParamTypeIDs(spv::Id F, llvm::ArrayRef<spv::Id> IDs) {
   ParamTypeIDs[F].assign(IDs.begin(), IDs.end());
 }
 
-cargo::optional<spv::Id> spirv_ll::Module::getParamTypeID(
-    spv::Id F, unsigned argno) const {
+std::optional<spv::Id> spirv_ll::Module::getParamTypeID(spv::Id F,
+                                                        unsigned argno) const {
   auto it = ParamTypeIDs.find(F);
   if (it == ParamTypeIDs.end()) {
     assert(false && "function type was not added before query");
-    return cargo::nullopt;
+    return std::nullopt;
   }
   auto &params = it->getSecond();
   if (argno >= params.size()) {
     assert(false && "invalid number of parameters for function");
-    return cargo::nullopt;
+    return std::nullopt;
   }
   return params[argno];
 }
@@ -703,10 +703,10 @@ void spirv_ll::Module::addSpecId(spv::Id id, spv::Id spec_id) {
   SpecIDs.insert({id, spec_id});
 }
 
-cargo::optional<uint32_t> spirv_ll::Module::getSpecId(spv::Id id) const {
+std::optional<uint32_t> spirv_ll::Module::getSpecId(spv::Id id) const {
   auto found = SpecIDs.find(id);
   if (found == SpecIDs.end()) {
-    return cargo::nullopt;
+    return std::nullopt;
   }
   return found->second;
 }

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -35,7 +35,7 @@ int outputSpecConstants(spirv_ll::Context &spvContext,
                         llvm::ArrayRef<uint32_t> spvCode,
                         llvm::raw_os_ostream &out);
 
-cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
+llvm::Expected<spirv_ll::DeviceInfo> getDeviceInfo(
     cargo::string_view api, cargo::array_view<cargo::string_view> capabilities,
     cargo::array_view<cargo::string_view> extensions, cargo::string_view bits,
     bool enableAll);
@@ -197,8 +197,8 @@ optional arguments:
 
   auto spvDeviceInfo =
       getDeviceInfo(api, capabilities, extensions, addressBits, enableAll);
-  if (!spvDeviceInfo) {
-    std::cerr << spvDeviceInfo.error() << "\n";
+  if (auto err = spvDeviceInfo.takeError()) {
+    std::cerr << llvm::toString(std::move(err)) << "\n";
     return 1;
   }
 
@@ -267,7 +267,7 @@ int outputSpecConstants(spirv_ll::Context &spvContext,
   return 0;
 }
 
-cargo::expected<spirv_ll::DeviceInfo, std::string> getDeviceInfo(
+llvm::Expected<spirv_ll::DeviceInfo> getDeviceInfo(
     cargo::string_view api, cargo::array_view<cargo::string_view> capabilities,
     cargo::array_view<cargo::string_view> extensions, cargo::string_view bits,
     bool enableAll) {


### PR DESCRIPTION
This commit changes most internal uses of cargo data types:

* `cargo::optional<spirv_ll::Error>` -> `llvm:Error`
* `cargo::optional<T>` -> `std::optional<T>`
* `cargo::expected<T, std::string>` -> `llvm::Expected<T>`

The rationale is that `spirv-ll` is inherently an LLVM-based tool - we don't build the tool at all in an LLVM-less build - and so making use of more "standard" types should be more intuitive - returning `llvm::Error::success()` instead of `cargo::nullopt`, for instance. We can also make use of LLVM's more extensive support for dedicated error handling, compared with our hand-rolled version.

I haven't changed the 'external' (or public) APIs just yet: those which the `compiler` module makes use of. That can come later, if we so wish.