### PR TITLE
[NFC] Silence CMake.

### DIFF
--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -58,7 +58,7 @@ configure_file(
 
 add_ca_cl_executable(UnitCL
   # General testing machinery
-  include/Common.h source/Common.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/include/Common.h source/Common.cpp
   include/EventWaitList.h
   ${CMAKE_CURRENT_BINARY_DIR}/include/Device.h
   source/main.cpp


### PR DESCRIPTION
# Overview

[NFC] Silence CMake.

# Reason for change

When I renamed Common.h to Common.h.in, I left a reference to include/Common.h untouched which resulted in a CMake warning:

  CMake Warning (dev) at cmake/AddCA.cmake:543 (add_executable):
    Policy CMP0115 is not set: Source file extensions must be explicit.  Run
    "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.

    File:

      oneapi-construction-kit/source/cl/test/UnitCL/include/Common.h.in
  Call Stack (most recent call first):
    source/cl/cmake/AddCACL.cmake:92 (add_ca_executable)
    source/cl/test/UnitCL/CMakeLists.txt:59 (add_ca_cl_executable)
  This warning is for project developers.  Use -Wno-dev to suppress it.

# Description of change

Like Device.h, the reference should be explicitly to {CMAKE_CURRENT_BINARY_DIR}/include/Common.h.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
