### PR TITLE
Increase main memory size limit in memory map

### DIFF
--- a/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
+++ b/examples/refsi/hal_refsi/external/refsidrv/source/refsidrv/refsi_device_g.cpp
@@ -27,8 +27,10 @@
 // Default memory area for storing kernel ELF binaries. When the RefSi device
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
+// We have increased the memory size from 1 << 20 to handle kernels larger than
+// 1MiB
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 // Memory area for per-hart storage.
 constexpr const uint64_t G_HART_LOCAL_BASE = 0x20800000;

--- a/examples/refsi/hal_refsi/include/device/program.lds
+++ b/examples/refsi/hal_refsi/include/device/program.lds
@@ -19,7 +19,7 @@ OUTPUT_ARCH( "riscv" )
 
 MEMORY
 {
-    mainmem : ORIGIN = 0x10000, LENGTH = (1 << 20)
+    mainmem : ORIGIN = 0x10000, LENGTH = (1 << 27)
     localmem : ORIGIN = 0x10000000, LENGTH = 0x200000
 }
 

--- a/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_g1.cpp
@@ -29,8 +29,10 @@
 // Default memory area for storing kernel ELF binaries. When the RefSi device
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
+// We have increased the memory size from 1 << 20 to handle kernels larger than
+// 1MiB
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 constexpr const uint64_t REFSI_MAX_HARTS = 64;
 

--- a/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
@@ -28,8 +28,10 @@
 // Default memory area for storing kernel ELF binaries. When the RefSi device
 // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
 // window is set up to map this memory area to a reserved area in DMA.
+// We have increased the memory size from 1 << 20 to handle kernels larger than
+// 1MiB
 constexpr const uint64_t REFSI_ELF_BASE = 0x10000ull;
-constexpr const uint64_t REFSI_ELF_SIZE = (1 << 20) - REFSI_ELF_BASE;
+constexpr const uint64_t REFSI_ELF_SIZE = (1 << 27) - REFSI_ELF_BASE;
 
 refsi_m1_hal_device::refsi_m1_hal_device(refsi_device_t device,
                                          riscv::hal_device_info_riscv_t *info,


### PR DESCRIPTION
# Overview
The SYCL CTS generates binaries larger than 1MiB, so this patch increases the limit.

# Reason for change

Reverts the size shrinking of e7f57440953ed62796de5459e63d398f29ef0df0 , which broke the CTS. Turns out the SYCL CTS requires binaries larger than 1MiB.

# Description of change

Size has been increased back to what it was before e7f57440953ed62796de5459e63d398f29ef0df0 

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
