### PR TITLE
Re-enable a bunch more tests.

### DIFF
--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -328,9 +328,9 @@ TEST_P(HalfOperatorTest, Precision_03_Half_Add) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2, 3 and 4 don't work.
+  // TODO: CA-2882: Vector width 3 doesn't work.
 #ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 3) || (getParam() == 4)) {
+  if (getParam() == 3) {
     GTEST_SKIP();
   }
 #endif
@@ -345,9 +345,9 @@ TEST_P(HalfOperatorTest, Precision_04_Half_Sub) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2, 3 and 4 don't work.
+  // TODO: CA-2882: Vector width 3 doesn't work.
 #ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 3) || (getParam() == 4)) {
+  if (getParam() == 3) {
     GTEST_SKIP();
   }
 #endif
@@ -362,9 +362,9 @@ TEST_P(HalfOperatorTest, Precision_05_Half_Mul) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2, 3 and 4 don't work.
+  // TODO: CA-2882: Vector width 3 doesn't work.
 #ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 3) || (getParam() == 4)) {
+  if (getParam() == 3) {
     GTEST_SKIP();
   }
 #endif
@@ -379,9 +379,9 @@ TEST_P(HalfOperatorTest, Precision_06_Half_Div) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2, 3 and 4 don't work.
+  // TODO: CA-2882: Vector width 3 doesn't work.
 #ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 3) || (getParam() == 4)) {
+  if (getParam() == 3) {
     GTEST_SKIP();
   }
 #endif
@@ -396,9 +396,9 @@ TEST_P(HalfOperatorTest, Precision_07_Half_Recip) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2, 3 and 4 don't work.
+  // TODO: CA-2882: Vector width 3 doesn't work.
 #ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 3) || (getParam() == 4)) {
+  if (getParam() == 3) {
     GTEST_SKIP();
   }
 #endif
