### PR TITLE
Downgrade half-precision being unsupported to a warning.

### DIFF
--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -75,7 +75,7 @@ set(fp16_supported_arches ARM64;ARM)
 if(CA_HOST_ENABLE_FP16)
   set(arch ${CMAKE_SYSTEM_PROCESSOR})
   if(NOT ${arch} IN_LIST fp16_supported_arches)
-    message(FATAL_ERROR "half-precision is not supported on ${arch} targets")
+    message(WARNING "half-precision is not supported on ${arch} targets")
   endif()
 endif()
 


### PR DESCRIPTION
# Overview

Downgrade half-precision being unsupported to a warning.

# Reason for change

Although half-precision does not currently work on all targets, it almost works, and it works well enough that for debugging issues on the targets where we support it, it is actually convenient to be able to build it on targets where we do not.

# Description of change

Nothing changes for supported builds.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
