### PR TITLE
Remove GCC 7 workaround.

### DIFF
--- a/modules/cargo/include/cargo/small_vector.h
+++ b/modules/cargo/include/cargo/small_vector.h
@@ -838,13 +838,7 @@ class small_vector {
     }
     std::copy(Begin, End, other.Begin);
     other.setEnd(other.Begin + size());
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-    // GCC <9 requires this redundant move, this branch of the #if can be
-    // deleted once the minimum supported version of GCC is at least 9.
-    return std::move(other);
-#else
     return other;
-#endif
   }
 
  private:

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -1125,11 +1125,5 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
     return cargo::make_unexpected(llvm::toString(std::move(err)));
   }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(module);
-#else
   return module;
-#endif
 }

--- a/source/cl/source/buffer.cpp
+++ b/source/cl/source/buffer.cpp
@@ -121,13 +121,7 @@ cargo::expected<std::unique_ptr<_cl_mem_buffer>, cl_int> _cl_mem_buffer::create(
     }
   }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(buffer);
-#else
   return buffer;
-#endif
 }
 
 cl_int _cl_mem_buffer::synchronize(cl_command_queue command_queue) {

--- a/source/cl/source/command_queue.cpp
+++ b/source/cl/source/command_queue.cpp
@@ -116,13 +116,7 @@ _cl_command_queue::create(cl_context context, cl_device_id device,
   OCL_CHECK(nullptr == queue,
             return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY));
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(queue);
-#else
   return queue;
-#endif
 }
 
 // Used by clCreateCommandQueueWithProperties and
@@ -194,13 +188,7 @@ _cl_command_queue::create(cl_context context, cl_device_id device,
 #endif
   }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(command_queue);
-#else
   return command_queue;
-#endif
 }
 
 cl_int _cl_command_queue::flush() {

--- a/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
+++ b/source/cl/source/extension/source/intel_unified_shared_memory/intel_unified_shared_memory.cpp
@@ -63,13 +63,7 @@ cargo::expected<cl_mem_alloc_flags_intel, cl_int> parseProperties(
       current += 2;
     } while (current[0] != 0);
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(alloc_flags);
-#else
   return alloc_flags;
-#endif
 }
 
 allocation_info *findAllocation(const cl_context context, const void *ptr) {
@@ -252,13 +246,7 @@ host_allocation_info::create(cl_context context,
 
   usm_alloc->alloc_flags = alloc_properties.value();
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(usm_alloc);
-#else
   return usm_alloc;
-#endif
 }
 
 cl_int host_allocation_info::allocate(cl_uint alignment) {
@@ -371,13 +359,7 @@ device_allocation_info::create(cl_context context, cl_device_id device,
 
   usm_alloc->alloc_flags = alloc_properties.value();
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(usm_alloc);
-#else
   return usm_alloc;
-#endif
 }
 
 cl_int device_allocation_info::allocate(cl_uint alignment) {

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -145,13 +145,7 @@ _cl_mutable_command_khr::create(cl_uint id, cl_kernel kernel) {
     return cargo::make_unexpected(error);
   }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(mutable_command);
-#else
   return mutable_command;
-#endif
 }
 
 _cl_command_buffer_khr::_cl_command_buffer_khr(cl_command_queue queue)
@@ -268,13 +262,7 @@ _cl_command_buffer_khr::create(
     }
   }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(command_buffer);
-#else
   return command_buffer;
-#endif
 }
 
 cl_command_buffer_state_khr _cl_command_buffer_khr::getState() const {
@@ -340,13 +328,7 @@ _cl_command_buffer_khr::convertWaitList(
       return cargo::make_unexpected(CL_OUT_OF_HOST_MEMORY);
     }
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(command_wait_list);
-#else
   return command_wait_list;
-#endif
 }
 
 cl_int _cl_command_buffer_khr::commandBarrierWithWaitList(

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -542,13 +542,7 @@ cargo::expected<std::unique_ptr<_cl_program>, cl_int> _cl_program::create(
           context->getCompilerTarget(device));
     }
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(program);
-#else
   return program;
-#endif
 }
 
 // Used by clCreateProgramWithIL, clCreateProgramWithILKHR.
@@ -583,13 +577,7 @@ cargo::expected<std::unique_ptr<_cl_program>, cl_int> _cl_program::create(
           context->getCompilerTarget(device));
     }
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(program);
-#else
   return program;
-#endif
 }
 
 // Used by clCreateProgramWithBinary.
@@ -650,13 +638,7 @@ cargo::expected<std::unique_ptr<_cl_program>, cl_int> _cl_program::create(
     return cargo::make_unexpected(error);
   }
   program->type = cl::program_type::BINARY;
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(program);
-#else
   return program;
-#endif
 }
 
 // Used by clCreateProgramWithBuiltInKernels.
@@ -752,13 +734,7 @@ cargo::expected<std::unique_ptr<_cl_program>, cl_int> _cl_program::create(
   if (!program->finalize({device_list, num_devices})) {
     return cargo::make_unexpected(CL_INVALID_VALUE);
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(program);
-#else
   return program;
-#endif
 }
 
 // Used by clLinkProgram.
@@ -787,13 +763,7 @@ cargo::expected<std::unique_ptr<_cl_program>, cl_int> _cl_program::create(
   if (!program->finalize(devices)) {
     return cargo::make_unexpected(CL_LINK_PROGRAM_FAILURE);
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(program);
-#else
   return program;
-#endif
 }
 
 cl_int _cl_program::compile(

--- a/source/vk/source/pipeline_cache.cpp
+++ b/source/vk/source/pipeline_cache.cpp
@@ -44,13 +44,7 @@ cargo::error_or<cached_shader> cached_shader::clone() const {
   } else {
     return clone_descriptor_bindings.error();
   }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
-  // GCC <9 requires this redundant move, this branch of the #if can be
-  // deleted once the minimum supported version of GCC is at least 9.
-  return std::move(clone);
-#else
   return clone;
-#endif
 }
 
 bool cached_shader::operator==(const cached_shader &other) const {


### PR DESCRIPTION
# Overview

Remove GCC 7 workaround.

# Reason for change

This came up in another PR, where this workaround copied and pasted into new code was confusing and it was not clear why we needed it.

# Description of change

This workaround was needed for GCC 7, but we do not build with GCC 7 and in fact error when building with GCC 7 for other reasons anyway. GCC 8 does not need this workaround, tested with gcc-8 (Ubuntu 8.4.0-3ubuntu2) 8.4.0, so remove it.

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
