### PR TITLE
[compiler] Improve diagnostics for failing sub-groups

### DIFF
--- a/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/verify-reqd-sg-size.ll
@@ -21,7 +21,7 @@
 ; RUN:   --passes "run-vecz,verify-reqd-sub-group-satisfied" %s 2>&1 \
 ; RUN: | FileCheck %s
 
-; CHECK: kernel.cl:10:0: kernel has required sub-group size 8 but the compiler was unable to sastify this constraint
+; CHECK: kernel.cl:10:0: kernel 'foo_sg8' has required sub-group size 8 but the compiler was unable to sastify this constraint
 define void @foo_sg8() #0 !dbg !5 !intel_reqd_sub_group_size !2 {
   ret void
 }

--- a/modules/compiler/test/lit/passes/verify-reqd-sg-size-1.ll
+++ b/modules/compiler/test/lit/passes/verify-reqd-sg-size-1.ll
@@ -16,12 +16,12 @@
 
 ; RUN: not muxc --device-sg-sizes 6,7,8,9 --passes=verify-reqd-sub-group-legal %s 2>&1 | FileCheck %s
 
-; CHECK: kernel.cl:10:0: kernel has required sub-group size 5 which is not supported by this device
+; CHECK: kernel.cl:10:0: kernel 'foo_sg5' has required sub-group size 5 which is not supported by this device
 define void @foo_sg5() !dbg !5 !intel_reqd_sub_group_size !2 {
   ret void
 }
 
-; CHECK-NOT: kernel has required sub-group size 6 which is not supported by this device
+; CHECK-NOT: kernel 'foo_sg6' has required sub-group size 6 which is not supported by this device
 define void @foo_sg6() !dbg !6 !intel_reqd_sub_group_size !3 {
   ret void
 }

--- a/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
+++ b/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
@@ -46,7 +46,8 @@ class DiagnosticInfoReqdSGSize : public DiagnosticInfoWithLocationBase {
   }
 
   void print(DiagnosticPrinter &DP) const override {
-    DP << getLocationStr() << ": kernel has required sub-group size " << SGSize;
+    DP << getLocationStr() << ": kernel '" << this->getFunction().getName()
+       << "' has required sub-group size " << SGSize;
     if (getKind() == DK_FailedReqdSGSize) {
       DP << " but the compiler was unable to sastify this constraint";
     } else {


### PR DESCRIPTION
Providing the name of the offending kernel is helpful when there is no diagnostic information to point to a specific line.

It doesn't guarantee that the function means anything to the application developer, as the failing function will (almost certainly) be mangled and may have been wrapped by some of our other compiler passes. Even then, this is still arguably useful information to present to people.