### PR TITLE
[spirv-ll] Add an interface for OpExtInstImport handlers

### DIFF
--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -47,6 +47,9 @@ endif()
 add_ca_library(spirv-ll STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/assert.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/builder.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/builder_glsl.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/builder_group_async_copies.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/builder_opencl.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/context.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/module.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-ll/opcodes.h

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_glsl.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_glsl.h
@@ -1,0 +1,50 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SPIRV_LL_SPV_BUILDER_GLSL_H_INCLUDED
+#define SPIRV_LL_SPV_BUILDER_GLSL_H_INCLUDED
+
+#include <spirv-ll/builder.h>
+
+namespace spirv_ll {
+
+class GLSLBuilder : public ExtInstSetHandler {
+ public:
+  /// @brief Constructor.
+  ///
+  /// @param builder `Builder` object that will own this object.
+  /// @param module The module being translated.
+  GLSLBuilder(Builder &builder, Module &module)
+      : ExtInstSetHandler(builder, module) {}
+
+  /// @see ExtendedInstrSet::create
+  virtual llvm::Error create(OpExtInst const &opc) override;
+
+ private:
+  /// @brief Create a GLSL extended instruction transformation to LLVM IR.
+  ///
+  /// @tparam inst The GLSL extended instruction to create.
+  /// @param opc The OpCode object to translate.
+  ///
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  template <enum GLSLstd450 inst>
+  llvm::Error create(OpExtInst const &opc);
+};
+
+}  // namespace spirv_ll
+
+#endif  // SPIRV_LL_SPV_BUILDER_GLSL_H_INCLUDED

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_group_async_copies.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_group_async_copies.h
@@ -1,0 +1,62 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SPIRV_LL_SPV_BUILDER_GROUP_ASYNC_COPIES_H_INCLUDED
+#define SPIRV_LL_SPV_BUILDER_GROUP_ASYNC_COPIES_H_INCLUDED
+
+#include <spirv-ll/builder.h>
+
+namespace spirv_ll {
+
+/// @brief builder for the Codeplay.GroupAsyncCopies extended instruction set.
+class GroupAsyncCopiesBuilder : public ExtInstSetHandler {
+ public:
+  /// @brief Constructor.
+  ///
+  /// @param[in] builder spirv_ll::Builder object that will own this object.
+  /// @param[in] module The module being translated.
+  GroupAsyncCopiesBuilder(Builder &builder, Module &module)
+      : ExtInstSetHandler(builder, module) {}
+
+  /// @brief Enumeration of instruction ID's in the Codeplay.GroupAsyncCopies
+  /// extended instruction set.
+  // TODO(CA-4119): If this vendor extension lives beyond any official Khronos
+  // extension, these definitions should be defined upstream in SPIRV-Headers.
+  enum Instruction {
+    GroupAsyncCopy2D2D = 1,  ///< Represents async_work_group_copy_2D2D.
+    GroupAsyncCopy3D3D = 2,  ///< Represents async_work_group_copy_3D3D.
+  };
+
+  /// @see ExtInstSetHandler::create
+  virtual llvm::Error create(OpExtInst const &opc) override;
+
+ private:
+  /// @brief Create a Codeplay.GroupAsyncCopies extended instruction
+  /// transformation to LLVM IR.
+  ///
+  /// @tparam inst The Codeplay.GroupAsyncCopies extended instruction to
+  /// create.
+  /// @param opc The spirv_ll::OpCode object to translate.
+  ///
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  template <Instruction inst>
+  llvm::Error create(OpExtInst const &opc);
+};
+
+}  // namespace spirv_ll
+
+#endif  // SPIRV_LL_SPV_BUILDER_GROUP_ASYNC_COPIES_H_INCLUDED

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_opencl.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_opencl.h
@@ -1,0 +1,61 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SPIRV_LL_SPV_BUILDER_OPENCL_H_INCLUDED
+#define SPIRV_LL_SPV_BUILDER_OPENCL_H_INCLUDED
+
+#include <spirv-ll/builder.h>
+
+namespace spirv_ll {
+
+class OpenCLBuilder : public spirv_ll::ExtInstSetHandler {
+ public:
+  /// @brief Constructor.
+  ///
+  /// @param builder `Builder` object that will own this object.
+  /// @param module The module being translated.
+  OpenCLBuilder(Builder &builder, Module &module)
+      : ExtInstSetHandler(builder, module) {}
+
+  /// @see ExtInstSetHandler::create
+  virtual llvm::Error create(OpExtInst const &opc) override;
+
+ private:
+  /// @brief Create an OpenCL extended instruction transformation to LLVM IR.
+  ///
+  /// @tparam T The OpenCL extended instruction class template to create.
+  /// @param opc The OpCode object to translate.
+  ///
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  template <typename T>
+  llvm::Error create(OpExtInst const &opc);
+
+  /// @brief Create a vector OpenCL extended instruction transformation to LLVM
+  /// IR.
+  ///
+  /// @tparam inst The OpenCL extended instruction to create.
+  /// @param opc The OpCode object to translate.
+  ///
+  /// @return Returns an `llvm::Error` object representing either success, or
+  /// an error value.
+  template <OpenCLLIB::Entrypoints inst>
+  llvm::Error createVec(OpExtInst const &opc);
+};
+
+}  // namespace spirv_ll
+
+#endif  // SPIRV_LL_SPV_BUILDER_OPENCL_H_INCLUDED

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -35,10 +35,7 @@ spirv_ll::Builder::Builder(spirv_ll::Context &context, spirv_ll::Module &module,
       deviceInfo(deviceInfo),
       IRBuilder(*context.llvmContext),
       DIBuilder(*module.llvmModule),
-      CurrentFunction(nullptr),
-      OpenCLBuilder(*this, module),
-      GLSLBuilder(*this, module),
-      GroupAsyncCopiesBuilder(*this, module) {}
+      CurrentFunction(nullptr) {}
 
 llvm::IRBuilder<> &spirv_ll::Builder::getIRBuilder() { return IRBuilder; }
 

--- a/modules/compiler/spirv-ll/source/builder_glsl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_glsl.cpp
@@ -18,7 +18,7 @@
 #include <llvm/IR/Instructions.h>
 #include <multi_llvm/vector_type_helper.h>
 #include <spirv-ll/assert.h>
-#include <spirv-ll/builder.h>
+#include <spirv-ll/builder_glsl.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
 #include <spirv/1.0/GLSL.std.450.h>

--- a/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
+++ b/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <spirv-ll/builder.h>
+#include <spirv-ll/builder_group_async_copies.h>
 #include <spirv-ll/module.h>
 
 namespace spirv_ll {

--- a/modules/compiler/spirv-ll/source/builder_opencl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_opencl.cpp
@@ -16,7 +16,7 @@
 
 #include <cargo/optional.h>
 #include <llvm/IR/Attributes.h>
-#include <spirv-ll/builder.h>
+#include <spirv-ll/builder_opencl.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
 


### PR DESCRIPTION
This goes part way towards making the handling of SPIR-V extended instruction sets more flexible and less dependent on changing `spirv-ll` itself.

By adding an abstract interface through which the handlers are registered and are asked to handle a given `OpExtInst`, users of this library may in the future be able to register their own external handlers, if we so wish. This has been a long-standing wish for the project.

In the short-term, it helpers to separate out almost all of the handling of extended instruction sets into separate files. We were previously defining all the handlers in the common `builder.h` header file.