### PR TITLE
More LLVM 18 fixups.

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -994,9 +994,15 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
                              getIDAsStr(op->IdResult(), &module) +
                              " is not an OpConstant");
     }
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+    return getDIBuilder(op).createStaticMemberType(
+        scope, *name, file, op->Line(), base_ty, flags,
+        cast<llvm::Constant>(val), llvm::dwarf::DW_TAG_variable);
+#else
     return getDIBuilder(op).createStaticMemberType(scope, *name, file,
                                                    op->Line(), base_ty, flags,
                                                    cast<llvm::Constant>(val));
+#endif
   }
 
   auto size_or_error = getConstantIntValue(op->Size());

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -916,7 +916,10 @@ void compiler::utils::Barrier::MakeLiveVariableMemType() {
 
     // Check if the alloca has a debug info source variable attached. If
     // so record this and the matching byte offset into the struct.
-#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+    SmallVector<DbgDeclareInst *, 1> DbgIntrinsics;
+    findDbgDeclares(DbgIntrinsics, member.value);
+#elif LLVM_VERSION_GREATER_EQUAL(17, 0)
     auto DbgIntrinsics = FindDbgDeclareUses(member.value);
 #else
     auto DbgIntrinsics = FindDbgAddrUses(member.value);

--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -183,7 +183,10 @@ bool BasicMem2RegPass::promoteAlloca(AllocaInst *Alloca) const {
       StoredValue = Store->getValueOperand();
       ToDelete.push_back(Store);
       DIBuilder DIB(*Alloca->getModule(), /*AllowUnresolved*/ false);
-#if LLVM_VERSION_GREATER_EQUAL(17, 0)
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+      SmallVector<DbgDeclareInst *, 1> DbgIntrinsics;
+      findDbgDeclares(DbgIntrinsics, Alloca);
+#elif LLVM_VERSION_GREATER_EQUAL(17, 0)
       auto DbgIntrinsics = FindDbgDeclareUses(Alloca);
 #else
       auto DbgIntrinsics = FindDbgAddrUses(Alloca);


### PR DESCRIPTION
# Overview

More LLVM 18 fixups.

# Reason for change

LLVM 18 changed a few more things.

# Description of change

* FindDbgDeclareUses got refactored, we have to call findDbgDeclares.
* DIBuilder::createStaticMemberType takes a DWARF tag now. Since we are processing a DebugTypeMember, we know it is always a data member and can set the tag to DW_TAG_variable.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
