### PR TITLE
More LLVM 18 fixups.

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -285,20 +285,23 @@ void {{cookiecutter.target_name.capitalize()}}Module::initializePassMachineryFor
   llvm::Triple TT = llvm::Triple(target_machine->getTargetTriple());
   auto TLII = llvm::TargetLibraryInfoImpl(TT);
 
-  switch (CGO.getVecLib()) {
-    case clang::CodeGenOptions::Accelerate:
+  // getVecLib()'s return type changed in LLVM 18.
+  auto VecLib = CGO.getVecLib();
+  using VecLibT = decltype(VecLib);
+  switch (VecLib) {
+    case VecLibT::Accelerate:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::Accelerate, TT);
       break;
-    case clang::CodeGenOptions::SVML:
+    case VecLibT::SVML:
       TLII.addVectorizableFunctionsFromVecLib(llvm::TargetLibraryInfoImpl::SVML,
                                               TT);
       break;
-    case clang::CodeGenOptions::MASSV:
+    case VecLibT::MASSV:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::MASSV, TT);
       break;
-    case clang::CodeGenOptions::LIBMVEC:
+    case VecLibT::LIBMVEC:
       switch (TT.getArch()) {
         default:
           break;

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/target.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/target.cpp
@@ -20,13 +20,18 @@
 
 #include <hal.h>
 
-#include <llvm/Support/Host.h>
 #include <llvm/Target/TargetMachine.h>
 #include <multi_llvm/multi_llvm.h>
 #include <{{cookiecutter.target_name}}/device_info.h>
 #include <{{cookiecutter.target_name}}/module.h>
 #include <{{cookiecutter.target_name}}/target.h>
 #include "{{cookiecutter.target_name}}/module.h"
+
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+#include <llvm/TargetParser/Host.h>
+#else
+#include <llvm/Support/Host.h>
+#endif
 
 namespace {{cookiecutter.target_name}} {
 {{cookiecutter.target_name.capitalize()}}Target::{{cookiecutter.target_name.capitalize()}}Target(const compiler::Info *compiler_info,

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -239,20 +239,23 @@ void RiscvModule::initializePassMachineryForFrontend(
   llvm::Triple TT = llvm::Triple(target_machine->getTargetTriple());
   auto TLII = llvm::TargetLibraryInfoImpl(TT);
 
-  switch (CGO.getVecLib()) {
-    case clang::CodeGenOptions::Accelerate:
+  // getVecLib()'s return type changed in LLVM 18.
+  auto VecLib = CGO.getVecLib();
+  using VecLibT = decltype(VecLib);
+  switch (VecLib) {
+    case VecLibT::Accelerate:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::Accelerate, TT);
       break;
-    case clang::CodeGenOptions::SVML:
+    case VecLibT::SVML:
       TLII.addVectorizableFunctionsFromVecLib(llvm::TargetLibraryInfoImpl::SVML,
                                               TT);
       break;
-    case clang::CodeGenOptions::MASSV:
+    case VecLibT::MASSV:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::MASSV, TT);
       break;
-    case clang::CodeGenOptions::LIBMVEC:
+    case VecLibT::LIBMVEC:
       switch (TT.getArch()) {
         default:
           break;

--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -75,21 +75,27 @@ target_include_directories(compiler-base SYSTEM PUBLIC
 # 'clangCodeGen' library target brings in the 'LLVM' dynamic library. It is
 # not safe for us to link with LLVM's dynamic library, due to LLVM's use of
 # global/static state.
-foreach(CLANG_LIB "clangCodeGen" "clangFrontend" "clangDriver"
-                  "clangParse" "clangSerialization" "clangSema"
-                  "clangAnalysis" "clangAST" "clangEdit" "clangASTMatchers"
-                  "clangLex" "clangBasic" "clangSupport")
-  list(APPEND CLANG_LIBS
-    "${CA_LLVM_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${CLANG_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-endforeach()
+set(CLANG_LIBS "clangCodeGen" "clangFrontend" "clangDriver"
+               "clangParse" "clangSerialization" "clangSema"
+               "clangAnalysis" "clangAST" "clangEdit" "clangASTMatchers"
+               "clangLex" "clangBasic" "clangSupport")
+set(LLVM_LIBS "LLVMCodeGen" "LLVMOption" "LLVMCoroutines" "LLVMCoverage"
+              "LLVMLTO" "LLVMWindowsDriver" "LLVMFrontendHLSL")
+if(LLVM_VERSION_MAJOR GREATER_EQUAL 18)
+  list(APPEND CLANG_LIBS "clangAPINotes" "clangBasic")
+  list(APPEND LLVM_LIBS "LLVMFrontendDriver")
+endif()
+list(TRANSFORM CLANG_LIBS
+     PREPEND "${CA_LLVM_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}")
+list(TRANSFORM CLANG_LIBS
+     APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 target_link_libraries(compiler-base PUBLIC
   builtins cargo mux spirv-ll compiler-utils vecz
   "${CLANG_LIBS}"
   # Link against version (for clang) on Windows.
   $<$<BOOL:${WIN32}>:version>
-  LLVMCodeGen LLVMOption LLVMCoroutines LLVMCoverage LLVMLTO LLVMWindowsDriver
-  LLVMFrontendHLSL
+  "${LLVM_LIBS}"
 )
 
 target_compile_definitions(compiler-base PRIVATE

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -274,7 +274,9 @@ std::unordered_map<std::string, CallingConv::ID> CallConvMap = {
     {"Cold", CallingConv::Cold},
     {"GHC", CallingConv::GHC},
     {"HiPE", CallingConv::HiPE},
+#if LLVM_VERSION_LESS(18, 0)
     {"WebKit_JS", CallingConv::WebKit_JS},
+#endif
     {"AnyReg", CallingConv::AnyReg},
     {"PreserveMost", CallingConv::PreserveMost},
     {"PreserveAll", CallingConv::PreserveAll},

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -84,7 +84,6 @@
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/EntryExitInstrumenter.h>
-#include <llvm/Transforms/Vectorize.h>
 #include <llvm/Transforms/Vectorize/LoopVectorize.h>
 #include <llvm/Transforms/Vectorize/SLPVectorizer.h>
 #include <multi_llvm/llvm_version.h>
@@ -2084,20 +2083,23 @@ void BaseModule::initializePassMachineryForFrontend(
   llvm::Triple TT = llvm::Triple(llvm_module->getTargetTriple());
   auto TLII = llvm::TargetLibraryInfoImpl(TT);
 
-  switch (CGO.getVecLib()) {
-    case clang::CodeGenOptions::Accelerate:
+  // getVecLib()'s return type changed in LLVM 18.
+  auto VecLib = CGO.getVecLib();
+  using VecLibT = decltype(VecLib);
+  switch (VecLib) {
+    case VecLibT::Accelerate:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::Accelerate, TT);
       break;
-    case clang::CodeGenOptions::SVML:
+    case VecLibT::SVML:
       TLII.addVectorizableFunctionsFromVecLib(llvm::TargetLibraryInfoImpl::SVML,
                                               TT);
       break;
-    case clang::CodeGenOptions::MASSV:
+    case VecLibT::MASSV:
       TLII.addVectorizableFunctionsFromVecLib(
           llvm::TargetLibraryInfoImpl::MASSV, TT);
       break;
-    case clang::CodeGenOptions::LIBMVEC:
+    case VecLibT::LIBMVEC:
       switch (TT.getArch()) {
         default:
           break;

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -29,10 +29,15 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/CodeGen.h>
-#include <llvm/Support/Host.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <multi_llvm/multi_llvm.h>
+
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+#include <llvm/TargetParser/Host.h>
+#else
+#include <llvm/Support/Host.h>
+#endif
 
 #include "host/device.h"
 #include "host/info.h"

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -1295,6 +1295,7 @@ Value *Packetizer::Impl::packetizeGroupBroadcast(Instruction *I) {
     op.getPacketValues(opPackets);
     auto factor = SimdWidth.divideCoefficientBy(opPackets.size());
     const unsigned subvecSize = factor.getFixedValue();
+    assert(subvecSize > 0 && "Subvector size cannot be zero");
     const unsigned idxVal = cast<ConstantInt>(vecIdx)->getZExtValue();
     // If individual elements are scalar (through instantiation, say) then just
     // use the desired packet directly.

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
@@ -118,7 +118,7 @@ entry:
 ; EE-UNI-VEC: [[T6:%.*]] = shl <vscale x 4 x i64> [[STEP]], shufflevector (<vscale x 4 x i64> insertelement (<vscale x 4 x i64> {{(undef|poison)}}, i64 2, {{(i32|i64)}} 0), <vscale x 4 x i64> {{(undef|poison)}}, <vscale x 4 x i32> zeroinitializer)
 
 ; LLVM 16 deduces add/or equivalence and uses `or` instead.
-; EE-UNI-VEC: [[T7:%.*]] = {{add|or}} <vscale x 4 x i64> [[T6]], [[MOD]]
+; EE-UNI-VEC: [[T7:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i64> [[T6]], [[MOD]]
 
 ; EE-UNI-VEC: [[T8:%.*]] = getelementptr inbounds float, ptr {{%.*}}, <vscale x 4 x i64> [[T7]]
 ; EE-UNI-VEC: [[T9:%.*]] = call <vscale x 4 x float> @__vecz_b_gather_load4_u5nxv4fu9nxv4u3ptr(<vscale x 4 x ptr> [[T8]])
@@ -132,7 +132,7 @@ entry:
 ; EE-INDICES: store <vscale x 16 x float> {{.*}}, ptr [[ALLOC]], align 64
 ; EE-INDICES: [[STEP:%.*]] = call <vscale x 4 x i32> @llvm.experimental.stepvector.nxv4i32()
 ; EE-INDICES: [[T4:%.*]] = shl <vscale x 4 x i32> [[STEP]], shufflevector (<vscale x 4 x i32> insertelement (<vscale x 4 x i32> {{(undef|poison)}}, i32 2, {{i32|i64}} 0), <vscale x 4 x i32> {{(undef|poison)}}, <vscale x 4 x i32> zeroinitializer)
-; EE-INDICES: [[T5:%.*]] = {{add|or}} <vscale x 4 x i32> [[T4]], [[T3]]
+; EE-INDICES: [[T5:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i32> [[T4]], [[T3]]
 ; EE-INDICES: [[IDX:%.*]] = sext <vscale x 4 x i32> [[T5]] to <vscale x 4 x i64>
 ; EE-INDICES: [[ADDR:%.*]] = getelementptr inbounds float, ptr [[ALLOC]], <vscale x 4 x i64> [[IDX]]
 ; EE-INDICES: [[GATHER:%.*]] = call <vscale x 4 x float> @__vecz_b_gather_load4_u5nxv4fu9nxv4u3ptr(<vscale x 4 x ptr> [[ADDR]])

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
@@ -102,7 +102,7 @@ entry:
 ; IE-INDICES: [[T2:%.*]] = shl <vscale x 4 x i32> [[T1]], shufflevector (<vscale x 4 x i32> insertelement (<vscale x 4 x i32> {{(undef|poison)}}, i32 2, {{(i32|i64)}} 0), <vscale x 4 x i32> {{(undef|poison)}}, <vscale x 4 x i32> zeroinitializer)
 
 ; LLVM 16 deduces add/or equivalence and uses `or` instead.
-; IE-INDICES: [[T3:%.*]] = {{add|or}} <vscale x 4 x i32> [[T2]], {{%.*}}
+; IE-INDICES: [[T3:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i32> [[T2]], {{%.*}}
 
 ; IE-INDICES: [[T4:%.*]] = sext <vscale x 4 x i32> [[T3]] to <vscale x 4 x i64>
 ; IE-INDICES: [[ADDR:%.*]] = getelementptr inbounds float, ptr %0, <vscale x 4 x i64> [[T4]]

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
@@ -48,7 +48,7 @@ define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrs
 ; CHECK: [[MUL:%.*]] = shl i32 %call, 2
 ; CHECK: [[SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[MUL]], i64 0
 ; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK: [[ID:%.*]] = or <4 x i32> [[SPLAT]], <i32 0, i32 1, i32 2, i32 3>
+; CHECK: [[ID:%.*]] = or {{(disjoint )?}}<4 x i32> [[SPLAT]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[EXT:%.*]] = sext i32 %call to i64
 ; CHECK: %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
 ; CHECK: store <4 x i32> [[ID]], ptr addrspace(1) %arrayidx


### PR DESCRIPTION
# Overview

More LLVM 18 fixups.

# Reason for change

This fixes a few more build errors against LLVM 18.

# Description of change

* LLVM 18 moves clang::CodeGenOptions::VectorLibrary to llvm::driver::VectorLibrary. Use decltype to handle both.
* LLVM 18 drops CallingConv::WebKit_JS.
* LLVM 18 drops <llvm/Transforms/Vectorize.h> which we include needlessly.
* LLVM 18 requires us to link in libLLVMFrontendDriver, libclangAPINotes, libclangBasic.
* LLVM 18 moves <llvm/Support/Host.h> to <llvm/TargetParser/Host.h>.
* LLVM 18 is able to infer that we could potentially end up with a subvector size of zero, in which case we would end up with a division by zero. A subvector size of zero would be a bug elsewhere in OCK, so add an assert that it is not zero.

# Anything else we should know?

Tested against LLVM commit https://github.com/llvm/llvm-project/commit/1c55b227fe7d42b3ad18bf9e485fca66f14fa751.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
