### PR TITLE
Minimal support for out-of-order queues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ ca_option(CA_ENABLE_EXAMPLES BOOL
   "Enable building example programs" ON)
 ca_option(CA_ENABLE_HOST_IMAGE_SUPPORT BOOL
   "Enable host image support" OFF)
+ca_option(CA_ENABLE_OUT_OF_ORDER_EXEC_MODE BOOL
+  "Enable out of order execution mode" ON)
 ca_immutable_option(CA_ENABLE_DEBUG_SUPPORT BOOL
   "Enable debug support regardless of build type" OFF)
 ca_option(CA_ENABLE_DEBUG_BACKTRACE BOOL

--- a/source/cl/include/cl/config.h.in
+++ b/source/cl/include/cl/config.h.in
@@ -63,4 +63,8 @@
 // even though it might encode extra information in the name.
 #define CA_HOST_CL_DEVICE_NAME_PREFIX "@CA_HOST_CL_DEVICE_NAME_PREFIX@"
 
-#endif // CL_CONFIG_H_INCLUDED
+// Whether we support out of order execution mode. Note that at the moment, this
+// only enables the mode, it has no impact on how commands are executed.
+#cmakedefine CA_ENABLE_OUT_OF_ORDER_EXEC_MODE
+
+#endif  // CL_CONFIG_H_INCLUDED

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -47,6 +47,11 @@ foreach(TARGET ${MUX_TARGET_LIBRARIES})
 endforeach()
 
 configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/Common.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/Common.h
+  @ONLY)
+
+configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/Device.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/Device.h
   @ONLY)

--- a/source/cl/test/UnitCL/include/Common.h.in
+++ b/source/cl/test/UnitCL/include/Common.h.in
@@ -39,6 +39,8 @@
 #include "ucl/types.h"
 #include "ucl/version.h"
 
+#cmakedefine CA_ENABLE_OUT_OF_ORDER_EXEC_MODE
+
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 

--- a/source/cl/test/UnitCL/source/cl_khr_create_command_queue/clCreateCommandQueueWithPropertiesKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_create_command_queue/clCreateCommandQueueWithPropertiesKHR.cpp
@@ -83,10 +83,10 @@ TEST_F(clCreateCommandQueueWithPropertiesKHRTest, InvalidDevice) {
 
 TEST_F(clCreateCommandQueueWithPropertiesKHRTest, InvalidQueueProperties) {
   cl_int error;
-  // We don't currently support CL_QUEUE_OUT_OF_ORDER and to get this return
+  // We don't currently support CL_QUEUE_ON_DEVICE and to get this return
   // value the properties need to be valid but unsupported by the device.
   std::array<cl_queue_properties_khr, 3> properties{
-      {CL_QUEUE_PROPERTIES, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0}};
+      {CL_QUEUE_PROPERTIES, CL_QUEUE_ON_DEVICE, 0}};
   cl_command_queue command_queue = clCreateCommandQueueWithPropertiesKHR(
       context, device, properties.data(), &error);
   ASSERT_EQ_ERRCODE(CL_INVALID_QUEUE_PROPERTIES, error);


### PR DESCRIPTION
# Overview

Minimal support for out-of-order queues

# Reason for change

Out-of-order queues impose additional restrictions on user code and grant additional freedom to the implementation, including the freedom to continue to execute in order. Therefore, we can trivially support out-of-order queues by removing the code that is specifically there to reject them, and continuing to run them in order.

DPC++ aims to support OpenCL implementations that lack out of order execution support, but it does so by creating temporary queues that appear to not get released (intel/llvm#11156). By claiming out of order execution support, we avoid leaks, and the specification for CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE only permits out-of-order execution, it does not and in general cannot mandate it, so this should be a valid minimal implementation.

# Description of change

In order to ease testing, this is optional for now, but enabled by default. -DCA_ENABLE_OUT_OF_ORDER_EXEC_MODE=OFF can be used to restore the prior behavior.

* CMakeLists.txt: add CA_ENABLE_OUT_OF_ORDER_EXEC_MODE option.
* config.h.in: report the CA_ENABLE_OUT_OF_ORDER_EXEC_MODE option.
* _cl_command_queue::create: tolerate CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE and pass it along to _cl_command_queue, provided CA_ENABLE_OUT_OF_ORDER_EXEC_MODE is enabled.
* cl::EnqueueWaitForEvents: tolerate CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE and ignore it, provided CA_ENABLE_OUT_OF_ORDER_EXEC_MODE is enabled.

Tests for unsupported properties are updated to test CL_QUEUE_ON_DEVICE rather than CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE.

# Anything else we should know?

Locally tested both with `CA_ENABLE_OUT_OF_ORDER_EXEC_MODE=ON` and `CA_ENABLE_OUT_OF_ORDER_EXEC_MODE=OFF`.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
