### PR TITLE
[NFC] Change startswith/endswith to starts_with/ends_with.

### DIFF
--- a/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
+++ b/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
@@ -37,7 +37,7 @@ PreservedAnalyses compiler::CheckForExtFuncsPass::run(Module &M,
   for (const auto &F : M) {
     auto FName = F.getName();
     if (F.isDeclaration() && !F.isIntrinsic() && !FName.equals("printf") &&
-        !FName.startswith("_Z") && !FName.startswith("__")) {
+        !FName.starts_with("_Z") && !FName.starts_with("__")) {
       M.getContext().diagnose(DiagnosticInfoExternalFunc(FName));
     }
   }

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -843,7 +843,7 @@ PreservedAnalyses compiler::PrintfReplacementPass::run(
   auto to_be_cloned_func = [&funcs_calling_printf](const Function &func,
                                                    bool &ClonedWithBody,
                                                    bool &ClonedNoBody) {
-    ClonedWithBody = !func.getName().startswith("__llvm") &&
+    ClonedWithBody = !func.getName().starts_with("__llvm") &&
                      funcs_calling_printf.count(&func);
     ClonedNoBody = false;
   };

--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -41,12 +41,12 @@ bool isImageType(llvm::StringRef type_name, const char *const compare) {
   }
 
   llvm::StringRef ro = "__read_only ";
-  if (type_name.startswith(ro) && type_name.substr(ro.size()) == compare) {
+  if (type_name.starts_with(ro) && type_name.substr(ro.size()) == compare) {
     return true;
   }
 
   llvm::StringRef wo = "__write_only ";
-  if (type_name.startswith(wo) && type_name.substr(wo.size()) == compare) {
+  if (type_name.starts_with(wo) && type_name.substr(wo.size()) == compare) {
     return true;
   }
 

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -270,8 +270,8 @@ Expected<std::unique_ptr<Module>> driver::convertInputToIR() {
   // Assume that .bc and .ll files are already IR unless told otherwise.
   if (InputLanguage == "ir" ||
       (InputLanguage.empty() &&
-       (IFN.endswith(".bc") || IFN.endswith(".bc32") || IFN.endswith(".bc64") ||
-        IFN.endswith(".ll")))) {
+       (IFN.ends_with(".bc") || IFN.ends_with(".bc32") ||
+        IFN.ends_with(".bc64") || IFN.ends_with(".ll")))) {
     return parseIRFileToModule(*LLVMContextToUse);
   }
   // Assume that stdin is IR unless told otherwise

--- a/modules/compiler/utils/source/mangling.cpp
+++ b/modules/compiler/utils/source/mangling.cpp
@@ -811,7 +811,7 @@ bool Lexer::Consume(unsigned Size) {
 bool Lexer::Consume(StringRef Pattern) {
   if (Left() < Pattern.size()) {
     return false;
-  } else if (!TextLeft().startswith(Pattern)) {
+  } else if (!TextLeft().starts_with(Pattern)) {
     return false;
   }
   Pos += Pattern.size();

--- a/modules/compiler/utils/source/pass_functions.cpp
+++ b/modules/compiler/utils/source/pass_functions.cpp
@@ -482,7 +482,7 @@ bool addParamToAllFunctions(llvm::Module &module,
         // don't clone and add arg to special functions starting with __llvm.
         // These are reserved for clang generated functions such as profile
         // related ones
-        ClonedWithBody = !func.getName().startswith("__llvm");
+        ClonedWithBody = !func.getName().starts_with("__llvm");
         ClonedNoBody = false;
       },
       updateMetaDataCallback);

--- a/modules/compiler/utils/source/rename_builtins_pass.cpp
+++ b/modules/compiler/utils/source/rename_builtins_pass.cpp
@@ -27,7 +27,7 @@ llvm::PreservedAnalyses compiler::utils::RenameBuiltinsPass::run(
   constexpr llvm::StringLiteral MuxFnPrefix = "__mux";
 
   for (auto &fn : M.functions()) {
-    if (!fn.getName().startswith(MuxFnPrefix)) {
+    if (!fn.getName().starts_with(MuxFnPrefix)) {
       continue;
     }
     Changed = true;

--- a/modules/compiler/vecz/source/vectorization_context.cpp
+++ b/modules/compiler/vecz/source/vectorization_context.cpp
@@ -198,7 +198,7 @@ VectorizationResult VectorizationContext::getVectorizedFunction(
 }
 
 bool VectorizationContext::isInternalBuiltin(const Function *F) {
-  return F->getName().startswith(VectorizationContext::InternalBuiltinPrefix);
+  return F->getName().starts_with(VectorizationContext::InternalBuiltinPrefix);
 }
 
 Function *VectorizationContext::getOrCreateInternalBuiltin(StringRef Name,

--- a/modules/compiler/vecz/source/vectorizer.cpp
+++ b/modules/compiler/vecz/source/vectorizer.cpp
@@ -183,7 +183,7 @@ void collectStatistics(VectorizationUnit &VU, Function *Scalar,
       // Detect vector splats
       // Count insert/extractelement instructions
       if (isa<InsertElementInst>(I) || isa<ExtractElementInst>(I)) {
-        if (I.getName().startswith(".splatinsert")) {
+        if (I.getName().starts_with(".splatinsert")) {
           ++VeczSplats;
         }
         ++VeczInsertExtract;


### PR DESCRIPTION
# Overview

[NFC] Change startswith/endswith to starts_with/ends_with.

# Reason for change

For consistency with C++20, LLVM renamed startswith to starts_with, and likewise for endswith. startswith and endswith are still available as wrappers that do nothing but call starts_with and ends_with, but as of LLVM 18 have been deprecated.

# Description of change

As the oldest LLVM we support (LLVM 16) already had starts_with and ends_with, we can just use that unconditionally, so this commit is nothing more than a global search and replace.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
