### PR TITLE
Avoid ChooseMSVCCRT on LLVM 18+.

### DIFF
--- a/cmake/DetectLLVMMSVCCRT.cmake
+++ b/cmake/DetectLLVMMSVCCRT.cmake
@@ -32,6 +32,19 @@ if(NOT MSVC)
   return()
 endif()
 
+# LLVM 18 uses the CMake default setting, which depends on the mode LLVM
+# was built in, not the mode we were built in.
+if(LLVM_VERSION_MAJOR GREATER_EQUAL 18)
+  if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+    if(LLVM_BUILD_TYPE STREQUAL "Debug")
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL")
+    else()
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    endif()
+  endif()
+  return()
+endif()
+
 # Get the directory of cl.exe
 get_filename_component(tools_dir "${CMAKE_C_COMPILER}" DIRECTORY)
 


### PR DESCRIPTION
# Overview

Avoid ChooseMSVCCRT on LLVM 18+.

# Reason for change

LLVM 18 removes ChooseMSVCCRT.cmake, which we include.

# Description of change

LLVM 18 already sets everything we should need in LLVMConfig.cmake, which is included already. We can just skip ChooseMSVCCRT entirely and do the trivial determination directly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
