### PR TITLE
[vecz] Provide more context when CFG conversion fails

### DIFF
--- a/modules/compiler/vecz/source/include/debugging.h
+++ b/modules/compiler/vecz/source/include/debugging.h
@@ -28,6 +28,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/IR/Value.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include <cstdlib>
@@ -63,6 +64,12 @@ struct VeczFailResult {
   template <typename T>
   operator std::optional<T>() const {
     return std::nullopt;
+  }
+
+  /// @brief For functions that return an llvm::Error
+  operator llvm::Error() const {
+    return llvm::make_error<llvm::StringError>("Unknown VeczFailResult",
+                                               llvm::inconvertibleErrorCode());
   }
 };
 
@@ -175,13 +182,16 @@ struct AnalysisFailResult : public internal::VeczFailResult {
 /// @param[in] F The function in which we are currently working
 /// @param[in] V The value (can be `nullptr`) to be included in the message
 /// @param[in] Msg The main remark message text
+/// @param[in] Note An optional additional note to provide more context/info.
 void emitVeczRemarkMissed(const llvm::Function *F, const llvm::Value *V,
-                          llvm::StringRef Msg);
+                          llvm::StringRef Msg, llvm::StringRef Note = "");
 /// @brief Emit a RemarkMissed message
 ///
 /// @param[in] F The function in which we are currently working
 /// @param[in] Msg The main remark message text
-void emitVeczRemarkMissed(const llvm::Function *F, llvm::StringRef Msg);
+/// @param[in] Note An optional additional note to provide more context/info.
+void emitVeczRemarkMissed(const llvm::Function *F, llvm::StringRef Msg,
+                          llvm::StringRef Note = "");
 /// @brief Emit a Remark message
 ///
 /// @param[in] F The function in which we are currently working

--- a/modules/compiler/vecz/test/lit/llvm/diverging_atomic.ll
+++ b/modules/compiler/vecz/test/lit/llvm/diverging_atomic.ll
@@ -1,0 +1,45 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -w 4 -vecz-passes=cfg-convert,verify -S \
+; RUN:   --pass-remarks-missed=vecz < %s 2>&1 | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+; CHECK: Vecz: Could not apply masks for function "kernel"
+; CHECK-NEXT: note: Could not apply mask to atomic instruction
+; CHECK-SAME:  %atomic = atomicrmw add ptr %arrayidx.in, i32 2 monotonic, align 4
+
+define spir_kernel void @kernel(ptr %in, ptr %out) {
+entry:
+  %gid = tail call i64 @__mux_get_global_id(i32 0)
+  %cmp = icmp eq i64 %gid, 0
+  br i1 %cmp, label %if.then, label %end
+
+if.then:
+  %arrayidx.in = getelementptr inbounds i32, ptr %in, i64 %gid
+  %atomic = atomicrmw add ptr %arrayidx.in, i32 2 monotonic, align 4
+  br label %end
+
+end:
+  %merge = phi i32 [ 0, %entry ], [ %atomic, %if.then ]
+  %arrayidx.out = getelementptr inbounds i32, ptr %out, i64 %gid
+  store i32 %merge, ptr %arrayidx.out, align 4
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)


### PR DESCRIPTION
This should help debugging (using `--pass-remarks-missed=vecz`) why control-flow conversion failed to apply masks to the CFG.  The previous diagnostics would only print the name of the function that couldn't be converted, but not any more specific information.

This commit adds an extra level of information via a 'note', which is optionally printed on the line after the main diagnostic.

This is not intended to be a full solution to better vecz diagnostics, but a good first step.