### PR TITLE
[tutorial] Fix various issues in the HAL tutorial and new-target scripts

### DIFF
--- a/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
@@ -121,7 +121,7 @@ after the ``Add final passes here`` comment, add:
 .. code:: cpp
 
   // Add final passes here by adding directly to PM as needed
-  PM.addPass(refsi::RefSiWrapperPass()); 
+  PM.addPass(refsi_tutorial::RefSiWrapperPass());
 
 Note you will also need to include the header file ``refsi_wrapper_pass.h`` you
 just created. 
@@ -172,7 +172,7 @@ we see the `IR` dumped after that pass, including the unchanged function:
 
 .. code:: console
 
-  ** IR Dump After refsi::RefSiWrapperPass on [module] ***
+  ** IR Dump After refsi_tutorial::RefSiWrapperPass on [module] ***
   ; ModuleID = 'kernel.opencl'
   source_filename = "kernel.opencl"
   target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"

--- a/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
@@ -541,7 +541,7 @@ Dumping the IR of your function should show your changes:
     %6 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 0
     store i64 %5, ptr %6, align 8
   
-    ; more load/stores like this top copy whole struct
+    ; more load/stores like this to copy the whole struct
   
     %34 = urem i64 %slice, %3
     %35 = udiv i64 %slice, %3

--- a/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/adapting-target-pass-pipeline.rst
@@ -350,24 +350,22 @@ id``.
     for (auto &Arg : F.getFunctionType()->params()) { 
       ArgTypes.push_back(Arg); 
     } 
-    Function *NewFunction = compiler::utils::createKernelWrapperFunction(M, F, ArgTypes);
+    Function *NewFunction = compiler::utils::createKernelWrapperFunction(
+        M, F, ArgTypes, ".refsi-wrapper");
 
-We now want to put together the arguments for calling the original function. The
-first parameters are a copy of the original parameters: 
+    // Copy over the old parameter names and attributes
+    for (unsigned i = 0, e = F.arg_size(); i != e; i++) {
+      auto *NewArg = NewFunction->getArg(i + 2);
+      NewArg->setName(F.getArg(i)->getName());
+      NewFunction->addParamAttrs(
+          i + 2, AttrBuilder(F.getContext(), F.getAttributes().getParamAttrs(i)));
+    }
+    NewFunction->getArg(InstanceArgIndex)->setName("instance");
+    NewFunction->getArg(SliceArgIndex)->setName("slice");
 
-.. code:: cpp
-
-      // get the arguments 
-      SmallVector<Value *, 8> Args;
-
-      unsigned int CountArgs = F.arg_size();
-      for (auto &Arg : NewFunction->args()) {
-        if (!(CountArgs--)) {
-          break;
-        }
-        Args.push_back(&Arg);
-      }
-
+    if (!NewFunction->hasFnAttribute(Attribute::NoInline)) {
+      NewFunction->addFnAttr(Attribute::AlwaysInline);
+    }
 
 We want to start creating code now, so create an ``IRBuilder`` for ease of use: 
 
@@ -401,7 +399,6 @@ structure on the stack:
 We can now copy the input structure to our copied structure:
 
 .. code:: cpp