@@ -417,12 +417,6 @@ TEST_P(HalfMathBuiltins, Precision_08_Half_Ldexp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto ldexp_ref = [](cl_float x, cl_int n) -> cl_float {
     return std::ldexp(x, n);
@@ -435,12 +429,6 @@ TEST_P(HalfMathBuiltins, Precision_09_Half_Exp10) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto exp10_ref = [](cl_float x) -> cl_float { return std::pow(10.0f, x); };
 
@@ -451,12 +439,6 @@ TEST_P(HalfMathBuiltins, Precision_10_Half_Exp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto exp_ref = [](cl_float x) -> cl_float { return std::exp(x); };
 
@@ -467,12 +449,6 @@ TEST_P(HalfMathBuiltins, Precision_11_Half_Exp2) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto exp2_ref = [](cl_float x) -> cl_float { return std::exp2(x); };
 
@@ -483,12 +459,6 @@ TEST_P(HalfMathBuiltins, Precision_12_Half_Expm1) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto expm1_ref = [](cl_float x) -> cl_float { return std::expm1(x); };
 
@@ -499,12 +469,6 @@ TEST_P(HalfMathBuiltins, Precision_13_Half_Fabs) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fabs_ref = [](cl_float x) -> cl_float { return std::fabs(x); };
 
@@ -515,12 +479,6 @@ TEST_P(HalfMathBuiltins, Precision_14_Half_Copysign) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto copysign_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::copysign(x, y);
@@ -533,12 +491,6 @@ TEST_P(HalfMathBuiltins, Precision_15_Half_Floor) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto floor_ref = [](cl_float x) -> cl_float { return std::floor(x); };
 
@@ -549,12 +501,6 @@ TEST_P(HalfMathBuiltins, Precision_16_Half_Ceil) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto ceil_ref = [](cl_float x) -> cl_float { return std::ceil(x); };
 
@@ -580,12 +526,6 @@ TEST_P(HalfMathBuiltins, Precision_18_Half_frexp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto frexp_ref = [](cl_float x, cl_int &exp_out) -> cl_float {
     return std::frexp(x, &exp_out);
@@ -598,12 +538,6 @@ TEST_P(HalfMathBuiltins, Precision_18_Half_frexp_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto frexp_ref = [](cl_float x, cl_int &exp_out) -> cl_float {
     return std::frexp(x, &exp_out);
@@ -616,12 +550,6 @@ TEST_P(HalfMathBuiltins, Precision_18_Half_frexp_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto frexp_ref = [](cl_float x, cl_int &exp_out) -> cl_float {
     return std::frexp(x, &exp_out);
@@ -634,12 +562,6 @@ TEST_P(HalfMathBuiltins, Precision_19_Half_rsqrt) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto rsqrt_ref = [](cl_float x) -> cl_float { return 1.0f / std::sqrt(x); };
 
@@ -650,12 +572,6 @@ TEST_P(HalfMathBuiltins, Precision_20_Half_Sinpi) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sinpi_ref = [](cl_float x) -> cl_float { return std::sin(M_PI * x); };
 
@@ -666,12 +582,6 @@ TEST_P(HalfMathBuiltins, Precision_21_Half_Cospi) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto cospi_ref = [](cl_float x) -> cl_float { return std::cos(M_PI * x); };
 
@@ -682,13 +592,6 @@ TEST_P(HalfMathBuiltins, Precision_22_Half_ilogb) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work.
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   // If x is NAN we must return INT_MAX as that is what abacus returns for nan.
   // The C++ spec allows for *either* INT_MIN *or* INT_MAX via the signaling
@@ -711,12 +614,6 @@ TEST_P(HalfMathBuiltins, Precision_23_Half_log2) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto log2_ref = [](cl_float x) -> cl_float { return std::log2(x); };
 
@@ -727,12 +624,6 @@ TEST_P(HalfMathBuiltins, Precision_24_Half_log10) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto log10_ref = [](cl_float x) -> cl_float { return std::log10(x); };
 
@@ -743,12 +634,6 @@ TEST_P(HalfMathBuiltins, Precision_25_Half_log) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto log_ref = [](cl_float x) -> cl_float { return std::log(x); };
 
@@ -759,13 +644,6 @@ TEST_P(HalfMathBuiltins, Precision_26_Half_fmax) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 or 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fmax_ref = [](cl_float x, cl_float y) -> cl_float {
     // Work around issue on 64-bit arm std::fmaxf by casting to double
@@ -780,13 +658,6 @@ TEST_P(HalfMathBuiltins, Precision_27_Half_fmin) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2 or 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto fmin_ref = [](cl_float x, cl_float y) -> cl_float {
     // Work around issue on 64-bit arm std::fminf by casting to double
     return std::fmin((double)x, (double)y);
@@ -799,13 +670,6 @@ TEST_P(HalfMathBuiltins, Precision_28_Half_Maxmag) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 or 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto maxmag_ref = [](cl_float a, cl_float b) -> cl_float {
     const cl_float mag_a = std::fabs(a);
@@ -827,13 +691,6 @@ TEST_P(HalfMathBuiltins, Precision_29_Half_Minmag) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2 or 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto minmag_ref = [](cl_float a, cl_float b) -> cl_float {
     const cl_float mag_a = std::fabs(a);
     const cl_float mag_b = std::fabs(b);
@@ -853,12 +710,6 @@ TEST_P(HalfMathBuiltins, Precision_30_Half_Trunc) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto trunc_ref = [](cl_float x) -> cl_float { return std::trunc(x); };
 
@@ -941,12 +792,6 @@ TEST_P(HalfMathBuiltins, Precision_33_Half_fmod) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fmod_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::fmod(x, y);
@@ -959,12 +804,6 @@ TEST_P(HalfMathBuiltins, Precision_34_Half_round) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto round_ref = [](cl_float x) -> cl_float { return std::round(x); };
 
@@ -975,12 +814,6 @@ TEST_P(HalfMathBuiltins, Precision_35_Half_rint) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto rint_ref = [](cl_float x) -> cl_float { return std::rint(x); };
 
@@ -991,12 +824,6 @@ TEST_P(HalfMathBuiltins, Precision_36_Half_remainder) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto remainder_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::remainder(x, y);
@@ -1009,12 +836,6 @@ TEST_P(HalfMathBuiltins, Precision_37_Half_remquo) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   TestAgainstIntReferenceArgRef<0_ULP>(Remquo7BitRef<cl_float>);
 }
@@ -1023,12 +844,6 @@ TEST_P(HalfMathBuiltins, Precision_37_Half_remquo_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   TestAgainstIntReferenceArgRef<0_ULP>(Remquo7BitRef<cl_float>);
 }
@@ -1037,12 +852,6 @@ TEST_P(HalfMathBuiltins, Precision_37_Half_remquo_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   TestAgainstIntReferenceArgRef<0_ULP>(Remquo7BitRef<cl_float>);
 }
@@ -1051,12 +860,6 @@ TEST_P(HalfMathBuiltins, Precision_38_Half_fdim) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fdim_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::fdim(x, y);
@@ -1069,12 +872,6 @@ TEST_P(HalfMathBuiltins, Precision_39_Half_fract) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fract_ref = [](cl_float x, cl_float &out) -> cl_float {
     // NaN and Infinity behaviour taken from `std::modf` which the CTS uses as
@@ -1101,12 +898,6 @@ TEST_P(HalfMathBuiltins, Precision_39_Half_fract_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fract_ref = [](cl_float x, cl_float &out) -> cl_float {
     // NaN and Infinity behaviour taken from `std::modf` which the CTS uses as
@@ -1133,12 +924,6 @@ TEST_P(HalfMathBuiltins, Precision_39_Half_fract_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto fract_ref = [](cl_float x, cl_float &out) -> cl_float {
     // NaN and Infinity behaviour taken from `std::modf` which the CTS uses as
@@ -1165,12 +950,6 @@ TEST_P(HalfMathBuiltins, Precision_40_Half_logb) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto logb_ref = [](cl_float x) -> cl_float { return std::logb(x); };
 
@@ -1181,12 +960,6 @@ TEST_P(HalfMathBuiltins, Precision_41_Half_modf) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto modf_ref = [](cl_float x, cl_float &out) -> cl_float {
     return std::modf(x, &out);
@@ -1199,12 +972,6 @@ TEST_P(HalfMathBuiltins, Precision_41_Half_modf_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto modf_ref = [](cl_float x, cl_float &out) -> cl_float {
     return std::modf(x, &out);
@@ -1217,12 +984,6 @@ TEST_P(HalfMathBuiltins, Precision_41_Half_modf_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto modf_ref = [](cl_float x, cl_float &out) -> cl_float {
     return std::modf(x, &out);
@@ -1235,13 +996,6 @@ TEST_P(HalfMathBuiltins, Precision_42_Half_nextafter) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   // Based on 1.2 CTS nextafter reference
   auto nextafter_ref = [](cl_float x, cl_float y) -> cl_float {
@@ -1283,13 +1037,6 @@ TEST_P(HalfMathBuiltins, Precision_43_Half_fma) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
-
   // fma() returns the correctly rounded floating point representation of the
   // sum of c with the infinitely precise product of a and b. Rounding of
   // intermediate products shall not occur.
@@ -1314,12 +1061,6 @@ TEST_P(HalfMathBuiltins, Precision_44_Half_log1p) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto log1p_ref = [](cl_float x) -> cl_float { return std::log1p(x); };
 
@@ -1330,12 +1071,6 @@ TEST_P(HalfMathBuiltins, Precision_45_Half_cbrt) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto cbrt_ref = [](cl_float x) -> cl_float { return std::cbrt(x); };
 
@@ -1346,12 +1081,6 @@ TEST_P(HalfMathBuiltins, Precision_46_Half_hypot) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto hypot_ref = [](cl_float x, cl_float y) -> cl_float {
     if (std::isinf(x) || std::isinf(y)) {
@@ -1370,12 +1099,6 @@ TEST_P(HalfMathBuiltins, Precision_47_Half_max) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto max_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::max(x, y);
@@ -1395,12 +1118,6 @@ TEST_P(HalfMathBuiltins, Precision_47_Half_max_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto max_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::max(x, y);
@@ -1423,12 +1140,6 @@ TEST_P(HalfMathBuiltins, Precision_48_Half_min) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto min_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::min(x, y);
@@ -1448,12 +1159,6 @@ TEST_P(HalfMathBuiltins, Precision_48_Half_min_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto min_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::min(x, y);
@@ -1477,13 +1182,6 @@ TEST_P(HalfMathBuiltins, Precision_49_Half_sign) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work.
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto sign_ref = [](cl_float x) -> cl_float {
     if (std::isnan(x)) {
       return 0.0f;
@@ -1501,13 +1199,6 @@ TEST_P(HalfMathBuiltins, Precision_50_Half_degrees) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto degrees_ref = [](cl_float radians) -> cl_float {
     return (180.0f / M_PI) * radians;
   };
@@ -1521,13 +1212,6 @@ TEST_P(HalfMathBuiltins, Precision_51_Half_radians) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work.
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto radians_ref = [](cl_float degrees) -> cl_float {
     return (M_PI / 180.0f) * degrees;
   };
@@ -1540,13 +1224,6 @@ TEST_P(HalfMathBuiltins, Precision_52_Half_clamp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto clamp_ref = [](cl_float x, cl_float min, cl_float max) -> cl_float {
     return std::min(std::max(x, min), max);
@@ -1564,13 +1241,6 @@ TEST_P(HalfMathBuiltins, Precision_52_Half_clamp_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto clamp_ref = [](cl_float x, cl_float min, cl_float max) -> cl_float {
     return std::min(std::max(x, min), max);
@@ -1591,13 +1261,6 @@ TEST_P(HalfMathBuiltins, Precision_53_Half_mix) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto mix_ref = [](cl_float x, cl_float y, cl_float a) -> cl_float {
     cl_float sub = y - x;
@@ -1624,14 +1287,6 @@ TEST_P(HalfMathBuiltins, Precision_53_Half_mix_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2731: Vector widths 2 and 8 don't work
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4) || (getParam() == 8)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto mix_ref = [](cl_float x, cl_float y, cl_float a) -> cl_float {
     cl_float sub = y - x;
@@ -1662,13 +1317,6 @@ TEST_P(HalfMathBuiltins, Precision_54_Half_step) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto step_ref = [](cl_float edge, cl_float x) -> cl_float {
     return x < edge ? 0.0f : 1.0f;
   };
@@ -1685,13 +1333,6 @@ TEST_P(HalfMathBuiltins, Precision_54_Half_step_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto step_ref = [](cl_float edge, cl_float x) -> cl_float {
     return x < edge ? 0.0f : 1.0f;
@@ -1712,13 +1353,6 @@ TEST_P(HalfMathBuiltins, Precision_55_Half_smoothstep) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto smoothstep_ref = [](cl_float edge0, cl_float edge1,
                            cl_float x) -> cl_float {
@@ -1754,13 +1388,6 @@ TEST_P(HalfMathBuiltins, Precision_55_Half_smoothstep_scalar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector widths 2 and 4 don't work
-#ifdef __arm__
-  if ((getParam() == 2) || (getParam() == 4)) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto smoothstep_ref = [](cl_float edge0, cl_float edge1,
                            cl_float x) -> cl_float {
@@ -1801,13 +1428,6 @@ TEST_P(HalfMathBuiltins, Precision_56_Half_asin) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto asin_ref = [](cl_float x) -> cl_float { return std::asin(x); };
 
   TestAgainstRef<2_ULP>(asin_ref);
@@ -1817,12 +1437,6 @@ TEST_P(HalfMathBuiltins, Precision_57_Half_acos) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto acos_ref = [](cl_float x) -> cl_float { return std::acos(x); };
 
@@ -1834,13 +1448,6 @@ TEST_P(HalfMathBuiltins, Precision_58_Half_atan) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto atan_ref = [](cl_float x) -> cl_float { return std::atan(x); };
 
   TestAgainstRef<2_ULP>(atan_ref);
@@ -1850,13 +1457,6 @@ TEST_P(HalfMathBuiltins, Precision_59_Half_sin) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sin_ref = [](cl_float x) -> cl_float { return std::sin(x); };
 
@@ -1868,13 +1468,6 @@ TEST_P(HalfMathBuiltins, Precision_60_Half_cos) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto cos_ref = [](cl_float x) -> cl_float { return std::cos(x); };
 
   TestAgainstRef<2_ULP>(cos_ref);
@@ -1884,13 +1477,6 @@ TEST_P(HalfMathBuiltins, Precision_61_Half_tan) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto tan_ref = [](cl_float x) -> cl_float { return std::tan(x); };
 
@@ -1902,13 +1488,6 @@ TEST_P(HalfMathBuiltins, Precision_62_Half_asinh) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto asinh_ref = [](cl_float x) -> cl_float { return std::asinh(x); };
 
   TestAgainstRef<2_ULP>(asinh_ref);
@@ -1918,13 +1497,6 @@ TEST_P(HalfMathBuiltins, Precision_63_Half_acosh) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto acosh_ref = [](cl_float x) -> cl_float { return std::acosh(x); };
 
@@ -1936,13 +1508,6 @@ TEST_P(HalfMathBuiltins, Precision_64_Half_atanh) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto atanh_ref = [](cl_float x) -> cl_float { return std::atanh(x); };
 
   TestAgainstRef<2_ULP>(atanh_ref);
@@ -1952,13 +1517,6 @@ TEST_P(HalfMathBuiltins, Precision_65_Half_asinpi) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto asinpi_ref = [](cl_float x) -> cl_float {
     return std::asin(x) * M_1_PI;
@@ -1972,13 +1530,6 @@ TEST_P(HalfMathBuiltins, Precision_66_Half_acospi) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto acospi_ref = [](cl_float x) -> cl_float {
     return std::acos(x) * M_1_PI;
   };
@@ -1991,13 +1542,6 @@ TEST_P(HalfMathBuiltins, Precision_67_Half_atanpi) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto atanpi_ref = [](cl_float x) -> cl_float {
     return std::atan(x) * M_1_PI;
   };
@@ -2009,13 +1553,6 @@ TEST_P(HalfMathBuiltins, Precision_68_Half_atan2) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto atan2_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::atan2(x, y);
@@ -2040,13 +1577,6 @@ TEST_P(HalfMathBuiltins, Precision_69_Half_atan2pi) {
     GTEST_SKIP();
   }
 
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
-
   auto atan2pi_ref = [](cl_float x, cl_float y) -> cl_float {
     return std::atan2(x, y) * M_1_PI;
   };
@@ -2069,12 +1599,6 @@ TEST_P(HalfMathBuiltins, Precision_70_Half_sincos) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sincos_ref = [](cl_float x, cl_float &out_cos) -> cl_float {
     out_cos = std::cos(x);
@@ -2088,12 +1612,6 @@ TEST_P(HalfMathBuiltins, Precision_70_Half_sincos_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sincos_ref = [](cl_float x, cl_float &out_cos) -> cl_float {
     out_cos = std::cos(x);
@@ -2107,12 +1625,6 @@ TEST_P(HalfMathBuiltins, Precision_70_Half_sincos_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sincos_ref = [](cl_float x, cl_float &out_cos) -> cl_float {
     out_cos = std::cos(x);
@@ -2126,12 +1638,6 @@ TEST_P(HalfMathBuiltins, Precision_71_Half_tanpi) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto tanpi_ref = [](cl_float x) -> cl_float {
     // We need to manually track the sign to get
@@ -2157,12 +1663,6 @@ TEST_P(HalfMathBuiltins, Precision_72_Half_erfc) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto erfc_ref = [](cl_float x) -> cl_float { return std::erfc(x); };
 
@@ -2173,12 +1673,6 @@ TEST_P(HalfMathBuiltins, Precision_73_Half_erf) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto erf_ref = [](cl_float x) -> cl_float { return std::erf(x); };
 
@@ -2189,12 +1683,6 @@ TEST_P(HalfMathBuiltins, Precision_74_Half_lgamma) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto lgamma_ref = [](cl_float x) -> cl_float { return std::lgamma(x); };
 
@@ -2206,12 +1694,6 @@ TEST_P(HalfMathBuiltins, Precision_75_Half_lgammar) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto lgammar_ref = [](cl_float x, cl_int &sign_out) -> cl_float {
     sign_out = std::signbit(std::tgamma(x)) ? -1 : 1;
@@ -2230,12 +1712,6 @@ TEST_P(HalfMathBuiltins, Precision_75_Half_lgammar_local) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto lgammar_ref = [](cl_float x, cl_int &sign_out) -> cl_float {
     sign_out = std::signbit(std::tgamma(x)) ? -1 : 1;
@@ -2254,12 +1730,6 @@ TEST_P(HalfMathBuiltins, Precision_75_Half_lgammar_private) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto lgammar_ref = [](cl_float x, cl_int &sign_out) -> cl_float {
     sign_out = std::signbit(std::tgamma(x)) ? -1 : 1;
@@ -2293,12 +1763,6 @@ TEST_P(HalfMathBuiltins, Precision_77_Half_sinh) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto sinh_ref = [](cl_float x) -> cl_float { return std::sinh(x); };
 
@@ -2309,12 +1773,6 @@ TEST_P(HalfMathBuiltins, Precision_78_Half_cosh) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
-  // TODO: CA-2882: Vector width 4 doesn't work
-#ifdef __arm__
-  if (getParam() == 4) {
-    GTEST_SKIP();
-  }
-#endif
 
   auto cosh_ref = [](cl_float x) -> cl_float { return std::cosh(x); };
 


### PR DESCRIPTION
# Overview

Re-enable a bunch more tests.

# Reason for change

These tests are currently passing as well, so re-enable them too.

# Description of change

This enables tests that were disabled for vector widths 2, 3, 4, but currently only fail for a vector width of 3, so re-enable the other ones.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
