### PR TITLE
Fix dependency on resources again.

### DIFF
--- a/cmake/ResourceCompiler.cmake
+++ b/cmake/ResourceCompiler.cmake
@@ -300,6 +300,10 @@ function(target_resources target)
     message(FATAL_ERROR "One or more NAMESPACES must be provided.")
   endif()
 
+  foreach(namespace ${args_NAMESPACES})
+    add_dependencies(${target} resources-${namespace})
+  endforeach()
+
   # Generate the .s/.rc files and add them to the specified target.
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 


### PR DESCRIPTION
# Overview

Fix dependency on resources again.

# Reason for change

In #210, I added `OBJECT_DEPENDS` for resources and removed `add_dependencies` as it should no longer be needed. Actually, we need both: the `OBJECT_DEPENDS` documentation says target-level dependencies need to be added as well.

# Description of change

File-level dependencies require target-level dependencies as well. The Ninja generator works fine without them, but the Makefile generator does not.

# Anything else we should know?

This partially reverts #210.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
