### PR TITLE
Revert "Fixed threading issues with usm and kernel execution"

### DIFF
--- a/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
+++ b/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
@@ -302,8 +302,7 @@ bool deviceSupportsHostAllocations(cl_device_id device);
 /// @param[in] kernel Kernel object used in command
 /// @param[in] type Command type to create event for
 /// @param[out] event Event created by function
-/// @note This is not thread safe and there should be a mutex on the context
-///       in the calling code.
+///
 /// @return CL_SUCCESS, or an OpenCL error code on failure.
 cl_int createBlockingEventForKernel(cl_command_queue queue, cl_kernel kernel,
                                     const cl_command_type type,

--- a/source/cl/source/kernel.cpp
+++ b/source/cl/source/kernel.cpp
@@ -1568,11 +1568,6 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueNDRangeKernel(
   cl_event return_event = nullptr;
   cl_int error = 0;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
-  // We need to lock the context for the remainder of the function as we need to
-  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
-  // sync as createBlockingEventForKernel adds to USM lists assuming that they
-  // reflect already queued events.
-  std::lock_guard<std::mutex> context_guard(command_queue->context->mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_NDRANGE_KERNEL, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);
@@ -1648,11 +1643,6 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueTask(cl_command_queue command_queue,
 
   cl_event return_event = nullptr;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
-  // We need to lock the context for the remainder of the function as we need to
-  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
-  // sync as createBlockingEventForKernel adds to USM lists assuming that they
-  // reflect already queued events.
-  std::lock_guard<std::mutex> context_guard(command_queue->context->mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_TASK, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);


### PR DESCRIPTION
This reverts commit 695309df35a12a6bf23160327b51182e04d040ac.

# Overview

The fix for the usm threading issue introduces another threading issue, and so need reverting

# Reason for change

Tsan build showed possible threading issues from putting a context mutex around a queue mutex as there are other cases where a context mutex is called under a queue mutex, in this case when we delete a program.

# Description of change

revert 695309df35a12a6bf23160327b51182e04d040ac
*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

