### PR TITLE
[refsi] Update Refsi memory specifications

### DIFF
--- a/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
+++ b/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
@@ -28,9 +28,7 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-// The upper region can be up to the tdcm start point at 0x10000000
-// We will make it approx 128MB to give some latitude
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
 
 // Memory area for per-hart storage.
 constexpr const uint64_t G_HART_LOCAL_BASE = 0x20800000;

--- a/examples/refsi/hal_refsi/include/device/program.lds
+++ b/examples/refsi/hal_refsi/include/device/program.lds
@@ -17,6 +17,12 @@
 
 OUTPUT_ARCH( "riscv" )
 
+MEMORY
+{
+    mainmem : ORIGIN = 0x10000, LENGTH = (1 << 20)
+    localmem : ORIGIN = 0x10000000, LENGTH = 0x200000
+}
+
 SECTIONS
 {
 
@@ -24,50 +30,44 @@ SECTIONS
   /* Code and read-only segment                                         */
   /*--------------------------------------------------------------------*/
 
-  /* Begining of code and text segment */
-  . = 0x00010000;
-
-  .text :
-  {
+  .text : {
     *(.text.init)
-  }
+  } >mainmem
 
   /* text: Program code section */
-  .text : 
+  .text :
   {
     *(.text)
     *(.text.*)
     *(.gnu.linkonce.t.*)
-  }
+  } >mainmem
 
   /* rodata: Read-only data */
-  .rodata : 
+  .rodata :
   {
     *(.rdata)
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
-  }
+  } >mainmem
 
   /* End of code and read-only segment */
-  . = ALIGN(0x1000);
 
   /*--------------------------------------------------------------------*/
   /* Initialized data segment                                           */
   /*--------------------------------------------------------------------*/
 
   /* data: Writable data */
-  .data : 
+  .data ALIGN(0x1000) :
   {
     *(.data)
     *(.data.*)
     *(.srodata*)
     *(.gnu.linkonce.d.*)
     *(.comment)
-  }
+  } >mainmem
 
   /* End of initialized data segment */
-  . = ALIGN(16);
 
   /*--------------------------------------------------------------------*/
   /* Uninitialized data segment                                         */
@@ -81,26 +81,23 @@ SECTIONS
 
   /* bss: Uninitialized writeable data section */
   . = .;
-  .bss : 
+  .bss ALIGN(16) :
   {
     *(.bss)
     *(.bss.*)
     *(.sbss*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-  }
+  } >mainmem
 
 
   /*--------------------------------------------------------------------*/
   /* Local memory                                                       */
   /*--------------------------------------------------------------------*/
-
-  . = 0x10000000;
-
   .local :
   {
     *(.local)
-  }
+  } >localmem
 
   /DISCARD/ : { *(.note.gnu.build-id) }
 }

--- a/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
@@ -30,9 +30,7 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-// The upper region can be up to the tdcm start point at 0x10000000
-// We will make it approx 128MB to give some latitude
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
 
 constexpr const uint64_t REFSI_MAX_HARTS = 64;
 

--- a/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
@@ -29,9 +29,7 @@
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-// The upper region can be up to the tdcm start point at 0x10000000
-// We will make it approx 128MB to give some latitude
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
 
 refsi_m1_hal_device::refsi_m1_hal_device(refsi_device_t device,
                                          riscv::hal_device_info_riscv_t *info,


### PR DESCRIPTION
# Overview

In the refsi simulator, there are two memory regions:
* "Main" memory, starting at 0x10000
* "Local" memory, starting at 0x10000000

When emitting the sections, we move the output cursor to location 0x10000000 before writing the sections for local memory. This has the effect of, in some unknown circumstances, resulting in the generated ELF file including padding in the file itself for 255MiB. Besides wasting memory, this also made the refsi simulator unable to load the binaries due to its 128MiB limit.

This patch updates the linker script to be more explicit about the memory layout, which also has the added advantage of having the linker verify that the binary isn't too large.

It also reverts 73c6af20, which was a workaround for this issue.

# Reason for change

This was causing a failure in our internal testing.

# Description of change

Fixes the internal elf file generation to stop it producing unloadable ~255MiB binaries.

# Anything else we should know?

I'm still not 100% sure why this issue came up in the first place, but this feels like a nicer way of doing things anyway.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
