### PR TITLE
[NFC] Change more startswith/endswith to starts_with/ends_with.

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -591,7 +591,7 @@ class Builder {
     llvm::SmallVector<llvm::StringRef, 16> subs;
     for (size_t nameIndex = 0; nameIndex < names.size(); nameIndex++) {
       llvm::StringRef name(names[nameIndex]);
-      if (name.startswith("Dv")) {
+      if (name.starts_with("Dv")) {
         auto found = std::find(subs.begin(), subs.end(), name);
         if (found == subs.end()) {
           subs.push_back(name);

--- a/modules/compiler/utils/include/compiler/utils/pipeline_parse_helpers.h
+++ b/modules/compiler/utils/include/compiler/utils/pipeline_parse_helpers.h
@@ -75,7 +75,7 @@ static bool checkParametrizedPassName(StringRef Name, StringRef PassName) {
   if (!Name.consume_front(PassName)) return false;
   // normal pass name w/o parameters == default parameters
   if (Name.empty()) return true;
-  return Name.startswith("<") && Name.endswith(">");
+  return Name.starts_with("<") && Name.ends_with(">");
 }
 
 inline Expected<StringRef> parseSinglePassStringRef(StringRef Params) {


### PR DESCRIPTION
# Overview

[NFC] Change more startswith/endswith to starts_with/ends_with.

# Reason for change

My previous PR to change startswith/endswith to starts_with/ends_with was intended to be limited to C++ sources, as we have a number of occurrences in Python files that should be left alone, but I did so by limiting to *.cpp files, when actually we have a few in *.h files that should be updated too.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
