### PR TITLE
Improve UnitCL pow testing.

### DIFF
--- a/source/cl/test/UnitCL/include/kts/execution.h
+++ b/source/cl/test/UnitCL/include/kts/execution.h
@@ -347,6 +347,9 @@ class HalfParamExecution : public ExecutionWithParam<unsigned> {
   /// @brief Returns true if parameter at index has a scalar type
   /// @param[in] Index of parameter to check
   bool IsArgScalar(unsigned index) const;
+
+  /// @brief Returns a vector of edge cases that need extra testing.
+  virtual const std::vector<cl_ushort> &GetEdgeCases() const;
 };
 
 template <typename T>

--- a/source/cl/test/UnitCL/source/kts/fp16_execution.cpp
+++ b/source/cl/test/UnitCL/source/kts/fp16_execution.cpp
@@ -79,14 +79,23 @@ bool HalfParamExecution::IsArgScalar(unsigned index) const {
          std::find(scalar_arg_indices.begin(), scalar_arg_indices.end(), index);
 }
 
+const std::vector<cl_ushort> &HalfParamExecution::GetEdgeCases() const {
+  static const std::vector<cl_ushort> EdgeCases =
+      std::vector<cl_ushort>(InputGenerator::half_edge_cases.begin(),
+                             InputGenerator::half_edge_cases.end());
+  return EdgeCases;
+}
+
 template <size_t N>
 unsigned HalfParamExecution::FillInputBuffers(
     std::array<input_details_t, N> &inputs) {
+  const auto &edge_cases = GetEdgeCases();
+
   // The more parameters a functions takes, the more data we need for verifying
   // it's behaviour across the increased range of input combinations. Even in
   // wimpy mode we want to test at least all the combinations of edge case
   // values which have been known to cause failures.
-  const unsigned edge_case_len = InputGenerator::half_edge_cases.size();
+  const unsigned edge_case_len = edge_cases.size();
   size_t cartesian_len = edge_case_len;
   for (size_t i = 1; i < N; i++) {
     cartesian_len *= edge_case_len;
@@ -136,8 +145,7 @@ unsigned HalfParamExecution::FillInputBuffers(
         edge_idx = i / div;
       }
 
-      input[i] =
-          cargo::bit_cast<cl_half>(InputGenerator::half_edge_cases[edge_idx]);
+      input[i] = cargo::bit_cast<cl_half>(edge_cases[edge_idx]);
     }
   }
 

--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -413,6 +413,17 @@ UCL_EXECUTION_TEST_SUITE_P(HalfOperatorTest, testing::Values(OPENCL_C),
 
 using HalfMathBuiltins = HalfParamExecution;
 
+struct HalfMathBuiltinsPow : HalfMathBuiltins {
+  const std::vector<cl_ushort> &GetEdgeCases() const override {
+    static const std::vector<cl_ushort> EdgeCases = [&] {
+      std::vector<cl_ushort> EdgeCases = HalfMathBuiltins::GetEdgeCases();
+      EdgeCases.push_back(0x39f6);
+      return EdgeCases;
+    }();
+    return EdgeCases;
+  }
+};
+
 TEST_P(HalfMathBuiltins, Precision_08_Half_Ldexp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
@@ -1774,7 +1785,7 @@ TEST_P(HalfMathBuiltins, Precision_79_Half_tanh) {
   TestAgainstRef<2_ULP>(tanh_ref);
 }
 
-TEST_P(HalfMathBuiltins, Precision_80_Half_pow) {
+TEST_P(HalfMathBuiltinsPow, Precision_80_Half_pow) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
@@ -1797,7 +1808,7 @@ TEST_P(HalfMathBuiltins, Precision_80_Half_pow) {
 }
 
 // TODO: OCK-523
-TEST_P(HalfMathBuiltins, DISABLED_Precision_81_Half_powr) {
+TEST_P(HalfMathBuiltinsPow, DISABLED_Precision_81_Half_powr) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
@@ -1833,7 +1844,7 @@ TEST_P(HalfMathBuiltins, DISABLED_Precision_81_Half_powr) {
   TestAgainstRef<4_ULP>(powr_ref);
 }
 
-TEST_P(HalfMathBuiltins, Precision_82_Half_pown) {
+TEST_P(HalfMathBuiltinsPow, Precision_82_Half_pown) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
@@ -1893,6 +1904,8 @@ TEST_P(HalfMathBuiltins, Precision_83_Half_rootn) {
 
 // Miss out half3 to avoid complications with having sizeof(half4)
 UCL_EXECUTION_TEST_SUITE_P(HalfMathBuiltins, testing::Values(OPENCL_C),
+                           testing::Values(1, 2, 4, 8, 16));
+UCL_EXECUTION_TEST_SUITE_P(HalfMathBuiltinsPow, testing::Values(OPENCL_C),
                            testing::Values(1, 2, 4, 8, 16));
 
 TEST_P(Execution, Precision_84_Double_Remquo) {


### PR DESCRIPTION
# Overview

Improve UnitCL pow testing.

# Reason for change

We single out the value 0x39f6 in our implementation of log2_extended_precision, so in tests that use that function, we should ensure that that value is always tested.

# Description of change

This adds an overridable `GetEdgeCases()` function, defaulting to the `InputGenerator::half_edge_cases` we previously used, but overridden for `HalfMathBuiltinsPow` to additionally add `0x39f6` as an edge case.

Tested by locally reverting commit 90cf2faccb27adb19ce330bbe7c7ec62c53c7018 and verifying that UnitCL reliably picks up the error.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
