### PR TITLE
[compiler] Handle scalable structs as barrier live variables

### DIFF
--- a/modules/compiler/test/lit/passes/barriers-live-vars-literal-structs.ll
+++ b/modules/compiler/test/lit/passes/barriers-live-vars-literal-structs.ll
@@ -1,0 +1,119 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Run the verifier first, as working with scalable vectors in literal structs
+; can be fraught with illegality (as discovered when writing this test).
+; RUN: muxc --passes verify,work-item-loops,verify -S %s  | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+; CHECK: %foo_live_mem_info = type { i8, [7 x i8], { <4 x i8>, i32, <8 x i1> }, [12 x i8], [0 x i8] }
+
+; Check that we can successfully save/reload fixed and scalable struct literals
+; across barriers. Scalable struct literals must be decomposed as it's invalid
+; to store them whole - they're "unsized". This might change in future versions
+; of LLVM.
+; CHECK: @foo.mux-barrier-region(ptr [[D:%.*]], ptr [[A:%.*]], ptr [[MEM:%.*]])
+; CHECK:  [[FIXED_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 2
+; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
+; CHECK:  [[NXV1I16_OFFS:%.*]] = mul i64 [[VSCALE]], 32
+; CHECK:  [[NXV1I16_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i64 [[NXV1I16_OFFS]]
+; CHECK:  [[NXV8I32_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i32 0
+; CHECK:  [[I8_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 0
+; CHECK:  [[IDX:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
+; We can store the fixed struct whole
+; CHECK:  [[FIXED_STRUCT:%.*]] = call { <4 x i8>, i32, <8 x i1> } @ext_fixed_vec()
+; CHECK:  store { <4 x i8>, i32, <8 x i1> } [[FIXED_STRUCT]], ptr [[FIXED_ADDR]], align 4
+; We must break down the scalable struct into pieces
+; CHECK:  [[SCALABLE_STRUCT:%.*]] = call { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } @ext_scalable_vec()
+; CHECK:  [[EXT0:%.*]] = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_STRUCT]], 0
+; CHECK:  store <vscale x 1 x i16> [[EXT0]], ptr [[NXV1I16_ADDR:%.*]], align 2
+; CHECK:  [[EXT1:%.*]] = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_STRUCT]], 1
+; CHECK:  store <vscale x 8 x i32> [[EXT1]], ptr [[NXV8I32_ADDR]], align 32
+; CHECK:  [[EXT2:%.*]] = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_STRUCT]], 2
+; CHECK:  store i8 [[EXT2]], ptr [[I8_ADDR]], align 1
+; CHECK:  ret i32 2
+
+
+; CHECK: @foo.mux-barrier-region.1(ptr [[D:%.*]], ptr [[A:%.*]], ptr [[MEM:%.*]])
+; CHECK:  [[FIXED_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 2
+; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
+; CHECK:  [[NXV1I16_OFFS:%.*]] = mul i64 [[VSCALE]], 32
+; CHECK:  [[NXV1I16_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i64 [[NXV1I16_OFFS]]
+; CHECK:  [[NXV8I32_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i32 0
+; CHECK:  [[I8_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 0
+; CHECK: [[IDX:%.*]] = {{(tail )?}}call i64 @__mux_get_global_id(i32 0)
+; We can reload the fixed struct directly
+; CHECK:  [[FIXED_LD:%.*]] = load { <4 x i8>, i32, <8 x i1> }, ptr [[FIXED_ADDR]], align 4
+; Load and insert the first scalable element
+; CHECK:  [[NXV1I16_LD:%.*]] = load <vscale x 1 x i16>, ptr [[NXV1I16_ADDR]], align 2
+; CHECK:  [[INS0:%.*]] = insertvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } poison, <vscale x 1 x i16> [[NXV1I16_LD]], 0
+; Load and insert the second scalable element
+; CHECK:  [[NXV8I32_LD:%.*]] = load <vscale x 8 x i32>, ptr [[NXV8I32_ADDR]], align 32
+; CHECK:  [[INS1:%.*]] = insertvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[INS0]], <vscale x 8 x i32> [[NXV8I32_LD]], 1
+; Load and insert the third and last scalable element
+; CHECK:  [[I8_LD:%.*]] = load i8, ptr [[I8_ADDR:%.*]], align 1
+; CHECK:  [[SCALABLE_LD:%.*]] = insertvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[INS1]], i8 [[I8_LD]], 2
+
+; All the original code from after the barrier
+; CHECK: %arrayidx1 = getelementptr inbounds i8, ptr %0, i64 [[IDX]]
+; CHECK: store { <4 x i8>, i32, <8 x i1> } [[FIXED_LD]], ptr %arrayidx1, align 4
+; CHECK: %elt0 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_LD]], 0
+; CHECK: %elt1 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_LD]], 1
+; CHECK: %elt2 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } [[SCALABLE_LD]], 2
+; CHECK: %arrayidx2 = getelementptr inbounds i8, ptr [[A]], i64 [[IDX]]
+; CHECK: store <vscale x 1 x i16> %elt0, ptr %arrayidx2, align 1
+; CHECK: store <vscale x 8 x i32> %elt1, ptr %arrayidx2, align 4
+; CHECK: store i8 %elt2, ptr %arrayidx2, align 1
+
+; CHECK: define void @foo.mux-barrier-wrapper(ptr %d, ptr %a)
+; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
+; CHECK:  [[SCALABLE_SIZE:%.*]] = mul i64 [[VSCALE:%.*]], 64
+; CHECK:  [[PER_WI_SIZE:%.*]] = add i64 [[SCALABLE_SIZE]], 32
+; CHECK:  [[TOTAL_WG_SIZE:%.*]] = mul i64 [[PER_WI_SIZE]], {{%.*}}
+; CHECK:  %live_variables = alloca i8, i64 [[TOTAL_WG_SIZE]], align 32
+define internal void @foo(ptr %d, ptr %a) #0 {
+entry:
+  %idx = tail call i64 @__mux_get_global_id(i32 0)
+  %fixed.struct.literal = call { <4 x i8>, i32, <8 x i1> } @ext_fixed_vec()
+  %scalable.struct.literal = call { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } @ext_scalable_vec()
+
+  tail call void @__mux_work_group_barrier(i32 0, i32 1, i32 272)
+
+  ; Do something with the value on the other side of the barrier.
+  %arrayidx1 = getelementptr inbounds i8, ptr %d, i64 %idx
+  store { <4 x i8>, i32, <8 x i1> } %fixed.struct.literal, ptr %arrayidx1, align 4
+
+  ; We can't store "unsized types", so manually extract values and store those.
+  %elt0 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } %scalable.struct.literal, 0
+  %elt1 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } %scalable.struct.literal, 1
+  %elt2 = extractvalue { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } %scalable.struct.literal, 2
+
+  %arrayidx2 = getelementptr inbounds i8, ptr %a, i64 %idx
+  store <vscale x 1 x i16> %elt0, ptr %arrayidx2, align 1
+  store <vscale x 8 x i32> %elt1, ptr %arrayidx2, align 4
+  store i8 %elt2, ptr %arrayidx2, align 1
+
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)
+declare void @__mux_work_group_barrier(i32, i32, i32)
+declare { <4 x i8>, i32, <8 x i1> } @ext_fixed_vec()
+declare { <vscale x 1 x i16>, <vscale x 8 x i32>, i8 } @ext_scalable_vec()
+
+attributes #0 = { "mux-kernel"="entry-point" }

--- a/modules/compiler/utils/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/utils/include/compiler/utils/barrier_regions.h
@@ -161,7 +161,10 @@ class Barrier {
   /// @brief struct to help retrieval of values from the barrier struct
   struct LiveValuesHelper {
     Barrier const &barrier;
-    llvm::DenseMap<const llvm::Value *, llvm::Value *> live_GEPs;
+    /// @brief A cache of queried live-values addresses (inside the live
+    /// variables struct), stored by the pair (value, member_idx).
+    llvm::DenseMap<std::pair<const llvm::Value *, unsigned>, llvm::Value *>
+        live_GEPs;
     llvm::DenseMap<const llvm::Value *, llvm::Value *> reloads;
     llvm::IRBuilder<> gepBuilder;
     llvm::Value *barrier_struct = nullptr;
@@ -173,9 +176,19 @@ class Barrier {
     LiveValuesHelper(Barrier const &b, llvm::BasicBlock *bb, llvm::Value *s)
         : barrier(b), gepBuilder(bb), barrier_struct(s) {}
 
-    /// @brief get a GEP instruction pointing to the given value in the barrier
-    /// struct.
-    llvm::Value *getGEP(const llvm::Value *live);
+    /// @brief Return a GEP instruction pointing to the given value/idx pair in
+    /// the barrier struct.
+    ///
+    /// @return The GEP corresponding to the address of the value in the
+    /// struct, or nullptr if the value could not be found in the struct.
+    llvm::Value *getGEP(const llvm::Value *live, unsigned member_idx = 0);
+
+    /// @brief Return a GEP instruction corresponding to the address of
+    /// the given ExtractValueInst in the barriers struct.
+    ///
+    /// @return The GEP corresponding to the address of the value in the
+    /// struct, or nullptr if the value is not an ExtractValueInst.
+    llvm::Value *getExtractValueGEP(const llvm::Value *live);
 
     /// @brief get a value reloaded from the barrier struct.
     ///
@@ -194,10 +207,13 @@ class Barrier {
       std::pair<llvm::DenseSet<llvm::Value *>, llvm::DenseSet<llvm::Value *>>;
   /// @brief Type for memory allocation of live variables at all of barriers
   using live_variable_mem_t = OrderedSet<llvm::Value *, 32>;
-  /// @brief Type for index of live variabless on live variable inforamtion
-  using live_variable_index_map_t = llvm::DenseMap<llvm::Value *, unsigned>;
-  /// @brief Type for index of live variabless on live variable inforamtion
-  using live_variable_scalables_map_t = llvm::DenseMap<llvm::Value *, unsigned>;
+  /// @brief Type for index of live variables on live variable information
+  /// Indexed by the pair (value, member_idx)
+  using live_variable_index_map_t =
+      llvm::DenseMap<std::pair<const llvm::Value *, unsigned>, unsigned>;
+  /// @brief Type for index of live variables on live variable information
+  /// Indexed by the pair (value, member_idx)
+  using live_variable_scalables_map_t = live_variable_index_map_t;
   /// @brief Type for ids of barriers
   using barrier_id_map_t = llvm::DenseMap<llvm::BasicBlock *, unsigned>;
   /// @brief Type for ids of new kernel functions

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/cmpxchg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/cmpxchg.ll
@@ -1,0 +1,66 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -w 4 -vecz-scalable -vecz-passes=packetizer,verify \
+; RUN:   --pass-remarks-missed=vecz -S < %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+; Note: we can't currently scalably packetize this kernel, due to the struct
+; type.
+; CHECK: Vecz: Could not packetize %old0 = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic, align 4
+define spir_kernel void @test_fn(ptr %p, ptr %q, ptr %r) {
+entry:
+  %call = call i64 @__mux_get_global_id(i32 0)
+
+  %old0 = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic
+  %val0 = extractvalue { i32, i1 } %old0, 0
+  %success0 = extractvalue { i32, i1 } %old0, 1
+
+  %out = getelementptr i32, ptr %q, i64 %call
+  store i32 %val0, ptr %out, align 4
+
+  %outsuccess = getelementptr i8, ptr %r, i64 %call
+  %outbyte = zext i1 %success0 to i8
+  store i8 %outbyte, ptr %outsuccess, align 1
+
+  ; Test a couple of insert/extract patterns
+
+  ; Test inserting a uniform value into a varying literal struct
+  %testinsertconst = insertvalue { i32, i1 } %old0, i1 false, 1
+  %testextract0 = extractvalue { i32, i1 } %testinsertconst, 1
+  %outbyte0 = zext i1 %testextract0 to i8
+  store i8 %outbyte0, ptr %outsuccess, align 1
+
+  ; Test inserting a varying value into a varying literal struct
+  %byte1 = load i8, ptr %outsuccess, align 1
+  %bool1 = trunc i8 %byte1 to i1
+  %testinsertvarying0 = insertvalue { i32, i1 } %old0, i1 %bool1, 1
+  %testextract1 = extractvalue { i32, i1 } %testinsertvarying0, 1
+  %outbyte1 = zext i1 %testextract1 to i8
+  store i8 %outbyte1, ptr %outsuccess, align 1
+
+  ; Test inserting a varying value into a uniform literal struct
+  %testinsertvarying1 = insertvalue { i32, i1 } poison, i1 %bool1, 1
+  %testextract2 = extractvalue { i32, i1 } %testinsertvarying1, 1
+  %outbyte2 = zext i1 %testextract2 to i8
+  store i8 %outbyte2, ptr %outsuccess, align 1
+
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/store_literal_struct.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/store_literal_struct.ll
@@ -1,0 +1,38 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Check that we do something correct when scalably packetizing struct literals.
+; Right now we fail to packetize, but if we could packetize this we'd have to
+; be careful as storing a struct literal containing scalable vectors is invalid
+; IR.
+; RUN: veczc -w 4 -vecz-scalable -vecz-passes=verify,packetizer,verify \
+; RUN:   --pass-remarks-missed=vecz -S < %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+; CHECK: Vecz: Could not packetize  %v = load { i32, i32 }, ptr %arrayidx.p, align 4
+define spir_kernel void @test_fn(ptr %p, ptr %q) {
+entry:
+  %idx = call i64 @__mux_get_global_id(i32 0)
+  %arrayidx.p = getelementptr { i32, i32 }, ptr %p, i64 %idx
+  %v = load { i32, i32 }, ptr %arrayidx.p, align 4
+  %arrayidx.q = getelementptr { i32, i32 }, ptr %q, i64 %idx
+  store { i32, i32 } %v, ptr %arrayidx.q, align 4
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)

--- a/modules/compiler/vecz/test/lit/llvm/cmpxchg.ll
+++ b/modules/compiler/vecz/test/lit/llvm/cmpxchg.ll
@@ -1,0 +1,161 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -w 4 -vecz-passes=packetizer,verify -S < %s | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+; CHECK: define spir_kernel void @__vecz_v4_test_fn(ptr %p, ptr %q, ptr %r)
+define spir_kernel void @test_fn(ptr %p, ptr %q, ptr %r) {
+entry:
+  %call = call i64 @__mux_get_global_id(i32 0)
+
+; Test that this cmpxchg is scalarized. Not ideal, but hey.
+; CHECK: [[A0:%.*]] = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic, align 4
+; CHECK: [[A1:%.*]] = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic, align 4
+; CHECK: [[A2:%.*]] = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic, align 4
+; CHECK: [[A3:%.*]] = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic, align 4
+
+; Then we insert the values into a strange struct
+; CHECK: [[INS0:%.*]] = insertvalue [4 x { i32, i1 }] undef, { i32, i1 } [[A0]], 0
+; CHECK: [[INS1:%.*]] = insertvalue [4 x { i32, i1 }] [[INS0]], { i32, i1 } [[A1]], 1
+; CHECK: [[INS2:%.*]] = insertvalue [4 x { i32, i1 }] [[INS1]], { i32, i1 } [[A2]], 2
+; CHECK: [[INS3:%.*]] = insertvalue [4 x { i32, i1 }] [[INS2]], { i32, i1 } [[A3]], 3
+  %old0 = cmpxchg ptr %p, i32 1, i32 2 acquire monotonic
+
+; To extract from this result, we extract each element individually then insert
+; each into a vector.
+; CHECK: [[ELT0_0_0:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 0, 0
+; CHECK: [[ELT0_0_1:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 1, 0
+; CHECK: [[ELT0_0_2:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 2, 0
+; CHECK: [[ELT0_0_3:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 3, 0
+; CHECK: [[INS0V0_0:%.*]] = insertelement <4 x i32> undef, i32 [[ELT0_0_0]], i32 0
+; CHECK: [[INS0V0_1:%.*]] = insertelement <4 x i32> [[INS0V0_0]], i32 [[ELT0_0_1]], i32 1
+; CHECK: [[INS0V0_2:%.*]] = insertelement <4 x i32> [[INS0V0_1]], i32 [[ELT0_0_2]], i32 2
+; CHECK: [[INS0V0_3:%.*]] = insertelement <4 x i32> [[INS0V0_2]], i32 [[ELT0_0_3]], i32 3
+  %val0 = extractvalue { i32, i1 } %old0, 0
+; Same again here
+; CHECK: [[ELT1_0_0:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 0, 1
+; CHECK: [[ELT1_0_1:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 1, 1
+; CHECK: [[ELT1_0_2:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 2, 1
+; CHECK: [[ELT1_0_3:%.*]] = extractvalue [4 x { i32, i1 }] [[INS3]], 3, 1
+; CHECK: [[INS1V0_0:%.*]] = insertelement <4 x i1> undef, i1 [[ELT1_0_0]], i32 0
+; CHECK: [[INS1V0_1:%.*]] = insertelement <4 x i1> [[INS1V0_0]], i1 [[ELT1_0_1]], i32 1
+; CHECK: [[INS1V0_2:%.*]] = insertelement <4 x i1> [[INS1V0_1]], i1 [[ELT1_0_2]], i32 2
+; CHECK: [[INS1V0_3:%.*]] = insertelement <4 x i1> [[INS1V0_2]], i1 [[ELT1_0_3]], i32 3
+  %success0 = extractvalue { i32, i1 } %old0, 1
+
+  %out = getelementptr i32, ptr %q, i64 %call
+; Stored as a vector
+; CHECK: store <4 x i32> [[INS0V0_3]], ptr
+  store i32 %val0, ptr %out, align 4
+
+; CHECK: [[PTR:%.*]] = getelementptr i8, ptr %r, i64 %call
+  %outsuccess = getelementptr i8, ptr %r, i64 %call
+; CHECK: [[ZEXT0:%.*]] = zext <4 x i1> [[INS1V0_3]] to <4 x i8>
+  %outbyte = zext i1 %success0 to i8
+; Stored as a vector
+; CHECK: store <4 x i8> [[ZEXT0]], ptr [[PTR]], align 1
+  store i8 %outbyte, ptr %outsuccess, align 1
+
+  ; Test a couple of insert/extract patterns
+
+; Test inserting a uniform value into a varying literal struct
+; This is very inefficient
+; CHECK: [[INSS0_0:%.*]] = insertvalue { i32, i1 } [[A0]], i1 false, 1
+; CHECK: [[INSS0_1:%.*]] = insertvalue { i32, i1 } [[A1]], i1 false, 1
+; CHECK: [[INSS0_2:%.*]] = insertvalue { i32, i1 } [[A2]], i1 false, 1
+; CHECK: [[INSS0_3:%.*]] = insertvalue { i32, i1 } [[A3]], i1 false, 1
+; CHECK: [[INSS1_0:%.*]] = insertvalue [4 x { i32, i1 }] undef, { i32, i1 } [[INSS0_0]], 0
+; CHECK: [[INSS1_1:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS1_0]], { i32, i1 } [[INSS0_1]], 1
+; CHECK: [[INSS1_2:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS1_1]], { i32, i1 } [[INSS0_2]], 2
+; CHECK: [[INSS1_3:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS1_2]], { i32, i1 } [[INSS0_3]], 3
+; CHECK: [[EXTS1_0:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS1_3]], 0, 1
+; CHECK: [[EXTS1_1:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS1_3]], 1, 1
+; CHECK: [[EXTS1_2:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS1_3]], 2, 1
+; CHECK: [[EXTS1_3:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS1_3]], 3, 1
+; CHECK: [[INS1V1_0:%.*]] = insertelement <4 x i1> undef, i1 [[EXTS1_0]], i32 0
+; CHECK: [[INS1V1_1:%.*]] = insertelement <4 x i1> [[INS1V1_0]], i1 [[EXTS1_1]], i32 1
+; CHECK: [[INS1V1_2:%.*]] = insertelement <4 x i1> [[INS1V1_1]], i1 [[EXTS1_2]], i32 2
+; CHECK: [[INS1V1_3:%.*]] = insertelement <4 x i1> [[INS1V1_2]], i1 [[EXTS1_3]], i32 3
+; CHECK: [[ZEXT1:%.*]] = zext <4 x i1> [[INS1V1_3]] to <4 x i8>
+; CHECK: store <4 x i8> [[ZEXT1]], ptr [[PTR]], align 1
+  %testinsertconst = insertvalue { i32, i1 } %old0, i1 false, 1
+  %testextract0 = extractvalue { i32, i1 } %testinsertconst, 1
+  %outbyte0 = zext i1 %testextract0 to i8
+  store i8 %outbyte0, ptr %outsuccess, align 1
+
+  ; Test inserting a varying value into a varying literal struct
+; CHECK: [[V4I8_LD:%.*]] = load <4 x i8>, ptr %outsuccess, align 1
+; CHECK: [[TRUNC:%.*]] = trunc <4 x i8> [[V4I8_LD]] to <4 x i1>
+; CHECK: [[EXTV0_0:%.*]] = extractelement <4 x i1> [[TRUNC]], i32 0
+; CHECK: [[EXTV0_1:%.*]] = extractelement <4 x i1> [[TRUNC]], i32 1
+; CHECK: [[EXTV0_2:%.*]] = extractelement <4 x i1> [[TRUNC]], i32 2
+; CHECK: [[EXTV0_3:%.*]] = extractelement <4 x i1> [[TRUNC]], i32 3
+; CHECK: [[INSS2_0:%.*]] = insertvalue { i32, i1 } [[A0]], i1 [[EXTV0_0]], 1
+; CHECK: [[INSS2_1:%.*]] = insertvalue { i32, i1 } [[A1]], i1 [[EXTV0_1]], 1
+; CHECK: [[INSS2_2:%.*]] = insertvalue { i32, i1 } [[A2]], i1 [[EXTV0_2]], 1
+; CHECK: [[INSS2_3:%.*]] = insertvalue { i32, i1 } [[A3]], i1 [[EXTV0_3]], 1
+; CHECK: [[INSS3_0:%.*]] = insertvalue [4 x { i32, i1 }] undef, { i32, i1 } [[INSS2_0]], 0
+; CHECK: [[INSS3_1:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS3_0]], { i32, i1 } [[INSS2_1]], 1
+; CHECK: [[INSS3_2:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS3_1]], { i32, i1 } [[INSS2_2]], 2
+; CHECK: [[INSS3_3:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS3_2]], { i32, i1 } [[INSS2_3]], 3
+; CHECK: [[EXTS3_0:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS3_3]], 0, 1
+; CHECK: [[EXTS3_1:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS3_3]], 1, 1
+; CHECK: [[EXTS3_2:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS3_3]], 2, 1
+; CHECK: [[EXTS3_3:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS3_3]], 3, 1
+; CHECK: [[INS1V2_0:%.*]] = insertelement <4 x i1> undef, i1 [[EXTS3_0]], i32 0
+; CHECK: [[INS1V2_1:%.*]] = insertelement <4 x i1> [[INS1V2_0]], i1 [[EXTS3_1]], i32 1
+; CHECK: [[INS1V2_2:%.*]] = insertelement <4 x i1> [[INS1V2_1]], i1 [[EXTS3_2]], i32 2
+; CHECK: [[INS1V2_3:%.*]] = insertelement <4 x i1> [[INS1V2_2]], i1 [[EXTS3_3]], i32 3
+; CHECK: [[ZEXT2:%.*]] = zext <4 x i1> [[INS1V2_3]] to <4 x i8>
+; CHECK: store <4 x i8> [[ZEXT2]], ptr [[PTR]], align 1
+  %byte1 = load i8, ptr %outsuccess, align 1
+  %bool1 = trunc i8 %byte1 to i1
+  %testinsertvarying0 = insertvalue { i32, i1 } %old0, i1 %bool1, 1
+  %testextract1 = extractvalue { i32, i1 } %testinsertvarying0, 1
+  %outbyte1 = zext i1 %testextract1 to i8
+  store i8 %outbyte1, ptr %outsuccess, align 1
+
+  ; Test inserting a varying value into a uniform literal struct
+; CHECK: [[INSS4_0:%.*]] = insertvalue { i32, i1 } poison, i1 [[EXTV0_0]], 1
+; CHECK: [[INSS4_1:%.*]] = insertvalue { i32, i1 } poison, i1 [[EXTV0_1]], 1
+; CHECK: [[INSS4_2:%.*]] = insertvalue { i32, i1 } poison, i1 [[EXTV0_2]], 1
+; CHECK: [[INSS4_3:%.*]] = insertvalue { i32, i1 } poison, i1 [[EXTV0_3]], 1
+; CHECK: [[INSS5_0:%.*]] = insertvalue [4 x { i32, i1 }] undef, { i32, i1 } [[INSS4_0]], 0
+; CHECK: [[INSS5_1:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS5_0]], { i32, i1 } [[INSS4_1]], 1
+; CHECK: [[INSS5_2:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS5_1]], { i32, i1 } [[INSS4_2]], 2
+; CHECK: [[INSS5_3:%.*]] = insertvalue [4 x { i32, i1 }] [[INSS5_2]], { i32, i1 } [[INSS4_3]], 3
+; CHECK: [[EXTS5_0:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS5_3]], 0, 1
+; CHECK: [[EXTS5_1:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS5_3]], 1, 1
+; CHECK: [[EXTS5_2:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS5_3]], 2, 1
+; CHECK: [[EXTS5_3:%.*]] = extractvalue [4 x { i32, i1 }] [[INSS5_3]], 3, 1
+; CHECK: [[INS2V3_0:%.*]] = insertelement <4 x i1> undef, i1 [[EXTS5_0]], i32 0
+; CHECK: [[INS2V3_1:%.*]] = insertelement <4 x i1> [[INS2V3_0]], i1 [[EXTS5_1]], i32 1
+; CHECK: [[INS2V3_2:%.*]] = insertelement <4 x i1> [[INS2V3_1]], i1 [[EXTS5_2]], i32 2
+; CHECK: [[INS2V3_3:%.*]] = insertelement <4 x i1> [[INS2V3_2]], i1 [[EXTS5_3]], i32 3
+; CHECK: [[ZEXT3:%.*]] = zext <4 x i1> [[INS2V3_3]] to <4 x i8>
+; CHECK: store <4 x i8> [[ZEXT3]], ptr [[PTR]], align 1
+  %testinsertvarying1 = insertvalue { i32, i1 } poison, i1 %bool1, 1
+  %testextract2 = extractvalue { i32, i1 } %testinsertvarying1, 1
+  %outbyte2 = zext i1 %testextract2 to i8
+  store i8 %outbyte2, ptr %outsuccess, align 1
+
+  ret void
+}
+
+declare i64 @__mux_get_global_id(i32)


### PR DESCRIPTION
The work-item loops pass would crash when faced with a live variable whose type was a struct containing scalable vectors.

We aren't legally allowed to store a struct type containing a mixture of scalable and fixed types (`{ <vscale x 1 x i8>, i8 }`) so we decompose such types into their constituent elements and store each individually. Note that scalable elements are stored in the scalable part of the live variables struct, and fixed elements are stored in the fixed part; in that way they are treated as if they were never a struct to begin with.

Note that there may be a future optimization possible here where we store all-scalable structs "whole", but this isn't currently a priority.

Note that this problem doesn't currently surface in the default pipeline in the main branch, because we only end up with scalable vectors when we vectorize as such, and we don't currently scalably vectorize any IR that's known to contain struct types, at least not in a way that creates a struct containing scalable vectors; see the new negative scalable vecz test as an example.

The plan is to start allowing this when we improve the vectorization of `cmpxhg` instructions. This should also improve the codegen for these structures; see the new fixed-length vecz test for an example of the poor codegen currently emitted.