### PR TITLE
Fix boundary case in log2_extended_precision_half_safe.

### DIFF
--- a/modules/compiler/builtins/abacus/include/abacus/internal/log2_extended_precision.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/log2_extended_precision.h
@@ -280,7 +280,8 @@ T log2_extended_precision_half_safe(const T &x, T *ans_lo, T *hiExp, T *loExp) {
 
   // Single awkward boundary value fix:
   const SignedType edge(abacus::detail::cast::as<UnsignedType>(x) == 0x39f6);
-  remainder = __abacus_select(remainder, T(-0.000144362f16), edge);
+  // -0.14783 ==> -0.000144362 * 2^10
+  remainder = __abacus_select(remainder, T(-0.14783f16), edge);
 
   // Set return parameters
   *hiExp = abacus::detail::cast::convert<T>(hiExpI);


### PR DESCRIPTION
# Overview

Fix boundary case in log2_extended_precision_half_safe.

# Reason for change

log2_extended_precision_half_safe is a modified version of log2_extended_precision_half_unsafe that avoids denormal intermediate results via scaling. The unsafe version gives one input, 0x39f6, special treatment because the approximation is known to be incorrect, but the safe version did not translate this special treatment correctly: the special casing happens before downscaling, therefore the constant needs to be upscaled.

This fixes a pow test failure on FTZ targets.

# Description of change

One constant is changed. Tested by forcing this particular input to be used by modifying InputGenerator::half_edge_cases.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
