### PR TITLE
Fix cross queue dependency when command buffer already dispatched.

### DIFF
--- a/source/cl/include/cl/command_queue.h
+++ b/source/cl/include/cl/command_queue.h
@@ -244,16 +244,17 @@ struct _cl_command_queue final : public cl::base<_cl_command_queue> {
   ///    associated with a user command buffer, get the current command
   ///    buffer or the last pending dispatch.
   /// 2. There are no wait events and the last pending dispatch is associated
-  ///    with a user command buffer, get an unsed (new or reseted and cached)
+  ///    with a user command buffer, get an unused (new or reset and cached)
   ///    command buffer.
   /// 3. There are wait events associated with a single pending dispatch, get
   ///    the associated command buffer.
   /// 4. There are wait events associated with multiple pending dispatches, get
-  ///    an unused (new or reseted and cached) command buffer.
+  ///    an unused (new or reset and cached) command buffer.
   /// 5. There are wait events with no associated pending dispatches (already
-  ///    dispatched), get an unused (new or reseted and cached) command buffer.
+  ///    dispatched), get an unused (new or reset and cached) command buffer.
+  /// 6. There are wait events associated with a different queue.
   ///
-  /// When commands can't be batched into a single comand group, semaphores are
+  /// When commands can't be batched into a single command group, semaphores are
   /// used to maintain submission order since the command queue is in-order.
   /// Dispatches will have wait semaphores in the following cases:
   ///
@@ -263,6 +264,7 @@ struct _cl_command_queue final : public cl::base<_cl_command_queue> {
   /// 3.  There are wait events associated with multiple command buffers.
   /// 4.  There are wait events, no pending dispatches, and there is a running
   ///     command buffer.
+  /// 5.  The wait event is cross queue.
   ///
   /// A user event completion callback is registered with all user events, it
   /// submits pending dispatches to the queue when the user event is in a

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
@@ -297,8 +297,8 @@ TEST_F(USMBlockingFreeTest, SingleQueueMultipleAlloc) {
 // Populates two device allocations, A & B, on their own queues using fill calls
 // before copying them to a separate allocation C. The copy operation is
 // enqueued on the queue C, so allocations A & B interact with multiple queues.
-TEST_F(USMBlockingFreeTest, DISABLED_MultipleQueueMultipleAlloc) {
-  std::array<cl_event, 2> events;
+TEST_F(USMBlockingFreeTest, MultipleQueueMultipleAlloc) {
+  std::array<cl_event, 2> events = {nullptr, nullptr};
   const cl_uint pattern_A = 42;
   auto &queue_A = fixture_queues[0];
   auto &device_ptr_A = fixture_device_ptrs[0];


### PR DESCRIPTION
# Overview

*Provide a brief overview of what your changes do, summarizing their effects
and consequences.*

# Reason for change

The UnitCL test USMBlockingFreeTest, MultipleQueueMultipleAlloc had previously been disabled due to sporadic fails. Tsan build showed that there was a dependency issue between the fill and copy commands.

This test did something like the following:

Q_A: Fill -> e[0]   BufA 4096
Q_B: Fill -> e[1]   BufB 4096
Q_C: e[0]->Memcpy   from BufA 2048
Q_C: e[1]->Memcpy   from BufB 2048

# Description of change

Much of the core dependencies for command buffers is done in _cl_command_queue::getCommandBufferPending(). In order to capture event dependencies, semaphores are waited on from pending or dispatched command buffers. The code would check events and then check to see if they were in pending command buffers and if so would add semaphores wait from them. If it could not find a pending command buffer it would add the wait on any running command buffers. This generally worked but for cross queues it was not checking the running command buffers of that queue. This collates all the queues that events wait on treats them the same.

Additionally there is an early out for the case of a single pending command buffer but if there is any cross queue events, we cannot use this.
