### PR TITLE
Fix powr and re-enable test.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_math/powr.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/powr.cpp
@@ -45,12 +45,14 @@ inline T powr(const T x, const T y) {
   result =
       __abacus_select(result, bit, SignedType(xIsInf | yIsInf | (x == 0.0f)));
 
-  // Return for any input where y is zero
-  result = __abacus_select(result, T(1.0), SignedType(y == 0.0f));
+  // Return 1 for any input where x is 1 or y is zero and we do not subsequently
+  // change it to NaN.
+  result =
+      __abacus_select(result, T(1.0f), SignedType((x == 1.0f) | (y == 0.0f)));
 
-  // Return NAN in the following conditions:
-  // * x is NAN
-  // * y is NAN
+  // Return NaN in the following conditions:
+  // * x is NaN
+  // * y is NaN
   // * x is less than zero
   // * x is +/- zero and y is +/- zero
   // * x is INFINITY and y is +/- zero

--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -1807,8 +1807,7 @@ TEST_P(HalfMathBuiltinsPow, Precision_80_Half_pow) {
   TestAgainstRef<4_ULP>(pow_ref);
 }
 
-// TODO: OCK-523
-TEST_P(HalfMathBuiltinsPow, DISABLED_Precision_81_Half_powr) {
+TEST_P(HalfMathBuiltinsPow, Precision_81_Half_powr) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }


### PR DESCRIPTION
# Overview

Fix powr and re-enable test.

# Reason for change

We already treat 1 as a special case in pow(). If we treat it as a special case in powr() too, that looks to be sufficient to avoid errors caused by internal overflow.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
