### PR TITLE
[host][riscv] Advertise/support a sub-group size of 32

### DIFF
--- a/modules/mux/targets/host/source/device.cpp
+++ b/modules/mux/targets/host/source/device.cpp
@@ -530,8 +530,8 @@ device_info_s::device_info_s(host::arch arch, host::os os, bool native,
 
   // A list of sub-group sizes we report. Roughly ordered according to
   // desirability.
-  static std::array<size_t, 4> sg_sizes = {
-      8, 4, 16,
+  static std::array<size_t, 5> sg_sizes = {
+      8, 4, 16, 32,
       1,  // we can always produce a 'trivial' sub-group if asked.
   };
   this->sub_group_sizes = sg_sizes.data();

--- a/modules/mux/targets/riscv/source/device_info.cpp
+++ b/modules/mux/targets/riscv/source/device_info.cpp
@@ -155,8 +155,8 @@ device_info_s::device_info_s()
 
   // A list of sub-group sizes we report. Roughly ordered according to
   // desirability.
-  static std::array<size_t, 4> sg_sizes = {
-      8, 4, 16,
+  static std::array<size_t, 5> sg_sizes = {
+      8, 4, 16, 32,
       1,  // we can always produce a 'trivial' sub-group if asked.
   };
   this->sub_group_sizes = sg_sizes.data();


### PR DESCRIPTION
Some SYCL benchmarks (seemingly ones ported to/from CUDA) require a sub-group size of 32.

There shouldn't be any harm in us advertising this, even if the vectorization width is larger than we typically consider:

* If it's required by a program and we don't support it, we'll fail to compile
* If we advertise it but fail to vectorize to that width, we'll fail to compile
* If we advertise it and successfully vectorize, then this is an improvement on what we had before

I've tried this with the `cudaSift` benchmark as part of Velocity Bench, as we do successfully vectorize to this amount. I've noticed some poor code-generation but we can work on improving that later.