### PR TITLE
Fixed threading issues with usm and kernel execution

### DIFF
--- a/source/cl/include/cl/context.h
+++ b/source/cl/include/cl/context.h
@@ -204,8 +204,17 @@ struct _cl_context final : public cl::base<_cl_context> {
   /// @brief List of devices the context targets.
   cargo::dynamic_array<cl_device_id> devices;
   /// @brief Mutex to protect accesses for _cl_context::context with is not
-  /// thread safe.
+  /// thread safe except for USM which has its own mutex. This must not be
+  /// used above a command queue mutex, as it call program destructor during
+  /// clean up
   std::mutex mutex;
+
+  /// @brief Mutex to protect accesses USM allocations. Note due to the nature
+  /// of usm allocations and queue related activities it is sometimes needed to
+  /// stay around beyond just accessing the list. It must not be below the
+  /// general context mutex or the queue mutex.
+  std::mutex usm_mutex;
+
   /// @brief List of the context's enabled properties.
   cargo::dynamic_array<cl_context_properties> properties;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory

--- a/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
+++ b/source/cl/source/extension/include/extension/intel_unified_shared_memory.h
@@ -361,6 +361,7 @@ cargo::expected<cl_mem_alloc_flags_intel, cl_int> parseProperties(
 /// @param[in] context Context containing list of USM allocations to search.
 /// @param[in] ptr Pointer to find an owning USM allocation for.
 ///
+/// @note this is not thread safe and a USM mutex should be used above it.
 /// @return Pointer to matching allocation on success, or nullptr on failure.
 allocation_info *findAllocation(const cl_context context, const void *ptr);
 

--- a/source/cl/source/kernel.cpp
+++ b/source/cl/source/kernel.cpp
@@ -1568,6 +1568,11 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueNDRangeKernel(
   cl_event return_event = nullptr;
   cl_int error = 0;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
+  // We need to lock the context for the remainder of the function as we need to
+  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
+  // sync as createBlockingEventForKernel adds to USM lists assuming that they
+  // reflect already queued events.
+  std::lock_guard<std::mutex> context_guard(command_queue->context->usm_mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_NDRANGE_KERNEL, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);
@@ -1643,6 +1648,11 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueTask(cl_command_queue command_queue,
 
   cl_event return_event = nullptr;
 #ifdef OCL_EXTENSION_cl_intel_unified_shared_memory
+  // We need to lock the context for the remainder of the function as we need to
+  // ensure any blocking operations such clMemBlockingFreeINTEL are entirely in
+  // sync as createBlockingEventForKernel adds to USM lists assuming that they
+  // reflect already queued events.
+  std::lock_guard<std::mutex> context_guard(command_queue->context->usm_mutex);
   error = extension::usm::createBlockingEventForKernel(
       command_queue, kernel, CL_COMMAND_TASK, return_event);
   OCL_CHECK(error != CL_SUCCESS, return error);


### PR DESCRIPTION
# Overview

Fix threading issues where usm is used as well as kernel execution and memory free operations.

# Reason for change

The velocity bench test svm was showing hangs and crashes when OCK was built in debug.

# Description of change

USM adds some extra event handling so that any freeing of usm
memory is safe. There is some attempt already to make this thread
safe but this leaves windows where we have added events to the usm
allocations but we have not actually added the kernel execution to
the queue. This can mean the functions such as clMemBlockingFreeINTEL
can end up waiting on an event in a queue too early.
    
A previous fix tried to reuse the context mutex, but this had issues as
this cannot be above a queue mutex. For this reason we have added a new
USM mutex which is expected to be above all other queue/context mutexes
and can last longer. The USM mutex is placed above both the USM
event creation and the push to the queue, which means that the
USM deletion correctly waits.
