### PR TITLE
[compiler] Include file offset when loading builtins PCH

### DIFF
--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -238,7 +238,12 @@ static bool loadKernelAPIHeader(clang::CompilerInstance &compiler,
   // stored inside the PCH file.
   llvm::BitstreamCursor &Cursor = moduleFile->InputFilesCursor;
   clang::SavedStreamPosition SavedPosition(Cursor);
-  if (Cursor.JumpToBit(moduleFile->InputFileOffsets[0])) {
+  uint64_t Base = 0;
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+  // LLVM 18 introduces a new offset that should be included
+  Base = moduleFile->InputFilesOffsetBase;
+#endif
+  if (Cursor.JumpToBit(Base + moduleFile->InputFileOffsets[0])) {
     return false;
   }
 
@@ -250,7 +255,7 @@ static bool loadKernelAPIHeader(clang::CompilerInstance &compiler,
   // warning.  However, this assert is guaranteed to be correct due to the
   // above `Cursor.JumpToBit` call, and provides enough information for
   // clang-tidy to understand that the undefined shift is impossible.
-  assert((Cursor.GetCurrentBitNo() == moduleFile->InputFileOffsets[0]) &&
+  assert((Cursor.GetCurrentBitNo() == Base + moduleFile->InputFileOffsets[0]) &&
          "Clang bitstream reader is in invalid state.");
   clang::ASTReader::RecordData Record;
   llvm::StringRef Filename;


### PR DESCRIPTION
# Overview
Commit d4a912153488 changed how the offsets into AST bitstream files are handled. This patch changes our loading of the builtinsPCH to include the new `InputFilesOffsetBase` field.
    
As this only affects LLVM tip/18, we also introduce a multi_llvm toggle.

# Reason for change
This was causing LLVM tip to crash when reading the headers on tip.

# Description of change

Upstream LLVM added a new `InputFilesOffsetBase` field for the module file which should be included when offsetting into the module.

As this was crashing our CI systems, a completed build with a debug mode compiler should be sufficient to prove that it fixes things.

# Anything else we should know?
N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
