### PR TITLE
Create a basic nightly OCK build and test vector-add using oneAPI. 

### DIFF
--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -1,0 +1,65 @@
+name: Build and Package
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs the workflow at midnight every day
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # build and run for RISCV
+  run_riscv_m1_nightly_package:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+       # installs tools, ninja, installs llvm and sets up sccache
+      - name: Setup ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          llvm_version: 17
+          llvm_build_type: RelAssert
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Build riscv M1
+        uses: ./.github/actions/do_build_ock/do_build_m1
+
+      - name: Download Daily Release
+        run: |
+          # TODO: Update the nightly release from intel/llvm from 2023-12-18 to daily once
+          # everything has stablised
+          wget "https://github.com/intel/llvm/releases/download/nightly-2023-12-18/sycl_linux.tar.gz"
+          mkdir linux_nightly_release
+          tar -xzf sycl_linux.tar.gz -C linux_nightly_release
+
+      - name: Clone oneAPI-samples
+        run: git clone https://github.com/oneapi-src/oneAPI-samples.git
+
+      - name: Setup environment and test Vector Add
+        run: |
+          export ONEAPI_ROOT=$(pwd)/linux_nightly_release
+          export PATH=$(pwd)/linux_nightly_release/bin:$PATH
+          export LD_LIBRARY_PATH=$(pwd)/linux_nightly_release/lib:$(pwd)/build/lib:$LD_LIBRARY_PATH
+
+          $(pwd)/linux_nightly_release/bin/clang++ -fsycl $(pwd)/oneAPI-samples/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp -o vect
+          CA_HAL_DEBUG=1 OCL_ICD_FILENAMES=$(pwd)/build/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc  SYCL_CONFIG_FILE_NAME="" ./vect
+
+      - name: Package Artifacts
+        run: |
+          tar -czf ock_build.tar.gz $(pwd)/build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: riscv-build
+          path: ock_build.tar.gz


### PR DESCRIPTION
# Overview
Create a basic nightly OCK build and test vector-add using oneAPI. 
The ock build is archived if the test passes which can then be used
other builds.

As a further step I am also trying to create a pre-release of OCK [here](https://github.com/codeplaysoftware/oneapi-construction-kit/pull/270)

