### PR TITLE
Publish pre-release OCK

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -70,6 +70,9 @@ inputs:
   enable_rvv_scalable_VP_vecz_check:
     description: "Enable RVV scalable vecz VP check (default OFF)"
     default: OFF
+  install_dir:
+    description: "Install directory for OCK"
+    default: install
 
 runs:
   # We don't want a new docker just a list of steps, so mark as composite
@@ -104,6 +107,7 @@ runs:
               -DCA_RISCV_ENABLED=${{ inputs.riscv_enabled }}
               -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vecz_check }}
               -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vp_vecz_check }}
+              -DCMAKE_INSTALL_PREFIX=${{ inputs.install_dir }}
                ${{ inputs.extra_flags }}
               .      
     - name: build_ock

--- a/.github/actions/do_build_ock/do_build_m1/action.yml
+++ b/.github/actions/do_build_ock/do_build_m1/action.yml
@@ -5,6 +5,9 @@ inputs:
   build_type:
     description: 'build type (Release, ReleaseAssert)'
     default: ReleaseAssert
+  extra_flags:
+    description: 'any additional flags'
+    default: ''
 
 runs:
   # We don't want a new docker just a list of steps, so mark as composite
@@ -20,3 +23,4 @@ runs:
         riscv_enabled: ON
         enable_rvv_scalable_vecz_check: ON
         enable_rvv_scalable_VP_vecz_check: ON
+        extra_flags: ${{ inputs.extra_flags }}

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -1,8 +1,8 @@
 name: Build and Package
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Runs the workflow at midnight every day
-  # Allows you to run this workflow manually from the Actions tab
+  push:
+    branches:
+      - stable
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +15,9 @@ jobs:
   run_riscv_m1_nightly_package:
     runs-on: ubuntu-22.04
 
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -24,7 +27,7 @@ jobs:
         uses:  ./.github/actions/setup_ubuntu_build
         with:
           llvm_version: 17
-          llvm_build_type: RelAssert
+          llvm_build_type: Release
 
       - name: Setup python
         uses: actions/setup-python@v4
@@ -33,6 +36,13 @@ jobs:
 
       - name: Build riscv M1
         uses: ./.github/actions/do_build_ock/do_build_m1
+        with:
+          build_type: Release
+          extra_flags: '-DCA_REFSI_M1_DEMO_MODE=ON'
+
+      - name: Create OCK install
+        run: |
+          ninja -C $(pwd)/build install
 
       - name: Download Daily Release
         run: |
@@ -49,17 +59,40 @@ jobs:
         run: |
           export ONEAPI_ROOT=$(pwd)/linux_nightly_release
           export PATH=$(pwd)/linux_nightly_release/bin:$PATH
-          export LD_LIBRARY_PATH=$(pwd)/linux_nightly_release/lib:$(pwd)/build/lib:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=$(pwd)/linux_nightly_release/lib:$(pwd)/install/lib:$LD_LIBRARY_PATH
 
           $(pwd)/linux_nightly_release/bin/clang++ -fsycl $(pwd)/oneAPI-samples/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp -o vect
-          CA_HAL_DEBUG=1 OCL_ICD_FILENAMES=$(pwd)/build/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc  SYCL_CONFIG_FILE_NAME="" ./vect
+          CA_RISCV_DUMP_IR=1 CA_HAL_DEBUG=1 OCL_ICD_FILENAMES=$(pwd)/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc SYCL_CONFIG_FILE_NAME="" ./vect
 
       - name: Package Artifacts
         run: |
-          tar -czf ock_build.tar.gz $(pwd)/build
+          tar -czf ock_install.tar.gz install
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: riscv-build
-          path: ock_build.tar.gz
+          path: ock_install.tar.gz
+
+      - name: Compute tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
+            echo "TAG=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+          else
+            # TODO: Use date of the commit?
+            echo "TAG=$(date +'%Y-%m-%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create OCK pre-release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          files:
+            ock_install.tar.gz
+          tag_name: nightly-${{ steps.tag.outputs.TAG }}
+          name: OCK daily ${{ steps.tag.outputs.TAG }}
+          prerelease: true
+          body: "Daily build ${{ steps.tag.outputs.TAG }}"
+          target_commitish: ${{ github.sha }}


### PR DESCRIPTION
Overview
Create a pre-release version of OCK on github stable branch on every new push.

Description of change
Every time there's a new push to the stable branch, this workflow will be triggered and will create
a new OCK release on github. 
It uses GITHUB_TOKEN, which has been added to the repository secrets and also uploaded on 1password.

