### PR TITLE
[mux][riscv] Fix getLocalSizeForSubGroupCount

### DIFF
--- a/modules/mux/test/muxQueryLocalSizeForSubGroupCount.cpp
+++ b/modules/mux/test/muxQueryLocalSizeForSubGroupCount.cpp
@@ -119,7 +119,7 @@ TEST_P(muxQueryLocalSizeForSubGroupCountTest, ValidateLocalSize) {
   // be 1.
   const auto one_dimensional_counts =
       std::count(std::begin(local_sizes), std::end(local_sizes), 1);
-  ASSERT_EQ(one_dimensional_counts, 2);
+  ASSERT_GE(one_dimensional_counts, 2);
 
   // The local size must be evenly divisible by the sub-group size with no
   // remainders.

--- a/source/cl/scripts/cts-3.0-online-ignore-linux-riscv.csv
+++ b/source/cl/scripts/cts-3.0-online-ignore-linux-riscv.csv
@@ -1306,6 +1306,3 @@ SPIR (cl_khr_spir),spir/test_spir conversions_double no-unzip
 Mipmaps (Kernel),images/kernel_read_write/test_image_streams test_mipmaps CL_FILTER_NEAREST
 Mipmaps (clCopyImage),images/clCopyImage/test_cl_copy_images
 Mipmaps (clReadWriteImage),images/clReadWriteImage/test_cl_read_write_images test_mipmaps
-
-# TODO(CA-4540): Fix cl12/api/test_api/sub_group_dispatch.
-API,api/test_api sub_group_dispatch


### PR DESCRIPTION
We hadn't fully fleshed out this query on riscv. We were returning 0,0,0 (an invalid work-group size) for anything other than 1 sub-group. This was being picked up as a failure by the OpenCL-CTS.

Instead, we must return a work-group size for which the work-group would execute the same number of sub-groups as we've been asked for. The returned work-group size is always 1D, hence we only care about the 'X' dimension.

We do this by taking the maximum sub-group size we've compiled, and returning the count multiplied by that size. This is because we know the kernel variant picking algorithm favours the kernel variant with the highest legal sub-group size. If the required work-group size is invalid we must also report 0,0,0.

This fixes a test failure in the OpenCL CTS.