-
 
     CopyElementToNewSchedStruct(
         Builder, MuxWorkGroupStructTy, SchedArg, SchedCopyInst,
@@ -456,6 +453,7 @@ scheduling struct with our copy and dropping the ``instance`` and ``slice`` argu
 .. code:: cpp
 
   unsigned int ArgIndex = 0;
+  SmallVector<Value *, 8> Args;
   for (auto &Arg : NewFunction->args()) {
     if (ArgIndex > SliceArgIndex) {
       if (ArgIndex == SchedStructArgIndex) {
@@ -472,8 +470,9 @@ complete now and we can return this created function.
 
 .. code:: cpp
 
-    auto CI = Builder.CreateCall(&F, Args); 
-    CI->setCallingConv(F.getCallingConv()); 
+    compiler::utils::createCallToWrappedFunction(
+        F, Args, Builder.GetInsertBlock(), Builder.GetInsertPoint());
+
     Builder.CreateRetVoid(); 
     return NewFunction; 
 
@@ -532,26 +531,26 @@ Dumping the IR of your function should show your changes:
    $ CA_LLVM_OPTIONS="-print-after=refsi-wrapper" bin/UnitCL \
      --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
 
-  ; Function Attrs: alwaysinline nounwind
-  define void @add(ptr %0, ptr %1, i64 %2, i64 %3) #3 !codeplay_ca_wrapper !12 !mux_scheduled_fn !15 {
-    %5 = alloca %MuxWorkGroupInfo, align 8
-    %6 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 1
-    %7 = load i64, ptr %6, align 8
-    %8 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 0
-    %9 = load i64, ptr %8, align 8
-    %10 = getelementptr %MuxWorkGroupInfo, ptr %5, i32 0, i32 1, i32 0
-    store i64 %9, ptr %10, align 8
+  ; Function Attrs: alwaysinline mustprogress nofree norecurse nounwind willreturn memory(read, argmem: readwrite)
+  define void @add.refsi-wrapper(i64 %instance, i64 %slice, ptr %packed-args, ptr noalias nonnull align 8 deferenceable(104) %wg-info) #3 !codeplay_ca_wrapper !12 !mux_scheduled_fn !15 {
+    %1 = alloca %MuxWorkGroupInfo, align 8
+    %2 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 1
+    %3 = load i64, ptr %2, align 8
+    %4 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 0
+    %5 = load i64, ptr %4, align 8
+    %6 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 1, i32 0
+    store i64 %5, ptr %6, align 8
   
     ; more load/stores like this top copy whole struct
   
-    %38 = urem i64 %3, %7
-    %39 = udiv i64 %3, %7
-    %40 = getelementptr %MuxWorkGroupInfo, ptr %5, i32 0, i32 0, i32 0
-    store i64 %2, ptr %40, align 8
-    %41 = getelementptr %MuxWorkGroupInfo, ptr %5, i32 0, i32 0, i32 1
-    store i64 %38, ptr %41, align 8
-    %42 = getelementptr %MuxWorkGroupInfo, ptr %5, i32 0, i32 0, i32 2
-    store i64 %39, ptr %42, align 8
-    call void @2(ptr %0, ptr %5)
+    %34 = urem i64 %slice, %3
+    %35 = udiv i64 %slice, %3
+    %36 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 0, i32 0
+    store i64 %instance, ptr %36, align 8
+    %37 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 0, i32 1
+    store i64 %34, ptr %37, align 8
+    %38 = getelementptr %MuxWorkGroupInfo, ptr %1, i32 0, i32 0, i32 2
+    store i64 %35, ptr %38, align 8
+    call void @add.mux-kernel-wrapper(ptr %packed-args, ptr noalias nonnull align 8 dereferenceable(104) %1)
     ret void
   }

--- a/doc/overview/tutorials/creating-a-new-mux-target/running-new-target-script.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/running-new-target-script.rst
@@ -6,7 +6,7 @@ should be based off `hal_refsi_tutorial`.
 
 The *RefSi* target is a RISC-V target which uses a command processor to run a
 kernel with any given parameters across different instances and slices. These
-parameters will all be indentical for each kernel execution.
+parameters will all be identical for each kernel execution.
 
 First of all we need an empty directory ``refsi_tutorial``. We also assume that
 the ``oneAPI Construction Kit`` exists at ``$ONEAPI_CON_KIT_PATH`` commands:
@@ -85,7 +85,7 @@ named after the `target_name` field. It also creates a ``CMakeLists.txt`` which
 can be used to build the oneAPI Construction Kit. After creating these new
 directories, we have a fully buildable target, ready for your ``HAL``. The ``mux``
 side handles the runtime aspects and the default generated here assumes it is on the
-same architecure as the host we build on. The ``compiler`` side manages the
+same architecture as the host we build on. The ``compiler`` side manages the
 compilation of kernels. It has a standard LLVM pipeline influenced by the `json`
 file, which is used to produce executable kernels.
 
@@ -114,7 +114,7 @@ The generated `CMakeLists.txt` is very simple and will look something like this:
     ${CMAKE_CURRENT_BINARY_DIR}/oneAPIConstructionKit)
 
 The ``CA_EXTERNAL_MUX_TARGET_DIRS`` and ``CA_EXTERNAL_MUX_COMPILER_DIRS`` are
-used to tell the oneAPI Construction Kit where to look for for the per target code,
+used to tell the oneAPI Construction Kit where to look for the per target code,
 both for ``mux`` (the runtime) and ``compiler`` (the code generation). The
 directory name should match the target name.
 
@@ -122,7 +122,7 @@ directory name should match the target name.
 target. This can be changed to wherever you have stored the final
 `hal_refsi_tutorial`, but defaults to within the current top level directory.
 
-``CA_EXTERNAL_ONEAPI_KIT_DIR`` is used to indicate where the `oneAPI construction kit` directory is.
+``CA_EXTERNAL_ONEAPI_KIT_DIR`` is used to indicate where the `oneAPI Construction Kit` directory is.
 
 
 Both of these variables can be overridden on the `cmake` line.

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
@@ -2,7 +2,7 @@ diff --git a/cmake/CompileKernel.cmake b/cmake/CompileKernel.cmake
 index d369b7c..166179e 100644
 --- a/cmake/CompileKernel.cmake
 +++ b/cmake/CompileKernel.cmake
-@@ -7,7 +7,17 @@ function(hal_refsi_tutorial_compile_kernel_source OBJECT SRC)
+@@ -21,7 +21,17 @@ function(hal_refsi_tutorial_compile_kernel_source OBJECT SRC)
    get_property(ROOT_DIR GLOBAL PROPERTY HAL_REFSI_TUTORIAL_DIR)
    get_target_property(REFSIDRV_SRC_DIR refsidrv SOURCE_DIR)
  
@@ -21,7 +21,7 @@ index d369b7c..166179e 100644
  endfunction()
  
  function(hal_refsi_tutorial_link_kernel BINARY)
-@@ -21,5 +31,9 @@ function(hal_refsi_tutorial_link_kernel BINARY)
+@@ -35,5 +45,9 @@ function(hal_refsi_tutorial_link_kernel BINARY)
    get_property(RISCV_LINKER_FLAGS GLOBAL PROPERTY RISCV_LINKER_FLAGS)
    get_property(ROOT_DIR GLOBAL PROPERTY HAL_REFSI_TUTORIAL_DIR)
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
@@ -2,7 +2,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index ca7810f..5a96851 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -7,14 +7,19 @@
+@@ -21,14 +21,19 @@
  
  #include "hal.h"
  #include "hal_riscv.h"
@@ -23,7 +23,7 @@ index ca7810f..5a96851 100644
    // find a specific kernel function in a compiled program
    // returns `hal_invalid_kernel` if no symbol could be found
    hal::hal_kernel_t program_find_kernel(hal::hal_program_t program,
-@@ -52,6 +57,7 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -66,6 +71,7 @@ class refsi_hal_device : public hal::hal_device_t {
   private:
    std::recursive_mutex &hal_lock;
    hal::hal_device_info_t *info;
@@ -35,7 +35,7 @@ diff --git a/source/hal_main.cpp b/source/hal_main.cpp
 index 42e7782..263c157 100644
 --- a/source/hal_main.cpp
 +++ b/source/hal_main.cpp
-@@ -29,10 +29,30 @@ class refsi_tutorial_hal : public hal::hal_t {
+@@ -43,10 +43,30 @@ class refsi_tutorial_hal : public hal::hal_t {
    }
  
    // request the creation of a new hal
@@ -72,7 +72,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 5d704c7..3fa5804 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -3,8 +3,14 @@
+@@ -17,8 +17,14 @@
  #include "refsi_hal.h"
  
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
@@ -88,7 +88,7 @@ index 5d704c7..3fa5804 100644
  
  hal::hal_kernel_t refsi_hal_device::program_find_kernel(
      hal::hal_program_t program, const char *name) {
-@@ -54,3 +60,5 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
+@@ -68,3 +74,5 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
    refsi_locker locker(hal_lock);
    return false;
  }

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
@@ -2,7 +2,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 3fa5804..1c976d6 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -2,6 +2,8 @@
+@@ -16,6 +16,8 @@
  
  #include "refsi_hal.h"
  
@@ -11,7 +11,7 @@ index 3fa5804..1c976d6 100644
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
                                     std::recursive_mutex &hal_lock)
-@@ -41,24 +43,34 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -55,24 +57,34 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
  hal::hal_addr_t refsi_hal_device::mem_alloc(hal::hal_size_t size,
                                              hal::hal_size_t alignment) {
    refsi_locker locker(hal_lock);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
@@ -2,15 +2,17 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index 5a96851..a0bf0c4 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -18,6 +18,7 @@
+@@ -18,13 +18,32 @@
  #define _HAL_REFSI_REFSI_HAL_H
  
  #include <mutex>
++#include <memory>
 +#include <string>
  
++#include "elf_loader.h"
  #include "hal.h"
  #include "hal_riscv.h"
-@@ -25,6 +26,14 @@
+ #include "refsidrv/refsidrv.h"
  
  using refsi_locker = std::lock_guard<std::recursive_mutex>;
  
@@ -22,6 +24,14 @@ index 5a96851..a0bf0c4 100644
 +  const std::string name;
 +};
 +
++struct refsi_hal_program {
++  refsi_hal_program(std::unique_ptr<ELFProgram> program)
++      : elf(std::move(program)) {}
++
++  std::unique_ptr<ELFProgram> elf;
++  std::map<std::string, std::unique_ptr<refsi_hal_kernel>> kernels;
++};
++
  class refsi_hal_device : public hal::hal_device_t {
   public:
    refsi_hal_device(riscv::hal_device_info_riscv_t *info, refsi_device_t device,
@@ -29,18 +39,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 1c976d6..4e97324 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -18,6 +18,10 @@
- 
- #include <string.h>
- 
-+#include <memory>
-+
-+#include "elf_loader.h"
-+
- refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
-                                    refsi_device_t device,
-                                    std::recursive_mutex &hal_lock)
-@@ -31,18 +35,35 @@ refsi_hal_device::~refsi_hal_device() {
+@@ -31,18 +35,46 @@ refsi_hal_device::~refsi_hal_device() {
  hal::hal_kernel_t refsi_hal_device::program_find_kernel(
      hal::hal_program_t program, const char *name) {
    refsi_locker locker(hal_lock);
@@ -48,12 +47,21 @@ index 1c976d6..4e97324 100644
 +  if (program == hal::hal_invalid_program) {
 +    return hal::hal_invalid_kernel;
 +  }
-+  ELFProgram *elf = (ELFProgram *)program;
-+  hal::hal_addr_t kernel = elf->find_symbol(name);
-+  if (kernel == hal::hal_nullptr) {
-+    return hal::hal_invalid_kernel;
++  refsi_hal_program *refsi_program = (refsi_hal_program *)program;
++  refsi_hal_kernel *refsi_kernel = nullptr;
++  if (auto it = refsi_program->kernels.find(name);
++      it != refsi_program->kernels.end()) {
++    refsi_kernel = it->second.get();
++  } else {
++    hal::hal_addr_t kernel = refsi_program->elf->find_symbol(name);
++    if (kernel == hal::hal_nullptr) {
++      return hal::hal_invalid_kernel;
++    }
++    refsi_program->kernels[name] =
++        std::make_unique<refsi_hal_kernel>(kernel, name);
++    refsi_kernel = refsi_program->kernels[name].get();
 +  }
-+  return (hal::hal_kernel_t) new refsi_hal_kernel(kernel, name);
++  return reinterpret_cast<hal::hal_kernel_t>(refsi_kernel);
  }
  
  hal::hal_program_t refsi_hal_device::program_load(const void *data,
@@ -65,7 +73,8 @@ index 1c976d6..4e97324 100644
 +  if (!new_program->read(elf_data)) {
 +    return hal::hal_invalid_program;
 +  }
-+  return (hal::hal_program_t)new_program.release();
++  auto *refsi_program = new refsi_hal_program(std::move(new_program));
++  return (hal::hal_program_t)refsi_program;
  }
  
  bool refsi_hal_device::program_free(hal::hal_program_t program) {
@@ -74,7 +83,8 @@ index 1c976d6..4e97324 100644
 +  if (program == hal::hal_invalid_program) {
 +    return false;
 +  }
-+  delete (ELFProgram *)program;
++  auto *refsi_program = (refsi_hal_program *)program;
++  delete refsi_program;
 +  return true;
  }
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
@@ -2,7 +2,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index 5a96851..a0bf0c4 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -4,6 +4,7 @@
+@@ -18,6 +18,7 @@
  #define _HAL_REFSI_REFSI_HAL_H
  
  #include <mutex>
@@ -10,7 +10,7 @@ index 5a96851..a0bf0c4 100644
  
  #include "hal.h"
  #include "hal_riscv.h"
-@@ -11,6 +12,14 @@
+@@ -25,6 +26,14 @@
  
  using refsi_locker = std::lock_guard<std::recursive_mutex>;
  
@@ -29,7 +29,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 1c976d6..4e97324 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -4,6 +4,10 @@
+@@ -18,6 +18,10 @@
  
  #include <string.h>
  
@@ -40,7 +40,7 @@ index 1c976d6..4e97324 100644
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
                                     std::recursive_mutex &hal_lock)
-@@ -17,18 +21,35 @@ refsi_hal_device::~refsi_hal_device() {
+@@ -31,18 +35,35 @@ refsi_hal_device::~refsi_hal_device() {
  hal::hal_kernel_t refsi_hal_device::program_find_kernel(
      hal::hal_program_t program, const char *name) {
    refsi_locker locker(hal_lock);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
@@ -41,16 +41,16 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index a0bf0c4..a2aaa02 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -19,6 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  #include <mutex>
+ #include <memory>
  #include <string>
 +#include <vector>
  
+ #include "elf_loader.h"
  #include "hal.h"
- #include "hal_riscv.h"
-@@ -34,15 +35,18 @@ struct refsi_hal_kernel {
-   const std::string name;
+@@ -44,15 +45,18 @@ struct refsi_hal_kernel {
+   std::map<std::string, std::unique_ptr<refsi_hal_kernel>> kernels;
  };
  
 +using refsi_locker = std::lock_guard<std::recursive_mutex>;
@@ -125,15 +125,15 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 4e97324..4bb197a 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -21,6 +21,7 @@
- #include <memory>
- 
- #include "elf_loader.h"
+@@ -17,6 +17,7 @@
+ #include "refsi_hal.h"
+
+ #include <string.h>
 +#include "refsi_command_buffer.h"
  
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
-@@ -72,7 +73,20 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -79,7 +80,20 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     const hal::hal_arg_t *args,
                                     uint32_t num_args, uint32_t work_dim) {
    refsi_locker locker(hal_lock);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
@@ -41,7 +41,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index a0bf0c4..a2aaa02 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -5,6 +5,7 @@
+@@ -19,6 +19,7 @@
  
  #include <mutex>
  #include <string>
@@ -49,7 +49,7 @@ index a0bf0c4..a2aaa02 100644
  
  #include "hal.h"
  #include "hal_riscv.h"
-@@ -20,15 +21,18 @@ struct refsi_hal_kernel {
+@@ -34,15 +35,18 @@ struct refsi_hal_kernel {
    const std::string name;
  };
  
@@ -73,7 +73,7 @@ diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
 index c8b2a30..38e8869 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -5,6 +5,7 @@ add_subdirectory(common)
+@@ -19,6 +19,7 @@ add_subdirectory(common)
  add_library(hal_refsi_tutorial SHARED
    hal_main.cpp
    refsi_hal.cpp
@@ -125,7 +125,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 4e97324..4bb197a 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -7,6 +7,7 @@
+@@ -21,6 +21,7 @@
  #include <memory>
  
  #include "elf_loader.h"
@@ -133,7 +133,7 @@ index 4e97324..4bb197a 100644
  
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
-@@ -58,7 +59,20 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -72,7 +73,20 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     const hal::hal_arg_t *args,
                                     uint32_t num_args, uint32_t work_dim) {
    refsi_locker locker(hal_lock);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
@@ -20,14 +20,15 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index a2aaa02..34b3bc1 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -21,12 +21,15 @@
+@@ -22,6 +22,7 @@
  #include <string>
  #include <vector>
  
 +#include "common_devices.h"
+ #include "elf_loader.h"
  #include "hal.h"
  #include "hal_riscv.h"
- #include "refsidrv/refsidrv.h"
+@@ -29,6 +30,8 @@
  
  using refsi_locker = std::lock_guard<std::recursive_mutex>;
  
@@ -36,7 +37,7 @@ index a2aaa02..34b3bc1 100644
  struct refsi_hal_kernel {
    refsi_hal_kernel(hal::hal_addr_t symbol, std::string name)
        : symbol(symbol), name(std::move(name)) {}
-@@ -82,9 +85,38 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -92,9 +95,38 @@ class refsi_hal_device : public hal::hal_device_t {
                   hal::hal_size_t size) override;
  
   private:
@@ -97,8 +98,8 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 4bb197a..f6ff7bc 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -23,6 +23,12 @@
- #include "elf_loader.h"
+@@ -19,6 +19,12 @@
+ #include <string.h>
  #include "refsi_command_buffer.h"
  
 +// Default memory area for storing kernel ELF binaries. When the RefSi device
@@ -110,11 +111,12 @@ index 4bb197a..f6ff7bc 100644
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
                                     std::recursive_mutex &hal_lock)
-@@ -74,11 +80,21 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -81,11 +87,22 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     uint32_t num_args, uint32_t work_dim) {
    refsi_locker locker(hal_lock);
  
-+  ELFProgram *elf = (ELFProgram *)program;
++  refsi_hal_program *refsi_program = (refsi_hal_program *)program;
++  ELFProgram *elf = refsi_program->elf.get();
    refsi_hal_kernel *kernel_wrapper = (refsi_hal_kernel *)kernel;
  
 +  // Load ELF into the RefSi device's memory.
@@ -132,7 +134,7 @@ index 4bb197a..f6ff7bc 100644
    cb.addFINISH();
  
    // Execute the command buffer.
-@@ -122,4 +138,61 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
+@@ -129,4 +146,61 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
    return true;
  }
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
@@ -20,7 +20,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index a2aaa02..34b3bc1 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -7,12 +7,15 @@
+@@ -21,12 +21,15 @@
  #include <string>
  #include <vector>
  
@@ -36,7 +36,7 @@ index a2aaa02..34b3bc1 100644
  struct refsi_hal_kernel {
    refsi_hal_kernel(hal::hal_addr_t symbol, std::string name)
        : symbol(symbol), name(std::move(name)) {}
-@@ -68,9 +71,38 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -82,9 +85,38 @@ class refsi_hal_device : public hal::hal_device_t {
                   hal::hal_size_t size) override;
  
   private:
@@ -97,7 +97,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index 4bb197a..f6ff7bc 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -9,6 +9,12 @@
+@@ -23,6 +23,12 @@
  #include "elf_loader.h"
  #include "refsi_command_buffer.h"
  
@@ -110,7 +110,7 @@ index 4bb197a..f6ff7bc 100644
  refsi_hal_device::refsi_hal_device(riscv::hal_device_info_riscv_t *info,
                                     refsi_device_t device,
                                     std::recursive_mutex &hal_lock)
-@@ -60,11 +66,21 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -74,11 +80,21 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     uint32_t num_args, uint32_t work_dim) {
    refsi_locker locker(hal_lock);
  
@@ -132,7 +132,7 @@ index 4bb197a..f6ff7bc 100644
    cb.addFINISH();
  
    // Execute the command buffer.
-@@ -108,4 +124,61 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
+@@ -122,4 +138,61 @@ bool refsi_hal_device::mem_write(hal::hal_addr_t dst, const void *src,
    return true;
  }
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
@@ -2,15 +2,15 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index 34b3bc1..cd2667c 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -22,6 +22,7 @@
+@@ -23,6 +23,7 @@
  #include <vector>
  
  #include "common_devices.h"
 +#include "device/device_if.h"
+ #include "elf_loader.h"
  #include "hal.h"
  #include "hal_riscv.h"
- #include "refsidrv/refsidrv.h"
-@@ -89,6 +90,12 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -99,6 +100,12 @@ class refsi_hal_device : public hal::hal_device_t {
    bool createWindow(refsi_command_buffer &cb, uint32_t win_id, uint32_t mode,
                      refsi_addr_t base, refsi_addr_t target, uint64_t scale,
                      uint64_t size);
@@ -27,7 +27,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index f6ff7bc..bfa1488 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -73,6 +73,55 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
+@@ -80,6 +80,55 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
    return true;
  }
  
@@ -83,7 +83,7 @@ index f6ff7bc..bfa1488 100644
  bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     hal::hal_kernel_t kernel,
                                     const hal::hal_ndrange_t *nd_range,
-@@ -89,12 +140,27 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -97,12 +146,27 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
  
@@ -113,7 +113,7 @@ index f6ff7bc..bfa1488 100644
    cb.addFINISH();
  
    // Execute the command buffer.
-@@ -102,6 +167,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -110,6 +174,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
@@ -50,8 +50,8 @@ index f6ff7bc..bfa1488 100644
 +                                              hal::hal_size_t &kub_desc,
 +                                              hal::hal_size_t &tsd_info) {
 +  auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-+    uint64_t padding = align - (buffer.size() % align);
-+    buffer.resize(buffer.size() + padding);
++    size_t aligned_size = (buffer.size() + align - 1) / align * align;
++    buffer.resize(aligned_size);
 +  };
 +  std::vector<uint8_t> kub_data;
 +

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
@@ -14,7 +14,7 @@ index 34b3bc1..cd2667c 100644
    bool createWindow(refsi_command_buffer &cb, uint32_t win_id, uint32_t mode,
                      refsi_addr_t base, refsi_addr_t target, uint64_t scale,
                      uint64_t size);
-+  bool populateSchedulingInfo(exec_state_t &exec,
++  bool populateSchedulingInfo(wg_info_t &wg,
 +                              const hal::hal_ndrange_t &range,
 +                              uint32_t work_dim);
 +  hal::hal_addr_t allocateKUB(const exec_state_t &exec,
@@ -27,15 +27,13 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index f6ff7bc..bfa1488 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -73,6 +73,57 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
+@@ -73,6 +73,55 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
    return true;
  }
  
-+bool refsi_hal_device::populateSchedulingInfo(exec_state_t &exec,
++bool refsi_hal_device::populateSchedulingInfo(wg_info_t &wg,
 +                                              const hal::hal_ndrange_t &range,
 +                                              uint32_t work_dim) {
-+  wg_info_t &wg(exec.wg);
-+  memset(&exec, 0, sizeof(exec_state_t));
 +  wg.num_dim = work_dim;
 +  for (int i = 0; i < DIMS; i++) {
 +    wg.local_size[i] = range.local[i];
@@ -85,13 +83,14 @@ index f6ff7bc..bfa1488 100644
  bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     hal::hal_kernel_t kernel,
                                     const hal::hal_ndrange_t *nd_range,
-@@ -89,12 +140,26 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -89,12 +140,27 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
  
 +  // Store work-group scheduling info for the kernel in the KUB.
 +  exec_state_t exec;
-+  if (!populateSchedulingInfo(exec, *nd_range, work_dim)) {
++  memset(&exec, 0, sizeof(exec_state_t));
++  if (!populateSchedulingInfo(exec.wg, *nd_range, work_dim)) {
 +    return false;
 +  }
 +  hal::hal_size_t kub_desc = 0;

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
@@ -2,7 +2,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index 34b3bc1..cd2667c 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -8,6 +8,7 @@
+@@ -22,6 +22,7 @@
  #include <vector>
  
  #include "common_devices.h"
@@ -10,7 +10,7 @@ index 34b3bc1..cd2667c 100644
  #include "hal.h"
  #include "hal_riscv.h"
  #include "refsidrv/refsidrv.h"
-@@ -75,6 +76,12 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -89,6 +90,12 @@ class refsi_hal_device : public hal::hal_device_t {
    bool createWindow(refsi_command_buffer &cb, uint32_t win_id, uint32_t mode,
                      refsi_addr_t base, refsi_addr_t target, uint64_t scale,
                      uint64_t size);
@@ -27,7 +27,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index f6ff7bc..bfa1488 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -59,6 +59,57 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
+@@ -73,6 +73,57 @@ bool refsi_hal_device::program_free(hal::hal_program_t program) {
    return true;
  }
  
@@ -85,7 +85,7 @@ index f6ff7bc..bfa1488 100644
  bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
                                     hal::hal_kernel_t kernel,
                                     const hal::hal_ndrange_t *nd_range,
-@@ -75,12 +126,26 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -89,12 +140,26 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
  
@@ -114,7 +114,7 @@ index f6ff7bc..bfa1488 100644
    cb.addFINISH();
  
    // Execute the command buffer.
-@@ -88,6 +153,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -102,6 +167,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
  

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
@@ -2,7 +2,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index cd2667c..e16389d 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -93,7 +93,8 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -103,7 +103,8 @@ class refsi_hal_device : public hal::hal_device_t {
    bool populateSchedulingInfo(wg_info_t &wg,
                                const hal::hal_ndrange_t &range,
                                uint32_t work_dim);
@@ -16,18 +16,18 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index bfa1488..3a22b6f 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -20,6 +20,7 @@
- 
- #include <memory>
- 
-+#include "arg_pack.h"
- #include "elf_loader.h"
+@@ -18,6 +18,7 @@
+
+ #include <string.h>
  #include "refsi_command_buffer.h"
- 
-@@ -88,7 +89,9 @@ bool refsi_hal_device::populateSchedulingInfo(wg_info_t &wg,
++#include "arg_pack.h"
+
+ // Default memory area for storing kernel ELF binaries. When the RefSi device
+ // does not have dedicated (TCIM) memory for storing kernel exeutables, a memory
+@@ -95,7 +96,9 @@ bool refsi_hal_device::populateSchedulingInfo(wg_info_t &wg,
    return true;
  }
- 
+
 -hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
 +hal::hal_addr_t refsi_hal_device::allocateKUB(const hal::hal_arg_t *args,
 +                                              uint32_t num_args,
@@ -35,10 +35,10 @@ index bfa1488..3a22b6f 100644
                                                hal::hal_size_t &kub_desc,
                                                hal::hal_size_t &tsd_info) {
    auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-@@ -97,6 +100,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
+@@ -104,6 +107,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
    };
    std::vector<uint8_t> kub_data;
- 
+
 +  // Pack arguments.
 +  hal::util::hal_argpack_t packer(64);
 +  if (!packer.build(args, num_args)) {
@@ -51,7 +51,7 @@ index bfa1488..3a22b6f 100644
    // Pack work-group scheduling info into the KUB.
    uint64_t sched_offset = kub_data.size();
    uint64_t sched_size = sizeof(exec_state_t);
-@@ -145,8 +157,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -153,8 +165,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
    hal::hal_size_t kub_desc = 0;
@@ -63,7 +63,7 @@ index bfa1488..3a22b6f 100644
    if (!kub_addr) {
      return false;
    }
-@@ -157,6 +171,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -165,6 +179,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
    cb.addWRITE_REG64(CMP_REG_ENTRY_PT_FN, kernel_wrapper->symbol);
    cb.addWRITE_REG64(CMP_REG_RETURN_ADDR, elf->find_symbol("kernel_exit"));
    cb.addWRITE_REG64(CMP_REG_KUB_DESC, kub_desc);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
@@ -3,7 +3,7 @@ index cd2667c..e16389d 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
 @@ -93,7 +93,8 @@ class refsi_hal_device : public hal::hal_device_t {
-   bool populateSchedulingInfo(exec_state_t &exec,
+   bool populateSchedulingInfo(wg_info_t &wg,
                                const hal::hal_ndrange_t &range,
                                uint32_t work_dim);
 -  hal::hal_addr_t allocateKUB(const exec_state_t &exec,
@@ -24,7 +24,7 @@ index bfa1488..3a22b6f 100644
  #include "elf_loader.h"
  #include "refsi_command_buffer.h"
  
-@@ -90,7 +91,9 @@ bool refsi_hal_device::populateSchedulingInfo(exec_state_t &exec,
+@@ -88,7 +89,9 @@ bool refsi_hal_device::populateSchedulingInfo(wg_info_t &wg,
    return true;
  }
  
@@ -35,7 +35,7 @@ index bfa1488..3a22b6f 100644
                                                hal::hal_size_t &kub_desc,
                                                hal::hal_size_t &tsd_info) {
    auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-@@ -99,6 +102,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
+@@ -97,6 +100,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
    };
    std::vector<uint8_t> kub_data;
  
@@ -51,7 +51,7 @@ index bfa1488..3a22b6f 100644
    // Pack work-group scheduling info into the KUB.
    uint64_t sched_offset = kub_data.size();
    uint64_t sched_size = sizeof(exec_state_t);
-@@ -146,8 +158,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -145,8 +157,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
    hal::hal_size_t kub_desc = 0;
@@ -63,7 +63,7 @@ index bfa1488..3a22b6f 100644
    if (!kub_addr) {
      return false;
    }
-@@ -158,6 +172,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -157,6 +171,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
    cb.addWRITE_REG64(CMP_REG_ENTRY_PT_FN, kernel_wrapper->symbol);
    cb.addWRITE_REG64(CMP_REG_RETURN_ADDR, elf->find_symbol("kernel_exit"));
    cb.addWRITE_REG64(CMP_REG_KUB_DESC, kub_desc);

--- a/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
+++ b/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
@@ -2,7 +2,7 @@ diff --git a/include/refsi_hal.h b/include/refsi_hal.h
 index cd2667c..e16389d 100644
 --- a/include/refsi_hal.h
 +++ b/include/refsi_hal.h
-@@ -79,7 +79,8 @@ class refsi_hal_device : public hal::hal_device_t {
+@@ -93,7 +93,8 @@ class refsi_hal_device : public hal::hal_device_t {
    bool populateSchedulingInfo(exec_state_t &exec,
                                const hal::hal_ndrange_t &range,
                                uint32_t work_dim);
@@ -16,7 +16,7 @@ diff --git a/source/refsi_hal.cpp b/source/refsi_hal.cpp
 index bfa1488..3a22b6f 100644
 --- a/source/refsi_hal.cpp
 +++ b/source/refsi_hal.cpp
-@@ -6,6 +6,7 @@
+@@ -20,6 +20,7 @@
  
  #include <memory>
  
@@ -24,7 +24,7 @@ index bfa1488..3a22b6f 100644
  #include "elf_loader.h"
  #include "refsi_command_buffer.h"
  
-@@ -76,7 +77,9 @@ bool refsi_hal_device::populateSchedulingInfo(exec_state_t &exec,
+@@ -90,7 +91,9 @@ bool refsi_hal_device::populateSchedulingInfo(exec_state_t &exec,
    return true;
  }
  
@@ -35,7 +35,7 @@ index bfa1488..3a22b6f 100644
                                                hal::hal_size_t &kub_desc,
                                                hal::hal_size_t &tsd_info) {
    auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-@@ -85,6 +88,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
+@@ -99,6 +102,15 @@ hal::hal_addr_t refsi_hal_device::allocateKUB(const exec_state_t &exec,
    };
    std::vector<uint8_t> kub_data;
  
@@ -51,7 +51,7 @@ index bfa1488..3a22b6f 100644
    // Pack work-group scheduling info into the KUB.
    uint64_t sched_offset = kub_data.size();
    uint64_t sched_size = sizeof(exec_state_t);
-@@ -132,8 +144,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -146,8 +158,10 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
      return false;
    }
    hal::hal_size_t kub_desc = 0;
@@ -63,7 +63,7 @@ index bfa1488..3a22b6f 100644
    if (!kub_addr) {
      return false;
    }
-@@ -144,6 +158,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
+@@ -158,6 +172,7 @@ bool refsi_hal_device::kernel_exec(hal::hal_program_t program,
    cb.addWRITE_REG64(CMP_REG_ENTRY_PT_FN, kernel_wrapper->symbol);
    cb.addWRITE_REG64(CMP_REG_RETURN_ADDR, elf->find_symbol("kernel_exit"));
    cb.addWRITE_REG64(CMP_REG_KUB_DESC, kub_desc);

--- a/doc/overview/tutorials/creating-new-hal/running-kernels/executing-kernels-without-scheduling.rst
+++ b/doc/overview/tutorials/creating-new-hal/running-kernels/executing-kernels-without-scheduling.rst
@@ -186,14 +186,15 @@ kernel's ELF:
                                        uint32_t num_args, uint32_t work_dim) {
       refsi_locker locker(hal_lock);
 
-      ELFProgram *elf = (ELFProgram *)program;     // Added
+      refsi_hal_program *refsi_program = (refsi_hal_program *)program; // Added
+      ELFProgram *elf = refsi_program->elf.get();                      // Added
       refsi_hal_kernel *kernel_wrapper = (refsi_hal_kernel *)kernel;
 
-      // Load ELF into the RefSi device's memory.  // Added
-      hal_mem_device mem_if(this);                 // Added
-      if (!elf->load(mem_if)) {                    // Added
-        return false;                              // Added
-      }                                            // Added
+      // Load ELF into the RefSi device's memory.                      // Added
+      hal_mem_device mem_if(this);                                     // Added
+      if (!elf->load(mem_if)) {                                        // Added
+        return false;                                                  // Added
+      }                                                                // Added
       ...
     }
 

--- a/doc/overview/tutorials/creating-new-hal/running-kernels/simple-kernel-scheduling.rst
+++ b/doc/overview/tutorials/creating-new-hal/running-kernels/simple-kernel-scheduling.rst
@@ -66,17 +66,14 @@ device. The ``populateSchedulingInfo`` function does the first part:
     bool refsi_hal_device::populateSchedulingInfo(wg_info_t &wg,
                                                   const hal::hal_ndrange_t &range,
                                                   uint32_t work_dim) {
-      exec_state_t &exec(wg.exec);
-      memset(&wg, 0, sizeof(wg_info_t));
-      wg.num_dim = exec.num_dim = work_dim;
+      wg.num_dim = work_dim;
       for (int i = 0; i < DIMS; i++) {
-        wg.local_size[i] = exec.local_size[i] = range.local[i];
-        wg.num_groups[i] = exec.num_groups[i] =
-            (range.global[i] / wg.local_size[i]);
+        wg.local_size[i] = range.local[i];
+        wg.num_groups[i] = (range.global[i] / wg.local_size[i]);
         if ((wg.num_groups[i] * wg.local_size[i]) != range.global[i]) {
           return false;
         }
-        wg.global_offset[i] = exec.offset[i] = range.offset[i];
+        wg.global_offset[i] = range.offset[i];
       }
       return true;
     }
@@ -91,7 +88,7 @@ prepares the values to write to the KUB and TSD registers:
       ...
      private:
       ...
-      hal::hal_addr_t allocateKUB(const wg_info_t &wg, hal::hal_size_t &kub_desc,
+      hal::hal_addr_t allocateKUB(const exec_state_t &exec, hal::hal_size_t &kub_desc,
                                   hal::hal_size_t &tsd_info); // Added
       ...
     };
@@ -150,7 +147,8 @@ of parallel harts to use is set to the device's default value:
       
       // Store work-group scheduling info for the kernel in the KUB.
       exec_state_t exec;
-      if (!populateSchedulingInfo(exec, *nd_range, work_dim)) {
+      memset(&exec, 0, sizeof(exec_state_t));
+      if (!populateSchedulingInfo(exec.wg, *nd_range, work_dim)) {
         return false;
       }
       hal::hal_size_t kub_desc = 0;

--- a/doc/overview/tutorials/creating-new-hal/running-kernels/simple-kernel-scheduling.rst
+++ b/doc/overview/tutorials/creating-new-hal/running-kernels/simple-kernel-scheduling.rst
@@ -100,8 +100,8 @@ prepares the values to write to the KUB and TSD registers:
                                                   hal::hal_size_t &kub_desc,
                                                   hal::hal_size_t &tsd_info) {
       auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-        uint64_t padding = align - (buffer.size() % align);
-        buffer.resize(buffer.size() + padding);
+        size_t aligned_size = (buffer.size() + align - 1) / align * align;
+        buffer.resize(aligned_size);
       };
       std::vector<uint8_t> kub_data;
 

--- a/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
+++ b/examples/refsi/hal_refsi/source/refsi_hal_m1.cpp
@@ -297,8 +297,8 @@ bool refsi_m1_hal_device::kernel_exec(hal::hal_program_t program,
   exec.kernel_entry = kernel_wrapper->symbol;
 
   auto alignBuffer = [](std::vector<uint8_t> &buffer, uint64_t align) {
-    uint64_t padding = align - (buffer.size() % align);
-    buffer.resize(buffer.size() + padding);
+    size_t aligned_size = (buffer.size() + align - 1) / align * align;
+    buffer.resize(aligned_size);
   };
 
   // Pack arguments.

--- a/scripts/create_target.py
+++ b/scripts/create_target.py
@@ -217,6 +217,7 @@ def main():
     parser.add_argument('config', help='json override description of target')
     args = parser.parse_args()
     base_computeaorta_dir = os.path.abspath(args.base_computeaorta_dir)
+    external_dir = os.path.abspath(args.external_dir)
 
     if args.base_config:
         base_config = os.path.abspath(args.base_config)
@@ -230,14 +231,14 @@ def main():
     compiler_dir_in_base = os.path.join(modules_dir_in_base, 'compiler')
     mux_dir_in_base = os.path.join(modules_dir_in_base, 'mux')
 
-    compiler_dir_out_base = os.path.join(args.external_dir, 'compiler')
-    mux_dir_out_base = os.path.join(args.external_dir, 'mux')
+    compiler_dir_out_base = os.path.join(external_dir, 'compiler')
+    mux_dir_out_base = os.path.join(external_dir, 'mux')
     external_dir_in_base = os.path.join(base_computeaorta_dir, 'external')
 
 
     context = create_context(base_config, args.config, base_computeaorta_dir, args.override)
     if context:
-        context['cookiecutter']['external_dir'] = args.external_dir
+        context['cookiecutter']['external_dir'] = external_dir
         update_string_values(context, ["llvm_cpu", "llvm_features", "llvm_triple"])
         result = create_subtarget(
             compiler_dir_in_base,
@@ -254,7 +255,7 @@ def main():
         if result:
             result = create_subtarget(
                 external_dir_in_base,
-                args.external_dir,
+                external_dir,
                 context,
                 overwrite_if_exists=True)                
         if not result:

--- a/scripts/setup_new_target_tutorial.sh
+++ b/scripts/setup_new_target_tutorial.sh
@@ -117,14 +117,14 @@ then
   then
     cp -r $ock_dir/examples/hals/hal_refsi_tutorial hal_refsi_tutorial
     cd hal_refsi_tutorial
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
-    git apply $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
     cd ..
     ln -s $ock_dir/examples/refsi/hal_refsi/external/refsidrv hal_refsi_tutorial/external
   fi

--- a/scripts/setup_new_target_tutorial.sh
+++ b/scripts/setup_new_target_tutorial.sh
@@ -107,25 +107,36 @@ cd $external_dir
 
 if [[ $run_script != "none" ]]
 then
-    # Create the new target
-    $ock_dir/scripts/create_target.py $ock_dir \
-      $ock_dir/scripts/new_target_templates/$json_file \
-         --external-dir $external_dir $overwrite \
-         $feature_enable $feature_enable_name $feature_enable_val \
-         $copyright_enable $copyright_enable_name $copyright_enable_val
+  # Create the new target
+  $ock_dir/scripts/create_target.py $ock_dir \
+    $ock_dir/scripts/new_target_templates/$json_file \
+      --external-dir $external_dir $overwrite \
+      $feature_enable $feature_enable_name $feature_enable_val \
+      $copyright_enable $copyright_enable_name $copyright_enable_val
   if [[ $do_overwrite_tutorial -eq 0 ]]
   then
-    cp -r $ock_dir/examples/hals/hal_refsi_tutorial hal_refsi_tutorial
-    cd hal_refsi_tutorial
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
-    patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
-    cd ..
-    ln -s $ock_dir/examples/refsi/hal_refsi/external/refsidrv hal_refsi_tutorial/external
+    if [[ -d hal_refsi_tutorial ]]
+    then
+      echo "Warning: $PWD/hal_refsi_tutorial already exists - no patches applied"
+    else
+      cp -r $ock_dir/examples/hals/hal_refsi_tutorial hal_refsi_tutorial
+      cd hal_refsi_tutorial
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step1.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step2.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step3.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step4.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub1.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub2.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub3.patch
+      patch -s -p1 < $ock_dir/doc/overview/tutorials/creating-new-hal/patches/tutorial1_step5_sub4.patch
+      cd ..
+    fi
+    if [[ -L hal_refsi_tutorial/external/refsidrv && -e hal_refsi_tutorial/external/refsidrv ]]
+    then
+      echo "Note: link already exists from hal_refsi_tutorial/external/refsidrv
+         to $ock_dir/examples/refsi/hal_refsi/external/refsidrv"
+    else
+      ln -s -i $ock_dir/examples/refsi/hal_refsi/external/refsidrv hal_refsi_tutorial/external
+    fi
   fi
 fi


### PR DESCRIPTION
This PR combines a bunch of fixes to the tutorial and new-target scripts. Each is split up into its own commit, but to summarize:

* An issue was fixed where the tutorial/example code was was internally inconsistent and had fallen behind current compiler code
* An issue was fixed that showed a kernel ABI mismatch in the HAL & new-target tutorials
* A memory leak in `program_find_kernel()` was fixed as per the reference HAL code
* The `alignBuffer` function behaves more intuitively when the buffer is already aligned
* The `create_target.py` script can take relative directories to `--external-dir`
* Patches were brought up to date and should no longer generate `.orig` files when applied
* A few spelling errors were fixed

This should fix all of the issues raised in #150 

It doesn't fix the fundamental issue that the tutorials may again fall behind during refactoring, but that's a larger issue to tackle.