### PR TITLE
Basic shared USM support

### DIFF
--- a/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
+++ b/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
@@ -103,6 +103,11 @@ class allocation_info {
   /// @return A matching Mux buffer object on success, or nullptr on failure
   virtual mux_buffer_t getMuxBufferForDevice(cl_device_id device) const = 0;
 
+  /// @brief Return the USM memory type for this allocation
+  ///
+  /// @return The enum variant corresponding to this memory allocation type
+  virtual cl_unified_shared_memory_type_intel getMemoryType() const = 0;
+
   /// @brief Checks if a pointer belongs to USM allocation
   ///
   /// @param[in] ptr Pointer to host memory address.
@@ -192,6 +197,13 @@ class host_allocation_info final : public allocation_info {
   /// @return A matching Mux buffer object on success, or nullptr on failure
   mux_buffer_t getMuxBufferForDevice(cl_device_id device) const override;
 
+  /// @brief Return the USM memory type for this allocation
+  ///
+  /// @return The enum variant corresponding to this memory allocation type
+  cl_unified_shared_memory_type_intel getMemoryType() const override {
+    return CL_MEM_TYPE_HOST_INTEL;
+  }
+
   /// @brief Mux memory object bound to every device in the OpenCL context.
   cargo::dynamic_array<mux_memory_t> mux_memories;
 
@@ -246,7 +258,83 @@ class device_allocation_info final : public allocation_info {
     return query_device == device ? mux_buffer : nullptr;
   };
 
+  /// @brief Return the USM memory type for this allocation
+  ///
+  /// @return The enum variant corresponding to this memory allocation type
+  cl_unified_shared_memory_type_intel getMemoryType() const override {
+    return CL_MEM_TYPE_DEVICE_INTEL;
+  }
+
   /// @brief OpenCL device associated with memory allocation
+  const cl_device_id device;
+  /// @brief Mux memory allocated on device
+  mux_memory_t mux_memory;
+  /// @brief Mux buffer tied to mux_memory
+  mux_buffer_t mux_buffer;
+};
+
+/// @brief Derived class for shared USM allocations
+class shared_allocation_info final : public allocation_info {
+ private:
+  /// @brief Private constructor, use the `create()` functions instead.
+  shared_allocation_info(const cl_context context, const cl_device_id device,
+                         const size_t size);
+
+  shared_allocation_info(const shared_allocation_info &) = delete;
+
+ public:
+  /// @brief Create a shared USM allocation
+  ///
+  /// @param[in] context Context the allocation will belong to.
+  /// @param[in] device Device associated with this shared allocation, may be
+  /// null to not associate it with a device.
+  /// @param[in] properties Properties bitfield encoding which properties to
+  /// enable.
+  /// @param[in] size Bytes to allocate.
+  /// @param[in] alignment Minimum alignment of allocation.
+  static cargo::expected<std::unique_ptr<shared_allocation_info>, cl_int>
+  create(cl_context context, cl_device_id device,
+         const cl_mem_properties_intel *properties, const size_t size,
+         cl_uint alignment);
+
+  /// @brief Destructor.
+  ~shared_allocation_info() override;
+
+  /// @brief Get device used when allocation was made, or nullptr if no device
+  /// was given
+  cl_device_id getDevice() const override { return device; }
+
+  /// @brief Allocates memory for the USM allocation and binds it to a Mux
+  /// buffer object if a device is associated with this allocation. Sets
+  /// 'mux_memory' and 'mux_buffer' members if bound, otherwise they remain
+  /// nullptr.
+  ///
+  /// @param[in] alignment Minimum alignment in bytes for allocation
+  ///
+  /// @return CL_SUCCESS or an OpenCL error code on failure
+  cl_int allocate(uint32_t alignment) override;
+
+  /// @brief Given an OpenCL device returns the Mux buffer object associated
+  /// with the device for this USM allocation.
+  ///
+  /// @param[in] query_device Device to find a buffer for.
+  ///
+  /// @return A matching Mux buffer object on success, or nullptr on failure
+  mux_buffer_t getMuxBufferForDevice(cl_device_id query_device) const override {
+    if (!device) {
+      return nullptr;
+    }
+    return query_device == device ? mux_buffer : nullptr;
+  };
+
+  /// @brief Return the USM memory type for this allocation
+  ///
+  /// @return The enum variant corresponding to this memory allocation type
+  cl_unified_shared_memory_type_intel getMemoryType() const override {
+    return CL_MEM_TYPE_SHARED_INTEL;
+  }
+
+  /// @brief OpenCL device associated with memory allocation, may be nullptr
   const cl_device_id device;
   /// @brief Mux memory allocated on device
   mux_memory_t mux_memory;
@@ -265,7 +353,7 @@ class device_allocation_info final : public allocation_info {
 /// an OpenCL error code if properties are malformed according to extension
 /// spec.
 cargo::expected<cl_mem_alloc_flags_intel, cl_int> parseProperties(
-    const cl_mem_properties_intel *properties);
+    const cl_mem_properties_intel *properties, bool is_shared);
 
 /// @brief Finds if a pointer belongs to the memory addresses of any USM memory
 /// allocations existing in the context.
@@ -291,6 +379,14 @@ bool deviceSupportsDeviceAllocations(cl_device_id device);
 ///
 /// @return True if device can support host allocations, false otherwise.
 bool deviceSupportsHostAllocations(cl_device_id device);
+
+/// @brief Checks if an OpenCL device can support shared USM allocations, an
+/// optional feature of the extension specification.
+///
+/// @param[in] device OpenCL device to query support for.
+///
+/// @return True if device can support host allocations, false otherwise.
+bool deviceSupportsSharedAllocations(cl_device_id device);
 
 /// @brief Creates an OpenCL event for use by kernel enqueue commands
 /// `clEnqueueNDRangeKernel` and `clEnqueueTask`.

--- a/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
@@ -25,8 +25,22 @@
 namespace extension {
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
 namespace usm {
+// Return whether a given alignment for a USM pointer is valid
+//
+// A valid alignment is a possibly 0 power of two. This function does not check
+// for device support.
+constexpr bool isAlignmentValid(cl_uint alignment) {
+  return !alignment || (alignment & (alignment - 1)) == 0;
+}
+
+/// Return whether multiple bits are set for the given value
+template <typename T>
+constexpr bool areMultipleBitsSet(T value) {
+  return value && (value & (value - 1)) != 0;
+};
+
 cargo::expected<cl_mem_alloc_flags_intel, cl_int> parseProperties(
-    const cl_mem_properties_intel *properties) {
+    const cl_mem_properties_intel *properties, bool is_shared) {
   cl_mem_alloc_flags_intel alloc_flags = 0;
   if (properties && properties[0] != 0) {
     auto current = properties;
@@ -37,16 +51,21 @@ cargo::expected<cl_mem_alloc_flags_intel, cl_int> parseProperties(
       switch (property) {
         case CL_MEM_ALLOC_FLAGS_INTEL: {
           if (0 == (seen & CL_MEM_ALLOC_FLAGS_INTEL)) {
-            if (value & (CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL |
-                         CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL)) {
-              // These options are valid only for shared memory allocations,
-              // which we don't yet support.
+            constexpr auto PLACEMENT =
+                CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL |
+                CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL;
+
+            const auto valid_flags =
+                CL_MEM_ALLOC_WRITE_COMBINED_INTEL | (is_shared ? PLACEMENT : 0);
+
+            if (value & ~valid_flags) {
+              // Either an invalid flag is set, or one of the "placement" ones
+              // set on a non-shared pointer
               return cargo::make_unexpected(CL_INVALID_PROPERTY);
             }
 
-            if (value >= (CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL << 1)) {
-              // Bit set which is more significant than the largest valid bit
-              // in bitfield.
+            if (areMultipleBitsSet(value & PLACEMENT)) {
+              // Options are mutually exclusive - Can't have both
               return cargo::make_unexpected(CL_INVALID_PROPERTY);
             }
 
@@ -109,6 +128,13 @@ bool deviceSupportsHostAllocations(cl_device_id device) {
 #error Unsupported pointer size
 #endif
   return can_access_host & ptr_widths_match;
+}
+
+bool deviceSupportsSharedAllocations(cl_device_id device) {
+  // Currently, we implement shared allocations as a wrapper around host
+  // allocations. Any device that supports host allocations also supports shared
+  // allocations.
+  return deviceSupportsHostAllocations(device);
 }
 
 cl_int createBlockingEventForKernel(cl_command_queue queue, cl_kernel kernel,
@@ -210,8 +236,7 @@ host_allocation_info::create(cl_context context,
                              const cl_mem_properties_intel *properties,
                              size_t size, cl_uint alignment) {
   OCL_CHECK(size == 0, return cargo::make_unexpected(CL_INVALID_BUFFER_SIZE));
-
-  OCL_CHECK((alignment & (alignment - 1)) != 0,
+  OCL_CHECK(!isAlignmentValid(alignment),
             return cargo::make_unexpected(CL_INVALID_VALUE));
 
   cl_uint max_align = 0;
@@ -230,13 +255,14 @@ host_allocation_info::create(cl_context context,
     alignment = max_align;
   }
 
-  auto alloc_properties = parseProperties(properties);
+  auto alloc_properties = parseProperties(properties, false);
   if (!alloc_properties) {
     return cargo::make_unexpected(alloc_properties.error());
   }
 
   auto usm_alloc = std::unique_ptr<host_allocation_info>(
       new (std::nothrow) host_allocation_info(context, size));
+  OCL_CHECK(!usm_alloc, return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY));
 
   OCL_CHECK(nullptr == usm_alloc,
             return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY));
@@ -332,8 +358,7 @@ device_allocation_info::create(cl_context context, cl_device_id device,
                                const cl_mem_properties_intel *properties,
                                size_t size, cl_uint alignment) {
   OCL_CHECK(size == 0, return cargo::make_unexpected(CL_INVALID_BUFFER_SIZE));
-
-  OCL_CHECK((alignment & (alignment - 1)) != 0,
+  OCL_CHECK(!isAlignmentValid(alignment),
             return cargo::make_unexpected(CL_INVALID_VALUE));
 
   const auto device_align = device->mux_device->info->buffer_alignment;
@@ -342,7 +367,7 @@ device_allocation_info::create(cl_context context, cl_device_id device,
   OCL_CHECK(alignment > device_align,
             return cargo::make_unexpected(CL_INVALID_VALUE));
 
-  auto alloc_properties = parseProperties(properties);
+  auto alloc_properties = parseProperties(properties, false);
   if (!alloc_properties) {
     return cargo::make_unexpected(alloc_properties.error());
   }
@@ -353,6 +378,7 @@ device_allocation_info::create(cl_context context, cl_device_id device,
 
   auto usm_alloc = std::unique_ptr<device_allocation_info>(
       new (std::nothrow) device_allocation_info(context, device, size));
+  OCL_CHECK(!usm_alloc, return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY));
 
   cl_int error = usm_alloc->allocate(alignment);
   OCL_CHECK(error != CL_SUCCESS, return cargo::make_unexpected(error));
@@ -400,6 +426,147 @@ cl_int device_allocation_info::allocate(cl_uint alignment) {
 
   return CL_SUCCESS;
 }
+
+shared_allocation_info::shared_allocation_info(const cl_context context,
+                                               const cl_device_id device,
+                                               const size_t size)
+    : allocation_info(context, size),
+      device(device),
+      mux_memory(nullptr),
+      mux_buffer(nullptr) {
+  if (device) {
+    cl::retainInternal(device);
+  }
+};
+
+shared_allocation_info::~shared_allocation_info() {
+  if (mux_buffer) {
+    assert(device);
+    (void)muxDestroyBuffer(device->mux_device, mux_buffer,
+                           device->mux_allocator);
+  }
+
+  if (mux_memory) {
+    assert(device);
+    muxFreeMemory(device->mux_device, mux_memory, device->mux_allocator);
+  }
+
+  // Free the host side allocation
+  if (base_ptr) {
+    cargo::free(base_ptr);
+  }
+
+  if (device) {
+    cl::releaseInternal(device);
+  }
+};
+
+cargo::expected<std::unique_ptr<shared_allocation_info>, cl_int>
+shared_allocation_info::create(cl_context context, cl_device_id device,
+                               const cl_mem_properties_intel *properties,
+                               size_t size, cl_uint alignment) {
+  OCL_CHECK(size == 0, return cargo::make_unexpected(CL_INVALID_BUFFER_SIZE));
+
+  if (device) {
+    OCL_CHECK(size > device->max_mem_alloc_size,
+              return cargo::make_unexpected(CL_INVALID_BUFFER_SIZE));
+    OCL_CHECK(alignment > device->mux_device->info->buffer_alignment,
+              return cargo::make_unexpected(CL_INVALID_VALUE));
+  } else {
+    // If no device is given, all devices that support shared USM must meet
+    // the max_alloc_size and alignment requirements
+    for (auto device : context->devices) {
+      if (deviceSupportsSharedAllocations(device)) {
+        const auto device_align = device->mux_device->info->buffer_alignment;
+        OCL_CHECK(size > device->max_mem_alloc_size,
+                  return cargo::make_unexpected(CL_INVALID_BUFFER_SIZE));
+        OCL_CHECK(alignment > device_align,
+                  return cargo::make_unexpected(CL_INVALID_VALUE));
+      }
+    }
+  }
+
+  OCL_CHECK(!isAlignmentValid(alignment),
+            return cargo::make_unexpected(CL_INVALID_VALUE));
+
+  if (alignment == 0) {
+    if (device) {
+      alignment = device->mux_device->info->buffer_alignment;
+    } else {
+      // Default alignment with no device is the highest alignment of all other
+      // devices that support shared allocations (must be at least one,
+      // otherwise this function is undefined)
+      cl_uint max_align = 2;
+      for (auto device : context->devices) {
+        if (deviceSupportsSharedAllocations(device)) {
+          const auto device_align = device->min_data_type_align_size;
+          max_align = std::max(device_align, max_align);
+        }
+      }
+      alignment = max_align;
+    }
+  }
+
+  auto alloc_properties = parseProperties(properties, true);
+  if (!alloc_properties) {
+    return cargo::make_unexpected(alloc_properties.error());
+  }
+
+  auto usm_alloc = std::unique_ptr<shared_allocation_info>(
+      new (std::nothrow) shared_allocation_info(context, device, size));
+  OCL_CHECK(!usm_alloc, return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY));
+
+  // Decide whether to allocate initially on device or not
+  // NOTE: The specification says these are only hints, so we ignore them for
+  // now
+  bool prefers_host = true;
+  if (*alloc_properties & CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL) {
+    prefers_host = false;
+  }
+  (void)prefers_host;
+
+  cl_int error = usm_alloc->allocate(alignment);
+  OCL_CHECK(error != CL_SUCCESS, return cargo::make_unexpected(error));
+
+  usm_alloc->alloc_flags = alloc_properties.value();
+
+  return usm_alloc;
+}
+
+cl_int shared_allocation_info::allocate(cl_uint alignment) {
+  base_ptr = cargo::alloc(size, alignment);
+  if (base_ptr == nullptr) {
+    return CL_OUT_OF_HOST_MEMORY;
+  }
+
+  if (device) {
+    if (!deviceSupportsSharedAllocations(device)) {
+      return CL_INVALID_OPERATION;
+    }
+
+    // Initialize the Mux objects needed by each device
+    if (muxCreateBuffer(device->mux_device, size, device->mux_allocator,
+                        &mux_buffer)) {
+      return CL_OUT_OF_HOST_MEMORY;
+    }
+
+    mux_result_t mux_error = muxCreateMemoryFromHost(
+        device->mux_device, size, base_ptr, device->mux_allocator, &mux_memory);
+    if (mux_error) {
+      return CL_OUT_OF_RESOURCES;
+    }
+
+    const uint64_t offset = 0;
+    mux_error =
+        muxBindBufferMemory(device->mux_device, mux_memory, mux_buffer, offset);
+    if (mux_error) {
+      return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+    }
+  }
+
+  return CL_SUCCESS;
+}
+
 }  // namespace usm
 #endif  // OCL_EXTENSION_cl_intel_unified_shared_memory
 
@@ -442,9 +609,15 @@ cl_int intel_unified_shared_memory::GetDeviceInfo(
       result = CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL;
       break;
     case CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-      CARGO_FALLTHROUGH;
+      if (!usm::deviceSupportsSharedAllocations(device)) {
+        break;
+      }
+      result = CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL;
+      break;
     case CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-      CARGO_FALLTHROUGH;
+      // Not supported yet
+      result = 0;
+      break;
     case CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL:
       break;
     default:

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_allocate.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_allocate.cpp
@@ -334,6 +334,16 @@ TEST_F(USMTests, SingleSharedMemAlloc_InvalidUsage) {
   const cl_uint align = 4;
   cl_int err;
 
+  // Require shared USM support - otherwise these functions may return
+  // CL_INVALID_OPERATION
+  cl_device_unified_shared_memory_capabilities_intel capabilities;
+  ASSERT_SUCCESS(clGetDeviceInfo(
+      device, CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+      sizeof(capabilities), &capabilities, nullptr));
+  if (0 == capabilities) {
+    GTEST_SKIP();
+  }
+
   // Invalid context
   void *shared_ptr =
       clSharedMemAllocINTEL(nullptr, device, nullptr, bytes, align, &err);
@@ -420,8 +430,7 @@ TEST_F(USMTests, SingleSharedMemAlloc_ValidUsage) {
   ASSERT_SUCCESS(clGetDeviceInfo(
       device, CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
       sizeof(cross_capabilities), &cross_capabilities, nullptr));
-  const bool shared_mem_support =
-      (single_capabilities != 0) && (cross_capabilities != 0);
+  const bool shared_mem_support = single_capabilities != 0;
 
   const size_t bytes = 128;
   const cl_uint align = 4;
@@ -475,6 +484,16 @@ TEST_F(USMTests, CrossSharedMemAlloc_InvalidUsage) {
   const size_t bytes = 256;
   const cl_uint align = 4;
   cl_int err;
+
+  // Require shared USM support - otherwise these functions may return
+  // CL_INVALID_OPERATION
+  cl_device_unified_shared_memory_capabilities_intel capabilities;
+  ASSERT_SUCCESS(clGetDeviceInfo(
+      device, CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+      sizeof(capabilities), &capabilities, nullptr));
+  if (0 == capabilities) {
+    GTEST_SKIP();
+  }
 
   // Invalid context
   void *shared_ptr =
@@ -556,8 +575,7 @@ TEST_F(USMTests, CrossSharedMemAlloc_ValidUsage) {
   ASSERT_SUCCESS(clGetDeviceInfo(
       device, CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
       sizeof(cross_capabilities), &cross_capabilities, nullptr));
-  const bool shared_mem_support =
-      (single_capabilities != 0) && (cross_capabilities != 0);
+  const bool shared_mem_support = single_capabilities != 0;
 
   const size_t bytes = 128;
   const cl_uint align = 4;

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
@@ -37,6 +37,17 @@ struct USMMemInfoTest : public cl_intel_unified_shared_memory_Test {
       ASSERT_TRUE(host_ptr != nullptr);
     }
 
+    cl_device_unified_shared_memory_capabilities_intel shared_capabilities;
+    ASSERT_SUCCESS(clGetDeviceInfo(
+        device, CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+        sizeof(shared_capabilities), &shared_capabilities, nullptr));
+    if (shared_capabilities != 0) {
+      shared_ptr =
+          clSharedMemAllocINTEL(context, device, {}, bytes, align, &err);
+      ASSERT_SUCCESS(err);
+      ASSERT_TRUE(shared_ptr != nullptr);
+    }
+
     device_ptr =
         clDeviceMemAllocINTEL(context, device, properties, bytes, align, &err);
     ASSERT_SUCCESS(err);
@@ -55,6 +66,11 @@ struct USMMemInfoTest : public cl_intel_unified_shared_memory_Test {
       EXPECT_SUCCESS(err);
     }
 
+    if (shared_ptr) {
+      cl_int err = clMemBlockingFreeINTEL(context, shared_ptr);
+      EXPECT_SUCCESS(err);
+    }
+
     if (host_ptr) {
       cl_int err = clMemBlockingFreeINTEL(context, host_ptr);
       EXPECT_SUCCESS(err);
@@ -67,6 +83,7 @@ struct USMMemInfoTest : public cl_intel_unified_shared_memory_Test {
 
   void *user_ptr = nullptr;
   void *host_ptr = nullptr;
+  void *shared_ptr = nullptr;
   void *device_ptr = nullptr;
 };
 
@@ -108,6 +125,21 @@ TEST_F(USMMemInfoTest, AllocType) {
         sizeof(host_alloc_type), &host_alloc_type, nullptr);
     EXPECT_SUCCESS(err);
     EXPECT_EQ(CL_MEM_TYPE_HOST_INTEL, host_alloc_type);
+  }
+
+  if (shared_ptr) {
+    err = clGetMemAllocInfoINTEL(context, shared_ptr, CL_MEM_ALLOC_TYPE_INTEL,
+                                 0, nullptr, &param_size);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(sizeof(cl_unified_shared_memory_type_intel), param_size);
+
+    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    cl_unified_shared_memory_type_intel shared_alloc_type = 0;
+    err = clGetMemAllocInfoINTEL(
+        context, offset_shared_ptr, CL_MEM_ALLOC_TYPE_INTEL,
+        sizeof(shared_alloc_type), &shared_alloc_type, nullptr);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(CL_MEM_TYPE_SHARED_INTEL, shared_alloc_type);
   }
 
   void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
@@ -155,6 +187,24 @@ TEST_F(USMMemInfoTest, AllocBasePtr) {
     EXPECT_EQ(host_ptr, host_alloc_base_addr);
   }
 
+  if (shared_ptr) {
+    err =
+        clGetMemAllocInfoINTEL(context, shared_ptr, CL_MEM_ALLOC_BASE_PTR_INTEL,
+                               0, nullptr, &param_size);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(sizeof(void *), param_size);
+
+    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    void *shared_alloc_base_addr = nullptr;
+
+    err = clGetMemAllocInfoINTEL(
+        context, offset_shared_ptr, CL_MEM_ALLOC_BASE_PTR_INTEL,
+        sizeof(shared_alloc_base_addr), &shared_alloc_base_addr, nullptr);
+
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(shared_ptr, shared_alloc_base_addr);
+  }
+
   void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
   void *alloc_base_addr = nullptr;
 
@@ -200,6 +250,23 @@ TEST_F(USMMemInfoTest, AllocSize) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(bytes, host_alloc_size);
   }
+
+  if (shared_ptr) {
+    err = clGetMemAllocInfoINTEL(context, shared_ptr, CL_MEM_ALLOC_SIZE_INTEL,
+                                 0, nullptr, &param_size);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(sizeof(size_t), param_size);
+
+    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    size_t shared_alloc_size = 0;
+
+    err = clGetMemAllocInfoINTEL(
+        context, offset_shared_ptr, CL_MEM_ALLOC_SIZE_INTEL,
+        sizeof(shared_alloc_size), &shared_alloc_size, nullptr);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(bytes, shared_alloc_size);
+  }
+
   void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
 
   size_t alloc_size = 0;
@@ -241,6 +308,21 @@ TEST_F(USMMemInfoTest, AllocDevice) {
         sizeof(host_alloc_device), &host_alloc_device, nullptr);
     EXPECT_SUCCESS(err);
     EXPECT_EQ(NULL, host_alloc_device);
+  }
+
+  if (shared_ptr) {
+    err = clGetMemAllocInfoINTEL(context, shared_ptr, CL_MEM_ALLOC_DEVICE_INTEL,
+                                 0, nullptr, &param_size);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(sizeof(cl_device_id), param_size);
+    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+
+    cl_device_id shared_alloc_device = device;
+    err = clGetMemAllocInfoINTEL(
+        context, offset_shared_ptr, CL_MEM_ALLOC_DEVICE_INTEL,
+        sizeof(shared_alloc_device), &shared_alloc_device, nullptr);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(device, shared_alloc_device);
   }
 
   void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
@@ -285,6 +367,23 @@ TEST_F(USMMemInfoTest, AllocFlags) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(CL_MEM_ALLOC_WRITE_COMBINED_INTEL, host_alloc_flags);
   }
+
+  if (shared_ptr) {
+    err = clGetMemAllocInfoINTEL(context, shared_ptr, CL_MEM_ALLOC_FLAGS_INTEL,
+                                 0, nullptr, &param_size);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(sizeof(cl_mem_alloc_flags_intel), param_size);
+
+    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+
+    cl_mem_alloc_flags_intel shared_alloc_flags = 0;
+    err = clGetMemAllocInfoINTEL(
+        context, offset_shared_ptr, CL_MEM_ALLOC_FLAGS_INTEL,
+        sizeof(shared_alloc_flags), &shared_alloc_flags, nullptr);
+    EXPECT_SUCCESS(err);
+    EXPECT_EQ(0, shared_alloc_flags);
+  }
+
   void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
 
   cl_mem_alloc_flags_intel alloc_flags = 0;


### PR DESCRIPTION
# Overview
This implements shared allocations for USM using the same machinery as host allocations. A shared USM allocation can be associated with at most one device, and is accessable on host and that device.

This should be compliant with the extension spec, but does not yet support cross device access or migrating the allocation to the device. Both `CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL` and `clEnqueueMigrateMemINTEL` have no effect.

# Reason for change

Some tests and examples required shared USM support.

# Description of change

Hacked together shared USM support using host memory support. It's not efficient, but it should be compliant and not require any extra work by the backends.

I had to update a test which required cross-device support to consider shared USM supported, but I don't think that's required as per the spec.

# Anything else we should know?

Spec: https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_unified_shared_memory.html

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
