### PR TITLE
Suppress cert-err33-c in error handling code

### DIFF
--- a/modules/cargo/include/cargo/error.h
+++ b/modules/cargo/include/cargo/error.h
@@ -46,8 +46,8 @@
 #ifndef NDEBUG
 #define CARGO_ASSERT(CONDITION, MESSAGE)                                      \
   if (!(CONDITION)) {                                                         \
-    std::fprintf(stderr, "%s:%d: assert: %s\n  %s: %s\n", __FILE__, __LINE__, \
-                 #CONDITION, CARGO_PRETTY_FUNCTION, MESSAGE);                 \
+    (void)std::fprintf(stderr, "%s:%d: assert: %s\n  %s: %s\n", __FILE__,     \
+                       __LINE__, #CONDITION, CARGO_PRETTY_FUNCTION, MESSAGE); \
     std::abort();                                                             \
   }                                                                           \
   (void)0

--- a/modules/compiler/builtins/libimg/include/libimg/validate.h
+++ b/modules/compiler/builtins/libimg/include/libimg/validate.h
@@ -36,21 +36,21 @@
 ///
 /// @param CONDITION Expression to evaluate and ensure is true.
 /// @param MESSAGE A human readable message describing the failure.
-#define IMG_ASSERT(CONDITION, MESSAGE)                                 \
-  if (!(CONDITION)) {                                                  \
-    fprintf(stderr, "%s: %d: libimg assert: %s\n", __FILE__, __LINE__, \
-            MESSAGE);                                                  \
-    abort();                                                           \
+#define IMG_ASSERT(CONDITION, MESSAGE)                                       \
+  if (!(CONDITION)) {                                                        \
+    (void)fprintf(stderr, "%s: %d: libimg assert: %s\n", __FILE__, __LINE__, \
+                  MESSAGE);                                                  \
+    abort();                                                                 \
   }
 
 /// @brief Abort due to a situation that should never happen. Disabled by NDEBUG
 ///
 /// @param MESSAGE A human readable message describing the failure.
-#define IMG_UNREACHABLE(MESSAGE)                                            \
-  {                                                                         \
-    fprintf(stderr, "%s: %d: libimg unreachable: %s\n", __FILE__, __LINE__, \
-            MESSAGE);                                                       \
-    abort();                                                                \
+#define IMG_UNREACHABLE(MESSAGE)                                        \
+  {                                                                     \
+    (void)fprintf(stderr, "%s: %d: libimg unreachable: %s\n", __FILE__, \
+                  __LINE__, MESSAGE);                                   \
+    abort();                                                            \
   }
 #else
 #define IMG_ASSERT(CONDITION, MESSAGE)

--- a/modules/compiler/builtins/source/bakery.cpp.in
+++ b/modules/compiler/builtins/source/bakery.cpp.in
@@ -67,20 +67,23 @@ cargo::array_view<const uint8_t> get_pch_file(
       resource = rc::builtins::builtins64_pch;
       break;
     default:
-      fprintf(stderr, "Illegal capabilities_bitfield\n");
+      (void)fprintf(stderr, "Illegal capabilities_bitfield\n");
       abort();
   }
   if (resource.size() == 1) {
-    fprintf(stderr,
-            "Attempted to load an unavailable PCH file with capabilities:\n");
-    fprintf(stderr, "Bit width: %d\n", (caps & file::CAPS_32BIT) ? 32 : 64);
-    fprintf(stderr, "Doubles: %s\n",
-            (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
-    fprintf(stderr, "Halfs: %s\n",
-            (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
-    fprintf(stderr,
-            "This usually indicates that the device capabilities were "
-            "incorrectly listed in the target device's CMakeLists.txt.\n");
+    (void)fprintf(
+        stderr,
+        "Attempted to load an unavailable PCH file with capabilities:\n");
+    (void)fprintf(stderr, "Bit width: %d\n",
+                  (caps & file::CAPS_32BIT) ? 32 : 64);
+    (void)fprintf(stderr, "Doubles: %s\n",
+                  (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
+    (void)fprintf(stderr, "Halfs: %s\n",
+                  (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
+    (void)fprintf(
+        stderr,
+        "This usually indicates that the device capabilities were "
+        "incorrectly listed in the target device's CMakeLists.txt.\n");
     abort();
   }
   return resource;
@@ -114,20 +117,23 @@ cargo::array_view<const uint8_t> get_bc_file(file::capabilities_bitfield caps) {
       resource = rc::builtins::builtins64_bc;
       break;
     default:
-      fprintf(stderr, "Illegal capabilities_bitfield\n");
+      (void)fprintf(stderr, "Illegal capabilities_bitfield\n");
       abort();
   }
   if (resource.size() == 1) {
-    fprintf(stderr,
-            "Attempted to load an unavailable BC file with capabilities:\n");
-    fprintf(stderr, "Bit width: %d\n", (caps & file::CAPS_32BIT) ? 32 : 64);
-    fprintf(stderr, "Doubles: %s\n",
-            (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
-    fprintf(stderr, "Halfs: %s\n",
-            (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
-    fprintf(stderr,
-            "This usually indicates that the device capabilities were "
-            "incorrectly listed in the target device's CMakeLists.txt.\n");
+    (void)fprintf(
+        stderr,
+        "Attempted to load an unavailable BC file with capabilities:\n");
+    (void)fprintf(stderr, "Bit width: %d\n",
+                  (caps & file::CAPS_32BIT) ? 32 : 64);
+    (void)fprintf(stderr, "Doubles: %s\n",
+                  (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
+    (void)fprintf(stderr, "Halfs: %s\n",
+                  (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
+    (void)fprintf(
+        stderr,
+        "This usually indicates that the device capabilities were "
+        "incorrectly listed in the target device's CMakeLists.txt.\n");
     abort();
   }
   return resource;

--- a/modules/compiler/builtins/source/printf.cpp
+++ b/modules/compiler/builtins/source/printf.cpp
@@ -26,11 +26,11 @@
 
 // TODO: Should we have a CA_ASSERT, if so where should it live?
 #ifndef NDEBUG
-#define ASSERT(CONDITION, MESSAGE)                                \
-  if (CONDITION) {                                                \
-    fprintf(stderr, "%s: %d: %s\n", __FILE__, __LINE__, MESSAGE); \
-    std::abort();                                                 \
-  }                                                               \
+#define ASSERT(CONDITION, MESSAGE)                                      \
+  if (CONDITION) {                                                      \
+    (void)fprintf(stderr, "%s: %d: %s\n", __FILE__, __LINE__, MESSAGE); \
+    std::abort();                                                       \
+  }                                                                     \
   (void)0
 #else
 #define ASSERT(CONDITION, MESSAGE)

--- a/modules/compiler/spirv-ll/include/spirv-ll/assert.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/assert.h
@@ -27,9 +27,9 @@
 #include <cstdio>
 #include <cstdlib>
 
-#define SPIRV_LL_ABORT(MESSAGE)                                          \
-  std::fprintf(stderr, "%s:%d: %s\n  %s\n", __FILE__, __LINE__, MESSAGE, \
-               SPIRV_LL_FUNCTION);                                       \
+#define SPIRV_LL_ABORT(MESSAGE)                                                \
+  (void)std::fprintf(stderr, "%s:%d: %s\n  %s\n", __FILE__, __LINE__, MESSAGE, \
+                     SPIRV_LL_FUNCTION);                                       \
   std::abort()
 
 #define SPIRV_LL_ASSERT(CONDITION, MESSAGE) \

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -26,6 +26,7 @@
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/FormatVariadic.h>
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/TypeSize.h>
 #include <multi_llvm/llvm_version.h>
@@ -531,10 +532,9 @@ llvm::Error Builder::create<OpTypeImage>(const OpTypeImage *op) {
   }
 
   if (!imageType) {
-    (void)fprintf(
-        stderr, "Unsupported type (Dim = %d) passed to 'create<OpTypeImage>'\n",
-        op->Dim());
-    std::abort();
+    return makeStringError(llvm::formatv(
+        "Unsupported type (Dim = {0}) passed to 'create<OpTypeImage>'\n",
+        op->Dim()));
   }
 
   module.addID(op->IdResult(), op, imageType);
@@ -2069,10 +2069,9 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
 
       } break;
       default:
-        fprintf(stderr, "Execution model (ID = %d) is not supported.\n",
-                ep_op->ExecutionModel());
-        std::abort();
-        break;
+        return makeStringError(
+            llvm::formatv("Execution model (ID = {0}) is not supported",
+                          ep_op->ExecutionModel()));
     }
   } else {
     // DPC++ rejects variadic functions in SYCL code, with the exception of
@@ -4480,8 +4479,7 @@ llvm::Error Builder::create<OpISubBorrow>(const OpISubBorrow *op) {
                      std::to_string(operandType->getIntegerBitWidth());
       break;
     default:
-      fprintf(stderr, "Unsupported integer type passed to OpISubBorrow\n");
-      abort();
+      return makeStringError("Unsupported integer type passed to OpISubBorrow");
   }
 
   llvm::Function *intrinsic = module.llvmModule->getFunction(functionName);

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -133,8 +133,8 @@ static llvm::TargetMachine *initLLVMTarget(llvm::StringRef triple_string,
   const llvm::Target *target =
       llvm::TargetRegistry::lookupTarget(triple.getTriple(), e);
   if (!target) {
-    ::fprintf(stderr, "can't get target %s:%s\n", triple.getTriple().c_str(),
-              e.c_str());
+    (void)::fprintf(stderr, "can't get target %s:%s\n",
+                    triple.getTriple().c_str(), e.c_str());
     ::exit(1);
   }
   llvm::PassRegistry &registry = *llvm::PassRegistry::getPassRegistry();
@@ -331,9 +331,9 @@ int main(const int argc, const char *const argv[]) {
       llvm::StringRef name;
       llvm::SmallVector<vecz::VeczPassOptions, 1> opts;
       if (!parsePassOptionsSwitch(S, name, opts)) {
-        fprintf(stderr,
-                "failed to parse kernel vectorization specification%s\n",
-                name.str().c_str());
+        (void)::fprintf(
+            stderr, "failed to parse kernel vectorization specification%s\n",
+            name.str().c_str());
         return 1;
       }
       if (!module->getFunction(name)) {

--- a/modules/loader/source/relocations.cpp
+++ b/modules/loader/source/relocations.cpp
@@ -85,7 +85,8 @@ bool resolveX86_32(const loader::Relocation &r, loader::ElfMap &map) {
   if (symbol_target_address == 0) {
 #ifndef NDEBUG
     auto name = map.getSymbolName(r.symbol_index).value_or("<unknown symbol>");
-    fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(), name.data());
+    (void)fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(),
+                  name.data());
 #endif
     return false;
   }
@@ -121,7 +122,8 @@ bool resolveX86_32(const loader::Relocation &r, loader::ElfMap &map) {
 #ifndef NDEBUG
       // If this warning is ever triggered, then we can investigate further
       if (implicit_addend & uint32_t(0x80008000)) {
-        fprintf(stderr, "WARNING: Relocation with possibly negative offset\n");
+        (void)fprintf(stderr,
+                      "WARNING: Relocation with possibly negative offset\n");
       }
 #endif
       uint32_t value = symbol_target_address + implicit_addend;
@@ -173,7 +175,8 @@ bool resolveX86_64(const loader::Relocation &r, loader::ElfMap &map) {
   if (symbol_target_address == 0) {
 #ifndef NDEBUG
     auto name = map.getSymbolName(r.symbol_index).value_or("<unknown symbol>");
-    fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(), name.data());
+    (void)fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(),
+                  name.data());
 #endif
     return false;
   }
@@ -282,7 +285,8 @@ bool resolveArm(const loader::Relocation &r, loader::ElfMap &map,
   if (symbol_target_address == 0) {
 #ifndef NDEBUG
     auto name = map.getSymbolName(r.symbol_index).value_or("<unknown symbol>");
-    fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(), name.data());
+    (void)fprintf(stderr, "Missing symbol: %.*s\n", (int)name.size(),
+                  name.data());
 #endif
     return false;
   }
@@ -396,8 +400,8 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
       map.getSymbolTargetAddress(r.symbol_index).value_or(0);
   if (symbol_target_address == 0) {
 #ifndef NDEBUG
-    fprintf(stderr, "Missing symbol: %.*s\n", (int)symbol_name.size(),
-            symbol_name.data());
+    (void)fprintf(stderr, "Missing symbol: %.*s\n", (int)symbol_name.size(),
+                  symbol_name.data());
 #endif
     return false;
   }
@@ -547,9 +551,10 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
       uint64_t stub_target = getOrCreateStub(symbol_target_address);
       if (0LU == stub_target) {
 #ifndef NDEBUG
-        fprintf(stderr,
-                "Out of stub space when constructing linker veneer for: %.*s\n",
-                (int)symbol_name.size(), symbol_name.data());
+        (void)fprintf(
+            stderr,
+            "Out of stub space when constructing linker veneer for: %.*s\n",
+            (int)symbol_name.size(), symbol_name.data());
 #endif
         return false;
       }
@@ -558,10 +563,11 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
       if (static_cast<int64_t>(relative_value) < -(1LL << 27) ||
           static_cast<int64_t>(relative_value) >= (1LL << 27)) {
 #ifndef NDEBUG
-        fprintf(stderr,
-                "Linker veneer for symbol %.*s beyond addressable span of "
-                "branch instruction",
-                (int)symbol_name.size(), symbol_name.data());
+        (void)fprintf(
+            stderr,
+            "Linker veneer for symbol %.*s beyond addressable span of "
+            "branch instruction",
+            (int)symbol_name.size(), symbol_name.data());
 #endif
         return false;
       }

--- a/modules/tracer/source/tracer.cpp
+++ b/modules/tracer/source/tracer.cpp
@@ -66,8 +66,8 @@ struct TracerVirtualMemFileImpl {
     int f = open(tmp_name.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 
     if (f == 0) {
-      fprintf(stderr, "Could not open %s temp file for tracing.\n",
-              tmp_name.c_str());
+      (void)fprintf(stderr, "Could not open %s temp file for tracing.\n",
+                    tmp_name.c_str());
       return;
     }
 
@@ -90,8 +90,8 @@ struct TracerVirtualMemFileImpl {
     lseek64(f, bytes, SEEK_SET);
     auto written = write(f, "", 1);
     if (0 == written) {
-      fprintf(stderr, "Failed to resize %s.\n", tmp_name.c_str());
-      remove(tmp_name.c_str());
+      (void)fprintf(stderr, "Failed to resize %s.\n", tmp_name.c_str());
+      (void)remove(tmp_name.c_str());
       return;
     }
     lseek64(f, 0, SEEK_SET);
@@ -101,8 +101,8 @@ struct TracerVirtualMemFileImpl {
     close(f);
 
     if (map == MAP_FAILED) {
-      fprintf(stderr, "Failed to map tmp file:%s.\n", strerror(errno));
-      remove(tmp_name.c_str());
+      (void)fprintf(stderr, "Failed to map tmp file:%s.\n", strerror(errno));
+      (void)remove(tmp_name.c_str());
     }
 
     // Buffer to keep things stack allocated.
@@ -132,9 +132,9 @@ struct TracerVirtualMemFileImpl {
       const char *ending = "\n\t]\n}\n";
 
       if (std::strlen(ending) + offset > max_offset) {
-        fprintf(stderr,
-                "Trace overflow, failed to write data, increase "
-                "CA_TRACE_FILE_BUFFER_MB");
+        (void)fprintf(stderr,
+                      "Trace overflow, failed to write data, increase "
+                      "CA_TRACE_FILE_BUFFER_MB");
       }
 
       writeToMemMap(ending, std::strlen(ending));
@@ -149,7 +149,7 @@ struct TracerVirtualMemFileImpl {
         fclose(file);
 
         if (idx != offset.load()) {
-          fprintf(stderr, "Trace file could not be shrunk down.");
+          (void)fprintf(stderr, "Trace file could not be shrunk down.");
         }
       }
 
@@ -216,7 +216,7 @@ struct TracerFileImpl {
     file = fopen(env, "w");
 
     if (nullptr == file) {
-      fprintf(stderr, "Could not open '%s' for tracing.\n", env);
+      (void)fprintf(stderr, "Could not open '%s' for tracing.\n", env);
       return;
     }
 

--- a/modules/utils/targets/host/source/relocations.cpp
+++ b/modules/utils/targets/host/source/relocations.cpp
@@ -80,7 +80,7 @@ void *dbg_memcpy(void *dest, const void *src, size_t count) {
     size_t write_count = static_cast<size_t>(write(null_fd, src, count));
     close(null_fd);
     if (write_count != count) {
-      fprintf(stderr, "memcpy (called from kernel) out-of-bounds read\n");
+      (void)fprintf(stderr, "memcpy (called from kernel) out-of-bounds read\n");
       std::abort();
     }
   }
@@ -90,7 +90,8 @@ void *dbg_memcpy(void *dest, const void *src, size_t count) {
     size_t read_count = static_cast<size_t>(read(zero_fd, dest, count));
     close(zero_fd);
     if (read_count != count) {
-      fprintf(stderr, "memcpy (called from kernel) out-of-bounds write\n");
+      (void)fprintf(stderr,
+                    "memcpy (called from kernel) out-of-bounds write\n");
       std::abort();
     }
   }
@@ -115,7 +116,8 @@ void *dbg_memset(void *dest, int ch, size_t count) {
     size_t cnt = static_cast<size_t>(read(zero_fd, dest, count));
     close(zero_fd);
     if (count != cnt) {
-      fprintf(stderr, "memset (called from kernel) out-of-bounds write\n");
+      (void)fprintf(stderr,
+                    "memset (called from kernel) out-of-bounds write\n");
       std::abort();
     }
   }

--- a/source/cl/include/cl/macros.h
+++ b/source/cl/include/cl/macros.h
@@ -34,12 +34,12 @@
 ///
 /// @param CONDITION Condition to test.
 /// @param MESSAGE Message to display on assertion failure.
-#define OCL_ASSERT(CONDITION, MESSAGE)                                     \
-  if (!(CONDITION)) {                                                      \
-    std::fprintf(stderr, "%s:%d: %s %s\n", __FILE__, __LINE__, #CONDITION, \
-                 MESSAGE);                                                 \
-    std::abort();                                                          \
-  }                                                                        \
+#define OCL_ASSERT(CONDITION, MESSAGE)                               \
+  if (!(CONDITION)) {                                                \
+    (void)std::fprintf(stderr, "%s:%d: %s %s\n", __FILE__, __LINE__, \
+                       #CONDITION, MESSAGE);                         \
+    std::abort();                                                    \
+  }                                                                  \
   (void)0
 #else
 #define OCL_ASSERT(CONDITION, MESSAGE) (void)0
@@ -48,11 +48,11 @@
 /// @brief Display a message to stderr and abort.
 ///
 /// @param MESSAGE Message to display prior to aborting.
-#define OCL_ABORT(MESSAGE)                                            \
-  {                                                                   \
-    std::fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, MESSAGE); \
-    std::abort();                                                     \
-  }                                                                   \
+#define OCL_ABORT(MESSAGE)                                                  \
+  {                                                                         \
+    (void)std::fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, MESSAGE); \
+    std::abort();                                                           \
+  }                                                                         \
   (void)0
 
 /// @brief Provides hints to the compiler about the likelihood of a condition

--- a/source/cl/test/UnitCL/include/ucl/assert.h
+++ b/source/cl/test/UnitCL/include/ucl/assert.h
@@ -24,17 +24,17 @@
 #include <cstdio>
 #include <cstdlib>
 
-#define UCL_ASSERT(CONDITION, MESSAGE)                                 \
-  if (!(CONDITION)) {                                                  \
-    std::fprintf(stderr, "%s: %d: %s\n", __FILE__, __LINE__, MESSAGE); \
-    std::abort();                                                      \
+#define UCL_ASSERT(CONDITION, MESSAGE)                                       \
+  if (!(CONDITION)) {                                                        \
+    (void)std::fprintf(stderr, "%s: %d: %s\n", __FILE__, __LINE__, MESSAGE); \
+    std::abort();                                                            \
   }
 
-#define UCL_ABORT(FORMAT, ...)                                              \
-  {                                                                         \
-    std::fprintf(stderr, "abort: %s: %d: " FORMAT "\n", __FILE__, __LINE__, \
-                 __VA_ARGS__);                                              \
-    std::abort();                                                           \
+#define UCL_ABORT(FORMAT, ...)                                          \
+  {                                                                     \
+    (void)std::fprintf(stderr, "abort: %s: %d: " FORMAT "\n", __FILE__, \
+                       __LINE__, __VA_ARGS__);                          \
+    std::abort();                                                       \
   }
 
 #endif  // UCL_ASSERT_H_INCLUDED

--- a/source/cl/tools/oclc/oclc.cpp
+++ b/source/cl/tools/oclc/oclc.cpp
@@ -395,7 +395,7 @@ bool oclc::Driver::ParseArguments(int argc, char **argv) {
     } else {
       const char *unknown = args.Peek();
       OCLC_CHECK(!unknown, "Expected another argument but got a nullptr");
-      fprintf(stderr, "error: unknown option '%s'.\n", unknown);
+      (void)fprintf(stderr, "error: unknown option '%s'.\n", unknown);
       return oclc::failure;
     }
 
@@ -408,7 +408,7 @@ bool oclc::Driver::ParseArguments(int argc, char **argv) {
   if (positional_args.size() != 1) {
     PrintUsage(argc, argv);
     if (positional_args.size() > 1) {
-      fprintf(stderr, "\nerror: too many positional arguments.\n");
+      (void)fprintf(stderr, "\nerror: too many positional arguments.\n");
     }
     return oclc::failure;
   }
@@ -819,12 +819,13 @@ std::vector<std::string> oclc::Driver::CreateRange(T a, T b, T stride) {
       vec.push_back(std::to_string(i));
     }
   } else if (stride == 0.0) {
-    fprintf(stderr,
-            "error: stride value of 0 for range() function not acceptable\n");
+    (void)fprintf(
+        stderr,
+        "error: stride value of 0 for range() function not acceptable\n");
   } else {
-    fprintf(stderr,
-            "error: the sign of (b - a) must match the sign of stride in "
-            "range() function\n");
+    (void)fprintf(stderr,
+                  "error: the sign of (b - a) must match the sign of stride in "
+                  "range() function\n");
   }
   return vec;
 }
@@ -1324,8 +1325,8 @@ bool oclc::Driver::BuildProgram() {
     fprintf(stderr, "%s", build_log.c_str());
 
     if (CL_SUCCESS != err) {
-      fprintf(stderr, "Build program failed with error: %s (%d)\n",
-              oclc::cl_error_code_to_name_map[err].c_str(), err);
+      (void)fprintf(stderr, "Build program failed with error: %s (%d)\n",
+                    oclc::cl_error_code_to_name_map[err].c_str(), err);
       return oclc::failure;
     }
   }
@@ -1458,8 +1459,8 @@ std::string oclc::Driver::BufferToString(const unsigned char *buffer, size_t n,
       stringVal += (std::to_string(halfBuffer[i]) + ",");
     }
   } else {
-    fprintf(stderr, "error printing buffer: unsupported data type (%s)\n",
-            dataType.c_str());
+    (void)fprintf(stderr, "error printing buffer: unsupported data type (%s)\n",
+                  dataType.c_str());
     return "";
   }
 
@@ -1479,7 +1480,7 @@ T *oclc::Driver::CastToTypeInteger(const std::vector<std::string> &source,
     size = casted_buffers.back().size() * sizeof(T);
     return casted_buffers.back().data();
   } else {
-    fprintf(
+    (void)fprintf(
         stderr,
         "error: floating point value passed into integer kernel argument\n");
     return nullptr;
@@ -1542,8 +1543,8 @@ bool oclc::Driver::CreateImage(
     typeName = "image1d_t";
     imageType = CL_MEM_OBJECT_IMAGE1D;
   } else {
-    fprintf(stderr, "error: %d-dimensional image '%s' not supported.\n",
-            dimensions, name.c_str());
+    (void)fprintf(stderr, "error: %d-dimensional image '%s' not supported.\n",
+                  dimensions, name.c_str());
     return oclc::failure;
   }
   cl_image_desc desc;
@@ -2248,7 +2249,7 @@ const char *oclc::Arguments::Take() {
 const char *oclc::Arguments::TakePositional(bool &failed) {
   const char *arg = Peek();
   if (!arg) {
-    fprintf(stderr, "error: no argument left to parse.\n");
+    (void)fprintf(stderr, "error: no argument left to parse.\n");
     failed |= true;
     return nullptr;
   } else if (arg[0] == '-') {
@@ -2260,7 +2261,7 @@ const char *oclc::Arguments::TakePositional(bool &failed) {
 bool oclc::Arguments::TakeKey(const char *key, bool &failed) {
   const char *arg = Peek();
   if (!arg) {
-    fprintf(stderr, "error: no argument left to parse.\n");
+    (void)fprintf(stderr, "error: no argument left to parse.\n");
     failed |= true;
     return oclc::failure;
   } else if (0 != strcmp(key, arg)) {
@@ -2275,7 +2276,8 @@ const char *oclc::Arguments::TakeKeyValue(const char *key, bool &failed) {
   if (!first_arg || (0 != strcmp(first_arg, key))) {
     return nullptr;
   } else if (!HasMore(2)) {
-    fprintf(stderr, "error: '%s' must be followed by another argument.\n", key);
+    (void)fprintf(stderr, "error: '%s' must be followed by another argument.\n",
+                  key);
     failed |= true;
     return nullptr;
   }

--- a/source/cl/tools/oclc/oclc.h
+++ b/source/cl/tools/oclc/oclc.h
@@ -31,28 +31,28 @@
 #include <vector>
 
 /// @brief Print an error message and return failure.
-#define OCLC_CHECK(cond, msg)              \
-  if ((cond)) {                            \
-    fprintf(stderr, "error: %s\n", (msg)); \
-    return oclc::failure;                  \
-  }                                        \
+#define OCLC_CHECK(cond, msg)                    \
+  if ((cond)) {                                  \
+    (void)fprintf(stderr, "error: %s\n", (msg)); \
+    return oclc::failure;                        \
+  }                                              \
   (void)0
 
 /// @brief Print a formatted error message and return failure.
-#define OCLC_CHECK_FMT(cond, fmt, ...) \
-  if (cond) {                          \
-    fprintf(stderr, fmt, __VA_ARGS__); \
-    return oclc::failure;              \
-  }                                    \
+#define OCLC_CHECK_FMT(cond, fmt, ...)       \
+  if (cond) {                                \
+    (void)fprintf(stderr, fmt, __VA_ARGS__); \
+    return oclc::failure;                    \
+  }                                          \
   (void)0
 
 /// @brief Print an error message and return failure.
-#define OCLC_CHECK_CL(ret, msg)                                     \
-  if ((ret) != CL_SUCCESS) {                                        \
-    fprintf(stderr, "error: %s (%s, %d)\n", (msg),                  \
-            (oclc::cl_error_code_to_name_map[ret].c_str()), (ret)); \
-    return oclc::failure;                                           \
-  }                                                                 \
+#define OCLC_CHECK_CL(ret, msg)                                           \
+  if ((ret) != CL_SUCCESS) {                                              \
+    (void)fprintf(stderr, "error: %s (%s, %d)\n", (msg),                  \
+                  (oclc::cl_error_code_to_name_map[ret].c_str()), (ret)); \
+    return oclc::failure;                                                 \
+  }                                                                       \
   (void)0
 
 template <typename T>


### PR DESCRIPTION
The `cert-err33-c` check checks that function return values are checked. This is a useful warning, so we don't want to disable it outright, but it isn't useful in all situations. One primary one is where we're handling an error and we print a message, typically to `stderr` using `fprintf`. There's not much value in checking that `fprintf` succeeded, as we're about to propagate the error anyway.

In these situations, add a `(void)` cast to suppress the warning.

I've gone through all cases I consider "error handling" locally and came out with a clean build. This isn't to say that such cases don't exist (e.g., that I missed or are present in other build configurations) but this is about being good enough, to avoid false positive warnings/errors.

Also in this PR we convert a couple of `spirv-ll` `fprintf` errors to LLVM errors to avoid suppressing the warning on them.