### PR TITLE
Fixed threading issues with usm and kernel execution

### DIFF
--- a/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
+++ b/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
@@ -302,7 +302,8 @@ bool deviceSupportsHostAllocations(cl_device_id device);
 /// @param[in] kernel Kernel object used in command
 /// @param[in] type Command type to create event for
 /// @param[out] event Event created by function
-///
+/// @note This is not thread safe and there should be a mutex on the context
+///       in the calling code.
 /// @return CL_SUCCESS, or an OpenCL error code on failure.
 cl_int createBlockingEventForKernel(cl_command_queue queue, cl_kernel kernel,
                                     const cl_command_type type,

--- a/source/cl/source/kernel.cpp
+++ b/source/cl/source/kernel.cpp
@@ -1568,6 +1568,11 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueNDRangeKernel(
   cl_event return_event = nullptr;
   cl_int error = 0;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
+  // We need to lock the context for the remainder of the function as we need to
+  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
+  // sync as createBlockingEventForKernel adds to USM lists assuming that they
+  // reflect already queued events.
+  std::lock_guard<std::mutex> context_guard(command_queue->context->mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_NDRANGE_KERNEL, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);
@@ -1643,6 +1648,11 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueTask(cl_command_queue command_queue,
 
   cl_event return_event = nullptr;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
+  // We need to lock the context for the remainder of the function as we need to
+  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
+  // sync as createBlockingEventForKernel adds to USM lists assuming that they
+  // reflect already queued events.
+  std::lock_guard<std::mutex> context_guard(command_queue->context->mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_TASK, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);


### PR DESCRIPTION
# Overview

Fix threading issues where usm is used as well as kernel execution and memory free operations.

# Reason for change

The velocity bench test svm was showing hangs and crashes when OCK was built in debug.

# Description of change

Usm adds some extra event handling so that any freeing of usm
memory is safe. There is some attempt already to make this thread
safe but this leaves windows where we have added events to the usm
allocations but we have not actually added the kernel execution to
the queue. This can mean the functions such as clMemBlockingFreeINTEL
can end up waiting on an event in a queue too early.

This resolves this by placing the context mutex across both the usm
event creation and the push to the queue, which means that the
usm deletion correctly waits.
