### PR TITLE
Improve precision of horner_polynomial

### DIFF
--- a/modules/compiler/builtins/abacus/include/abacus/internal/atan_unsafe.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/atan_unsafe.h
@@ -70,7 +70,7 @@ T atan_unsafe(const T &x) {
       -0.27671732461794832889713721816369215e-1,
       0.12384767226415412063082059444905478e-1};
 
-  T r = c * abacus::internal::horner_polynomial<T, 15>(c * c, polynomial);
+  T r = c * abacus::internal::horner_polynomial(c * c, polynomial);
 
   // atan(PI/7) in two constants for Cody & Waite reduction
   const abacus_double atank1 =

--- a/modules/compiler/builtins/abacus/include/abacus/internal/exp_unsafe.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/exp_unsafe.h
@@ -58,8 +58,7 @@ struct exp_unsafe_helper<T, abacus_half> {
                                        1.0833740234375e-2f16};
 
     // Minimax polynomial approximation in the domain [0, ln(2)] of e^x
-    const T result =
-        abacus::internal::horner_polynomial<T, 6>(rr_x, polynomial);
+    const T result = abacus::internal::horner_polynomial(rr_x, polynomial);
 
     // Polynomial approximation * 2^k
     return abacus::internal::ldexp_unsafe(result, k);
@@ -87,7 +86,7 @@ struct exp_unsafe_helper<T, abacus_float> {
         0.272579824216659e-5f};
 
     // minimax from 0 -> ln(2) of e^x
-    const T result = abacus::internal::horner_polynomial<T, 10>(r, polynomial);
+    const T result = abacus::internal::horner_polynomial(r, polynomial);
 
     return abacus::internal::ldexp_unsafe(result, k);
   }
@@ -126,7 +125,7 @@ struct exp_unsafe_helper<T, abacus_double> {
                                           0.294609311301038779771435680411e-8};
 
     // minimax from 0 -> ln(2) of e^x
-    const T result = abacus::internal::horner_polynomial<T, 15>(r, polynomial);
+    const T result = abacus::internal::horner_polynomial(r, polynomial);
 
     return abacus::internal::ldexp_unsafe(result, k);
   }

--- a/modules/compiler/builtins/abacus/include/abacus/internal/half_sincos_approx.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/half_sincos_approx.h
@@ -34,9 +34,9 @@ inline T half_sincos_approx(const T &x, T *cosVal) {
 
   // minimax polynomials from 0 -> PI/4
   const T xx = x * x;
-  *cosVal = abacus::internal::horner_polynomial<T, 4>(xx, _half_sincos_coefc);
+  *cosVal = abacus::internal::horner_polynomial(xx, _half_sincos_coefc);
 
-  return x * abacus::internal::horner_polynomial<T, 4>(xx, _half_sincos_coefs);
+  return x * abacus::internal::horner_polynomial(xx, _half_sincos_coefs);
 }
 }  // namespace internal
 }  // namespace abacus

