### PR TITLE
[spirv-ll] Refactor how debug ranges/scopes are handled

### DIFF
--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -65,7 +65,6 @@ spirv_ll::Module::Module(
       sourceMetadataString(),
       CompileUnit(nullptr),
       File(nullptr),
-      CurrentOpLineRange(std::nullopt),
       LoopControl(),
       specInfo(specInfo),
       PushConstantStructVariable(nullptr),
@@ -90,7 +89,6 @@ spirv_ll::Module::Module(spirv_ll::Context &context,
       sourceMetadataString(),
       CompileUnit(nullptr),
       File(nullptr),
-      CurrentOpLineRange(std::nullopt),
       LoopControl(),
       specInfo(),
       PushConstantStructVariable(nullptr),
@@ -221,28 +219,6 @@ std::optional<std::string> spirv_ll::Module::getDebugString(spv::Id id) const {
     return iter->getSecond();
   }
   return std::nullopt;
-}
-
-void spirv_ll::Module::setCurrentOpLineRange(
-    const LineRangeBeginTy &range_begin) {
-  CurrentOpLineRange = range_begin;
-}
-
-void spirv_ll::Module::closeCurrentOpLineRange() { CurrentOpLineRange.reset(); }
-
-void spirv_ll::Module::addCompleteOpLineRange(
-    llvm::DILocation *location,
-    std::pair<llvm::BasicBlock::iterator, llvm::BasicBlock::iterator> range) {
-  OpLineRanges[location].push_back(range);
-}
-
-spirv_ll::Module::OpLineRangeMap &spirv_ll::Module::getOpLineRanges() {
-  return OpLineRanges;
-}
-
-std::optional<spirv_ll::Module::LineRangeBeginTy>
-spirv_ll::Module::getCurrentOpLineRange() const {
-  return CurrentOpLineRange;
 }
 
 void spirv_ll::Module::addLexicalBlock(llvm::BasicBlock *b_block,

--- a/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/debug_info.spvasm
@@ -28,8 +28,10 @@
                OpSource GLSL 450
        %file = OpString "modules/spirv-ll-tool/test/spvasm/debug_info.comp"
                OpName %main "main"
+               OpName %testfn2 "testfn2"
                OpName %a "a"
                OpName %b "b"
+               OpName %c "c"
                OpName %file "file"
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
@@ -81,7 +83,26 @@
 ; CHECK: ret void
                OpFunctionEnd
 ; CHECK: }
-;
+
+    %testfn2 = OpFunction %void None %3
+; CHECK: define private spir_func void @testfn2(){{.*}} !dbg [[testfn2Subprogram:![0-9]+]]
+               OpLine %file 5 2
+         %19 = OpLabel
+               OpLine %file 6 3
+          %c = OpVariable %_ptr_Function_bool Function
+; CHECK: %c = alloca i1{{(, align [0-9])?}}, !dbg [[cLocation:![0-9]+]]
+               OpBranch %20
+         %20 = OpLabel
+         %21 = OpLoad %bool %c
+; Check we're not mistakenly adding debug locations to the instructions in this
+; block; the range should have ended at the last block terminator instruction
+; (the OpBranch)
+; CHECK: = load i1, ptr %c{{(, align [0-9])?$}}
+               OpReturn
+; CHECK: ret void{{$}}
+               OpFunctionEnd
+; CHECK: }
+
 ; CHECK: !llvm.dbg.cu = !{[[CompileUnit:![0-9]+]]}
 ; CHECK: !llvm.ident = !{!{{[0-9]+}}}
 ;
@@ -103,3 +124,9 @@
 ; CHECK: [[ifTrueBlockLocation]] = !DILocation(line: 8, column: 3, scope: [[ifLexicalBlock:![0-9]+]])
 ; CHECK: [[ifLexicalBlock]] = distinct !DILexicalBlock(scope: [[mainSubprogram]], file: !{{[0-9]+}}, line: 8, column: 3)
 ; CHECK: [[ifJoinLocation]] = !DILocation(line: 9, column: 5, scope: [[ifLexicalBlock]])
+
+; CHECK: [[testfn2Subprogram]] = distinct !DISubprogram(name: "testfn2", linkageName: "testfn2",
+; CHECK-SAME: scope: null, file: [[File]],
+; CHECK-SAME: line: 5, type: [[mainSubroutineType]],
+; CHECK-SAME: scopeLine: 1, spFlags: DISPFlagDefinition,
+; CHECK-SAME: unit: {{![0-9]+}}{{(, retainedNodes: ![0-9]+)?}})


### PR DESCRIPTION
This commit aims to simplify how we handle the management of different types of debug scope.

Debug info is now attached to instructions when we close a range. We no longer store all of the ranges and process them at the end of the module. This keeps debug information better contained within the builder, and means we have to track less volatile data. The code should be simpler as a result, and hopefully easier to maintain.

We also introduce a new concept to help manage debug info. In addition to the old 'line' range which is built in to SPIR-V, we introduce another: a 'lexical scope'. This will be used for the translation of the various DebugInfo extended instruction sets.

The lexical scopes and line ranges do interact, in the same way that the DebugInfo instruction sets interact with the score spec: the DebugInfo instruction sets still rely on line number information provided by line ranges. A lexical scope is of no use without line information. We may define lexical scopes in one of two ways, in priority order:

1. The DebugInfo extended instruction sets generate them using dedicated instructions
2. We generate them on the fly when attaching debug info when we process line ranges

Thus, when we close a line range or a lexical scope, we apply debug info to all instructions within the range. For the scope information, we take the lexical scope information, if set, and else we generate one on the fly.