### PR TITLE
Use version macro for update after name change

### DIFF
--- a/modules/compiler/utils/source/align_module_structs_pass.cpp
+++ b/modules/compiler/utils/source/align_module_structs_pass.cpp
@@ -27,6 +27,7 @@
 #include <llvm/IR/ValueMap.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
+#include <multi_llvm/llvm_version.h>
 
 #include <cassert>
 
@@ -274,7 +275,11 @@ Function *cloneFunctionUpdatingTypes(Function &func,
 
   // Take attributes of old function
   newFunc->takeName(&func);
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+  newFunc->updateAfterNameChange();
+#else
   newFunc->recalculateIntrinsicID();
+#endif
   newFunc->setCallingConv(func.getCallingConv());
 
   assert(func.isIntrinsic() == newFunc->isIntrinsic() &&


### PR DESCRIPTION
# Overview

https://github.com/llvm/llvm-project/pull/72867 renamed `recalculateIntrinsicID` to `updateAfterNameChange`, this PR accounts for this change in LLVM tip.