--- a/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
@@ -27,7 +27,7 @@ inline T horner_polynomial(const T x, const TCoef *p_coef, size_t N) {
   T coef_sum = T(p_coef[N - 1]);
 
   for (size_t n = N - 1; n > 0; n--) {
-    coef_sum = T(p_coef[n - 1]) + x * coef_sum;
+    coef_sum = __abacus_fma(coef_sum, x, T(p_coef[n - 1]));
   }
 
   return coef_sum;

--- a/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
@@ -22,71 +22,21 @@
 
 namespace abacus {
 namespace internal {
-#ifdef __CA_BUILTINS_HALF_SUPPORT
-inline abacus_half horner_polynomial(const abacus_half x,
-                                     ABACUS_CONSTANT abacus_half *p_coef,
-                                     int N) {
-  abacus_half coef_sum = p_coef[N - 1];
+template <typename T, typename TCoef>
+inline T horner_polynomial(const T x, const TCoef *p_coef, size_t N) {
+  T coef_sum = T(p_coef[N - 1]);
 
-  for (int n = N - 1; n > 0; n--) {
-    coef_sum = p_coef[n - 1] + x * coef_sum;
-  }
-
-  return coef_sum;
-}
-#endif  // __CA_BUILTINS_HALF_SUPPORT
-
-inline abacus_float horner_polynomial(const abacus_float x,
-                                      ABACUS_CONSTANT abacus_float *p_coef,
-                                      int N) {
-  abacus_float coef_sum = p_coef[N - 1];
-
-  for (int n = N - 1; n > 0; n--) {
-    coef_sum = p_coef[n - 1] + x * coef_sum;
+  for (size_t n = N - 1; n > 0; n--) {
+    coef_sum = T(p_coef[n - 1]) + x * coef_sum;
   }
 
   return coef_sum;
 }
 
-#ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-inline abacus_double horner_polynomial(const abacus_double x,
-                                       ABACUS_CONSTANT abacus_double *p_coef,
-                                       int N) {
-  abacus_double coef_sum = p_coef[N - 1];
-
-  for (int n = N - 1; n > 0; n--) {
-    coef_sum = p_coef[n - 1] + x * coef_sum;
-  }
-
-  return coef_sum;
+template <typename T, size_t N, typename TCoef>
+inline T horner_polynomial(const T x, const TCoef (&coef)[N]) {
+  return horner_polynomial(x, coef, N);
 }
-#endif  // __CA_BUILTINS_DOUBLE_SUPPORT
-
-template <typename T, unsigned int N>
-inline T horner_polynomial(
-    const T &x, const typename TypeTraits<T>::ElementType *coefficients) {
-  T sum = coefficients[N - 1];
-
-  for (unsigned int n = N - 1; n > 0; n--) {
-    sum = ((T)coefficients[n - 1]) + x * sum;
-  }
-
-  return sum;
-}
-
-#ifdef __OPENCL_VERSION__
-template <typename T, unsigned int N>
-inline T horner_polynomial(const T &x, ABACUS_CONSTANT
-                           typename TypeTraits<T>::ElementType *coefficients) {
-  T sum = coefficients[N - 1];
-
-  for (unsigned int n = N - 1; n > 0; n--) {
-    sum = ((T)coefficients[n - 1]) + x * sum;
-  }
-
-  return sum;
-}
-#endif
 }  // namespace internal
 }  // namespace abacus
 

--- a/modules/compiler/builtins/abacus/include/abacus/internal/lgamma_positive.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/lgamma_positive.h
@@ -175,8 +175,9 @@ inline T lgamma_positive(const T &x) {
     const SignedType cond = x > _intervals[i];
     interval = __abacus_select(interval, i, cond);
 
-    const T poly = abacus::internal::horner_polynomial<T, 8>(
-        x - _lgamma_translation[i], __codeplay_lgamma_positive_coeff + i * 8);
+    const T poly = abacus::internal::horner_polynomial(
+        x - _lgamma_translation[i], __codeplay_lgamma_positive_coeff + i * 8,
+        8);
 
     ans = __abacus_select(ans, poly, cond);
   }
@@ -212,9 +213,9 @@ inline T lgamma_positive_half(const T &x) {
     const SignedType cond = x > _intervals_half[i];
     interval = __abacus_select(interval, i, cond);
 
-    const T poly = abacus::internal::horner_polynomial<T, 8>(
+    const T poly = abacus::internal::horner_polynomial(
         x - _lgamma_translation_half[i],
-        __codeplay_lgamma_positive_coeff_half + i * 8);
+        __codeplay_lgamma_positive_coeff_half + i * 8, 8);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/include/abacus/internal/log2_extended_precision.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/log2_extended_precision.h
@@ -35,8 +35,10 @@ namespace {
 // Aprroximation of log2(x+1) between [-0.25;0.5]
 // See log2_extended_precision.sollya for derivation
 // In order to gain performance we've dropped the first term of the polynomial
-// out, 1.442689418792724609375, since it's in 32-bit precision and we'll
-// manually add it in exactly by splitting into 16-bit values.
+// out, since it's in 32-bit precision and we'll manually add it in exactly by
+// splitting into 16-bit values.
+static constexpr ABACUS_CONSTANT abacus_float
+    __codeplay_log2_extended_precision_coeffH0 = 1.442689418792724609375f;
 static ABACUS_CONSTANT abacus_half
     __codeplay_log2_extended_precision_coeffH[5] = {
         -0.72119140625f16, 0.4814453125f16, -0.369384765625f16, 0.2919921875f16,
@@ -64,7 +66,7 @@ struct log2_extended_precision_helper<T, abacus_float> {
   static T _(const T &xMant, T *out_remainder) {
     T xMAnt1m = xMant - 1.0f;
 
-    T poly = abacus::internal::horner_polynomial<T, 16>(
+    T poly = abacus::internal::horner_polynomial(
         xMAnt1m, __codeplay_log2_extended_precision_coeff);
 
     T poly_times_x_lo;
@@ -147,7 +149,7 @@ T log2_extended_precision_half_unsafe(const T &x, T *ans_lo, T *xExp) {
 
   // Approximate log2(x+1) with polynomial
   xMant = xMant - 1.0f16;
-  T poly_start = abacus::internal::horner_polynomial<T, 5>(
+  T poly_start = abacus::internal::horner_polynomial(
       xMant, __codeplay_log2_extended_precision_coeffH);
 
   T poly_lo;
@@ -222,7 +224,7 @@ T log2_extended_precision_half_safe(const T &x, T *ans_lo, T *hiExp, T *loExp) {
   // Approximate log2(x+1) with polynomial
   xMant = xMant - 1.0f16;
 
-  T poly_start = abacus::internal::horner_polynomial<T, 5>(
+  T poly_start = abacus::internal::horner_polynomial(
       xMant, __codeplay_log2_extended_precision_coeffH);
 
   // Avoid creating denormal numbers in the lo components of exact add and

--- a/modules/compiler/builtins/abacus/include/abacus/internal/log_extended_precision.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/log_extended_precision.h
@@ -61,7 +61,7 @@ namespace internal {
 template <typename T>
 inline T log_extended_precision(const T &xMant, T *out_remainder) {
   const T xMant1m = xMant - 1.0f;
-  const T poly = abacus::internal::horner_polynomial<T, 26>(
+  const T poly = abacus::internal::horner_polynomial(
       xMant1m, __codeplay_natural_log_extended_precision_coeffD);
 
   // We need xMant1m*(xMant1m*(xMant1m*(xMant1m*poly + 1/3) - 0.5) + 1)

--- a/modules/compiler/builtins/abacus/include/abacus/internal/pow_unsafe.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/pow_unsafe.h
@@ -161,7 +161,7 @@ struct pow_unsafe_helper<T, abacus_half> {
 
     // Now a normal exp2 should do the trick:
     // We know that 0 <= y_times_log2X <= 1 so we can just use a polynomial
-    T result = abacus::internal::horner_polynomial<T, 6>(
+    T result = abacus::internal::horner_polynomial(
         y_times_log2X, __codeplay_pow_unsafe_coeffH);
 
     // We do the same trick as for __log2_extra_precision here, using some extra
@@ -238,8 +238,8 @@ struct pow_unsafe_helper<T, abacus_float> {
     exponent_mantissa -= abacus::detail::cast::convert<T>(
         abacus::internal::floor_unsafe(exponent_mantissa));
 
-    T result = abacus::internal::horner_polynomial<T, 8>(
-        exponent_mantissa, __codeplay_pow_unsafe_coeff);
+    T result = abacus::internal::horner_polynomial(exponent_mantissa,
+                                                   __codeplay_pow_unsafe_coeff);
 
     result = __abacus_ldexp(result, exponent_floor);
 
@@ -326,10 +326,9 @@ struct pow_unsafe_helper<T, abacus_double> {
     exponent_floor += mantissa_trunc;
     exponent_mantissa -= abacus::detail::cast::convert<T>(mantissa_trunc);
 
-    T result =
-        (T)1.0 + exponent_mantissa *
-                     abacus::internal::horner_polynomial<T, 18>(
-                         exponent_mantissa, __codeplay_pow_unsafe_coeffD);
+    T result = (T)1.0 + exponent_mantissa * abacus::internal::horner_polynomial(
+                                                exponent_mantissa,
+                                                __codeplay_pow_unsafe_coeffD);
 
     result = __abacus_ldexp(
         result, abacus::detail::cast::convert<IntVecType>(exponent_floor));

--- a/modules/compiler/builtins/abacus/include/abacus/internal/sincos_approx.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/sincos_approx.h
@@ -62,10 +62,9 @@ struct sincos_approx_helper<T, abacus_half> {
     using UnsignedType = typename TypeTraits<T>::UnsignedType;
 
     const T xx = x * x;
-    *out_cos = abacus::internal::horner_polynomial<T, 4>(xx, _sincos_coefcH);
+    *out_cos = abacus::internal::horner_polynomial(xx, _sincos_coefcH);
 
-    const T sin =
-        x * abacus::internal::horner_polynomial<T, 4>(xx, _sincos_coefsH);
+    const T sin = x * abacus::internal::horner_polynomial(xx, _sincos_coefsH);
 
     // 0.151611328125 (0x30da) is only slightly above 2 ULP. It's faster to
     // add a special case for this input using select instead of changing the
@@ -81,9 +80,9 @@ template <typename T>
 struct sincos_approx_helper<T, abacus_float> {
   static T _(const T &x, T *out_cos) {
     const T xx = x * x;
-    *out_cos = abacus::internal::horner_polynomial<T, 4>(xx, _sincos_coefc);
+    *out_cos = abacus::internal::horner_polynomial(xx, _sincos_coefc);
 
-    return x * abacus::internal::horner_polynomial<T, 4>(xx, _sincos_coefs);
+    return x * abacus::internal::horner_polynomial(xx, _sincos_coefs);
   }
 };
 
@@ -92,9 +91,9 @@ template <typename T>
 struct sincos_approx_helper<T, abacus_double> {
   static T _(const T &x, T *out_cos) {
     const T xx = x * x;
-    *out_cos = abacus::internal::horner_polynomial<T, 7>(xx, _sincos_coefcD);
+    *out_cos = abacus::internal::horner_polynomial(xx, _sincos_coefcD);
 
-    return x * abacus::internal::horner_polynomial<T, 7>(xx, _sincos_coefsD);
+    return x * abacus::internal::horner_polynomial(xx, _sincos_coefsD);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/acos.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/acos.cpp
@@ -156,8 +156,8 @@ T acos(const T x) {
     const SignedType cond = xAbs <= intervals[i];
     interval = __abacus_select(interval, i, cond);
 
-    const T poly = abacus::internal::horner_polynomial<T, 4>(
-        i < 12 ? oneMinusXAbs : xAbs, polynomial + i * 4);
+    const T poly = abacus::internal::horner_polynomial(
+        i < 12 ? oneMinusXAbs : xAbs, polynomial + i * 4, 4);
 
     ans = __abacus_select(ans, poly, cond);
   }
@@ -217,7 +217,7 @@ T ABACUS_API acos_half(T x) {
 
   xAbs = xAbs - T(1.0f16);
   T ansBig =
-      xAbs * abacus::internal::horner_polynomial<T, 3>(xAbs, __codeplay_acos_1);
+      xAbs * abacus::internal::horner_polynomial(xAbs, __codeplay_acos_1);
 
   ansBig = abacus::internal::sqrt(ansBig);
 

--- a/modules/compiler/builtins/abacus/source/abacus_math/acosh.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/acosh.cpp
@@ -75,7 +75,7 @@ T acosh_half(const T x) {
 
   const T small_return =
       abacus::internal::sqrt(x - 1.0f16) *
-      abacus::internal::horner_polynomial<T, 3>(x - T(1.0f16), _acoshH);
+      abacus::internal::horner_polynomial(x - T(1.0f16), _acoshH);
 
   ans = __abacus_select(ans, small_return, SignedType(x < T(2.0f16)));
 
@@ -86,8 +86,7 @@ template <>
 abacus_half acosh_half(const abacus_half x) {
   if (x < 2.0f16) {
     return abacus::internal::sqrt(x - 1.0f16) *
-           abacus::internal::horner_polynomial<abacus_half, 3>(x - 1.0f16,
-                                                               _acoshH);
+           abacus::internal::horner_polynomial(x - 1.0f16, _acoshH);
   }
 
   // As x > 11.7, acosh(x) = log(x + sqrt(x^2 - 1)) converges to

--- a/modules/compiler/builtins/abacus/source/abacus_math/acospi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/acospi.cpp
@@ -50,10 +50,10 @@ T acospi_half(const T x) {
 
   // TODO maybe there's a way to pick the coefficients of the polynomials
   // branchlessly, then this wouldn't branch
-  const T poly1 = abacus::internal::horner_polynomial<T, 3>(
-      x2, __codeplay_acospi_coeff_halfH2);
-  const T poly2 = abacus::internal::horner_polynomial<T, 3>(
-      xAbs, __codeplay_acospi_coeff_halfH1);
+  const T poly1 =
+      abacus::internal::horner_polynomial(x2, __codeplay_acospi_coeff_halfH2);
+  const T poly2 =
+      abacus::internal::horner_polynomial(xAbs, __codeplay_acospi_coeff_halfH1);
 
   ans = xAbs * __abacus_select(poly1, poly2, cond1);
 
@@ -71,13 +71,13 @@ abacus_half acospi_half(const abacus_half x) {
 
   if (xAbs > 5.9375E-1f16) {
     xAbs = xAbs - 1.0f16;
-    ans = xAbs * abacus::internal::horner_polynomial<abacus_half, 3>(
+    ans = xAbs * abacus::internal::horner_polynomial(
                      xAbs, __codeplay_acospi_coeff_halfH1);
 
     ans = abacus::internal::sqrt(ans);
   } else {
     const abacus_half x2 = x * x;
-    ans = xAbs * abacus::internal::horner_polynomial<abacus_half, 3>(
+    ans = xAbs * abacus::internal::horner_polynomial(
                      x2, __codeplay_acospi_coeff_halfH2);
 
     ans = ans + 0.5f16;

--- a/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
@@ -161,12 +161,12 @@ T asin_half(const T x) {
   // around x = 1 we want to estimate (asin(x) - pi/2)^2
   SignedType xBig = (xAbs > T(5.9375E-1f16));
   const T x2 = x * x;
-  T ans = x * abacus::internal::horner_polynomial<T, 3>(x2, __codeplay_asin_2);
+  T ans = x * abacus::internal::horner_polynomial(x2, __codeplay_asin_2);
 
   xAbs = xAbs - T(1.0f16);
 
   T ansBig =
-      xAbs * abacus::internal::horner_polynomial<T, 3>(xAbs, __codeplay_asin_1);
+      xAbs * abacus::internal::horner_polynomial(xAbs, __codeplay_asin_1);
 
   ansBig = -abacus::internal::sqrt(ansBig) + ABACUS_PI_2_H;
   ansBig = __abacus_copysign(ansBig, x);
@@ -197,8 +197,7 @@ abacus_half asin_half(const abacus_half x) {
 
     // Estimate (asin(x + 1) - pi / 2)^2 (see solly script)
     abacus_half ans =
-        xAbs * abacus::internal::horner_polynomial<abacus_half, 3>(
-                   xAbs, __codeplay_asin_1);
+        xAbs * abacus::internal::horner_polynomial(xAbs, __codeplay_asin_1);
 
     ans = -abacus::internal::sqrt(ans) + ABACUS_PI_2_H;
     return __abacus_copysign(ans, x);
@@ -206,8 +205,7 @@ abacus_half asin_half(const abacus_half x) {
 
   // Estimate the remaining values
   const abacus_half x2 = x * x;
-  return x * abacus::internal::horner_polynomial<abacus_half, 3>(
-                 x2, __codeplay_asin_2);
+  return x * abacus::internal::horner_polynomial(x2, __codeplay_asin_2);
 }
 }  // namespace
 
@@ -229,8 +227,8 @@ T asin(const T x) {
     const SignedType cond = xAbs < intervals[i];
     interval = __abacus_select(interval, i, cond);
 
-    const T poly = abacus::internal::horner_polynomial<T, 5>(
-        i < 9 ? oneMinusXAbs : xAbs, __codeplay_asin_coeff + i * 5);
+    const T poly = abacus::internal::horner_polynomial(
+        i < 9 ? oneMinusXAbs : xAbs, __codeplay_asin_coeff + i * 5, 5);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
@@ -172,8 +172,8 @@ T asinh(const T x) {
     const SignedType cond = xAbs < intervals[i];
     interval = __abacus_select(interval, i, cond);
 
-    const T poly = abacus::internal::horner_polynomial<T, 5>(
-        xAbs, __codeplay_asinh_coeff + i * 5);
+    const T poly = abacus::internal::horner_polynomial(
+        xAbs, __codeplay_asinh_coeff + i * 5, 5);
 
     ans = __abacus_select(ans, poly, cond);
   }
@@ -242,8 +242,7 @@ T asinhD(const T x) {
       0.7670591834281017654139093e-2, -0.5403578695078777809556689e-2,
       0.2818764122836144912311135e-2, -0.7716999562952834196266079e-3};
 
-  const T poly =
-      x * abacus::internal::horner_polynomial<T, 14>(x * x, polynomial);
+  const T poly = x * abacus::internal::horner_polynomial(x * x, polynomial);
 
   const SignedType small = xAbs <= 0.6;
   T result = __abacus_select(afterLog, poly, small);
@@ -302,7 +301,7 @@ T asinhH(const T x) {
   const T logX = __abacus_log(log_input);
 
   // Since we have to calculate log(x) anyway, we may as well use it:
-  T ans = abacus::internal::horner_polynomial<T, 6>(logX, _asinhH1);
+  T ans = abacus::internal::horner_polynomial(logX, _asinhH1);
 
   // Logically, this case should be log(2x). However, to avoid calling
   // __abacus_log twice, we change the input of __abacus_log above to be 2x,
@@ -312,7 +311,7 @@ T asinhH(const T x) {
   ans = __abacus_select(ans, sign * (ABACUS_LN2_H + logX),
                         SignedType(xAbs >= xOverflowBound));
   ans = __abacus_select(
-      ans, x * abacus::internal::horner_polynomial<T, 2>(x * x, _asinhH2),
+      ans, x * abacus::internal::horner_polynomial(x * x, _asinhH2),
       SignedType(xAbs < 0.55f16));
 
   // When denormals are unavailable, we need to handle the smallest FP16 value
@@ -339,8 +338,7 @@ abacus_half asinhH(const abacus_half x) {
   // themselves for fabs(x) > 0.55.
   // For values less than this we use a direct polynomial to get the answer:
   if (xAbs < 0.55f16) {
-    return x *
-           abacus::internal::horner_polynomial<abacus_half, 2>(x * x, _asinhH2);
+    return x * abacus::internal::horner_polynomial(x * x, _asinhH2);
   }
 
   const abacus_half sign = __abacus_copysign(1.0f16, x);
@@ -359,8 +357,7 @@ abacus_half asinhH(const abacus_half x) {
   }
 
   // Since we have to calculate log(x) anyway, we may as well use it:
-  const abacus_half ans =
-      abacus::internal::horner_polynomial<abacus_half, 6>(logX, _asinhH1);
+  const abacus_half ans = abacus::internal::horner_polynomial(logX, _asinhH1);
 
   return sign * ans;
 }

--- a/modules/compiler/builtins/abacus/source/abacus_math/asinpi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asinpi.cpp
@@ -43,7 +43,7 @@ T asinpi_half(const T x) {
   T xAbs = __abacus_fabs(x);
   const T x2 = x * x;
 
-  T ans = x * abacus::internal::horner_polynomial<T, 3>(
+  T ans = x * abacus::internal::horner_polynomial(
                   x2, __codeplay_asinpi_coeff_halfH2);
 
   const SignedType cond1 = (xAbs > 5.9375E-1f16);
@@ -52,7 +52,7 @@ T asinpi_half(const T x) {
 
   xAbs = xAbs - 1.0f16;
 
-  T ansCond = xAbs * abacus::internal::horner_polynomial<T, 3>(
+  T ansCond = xAbs * abacus::internal::horner_polynomial(
                          xAbs, __codeplay_asinpi_coeff_halfH1);
   ansCond = -abacus::internal::sqrt(ansCond) + 0.5f16;
   ansCond = __abacus_copysign(ansCond, x);
@@ -72,16 +72,15 @@ abacus_half asinpi_half(const abacus_half x) {
   if (xAbs > 5.9375E-1f16) {
     xAbs = xAbs - 1.0f16;
 
-    abacus_half ans =
-        xAbs * abacus::internal::horner_polynomial<abacus_half, 3>(
-                   xAbs, __codeplay_asinpi_coeff_halfH1);
+    abacus_half ans = xAbs * abacus::internal::horner_polynomial(
+                                 xAbs, __codeplay_asinpi_coeff_halfH1);
 
     ans = -abacus::internal::sqrt(ans) + 0.5f16;
     return __abacus_copysign(ans, x);
   }
 
   const abacus_half x2 = x * x;
-  return x * abacus::internal::horner_polynomial<abacus_half, 3>(
+  return x * abacus::internal::horner_polynomial(
                  x2, __codeplay_asinpi_coeff_halfH2);
 }
 #endif  // __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/atan.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/atan.cpp
@@ -60,8 +60,8 @@ T ABACUS_API atan(T x) {
 
   x = __abacus_select(x, (T)1.0f / x, recip_x);
 
-  const T result = x * abacus::internal::horner_polynomial<T, 8>(
-                           x * x, __codeplay_atan_coeff);
+  const T result =
+      x * abacus::internal::horner_polynomial(x * x, __codeplay_atan_coeff);
 
   return __abacus_select(result, __abacus_copysign(ABACUS_PI_2_F, x) - result,
                          recip_x);
@@ -97,8 +97,7 @@ T ABACUS_API atan_half(T x) {
 
   x = __abacus_select(x, 1.0f16 / x, inverse);
 
-  T ans = x * abacus::internal::horner_polynomial<T, 4>(x * x,
-                                                        __codeplay_atan_half);
+  T ans = x * abacus::internal::horner_polynomial(x * x, __codeplay_atan_half);
 
   ans = __abacus_select(ans, __abacus_copysign(ABACUS_PI_2_H, ans) - ans,
                         inverse);

--- a/modules/compiler/builtins/abacus/source/abacus_math/atan2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/atan2.cpp
@@ -33,7 +33,7 @@ struct helper<T, abacus_float> {
         -0.142035440289f,    +0.106405958967f,    -0.750364848983e-1f,
         +0.426844903103e-1f, -0.160645730104e-1f, +0.284892648503e-2f};
 
-    return x * abacus::internal::horner_polynomial<T, 9>(x * x, polynomial);
+    return x * abacus::internal::horner_polynomial(x * x, polynomial);
   }
 };
 
@@ -54,7 +54,7 @@ static ABACUS_CONSTANT abacus_double polynomialD[19] = {
 template <typename T>
 struct helper<T, abacus_double> {
   static T _(const T x) {
-    return x * abacus::internal::horner_polynomial<T, 19>(x * x, polynomialD);
+    return x * abacus::internal::horner_polynomial(x * x, polynomialD);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
@@ -124,7 +124,7 @@ T atan2_half(const T y, const T x) {
 
   const T x2 = ratio * ratio;
 
-  T ans = ratio * abacus::internal::horner_polynomial<T, 5>(x2, _atan2H);
+  T ans = ratio * abacus::internal::horner_polynomial(x2, _atan2H);
 
   T pi_multiplication_factor = 0.0f16;
 
@@ -213,8 +213,7 @@ abacus_half atan2_half(const abacus_half y, const abacus_half x) {
 
   const abacus_half x2 = ratio * ratio;
 
-  abacus_half ans =
-      ratio * abacus::internal::horner_polynomial<abacus_half, 5>(x2, _atan2H);
+  abacus_half ans = ratio * abacus::internal::horner_polynomial(x2, _atan2H);
 
   abacus_half pi_multiplication_factor = 0.0f16;
 

--- a/modules/compiler/builtins/abacus/source/abacus_math/atan2pi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/atan2pi.cpp
@@ -81,7 +81,7 @@ T atan2pi_half(const T y, const T x) {
 
   const T x2 = ratio * ratio;
 
-  const T poly = atan2pi_horner_polynomial<T>(x2);
+  const T poly = atan2pi_horner_polynomial(x2);
 
   // Adding this small constant to the polynomial, then multiplying by 'ratio',
   // loses too much precision in cases where the other operands are large.
@@ -117,8 +117,7 @@ T atan2pi_half(const T y, const T x) {
     const T remaining_term = 0.318359375f16 * 8.0f16;
 
     // Compute horner polynomial.
-    T ans_ftz =
-        abacus::internal::horner_polynomial<T, 3>(abs_ratio, _atan2piH_ftz);
+    T ans_ftz = abacus::internal::horner_polynomial(abs_ratio, _atan2piH_ftz);
     ans_ftz = remaining_term + ans_ftz;
     // Perform final multiplcation, then undo the scaling.
     ans_ftz = (abs_ratio * ans_ftz) * 0.125f16;
@@ -221,7 +220,7 @@ abacus_half atan2pi_half(const abacus_half y, const abacus_half x) {
 
   const abacus_half x2 = ratio * ratio;
 
-  const abacus_half poly = atan2pi_horner_polynomial<abacus_half>(x2);
+  const abacus_half poly = atan2pi_horner_polynomial(x2);
 
   // Adding this small constant to the polynomial, then multiplying by 'ratio',
   // loses too much precision in cases where the other operands are large.
@@ -263,8 +262,7 @@ abacus_half atan2pi_half(const abacus_half y, const abacus_half x) {
       const abacus_half remaining_term = 0.318359375f16 * 8.0f16;
 
       // Compute horner polynomial.
-      ans = abacus::internal::horner_polynomial<abacus_half, 3>(abs_ratio,
-                                                                _atan2piH_ftz);
+      ans = abacus::internal::horner_polynomial(abs_ratio, _atan2piH_ftz);
       ans = remaining_term + ans;
 
       // Perform final multiplcation, then undo the scaling.

--- a/modules/compiler/builtins/abacus/source/abacus_math/atanh.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/atanh.cpp
@@ -38,9 +38,9 @@ T atanh_half(const T x) {
   // return T(0.5f16) * (__abacus_log(T(1.0) + x) - __abacus_log(T(1.0) - x));
   T ans = 0.5f16 * (__abacus_log((1.0f16 + x) / (1.0f16 - x)));
 
-  ans = __abacus_select(
-      ans, x * abacus::internal::horner_polynomial<T, 3>(x * x, _atanhH),
-      __abacus_fabs(x) < 0.5f16);
+  ans = __abacus_select(ans,
+                        x * abacus::internal::horner_polynomial(x * x, _atanhH),
+                        __abacus_fabs(x) < 0.5f16);
 
   return ans;
 }
@@ -48,8 +48,7 @@ T atanh_half(const T x) {
 template <>
 abacus_half atanh_half(const abacus_half x) {
   if (__abacus_fabs(x) < 0.5f16) {
-    return x *
-           abacus::internal::horner_polynomial<abacus_half, 3>(x * x, _atanhH);
+    return x * abacus::internal::horner_polynomial(x * x, _atanhH);
   }
 
   // Both of these work, one has a divide, the other calls log twice. Divide is

--- a/modules/compiler/builtins/abacus/source/abacus_math/atanpi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/atanpi.cpp
@@ -45,7 +45,7 @@ T atanpi_half(const T x) {
   x_local = __abacus_select(x_local, 1.0f16 / x_local, inverse);
 
   const T x2 = x_local * x_local;
-  T ans = x_local * abacus::internal::horner_polynomial<T, 5>(
+  T ans = x_local * abacus::internal::horner_polynomial(
                         x2, __codeplay_atanpi_coeff_halfH1);
 
   ans = __abacus_select(ans, __abacus_copysign(0.5f16, ans) - ans, inverse);
@@ -64,9 +64,8 @@ abacus_half atanpi_half(const abacus_half x) {
   }
 
   const abacus_half x2 = x_local * x_local;
-  abacus_half ans =
-      x_local * abacus::internal::horner_polynomial<abacus_half, 5>(
-                    x2, __codeplay_atanpi_coeff_halfH1);
+  abacus_half ans = x_local * abacus::internal::horner_polynomial(
+                                  x2, __codeplay_atanpi_coeff_halfH1);
 
   if (!inverse) {
     return ans;

--- a/modules/compiler/builtins/abacus/source/abacus_math/cbrt.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/cbrt.cpp
@@ -217,7 +217,7 @@ struct helper<T, abacus_double> {
         -0.2577879379162866445639990e0};
 
     // estimate the cbrt here, xMant [0.5 -> 1]:
-    T ans = abacus::internal::horner_polynomial<T, 11>(xMant, polynomial);
+    T ans = abacus::internal::horner_polynomial(xMant, polynomial);
 
     abacus_double4 cbrts;
     // skip term

--- a/modules/compiler/builtins/abacus/source/abacus_math/cospi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/cospi.cpp
@@ -38,7 +38,7 @@ struct helper<T, abacus_half> {
     // multiply_exact / add_exact.
     const abacus_half polynomial[3] = {3.140625f16, -5.13671875f16,
                                        2.298828125f16};
-    const T poly = abacus::internal::horner_polynomial<T, 2>(x, &polynomial[1]);
+    const T poly = abacus::internal::horner_polynomial(x, &polynomial[1], 2);
 
     // Perform last horner_polynomial step by hand.
     T poly_mul_lo;
@@ -65,7 +65,7 @@ struct helper<T, abacus_float> {
                                         +2.5500695377459f, -0.59824115267029f,
                                         +0.77558697671848e-1f};
 
-    return abacus::internal::horner_polynomial<T, 5>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 
@@ -80,7 +80,7 @@ struct helper<T, abacus_double> {
         0.466299691216533729550e-3, -0.219031914477628858710e-4,
         7.69478758985541321889e-7};
 
-    return abacus::internal::horner_polynomial<T, 9>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/erf.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/erf.cpp
@@ -38,18 +38,18 @@ struct erf_helper<T, abacus_half> {
     // Polynomial over range [0, 0.8]
     const abacus_half polynomial0[4] = {1.1279296875f16, 1.10321044921875e-2f16,
                                         -0.44189453125f16, 0.1436767578125f16};
-    const T s0 = abacus::internal::horner_polynomial<T, 4>(xAbs, polynomial0);
+    const T s0 = abacus::internal::horner_polynomial(xAbs, polynomial0);
 
     // Polynomial over range [0.8, 1.75]
     const abacus_half polynomial1[4] = {1.234375f16, -0.2978515625f16,
                                         -0.15478515625f16,
                                         6.0638427734375e-2f16};
-    const T s1 = abacus::internal::horner_polynomial<T, 4>(xAbs, polynomial1);
+    const T s1 = abacus::internal::horner_polynomial(xAbs, polynomial1);
 
     // Polynomial over range [1.75, 2.1]
     const abacus_half polynomial2[3] = {1.40234375f16, -0.66650390625f16,
                                         0.1070556640625f16};
-    const T s2 = abacus::internal::horner_polynomial<T, 3>(xAbs, polynomial2);
+    const T s2 = abacus::internal::horner_polynomial(xAbs, polynomial2);
 
     // Select the last interval as the default value
     T result = s2;
@@ -93,32 +93,31 @@ struct erf_helper<T, abacus_float> {
         -0.480089943431e-2f, .1291708894549f,  -0.2738900335275e-1f,
         -0.7265839921372e-2f};
 
-    const T s0 =
-        xAbs * abacus::internal::horner_polynomial<T, 7>(xAbs, polynomial0);
+    const T s0 = xAbs * abacus::internal::horner_polynomial(xAbs, polynomial0);
 
     const abacus_float polynomial1[7] = {
         .1572988043812f,     -.4151063740764f,     .4151681759610f,
         -.1386338728462f,    -0.6996173760407e-1f, 0.7588668092134e-1f,
         -0.1999414841696e-1f};
 
-    const T s1 = (T)1.0f - abacus::internal::horner_polynomial<T, 7>(
-                               xAbs - 1.0f, polynomial1);
+    const T s1 =
+        (T)1.0f - abacus::internal::horner_polynomial(xAbs - 1.0f, polynomial1);
 
     const abacus_float polynomial2[7] = {
         0.4677923940847e-2f,  -0.2066698149162e-1f, 0.4131261993220e-1f,
         -0.4814201425671e-1f, 0.3459644561569e-1f,  -0.1449449409692e-1f,
         0.2739553512239e-2f};
 
-    const T s2 = (T)1.0f - abacus::internal::horner_polynomial<T, 7>(
-                               xAbs - 2.0f, polynomial2);
+    const T s2 =
+        (T)1.0f - abacus::internal::horner_polynomial(xAbs - 2.0f, polynomial2);
 
     const abacus_float polynomial3[7] = {
         0.221830562446e-4f,  -0.140925585762e-3f, 0.420115643592e-3f,
         -0.743785588448e-3f, 0.804037923904e-3f,  -0.488747786554e-3f,
         0.127400179584e-3f};
 
-    const T s3 = (T)1.0f - abacus::internal::horner_polynomial<T, 7>(
-                               xAbs - 3.0f, polynomial3);
+    const T s3 =
+        (T)1.0f - abacus::internal::horner_polynomial(xAbs - 3.0f, polynomial3);
 
     // select the last interval as the default value
     T result = s3;
@@ -159,8 +158,7 @@ struct erf_helper<T, abacus_double> {
         -0.8502053102671020146012240e-3, -0.131562968994956982451090e-4,
         0.1453015580982363557541757e-3,  -0.2803416013593745284248751e-4};
 
-    const T s =
-        x * abacus::internal::horner_polynomial<T, 14>(xAbs, polynomial);
+    const T s = x * abacus::internal::horner_polynomial(xAbs, polynomial);
 
     const SignedType c0 = xAbs < 0.3;
     result = __abacus_select(result, s, c0);

--- a/modules/compiler/builtins/abacus/source/abacus_math/erfc.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/erfc.cpp
@@ -40,18 +40,18 @@ struct erfc_helper<T, abacus_half> {
     // Polynomial of erfc() for range [0, 0.8]
     const abacus_half polynomial0[4] = {1.0009765625f16, -1.15625f16,
                                         0.1346435546875f16, 0.1875f16};
-    const T s0 = abacus::internal::horner_polynomial<T, 4>(xAbs, polynomial0);
+    const T s0 = abacus::internal::horner_polynomial(xAbs, polynomial0);
 
     // Polynomial approximation of 'erfc(x) * x^2 * exp(x^2)' over [0.8, 1.75]
     const abacus_half polynomial1[4] = {-9.47265625e-2f16, 0.439453125f16,
                                         0.1070556640625f16,
                                         -2.41851806640625e-2f16};
-    const T s1 = abacus::internal::horner_polynomial<T, 4>(xAbs, polynomial1);
+    const T s1 = abacus::internal::horner_polynomial(xAbs, polynomial1);
 
     // Polynomial approximation of 'erfc(x) * x^2 * exp(x^2)' over [1.75, 2.5]
     const abacus_half polynomial2[3] = {-0.1822509765625f16, 0.609375f16,
                                         -3.73077392578125e-3f16};
-    const T s2 = abacus::internal::horner_polynomial<T, 3>(xAbs, polynomial2);
+    const T s2 = abacus::internal::horner_polynomial(xAbs, polynomial2);
 
     // Select the last interval as the default value
     T result = s2;
@@ -96,21 +96,21 @@ struct erfc_helper<T, abacus_float> {
         1.000000099f,    -1.128392934f, 0.3227568e-3f,    .3731939303f,
         0.131956151e-1f, -.1449755580f, 0.4206089062e-1f, 0.1936482390e-2f,
     };
-    const T s0 = abacus::internal::horner_polynomial<T, 8>(xAbs, polynomial0);
+    const T s0 = abacus::internal::horner_polynomial(xAbs, polynomial0);
 
     // Polynomial approximation of 'erfc(x) * x^2 * exp(x^2)' over [0.8, 2.0]
     const abacus_float polynomial1[8] = {-0.1195251196e-1f, 0.858939377e-1f,
                                          0.7237242471e0f,   -0.5984700845e0f,
                                          0.3146238633e0f,   -0.1046465402e0f,
                                          0.2011317702e-1f,  -0.1702538918e-2f};
-    const T s1 = abacus::internal::horner_polynomial<T, 8>(xAbs, polynomial1);
+    const T s1 = abacus::internal::horner_polynomial(xAbs, polynomial1);
 
     // Polynomial approximation of 'erfc(x) * x^2 * exp(x^2)' over [2.0, 4.5]
     const abacus_float polynomial2[8] = {-0.1314926638e0f, 0.4923351369e0f,
                                          0.1059452967e0f,  -0.5427770214e-1f,
                                          0.1550428873e-1f, -0.2610687156e-2f,
                                          0.2431079121e-3f, -0.9688281705e-5f};
-    const T s2 = abacus::internal::horner_polynomial<T, 8>(xAbs, polynomial2);
+    const T s2 = abacus::internal::horner_polynomial(xAbs, polynomial2);
 
     // Polynomial approximation of 'erfc(x) * x^2 * exp(x^2)' over [4.5, 10]
     const abacus_float polynomial3[8] = {-0.2132052659e0f,  0.6462258403e0f,
@@ -118,7 +118,7 @@ struct erfc_helper<T, abacus_float> {
                                          -0.3095515185e-3f, 0.2004225582e-4f,
                                          -0.7474507440e-6f, 0.1223817901e-7f};
 
-    const T s3 = abacus::internal::horner_polynomial<T, 8>(xAbs, polynomial3);
+    const T s3 = abacus::internal::horner_polynomial(xAbs, polynomial3);
 
     // Select the last interval as the default value
     T result = s3;
@@ -174,7 +174,7 @@ struct erfc_helper<T, abacus_double> {
         0.22315411099578621908783495598284443407283662209588e-22};
 
     const T s0 =
-        abacus::internal::horner_polynomial<T, 16>((T)25.0 - xAbs, polynomial0);
+        abacus::internal::horner_polynomial((T)25.0 - xAbs, polynomial0);
 
     const abacus_double polynomial1[16] = {
         0.26835813158647956642164066632119246357135547849751e-1,
@@ -195,7 +195,7 @@ struct erfc_helper<T, abacus_double> {
         0.35108463749050907584106554056394450250981113580702e-21};
 
     const T s1 =
-        abacus::internal::horner_polynomial<T, 16>((T)21.0 - xAbs, polynomial1);
+        abacus::internal::horner_polynomial((T)21.0 - xAbs, polynomial1);
 
     const abacus_double polynomial2[16] = {
         0.33130499999725536698661233824251148061300199979814e-1,
@@ -216,7 +216,7 @@ struct erfc_helper<T, abacus_double> {
         0.97212298021469650250629966132938751449592339693735e-20};
 
     const T s2 =
-        abacus::internal::horner_polynomial<T, 16>((T)17.0 - xAbs, polynomial2);
+        abacus::internal::horner_polynomial((T)17.0 - xAbs, polynomial2);
 
     const abacus_double polynomial3[16] = {
         0.43271921864609692570782914322398106742898737622031e-1,
@@ -237,7 +237,7 @@ struct erfc_helper<T, abacus_double> {
         0.62999013306513108998342864875729309153681534750350e-18};
 
     const T s3 =
-        abacus::internal::horner_polynomial<T, 16>((T)13.0 - xAbs, polynomial3);
+        abacus::internal::horner_polynomial((T)13.0 - xAbs, polynomial3);
 
     const abacus_double polynomial4[16] = {
         0.62307724037774650307656620378742578230490125142309e-1,
@@ -258,7 +258,7 @@ struct erfc_helper<T, abacus_double> {
         0.16739939975355356338814822591192186560474315370372e-15};
 
     const T s4 =
-        abacus::internal::horner_polynomial<T, 16>((T)9.0 - xAbs, polynomial4);
+        abacus::internal::horner_polynomial((T)9.0 - xAbs, polynomial4);
 
     const abacus_double polynomial5[16] = {
         0.11070463773286169990372436653511241845044712161429e0,
@@ -279,7 +279,7 @@ struct erfc_helper<T, abacus_double> {
         0.67103905111008702565383310413536484200906759877260e-12};
 
     const T s5 =
-        abacus::internal::horner_polynomial<T, 16>((T)5.0 - xAbs, polynomial5);
+        abacus::internal::horner_polynomial((T)5.0 - xAbs, polynomial5);
 
     // default to the first interval (xAbs <= 27)
     T result = s0;
@@ -317,8 +317,7 @@ struct erfc_helper<T, abacus_double> {
         -0.769303783427077728603115605154e-11,
         0.649208507303079943817283734212e-12};
 
-    const T s6 =
-        x * abacus::internal::horner_polynomial<T, 18>(x - 2.0, polynomial6);
+    const T s6 = x * abacus::internal::horner_polynomial(x - 2.0, polynomial6);
 
     const abacus_double polynomial7[18] = {
         -0.184960550993324824857621355148e1,
@@ -340,8 +339,7 @@ struct erfc_helper<T, abacus_double> {
         0.719978845989106022397954580379e-10,
         -0.112483613328048316890929995550e-10};
 
-    const T s7 =
-        x * abacus::internal::horner_polynomial<T, 18>(x - 1.0, polynomial7);
+    const T s7 = x * abacus::internal::horner_polynomial(x - 1.0, polynomial7);
 
     const abacus_double polynomial8[18] = {-0.112837916709551257387779218929e1,
                                            -0.636619772367581355079779256278e0,
@@ -362,7 +360,7 @@ struct erfc_helper<T, abacus_double> {
                                            -0.130665471764135727617959508462e-7,
                                            0.147819914464175590200096454488e-8};
 
-    const T s8 = x * abacus::internal::horner_polynomial<T, 18>(x, polynomial8);
+    const T s8 = x * abacus::internal::horner_polynomial(x, polynomial8);
 
     result = __abacus_select(result, s6, (SignedType)(xAbs <= 3.0));
     result = __abacus_select(result, s7, (SignedType)(xAbs <= 2.0));

--- a/modules/compiler/builtins/abacus/source/abacus_math/exp10.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/exp10.cpp
@@ -70,8 +70,7 @@ struct helper<T, abacus_half> {
 
     // Minimax polynomial approximation in the domain
     // [-log(2)/(2*log(10)), log(2)/(2*log(10))]
-    const T result =
-        abacus::internal::horner_polynomial<T, 5>(rr_x, polynomial);
+    const T result = abacus::internal::horner_polynomial(rr_x, polynomial);
 
     const IntType kInt = abacus::detail::cast::convert<IntType>(k);
     const T raise = __abacus_ldexp(result, kInt);
@@ -107,7 +106,7 @@ struct helper<T, abacus_float> {
                                         0.206220193305040f};
 
     // Minimax polynomial approximation in the domain [-log10(2)/2, log10(2)/2]
-    const T result = abacus::internal::horner_polynomial<T, 7>(r, polynomial);
+    const T result = abacus::internal::horner_polynomial(r, polynomial);
 
     return __abacus_select(__abacus_ldexp(result, k), 0.0f,
                            x < -44.8534698486328125f);
@@ -143,7 +142,7 @@ struct helper<T, abacus_double> {
         0.6543870973084372896203514e-4};
 
     // minimax from 0 -> ln(10)/ln(2) of 10^x
-    const T fract = abacus::internal::horner_polynomial<T, 13>(r, polynomial);
+    const T fract = abacus::internal::horner_polynomial(r, polynomial);
 
     // The answer is ldexp(poly, quotient), but we don't need the full ldexp
     const T factor1 = abacus::detail::cast::as<T>((k / 2 + 1023) << 52);

--- a/modules/compiler/builtins/abacus/source/abacus_math/exp2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/exp2.cpp
@@ -46,8 +46,7 @@ struct helper<T, abacus_half> {
 
     // We know remainder will be in the reduced range [0.0, 1.0], so we use a
     // polynomial approximation to calculate 2^remainder
-    const T fract =
-        abacus::internal::horner_polynomial<T, 4>(remainder, polynomial);
+    const T fract = abacus::internal::horner_polynomial(remainder, polynomial);
 
     // Multiply 2^floor by approximation of 2^remainder to get the final result
     T result = __abacus_ldexp(fract, floor);
@@ -94,7 +93,7 @@ struct helper<T, abacus_float> {
 
     // Minimax polynomial approximation in the domain [0.0, 1.0]
     // ideal maximum error +8.256512799094739296267877813873319906884e-13
-    T result = abacus::internal::horner_polynomial<T, 9>(r, polynomial);
+    T result = abacus::internal::horner_polynomial(r, polynomial);
 
     result = __abacus_ldexp(result, k);
 
@@ -133,7 +132,7 @@ struct helper<T, abacus_double> {
                                           4.1791513827899285111307e-10,
                                           3.5365538828220154193844e-11};
 
-    const T fract = abacus::internal::horner_polynomial<T, 13>(r, polynomial);
+    const T fract = abacus::internal::horner_polynomial(r, polynomial);
 
     const T factor1 = abacus::detail::cast::as<T>((k / 2 + 1023) << 52);
     const T factor2 = abacus::detail::cast::as<T>((k - (k / 2) + 1023) << 52);

--- a/modules/compiler/builtins/abacus/source/abacus_math/expm1.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/expm1.cpp
@@ -43,7 +43,7 @@ struct helper<T, abacus_half> {
                                         -6.186962127685546875e-5f16};
 
     // Use polynomial within bound [-0.6, 1.7] where we need to be more precise
-    T result = abacus::internal::horner_polynomial<T, 10>(x, polynomial);
+    T result = abacus::internal::horner_polynomial(x, polynomial);
 
     // Use naive `exp() - 1` implementation outwith bounds [-0.6, 1.7]
     const T naive = __abacus_exp(x) - 1.0f16;
@@ -69,7 +69,7 @@ struct helper<T, abacus_float> {
                                          0.2259264801e-4f,
                                          0.4331310997e-5f};
 
-    const T result = abacus::internal::horner_polynomial<T, 10>(x, polynomial);
+    const T result = abacus::internal::horner_polynomial(x, polynomial);
 
     return __abacus_select(result, __abacus_exp(x) - 1.0f,
                            (x < -0.6f) | (x > 1.60809791088104248046875f));
@@ -116,19 +116,17 @@ struct helper<T, abacus_double> {
 
     T result = __abacus_select(
         __abacus_exp(x) - 1.0,
-        x * abacus::internal::horner_polynomial<T, 15>(x, polynomial1), cond1);
+        x * abacus::internal::horner_polynomial(x, polynomial1), cond1);
 
     const SignedType cond2 = (x > 0.0) & (x <= 0.8);
 
     result = __abacus_select(
-        result, x * abacus::internal::horner_polynomial<T, 14>(x, polynomial2),
-        cond2);
+        result, x * abacus::internal::horner_polynomial(x, polynomial2), cond2);
 
     const SignedType cond3 = (x > 0.8) & (x < 1.7);
 
     result = __abacus_select(
-        result, abacus::internal::horner_polynomial<T, 15>(x, polynomial3),
-        cond3);
+        result, abacus::internal::horner_polynomial(x, polynomial3), cond3);
 
     return result;
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/half_exp2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/half_exp2.cpp
@@ -46,8 +46,8 @@ T half_exp2(T x) {
   SignedType xFloor = abacus::internal::floor_unsafe(x);
   T xMant = x - abacus::detail::cast::convert<T>(xFloor);
 
-  T exp2_xMant = abacus::internal::horner_polynomial<T, 4>(
-      xMant, __codeplay_half_exp2_coeff);
+  T exp2_xMant =
+      abacus::internal::horner_polynomial(xMant, __codeplay_half_exp2_coeff);
 
   T result = abacus::internal::ldexp_unsafe(exp2_xMant, xFloor);
 

--- a/modules/compiler/builtins/abacus/source/abacus_math/half_log2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/half_log2.cpp
@@ -40,7 +40,7 @@ T _(const T x) {
 
   xMant -= (T)1.0f;
 
-  T log2_xMant = xMant * abacus::internal::horner_polynomial<T, 4>(
+  T log2_xMant = xMant * abacus::internal::horner_polynomial(
                              xMant, __codeplay_half_log2_coeff);
 
   T result = abacus::detail::cast::convert<T>(xExp) + log2_xMant;

--- a/modules/compiler/builtins/abacus/source/abacus_math/hypot.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/hypot.cpp
@@ -142,7 +142,7 @@ struct hypot_helper<T, abacus_half> {
 
     // Estimate sqrt(1 + x^2) from x in [0,1]:
     // P = fpminimax(sqrt(1 + x^2), 4, [|11...|],[0;1],floating,relative);
-    const T sqrt_guess = abacus::internal::horner_polynomial<T, 5>(
+    const T sqrt_guess = abacus::internal::horner_polynomial(
         xReduced, __codeplay_hypot_coeff_half);
 
     return max_xy * sqrt_guess;

--- a/modules/compiler/builtins/abacus/source/abacus_math/log.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/log.cpp
@@ -65,9 +65,8 @@ struct helper<abacus_half, abacus_half> {
     // input by one.
     significand = significand - 1.0f16;
 
-    const abacus_half poly_approx =
-        abacus::internal::horner_polynomial<abacus_half, 9>(
-            significand, __codeplay_log_coeff_half);
+    const abacus_half poly_approx = abacus::internal::horner_polynomial(
+        significand, __codeplay_log_coeff_half);
 
     const abacus_half result = significand * poly_approx;
     const abacus_half fexponent(exponent);
@@ -100,7 +99,7 @@ struct helper<T, abacus_half> {
     // input by one.
     significand = significand - 1.0f16;
 
-    T result = significand * abacus::internal::horner_polynomial<T, 9>(
+    T result = significand * abacus::internal::horner_polynomial(
                                  significand, __codeplay_log_coeff_half);
 
     result = result + (abacus::detail::cast::convert<T>(exponent_short) *

--- a/modules/compiler/builtins/abacus/source/abacus_math/log1p.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/log1p.cpp
@@ -87,8 +87,8 @@ struct helper<abacus_half, abacus_half> {
     if (-0.4f16 < x && x < 0.7f16) {
       // p = fpminimax(log1p(x), [|1,2,3,4,5,6,7,8|],[|11...|],[-0.4;0.7], 0,
       // floating, relative);
-      abacus_half result = abacus::internal::horner_polynomial<abacus_half, 8>(
-          x, __codeplay_log1p_coeff_halfH1);
+      abacus_half result =
+          abacus::internal::horner_polynomial(x, __codeplay_log1p_coeff_halfH1);
       return x * result;
     }
 
@@ -122,9 +122,8 @@ struct helper<abacus_half, abacus_half> {
     // log(x + 1) ~ x(a0 + a1*x + a2*x^2 + ...) = a0*x + a1*x^2 + a2*x^3 + ...
     // aka a poynomial with no constant term.
 
-    abacus_half poly_approx =
-        abacus::internal::horner_polynomial<abacus_half, 9>(
-            significand, __codeplay_log1p_coeff_halfH2);
+    abacus_half poly_approx = abacus::internal::horner_polynomial(
+        significand, __codeplay_log1p_coeff_halfH2);
 
     abacus_half result = poly_approx * significand;
 
@@ -159,7 +158,7 @@ struct helper<T, abacus_half> {
     // input by one.
     significand = significand - 1.0f16;
 
-    T result = significand * abacus::internal::horner_polynomial<T, 9>(
+    T result = significand * abacus::internal::horner_polynomial(
                                  significand, __codeplay_log1p_coeff_halfH2);
 
     result = result +
@@ -170,7 +169,7 @@ struct helper<T, abacus_half> {
 
     result =
         __abacus_select(result,
-                        x * abacus::internal::horner_polynomial<T, 8>(
+                        x * abacus::internal::horner_polynomial(
                                 x, __codeplay_log1p_coeff_halfH1),
                         (approx_threshold_2 < x) && (x < approx_threshold_1));
 
@@ -296,8 +295,8 @@ struct helper<T, abacus_float> {
     // input by one.
     significand = significand - 1.0f;
 
-    T result = abacus::internal::horner_polynomial<T, 10>(
-        significand, __codeplay_log1p_coeff);
+    T result = abacus::internal::horner_polynomial(significand,
+                                                   __codeplay_log1p_coeff, 10);
 
     result = significand + significand * significand * result;
 
@@ -307,18 +306,18 @@ struct helper<T, abacus_float> {
     const T approx_threshold_1 =
         __abacus_as_float(0x3f2610c3);  // 6.48693263530731201171875E-1
 
-    result = __abacus_select(result,
-                             abacus::internal::horner_polynomial<T, 10>(
-                                 x, __codeplay_log1p_coeff + 20),
-                             (x <= approx_threshold_1) & (x >= 0));
+    result = __abacus_select(
+        result,
+        abacus::internal::horner_polynomial(x, __codeplay_log1p_coeff + 20, 10),
+        (x <= approx_threshold_1) & (x >= 0));
 
     const T approx_threshold_2 =
         __abacus_as_float(0xbec974cf);  //-3.934693038463592529296875E-1
 
-    result = __abacus_select(result,
-                             abacus::internal::horner_polynomial<T, 10>(
-                                 x, __codeplay_log1p_coeff + 10),
-                             (x < 0) & (x >= approx_threshold_2));
+    result = __abacus_select(
+        result,
+        abacus::internal::horner_polynomial(x, __codeplay_log1p_coeff + 10, 10),
+        (x < 0) & (x >= approx_threshold_2));
 
     result = __abacus_select(result, __abacus_copysign(ABACUS_INFINITY, x),
                              (x == -1.0f) | __abacus_isinf(x));
@@ -371,14 +370,11 @@ template <>
 struct helper<abacus_double, abacus_double> {
   static abacus_double _(abacus_double x) {
     if (-0.5 <= x && x < 0.0) {
-      return x * abacus::internal::horner_polynomial<abacus_double, 21>(
-                     x, polynomialD1);
+      return x * abacus::internal::horner_polynomial(x, polynomialD1);
     } else if (0.0 <= x && x < 1.0) {
-      return x * abacus::internal::horner_polynomial<abacus_double, 24>(
-                     x, polynomialD2);
+      return x * abacus::internal::horner_polynomial(x, polynomialD2);
     } else if (1.0 <= x && x < 2.0) {
-      return abacus::internal::horner_polynomial<abacus_double, 16>(
-          x - 1.0, polynomialD3);
+      return abacus::internal::horner_polynomial(x - 1.0, polynomialD3);
     } else {
       return __abacus_log(x + 1.0);
     }
@@ -394,18 +390,17 @@ struct helper<T, abacus_double> {
 
     const SignedType cond1 = (x >= -0.5) & (x < 0.0);
     result = __abacus_select(
-        result, x * abacus::internal::horner_polynomial<T, 21>(x, polynomialD1),
+        result, x * abacus::internal::horner_polynomial(x, polynomialD1),
         cond1);
 
     const SignedType cond2 = (x >= 0.0) & (x < 1.0);
     result = __abacus_select(
-        result, x * abacus::internal::horner_polynomial<T, 24>(x, polynomialD2),
+        result, x * abacus::internal::horner_polynomial(x, polynomialD2),
         cond2);
 
     const SignedType cond3 = (x >= 1.0) & (x < 2.0);
     result = __abacus_select(
-        result,
-        abacus::internal::horner_polynomial<T, 16>(x - 1.0, polynomialD3),
+        result, abacus::internal::horner_polynomial(x - 1.0, polynomialD3),
         cond3);
 
     return result;

--- a/modules/compiler/builtins/abacus/source/abacus_math/log2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/log2.cpp
@@ -37,7 +37,7 @@ struct helper<T, abacus_half> {
         4.06640625f16,     -6.3828125f16,      -1.4638671875f16,
     };
 
-    return x * abacus::internal::horner_polynomial<T, 9>(x, polynomial);
+    return x * abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 #endif
@@ -58,7 +58,7 @@ struct helper<T, abacus_float> {
                                          -1.675888001918792724609375E-1f,
                                          9.700144827365875244140625E-2f};
 
-    return x * abacus::internal::horner_polynomial<T, 11>(x, polynomial);
+    return x * abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 
@@ -79,7 +79,7 @@ static ABACUS_CONSTANT abacus_double polynomialD[21] = {
 template <typename T>
 struct helper<T, abacus_double> {
   static T _(const T x) {
-    return x * abacus::internal::horner_polynomial<T, 21>(x, polynomialD);
+    return x * abacus::internal::horner_polynomial(x, polynomialD);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_exp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_exp.cpp
@@ -41,7 +41,7 @@ T native_exp(const T x) {
   const abacus_float polynomial[3] = {1.00172475857779f, .948768609890313f,
                                       .701815635555134f};
 
-  const T twoToTheF = abacus::internal::horner_polynomial<T, 3>(f, polynomial);
+  const T twoToTheF = abacus::internal::horner_polynomial(f, polynomial);
   return abacus::internal::ldexp_unsafe(twoToTheF, k);
 }
 }  // namespace

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_exp10.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_exp10.cpp
@@ -40,7 +40,7 @@ T native_exp10(const T x) {
   const abacus_float polynomial[3] = {1.00172475857780f, 2.18462045783410f,
                                       3.72095499205386f};
 
-  const T twoToTheF = abacus::internal::horner_polynomial<T, 3>(f, polynomial);
+  const T twoToTheF = abacus::internal::horner_polynomial(f, polynomial);
   return abacus::internal::ldexp_unsafe(twoToTheF, k);
 }
 }  // namespace

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_exp2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_exp2.cpp
@@ -36,7 +36,7 @@ T native_exp2(const T x) {
   const abacus_float polynomial[3] = {1.00172475857779f, .657636286949233f,
                                       .337189437317397f};
 
-  const T twoToTheF = abacus::internal::horner_polynomial<T, 3>(f, polynomial);
+  const T twoToTheF = abacus::internal::horner_polynomial(f, polynomial);
   return abacus::internal::ldexp_unsafe(twoToTheF, k);
 }
 }  // namespace

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_log.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_log.cpp
@@ -37,7 +37,7 @@ T native_log(const T x) {
                                       .676185676420138f};
 
   // helper calculates log(f + 1) / f
-  const T logf = abacus::internal::horner_polynomial<T, 3>(f - 1, polynomial);
+  const T logf = abacus::internal::horner_polynomial(f - 1, polynomial);
 
   const T oneOverlog2e = 0.693147180559945309417232121458;
   return f * logf + abacus::detail::cast::convert<T>(n) * oneOverlog2e;

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_log10.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_log10.cpp
@@ -37,7 +37,7 @@ T native_log10(const T x) {
                                       .293663708011290f};
 
   // polynomial calculates log10(f + 1) / f
-  const T log10f = abacus::internal::horner_polynomial<T, 3>(f - 1, polynomial);
+  const T log10f = abacus::internal::horner_polynomial(f - 1, polynomial);
 
   const abacus_float oneOverlog210 = 0.301029995663981195213738894725f;
   return f * log10f + abacus::detail::cast::convert<T>(n) * oneOverlog210;

--- a/modules/compiler/builtins/abacus/source/abacus_math/native_log2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/native_log2.cpp
@@ -40,7 +40,7 @@ T native_log2(const T x) {
   // mycurvefit.com, a simple online tool.
   const abacus_float polynomial[6] = {-3.810813f, 10.26252f,  -14.43957f,
                                       13.39757f,  -6.918097f, 1.508444f};
-  const T log2f = abacus::internal::horner_polynomial<T, 6>(f, polynomial);
+  const T log2f = abacus::internal::horner_polynomial(f, polynomial);
 
   // Make the effort to return NaN and inf in the appropriate cases (x<0 and
   // x==0 repectively).

--- a/modules/compiler/builtins/abacus/source/abacus_math/pown.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/pown.cpp
@@ -167,7 +167,7 @@ struct helper<T, abacus_half> {
 
     // Now a normal exp2 should do the trick:
     // We know that 0 <= n_times_log2X <= 1 so we can just use a polynomial
-    T result = abacus::internal::horner_polynomial<T, 6>(
+    T result = abacus::internal::horner_polynomial(
         n_times_log2X, __codeplay_pown_unsafe_coeffH);
 
     // We do the same trick as for __log2_extra_precision here, using some extra
@@ -178,7 +178,7 @@ struct helper<T, abacus_half> {
     // rules exp(n + remainder) ==> exp(n) * exp(remainder)
     const T remainder_times_log2X =
         mul1_remainder + mul2_remainder + mul3_remainder;
-    const T remainder_poly = abacus::internal::horner_polynomial<T, 6>(
+    const T remainder_poly = abacus::internal::horner_polynomial(
         remainder_times_log2X, __codeplay_pown_unsafe_coeffH);
     result *= remainder_poly;
 
@@ -259,8 +259,8 @@ struct helper<T, abacus_float> {
         log2_hi, log2_lo, xExp_float, n, &exponent_floor);
 
     // 2^x from 0 -> 1
-    T result = abacus::internal::horner_polynomial<T, 6>(exponent_mantissa,
-                                                         __codeplay_pown_coeff);
+    T result = abacus::internal::horner_polynomial(exponent_mantissa,
+                                                   __codeplay_pown_coeff);
 
     result = __abacus_ldexp(result, exponent_floor);
 
@@ -347,10 +347,9 @@ struct helper<T, abacus_double> {
     exponent_mantissa -=
         abacus::detail::cast::convert<T>(trunced_exponent_mantissa);
 
-    T result =
-        (T)1.0 + exponent_mantissa *
-                     abacus::internal::horner_polynomial<T, 18>(
-                         exponent_mantissa, __codeplay_pow_unsafe_coeffD);
+    T result = (T)1.0 + exponent_mantissa * abacus::internal::horner_polynomial(
+                                                exponent_mantissa,
+                                                __codeplay_pow_unsafe_coeffD);
 
     result = __abacus_ldexp(
         result, abacus::detail::cast::convert<IntVecType>(exponent_floor));

--- a/modules/compiler/builtins/abacus/source/abacus_math/rootn.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/rootn.cpp
@@ -37,8 +37,7 @@ struct helper<T, abacus_half> {
 
     const T x_minus_one = x - 1.0f;
 
-    return x_minus_one *
-           abacus::internal::horner_polynomial<T, 7>(x, polynomial);
+    return x_minus_one * abacus::internal::horner_polynomial(x, polynomial);
   }
 
   static T refinement(const T x) {
@@ -47,7 +46,7 @@ struct helper<T, abacus_half> {
     const abacus_half polynomial[4] = {1.0f16, 0.693359375f16, 0.234375f16,
                                        7.177734375e-2f16};
 
-    return abacus::internal::horner_polynomial<T, 4>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 #endif  // __CA_BUILTINS_HALF_SUPPORT
@@ -62,8 +61,7 @@ struct helper<T, abacus_float> {
 
     const T x_minus_one = x - 1.0f;
 
-    return x_minus_one *
-           abacus::internal::horner_polynomial<T, 7>(x, polynomial);
+    return x_minus_one * abacus::internal::horner_polynomial(x, polynomial);
   }
 
   static T refinement(const T x) {
@@ -71,7 +69,7 @@ struct helper<T, abacus_float> {
         .999999925066056f,    .693153073167932f,    .240153617206963f,
         .558263175864784e-1f, .898934063766142e-2f, .187757646702639e-2f};
 
-    return abacus::internal::horner_polynomial<T, 6>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 
@@ -95,7 +93,7 @@ struct helper<T, abacus_double> {
     const T x_minus_one = x - 1.0;
 
     return x_minus_one *
-           abacus::internal::horner_polynomial<T, 19>(x_minus_one, polynomialD);
+           abacus::internal::horner_polynomial(x_minus_one, polynomialD);
   }
 
   static T refinement(const T x) {
@@ -112,7 +110,7 @@ struct helper<T, abacus_double> {
                                           0.6641338398972727973820141e-8,
                                           0.6109234053107283700972839e-9};
 
-    return abacus::internal::horner_polynomial<T, 12>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/sinpi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/sinpi.cpp
@@ -40,7 +40,7 @@ struct helper<T, abacus_half> {
     // multiply_exact / add_exact.
     const abacus_half polynomial[3] = {3.140625f16, -5.13671875f16,
                                        2.298828125f16};
-    const T poly = abacus::internal::horner_polynomial<T, 2>(x, &polynomial[1]);
+    const T poly = abacus::internal::horner_polynomial(x, &polynomial[1], 2);
 
     // Perform last horner_polynomial step by hand.
     T poly_mul_lo;
@@ -67,7 +67,7 @@ struct helper<T, abacus_float> {
                                         +2.5500695377459f, -0.59824115267029f,
                                         +0.77558697671848e-1f};
 
-    return abacus::internal::horner_polynomial<T, 5>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 
@@ -82,7 +82,7 @@ struct helper<T, abacus_double> {
         0.466299691216533729550e-3, -0.219031914477628858710e-4,
         7.69478758985541321889e-7};
 
-    return abacus::internal::horner_polynomial<T, 9>(x, polynomial);
+    return abacus::internal::horner_polynomial(x, polynomial);
   }
 };
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/tan.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/tan.cpp
@@ -50,7 +50,7 @@ struct helper<T, abacus_double> {
         2.0758861431786944948715354363504356e-8,
         -5.9926098258796618469322956805282730e-12};
 
-    const T y = abacus::internal::horner_polynomial<T, 5>(xSq, polynomial);
+    const T y = abacus::internal::horner_polynomial(xSq, polynomial);
     return x * .78539816339744830961566084582040377 +
            x * xSq * .85737772729049709971879473936502462 * y;
   }
@@ -65,7 +65,7 @@ struct helper<T, abacus_double> {
         5.5444607846133240887999568049688666e-7,
         -5.0244514118826496404940417101797213e-10};
 
-    const T y = abacus::internal::horner_polynomial<T, 5>(xSq, polynomial);
+    const T y = abacus::internal::horner_polynomial(xSq, polynomial);
     return xSq * y * .85737772729049709971879473936502462 + 1.0;
   }
 };
@@ -204,7 +204,7 @@ T tan_half(const T x) {
 
   T poly_add_lo = 0;
   const T poly_add_hi = abacus::internal::add_exact(
-      abacus::internal::horner_polynomial<T, 5>(x2, _tan1H),
+      abacus::internal::horner_polynomial(x2, _tan1H),
       poly1_extra_precision_term1, &poly_add_lo);
 
   T tanX = 0;
@@ -233,8 +233,7 @@ T tan_half(const T x) {
   }
 
   // Calculate cot(xReduced):
-  const T cotX =
-      abacus::internal::horner_polynomial<T, 5>(x2, _tan2H) / xReduced;
+  const T cotX = abacus::internal::horner_polynomial(x2, _tan2H) / xReduced;
 
   // Select either tan(xReduced) or cot(xReduced) depending on the section of
   // the unit circle that x resides in. tan has a period of 'pi', so we only

--- a/modules/compiler/builtins/abacus/source/abacus_math/tanpi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/tanpi.cpp
@@ -48,7 +48,7 @@ struct helper<T, abacus_half> {
                                        2.55859375f16, -0.66943359375f16};
     const abacus_half polynomial_0_hi = 3.140625f16;
     return x * (polynomial_0_hi +
-                abacus::internal::horner_polynomial<T, 4>(x * x, polynomial));
+                abacus::internal::horner_polynomial(x * x, polynomial));
   }
 
   static T denominator(const T x) {
@@ -56,7 +56,7 @@ struct helper<T, abacus_half> {
     // See tanpi.sollya
     const abacus_half polynomial[4] = {1.0f16, -4.93359375f16, 4.00390625f16,
                                        -0.74072265625f16};
-    return abacus::internal::horner_polynomial<T, 4>(x * x, polynomial);
+    return abacus::internal::horner_polynomial(x * x, polynomial);
   }
 
   static T handle_edge_cases(const T xAbs, const T ans) {
@@ -97,7 +97,7 @@ struct helper<T, abacus_double> {
         3.6490197133941196023, -4.6200497777346237839, 0.99735716184355045101,
         -0.26253549797567171127e-1};
 
-    return x * abacus::internal::horner_polynomial<T, 4>(x * x, polynomial);
+    return x * abacus::internal::horner_polynomial(x * x, polynomial);
   }
 
   static T denominator(const T x) {
@@ -105,7 +105,7 @@ struct helper<T, abacus_double> {
         1.1615190496528906454, -5.2918520270485559140, 2.6412953506383059363,
         -0.23276806353523888909};
 
-    return abacus::internal::horner_polynomial<T, 4>(x * x, polynomial);
+    return abacus::internal::horner_polynomial(x * x, polynomial);
   }
 
   static T handle_edge_cases(const T, const T ans) { return ans; }

--- a/modules/compiler/builtins/abacus/source/abacus_math/tanpi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/tanpi.cpp
@@ -68,10 +68,8 @@ struct helper<T, abacus_half> {
     // and `add_exact` in the return expression, adding dozens of extra FP16
     // operations. Instead of adding these extra calculations, we handle that
     // case explicitly here.
-    using UnsignedType = typename TypeTraits<T>::UnsignedType;
-    return __abacus_select(ans,
-                           abacus::detail::cast::as<T>(UnsignedType(0x3bbf)),
-                           UnsignedType(xAbs == 0.244873046875f16));
+    using SignedType = typename TypeTraits<T>::SignedType;
+    return __abacus_select(ans, T(0.978027f16), SignedType(xAbs == 0.24646f16));
   }
 };
 #endif  // __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/tgamma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/tgamma.cpp
@@ -186,50 +186,38 @@ abacus_half ABACUS_API __abacus_tgamma(abacus_half x) {
   switch (x_ushort) {
     default:
       break;
-    case 0x3F5E:  // 1.841796875f16
-      return 0.943359375f16;
-    case 0x3FC1:  // 1.9384765625f16
-      return 0.9755859375f16;
     case 0x4530:  // 5.1875f16
       return 31.953125f16;
-    case 0xB58D:  // -0.346923828125f16
-      return -3.974609375f16;
-    case 0xB6E9:  // -0.431884765625f16
-      return -3.62890625f16;
-    case 0xBAE3:  // -0.86083984375f16
-      return -7.8203125f16;
-    case 0xBF5E:  // -1.841796875f16
-      return 3.79296875f16;
-    case 0xC0F3:  // -2.474609375f16
-      return -0.97509765625f16;
-    case 0xC135:  // -2.603515625f16
-      return -0.88818359375f16;
-    case 0xC144:  // -2.6328125f16
-      return -0.890625f16;
-    case 0xC17D:  // -2.744140625f16
-      return -0.9931640625f16;
-    case 0xC28E:  // -3.27734375f16
-      return 0.477783203125f16;
-    case 0xC351:  // -3.658203125f16
-      return 0.245849609375f16;
-    case 0xC361:  // -3.689453125f16
-      return 0.2496337890625f16;
-    case 0xC534:  // -5.203125f16
-      return 0.0309600830078125f16;
-    case 0xC5FA:  // -5.9765625f16
-      return 0.061981201171875f16;
-    case 0xC67B:  // -6.48046875f16
-      return -0.00174713134765625f16;
-    case 0xC69D:  // -6.61328125f16
-      return -0.00143527984619140625f16;
-    case 0xC6D9:  // -6.84765625f16
-      return -0.0018367767333984375f16;
-    case 0xC718:  // -7.09375f16
-      return 0.00177669525146484375f16;
-    case 0xC786:  // -7.5234375f16
-      return 0.00021374225616455078125f16;
-    case 0xC7D3:  // -7.82421875f16
-      return 0.000216007232666015625f16;
+    case 0xb5e9:  // -0.369385f16
+      return -3.85156f16;
+    case 0xb6c8:  // -0.423828f16
+      return -3.64844f16;
+    case 0xb6e9:  // -0.431885f16
+      return -3.62891f16;
+    case 0xb7cb:  // -0.487061f16
+      return -3.54883f16;
+    case 0xb834:  // -0.525391f16
+      return -3.55273f16;
+    case 0xbade:  // -0.858398f16
+      return -7.69922f16;
+    case 0xbfd4:  // -1.95703f16
+      return 12.1406f16;
+    case 0xc0f3:  // -2.47461f16
+      return -0.975098f16;
+    case 0xc135:  // -2.60352f16
+      return -0.888184f16;
+    case 0xc586:  // -5.52344f16
+      return 0.0104904f16;
+    case 0xc5e1:  // -5.87891f16
+      return 0.0147247f16;
+    case 0xc5fa:  // -5.97656f16
+      return 0.0619812f16;
+    case 0xc67b:  // -6.48047f16
+      return -0.00174713f16;
+    case 0xc69d:  // -6.61328f16
+      return -0.00143528f16;
+    case 0xc814:  // -8.15625f16
+      return -0.000118136f16;
   }
 
   const abacus_half xAbs = __abacus_fabs(x);

--- a/modules/compiler/builtins/abacus/source/abacus_math/tgamma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/tgamma.cpp
@@ -72,33 +72,33 @@ abacus_half tgamma_poly(abacus_half x, abacus_half *exp_neg_x,
     // over range [0.5, 1]
     const abacus_half coeffs[4] = {4.9140625f16, -6.76171875f16, 6.5390625f16,
                                    -1.974609375f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   } else if (x < 1.6f16) {
     // Polynomial approximation of gamma(x) / (exp(-x) * x^((0.5 * x) - 0.25))
     // over range [1, 1.6]
     const abacus_half coeffs[4] = {3.326171875f16, -1.673828125f16,
                                    1.0390625f16, 2.6641845703125e-2f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   } else if (x < 1.7998f16) {
     // Polynomial approximation of gamma(x) / (exp(-x) * x^((0.5 * x) - 0.25))
     // over range [1.6, 1.8]
     const abacus_half coeffs[4] = {2.099609375f16, 0.751953125f16,
                                    -0.56494140625f16, 0.381103515625f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   } else if (x < 3.0f16) {
     // Polynomial approximation of gamma(x) / (exp(-x) * x^(x - 0.5))
     // over range [1.8, 3]
     const abacus_half coeffs[4] = {2.87890625f16, -0.2421875f16,
                                    6.9091796875e-2f16,
                                    -7.305145263671875e-3f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   } else if (x < 6.0f16) {
     // Polynomial approximation of gamma(x) / (exp(-x) * x^(x - 0.5))
     // over range [3, 6]
     const abacus_half coeffs[4] = {2.708984375f16, -7.110595703125e-2f16,
                                    1.08489990234375e-2f16,
                                    -6.07967376708984375e-4f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   } else {
     // Polynomial approximation of gamma(x) / (exp(-x) * x^(x - 2))
     // over range [6, 9.2]
@@ -109,7 +109,7 @@ abacus_half tgamma_poly(abacus_half x, abacus_half *exp_neg_x,
     *pow_sqrt = __abacus_powr(x, (x - 2.0f16) * 0.5f16);
     const abacus_half coeffs[4] = {-2.876953125f16, 3.875f16, 0.5185546875f16,
                                    -7.808685302734375e-3f16};
-    return abacus::internal::horner_polynomial<abacus_half, 4>(x, coeffs);
+    return abacus::internal::horner_polynomial(x, coeffs);
   }
 }
 

--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -417,7 +417,13 @@ struct HalfMathBuiltinsPow : HalfMathBuiltins {
   const std::vector<cl_ushort> &GetEdgeCases() const override {
     static const std::vector<cl_ushort> EdgeCases = [&] {
       std::vector<cl_ushort> EdgeCases = HalfMathBuiltins::GetEdgeCases();
+      // 0x39f6 is singled out as a special case in log2_extended_precision.
       EdgeCases.push_back(0x39f6);
+      // pow(0x39f0, 0xd00e) is just one example where evaluating
+      // horner_polynomial without FMA gives results with insufficient
+      // precision.
+      EdgeCases.push_back(0x39f0);
+      EdgeCases.push_back(0xd00e);
       return EdgeCases;
     }();
     return EdgeCases;


### PR DESCRIPTION
# Overview

Improve precision of horner_polynomial

# Reason for change

We were previously implicitly relying on LLVM's behaviour of promoting f16 operations to f32 and getting extra precision that amounts to getting the same results as FMA. We never did that consistently (it varied between platforms) and we now consistently do not do that, resulting in incorrect results for at least half-precision pow. Use FMA to fix that.

# Description of change

This MR consists of two commits that are not intended to be squashed, and are best reviewed separately. There is a large mostly mechanical NFC commit to simplify how `horner_polynomial` is used, followed by a small commit that fixes its implementation.

# Anything else we should know?

With this change, we pass OpenCL CTS `fp16-staging` branch's testing for half-precision `pow`.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
