### PR TITLE
[NFC] Build Abacus in C++17 mode.

### DIFF
--- a/modules/compiler/builtins/abacus/generate/abacus_config/abacus_config.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_config/abacus_config.in
@@ -28,11 +28,11 @@
   #endif
 
   #if __has_attribute(overloadable)
-    #define ABACUS_API __attribute__((overloadable))
-    #define ABACUS_EXPORT_API __attribute__((overloadable, visibility("hidden")))
+    #define ABACUS_API __attribute__((overloadable, nothrow))
+    #define ABACUS_EXPORT_API __attribute__((overloadable, nothrow, visibility("hidden")))
   #else
-    #define ABACUS_API
-    #define ABACUS_EXPORT_API __attribute__((visibility("hidden")))
+    #define ABACUS_API __attribute__((nothrow))
+    #define ABACUS_EXPORT_API __attribute__((nothrow, visibility("hidden")))
   #endif
 #elif defined(__cplusplus)
   #ifdef _MSC_VER
@@ -48,8 +48,8 @@
 
     #define ABACUS_API ABACUS_EXPORT_API
   #else
-    #define ABACUS_API
-    #define ABACUS_EXPORT_API __attribute__((visibility("default")))
+    #define ABACUS_API __attribute__((nothrow))
+    #define ABACUS_EXPORT_API __attribute__((nothrow, visibility("default")))
   #endif
 #else
   #error Abacus only support C++ and OpenCL compilation!

--- a/modules/compiler/builtins/abacus/generate/abacus_config/generate.cmakescript
+++ b/modules/compiler/builtins/abacus/generate/abacus_config/generate.cmakescript
@@ -4,6 +4,4 @@ if(NOT DEFINED GENERATE_OUTPUT_FILE)
   )
 endif()
 
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/abacus_config.in" abacus_config)
-string(CONFIGURE "${abacus_config}" abacus_config @ONLY)
-file(WRITE "${GENERATE_OUTPUT_FILE}" "${abacus_config}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/abacus_config.in" "${GENERATE_OUTPUT_FILE}" @ONLY)

--- a/modules/compiler/builtins/abacus/include/abacus/internal/convert_helper.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/convert_helper.h
@@ -782,40 +782,46 @@ T convert_sat_rtp(const U &u) {
 }
 }  // namespace
 
-#define DEF_WITH_BOTH_TYPES(IN_TYPE, OUT_TYPE)                              \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE(abacus_##IN_TYPE x) {       \
-    return convert<abacus_##OUT_TYPE>(x);                                   \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_rte(abacus_##IN_TYPE x) { \
-    return convert_rte<abacus_##OUT_TYPE>(x);                               \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_rtn(abacus_##IN_TYPE x) { \
-    return convert_rtn<abacus_##OUT_TYPE>(x);                               \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_rtz(abacus_##IN_TYPE x) { \
-    return convert_rtz<abacus_##OUT_TYPE>(x);                               \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_rtp(abacus_##IN_TYPE x) { \
-    return convert_rtp<abacus_##OUT_TYPE>(x);                               \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_sat(abacus_##IN_TYPE x) { \
-    return convert_sat<abacus_##OUT_TYPE>(x);                               \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_sat_rte(                  \
-      abacus_##IN_TYPE x) {                                                 \
-    return convert_sat_rte<abacus_##OUT_TYPE>(x);                           \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_sat_rtn(                  \
-      abacus_##IN_TYPE x) {                                                 \
-    return convert_sat_rtn<abacus_##OUT_TYPE>(x);                           \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_sat_rtz(                  \
-      abacus_##IN_TYPE x) {                                                 \
-    return convert_sat_rtz<abacus_##OUT_TYPE>(x);                           \
-  }                                                                         \
-  abacus_##OUT_TYPE __abacus_convert_##OUT_TYPE##_sat_rtp(                  \
-      abacus_##IN_TYPE x) {                                                 \
-    return convert_sat_rtp<abacus_##OUT_TYPE>(x);                           \
+#define DEF_WITH_BOTH_TYPES(IN_TYPE, OUT_TYPE)                        \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE(           \
+      abacus_##IN_TYPE x) {                                           \
+    return convert<abacus_##OUT_TYPE>(x);                             \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_rte(     \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_rte<abacus_##OUT_TYPE>(x);                         \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_rtn(     \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_rtn<abacus_##OUT_TYPE>(x);                         \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_rtz(     \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_rtz<abacus_##OUT_TYPE>(x);                         \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_rtp(     \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_rtp<abacus_##OUT_TYPE>(x);                         \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_sat(     \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_sat<abacus_##OUT_TYPE>(x);                         \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_sat_rte( \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_sat_rte<abacus_##OUT_TYPE>(x);                     \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_sat_rtn( \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_sat_rtn<abacus_##OUT_TYPE>(x);                     \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_sat_rtz( \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_sat_rtz<abacus_##OUT_TYPE>(x);                     \
+  }                                                                   \
+  abacus_##OUT_TYPE ABACUS_API __abacus_convert_##OUT_TYPE##_sat_rtp( \
+      abacus_##IN_TYPE x) {                                           \
+    return convert_sat_rtp<abacus_##OUT_TYPE>(x);                     \
   }
 
 #define DEF_INTERGRAL_TYPES(TYPE, SIZE)         \

--- a/modules/compiler/builtins/abacus/source/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/source/CMakeLists.txt
@@ -56,8 +56,6 @@ if(COMMAND add_ca_tidy)
   endif()
 endif()
 
-set_property(TARGET abacus_static PROPERTY CXX_STANDARD 11)
-
 target_include_directories(abacus_static PUBLIC
   ${CMAKE_BINARY_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/../include)
@@ -200,7 +198,7 @@ target datalayout = \"e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:
       set(DEPFILE_ARGS -dependency-file "${OUTPUT}.d" -MT "${OUTPUT}" -sys-header-deps)
       if(SOURCE_TYPE STREQUAL ".cpp")
         set(XTYPE "c++")
-        set(XOPTS "-std=c++11")
+        set(XOPTS "-std=c++17")
       elseif(SOURCE_TYPE STREQUAL ".cl")
         set(XTYPE "cl")
         set(XOPTS "-cl-std=CL1.2")

--- a/modules/compiler/builtins/abacus/source/abacus_common/clamp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/clamp.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                                  \
-  TYPE __abacus_clamp(TYPE x, TYPE y, TYPE z) {    \
-    return abacus::detail::common::clamp(x, y, z); \
+#define DEF(TYPE)                                          \
+  TYPE ABACUS_API __abacus_clamp(TYPE x, TYPE y, TYPE z) { \
+    return abacus::detail::common::clamp(x, y, z);         \
   }
-#define DEF2(TYPE, TYPE2)                          \
-  TYPE __abacus_clamp(TYPE x, TYPE2 y, TYPE2 z) {  \
-    return abacus::detail::common::clamp(x, y, z); \
+#define DEF2(TYPE, TYPE2)                                    \
+  TYPE ABACUS_API __abacus_clamp(TYPE x, TYPE2 y, TYPE2 z) { \
+    return abacus::detail::common::clamp(x, y, z);           \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/degrees.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/degrees.cpp
@@ -17,8 +17,10 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE) \
-  TYPE __abacus_degrees(TYPE x) { return abacus::detail::common::degrees(x); }
+#define DEF(TYPE)                              \
+  TYPE ABACUS_API __abacus_degrees(TYPE x) {   \
+    return abacus::detail::common::degrees(x); \
+  }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
 DEF(abacus_half);

--- a/modules/compiler/builtins/abacus/source/abacus_common/max.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/max.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                             \
-  TYPE __abacus_max(TYPE x, TYPE y) {         \
-    return abacus::detail::common::max(x, y); \
+#define DEF(TYPE)                                \
+  TYPE ABACUS_API __abacus_max(TYPE x, TYPE y) { \
+    return abacus::detail::common::max(x, y);    \
   }
-#define DEF2(TYPE, TYPE2)                     \
-  TYPE __abacus_max(TYPE x, TYPE2 y) {        \
-    return abacus::detail::common::max(x, y); \
+#define DEF2(TYPE, TYPE2)                         \
+  TYPE ABACUS_API __abacus_max(TYPE x, TYPE2 y) { \
+    return abacus::detail::common::max(x, y);     \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/min.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/min.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                             \
-  TYPE __abacus_min(TYPE x, TYPE y) {         \
-    return abacus::detail::common::min(x, y); \
+#define DEF(TYPE)                                \
+  TYPE ABACUS_API __abacus_min(TYPE x, TYPE y) { \
+    return abacus::detail::common::min(x, y);    \
   }
-#define DEF2(TYPE, TYPE2)                     \
-  TYPE __abacus_min(TYPE x, TYPE2 y) {        \
-    return abacus::detail::common::min(x, y); \
+#define DEF2(TYPE, TYPE2)                         \
+  TYPE ABACUS_API __abacus_min(TYPE x, TYPE2 y) { \
+    return abacus::detail::common::min(x, y);     \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/mix.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/mix.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                                \
-  TYPE __abacus_mix(TYPE x, TYPE y, TYPE a) {    \
-    return abacus::detail::common::mix(x, y, a); \
+#define DEF(TYPE)                                        \
+  TYPE ABACUS_API __abacus_mix(TYPE x, TYPE y, TYPE a) { \
+    return abacus::detail::common::mix(x, y, a);         \
   }
-#define DEF2(TYPE, TYPE2)                        \
-  TYPE __abacus_mix(TYPE x, TYPE y, TYPE2 a) {   \
-    return abacus::detail::common::mix(x, y, a); \
+#define DEF2(TYPE, TYPE2)                                 \
+  TYPE ABACUS_API __abacus_mix(TYPE x, TYPE y, TYPE2 a) { \
+    return abacus::detail::common::mix(x, y, a);          \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/radians.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/radians.cpp
@@ -17,8 +17,10 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE) \
-  TYPE __abacus_radians(TYPE x) { return abacus::detail::common::radians(x); }
+#define DEF(TYPE)                              \
+  TYPE ABACUS_API __abacus_radians(TYPE x) {   \
+    return abacus::detail::common::radians(x); \
+  }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
 DEF(abacus_half);

--- a/modules/compiler/builtins/abacus/source/abacus_common/sign.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/sign.cpp
@@ -17,8 +17,10 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE) \
-  TYPE __abacus_sign(TYPE x) { return abacus::detail::common::sign(x); }
+#define DEF(TYPE)                           \
+  TYPE ABACUS_API __abacus_sign(TYPE x) {   \
+    return abacus::detail::common::sign(x); \
+  }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
 DEF(abacus_half);

--- a/modules/compiler/builtins/abacus/source/abacus_common/smoothstep.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/smoothstep.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                                         \
-  TYPE __abacus_smoothstep(TYPE e0, TYPE e1, TYPE x) {    \
-    return abacus::detail::common::smoothstep(e0, e1, x); \
+#define DEF(TYPE)                                                 \
+  TYPE ABACUS_API __abacus_smoothstep(TYPE e0, TYPE e1, TYPE x) { \
+    return abacus::detail::common::smoothstep(e0, e1, x);         \
   }
-#define DEF2(TYPE, TYPE2)                                 \
-  TYPE __abacus_smoothstep(TYPE2 e0, TYPE2 e1, TYPE x) {  \
-    return abacus::detail::common::smoothstep(e0, e1, x); \
+#define DEF2(TYPE, TYPE2)                                           \
+  TYPE ABACUS_API __abacus_smoothstep(TYPE2 e0, TYPE2 e1, TYPE x) { \
+    return abacus::detail::common::smoothstep(e0, e1, x);           \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/step.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/step.cpp
@@ -17,13 +17,13 @@
 #include <abacus/abacus_common.h>
 #include <abacus/abacus_detail_common.h>
 
-#define DEF(TYPE)                              \
-  TYPE __abacus_step(TYPE e, TYPE x) {         \
-    return abacus::detail::common::step(e, x); \
+#define DEF(TYPE)                                 \
+  TYPE ABACUS_API __abacus_step(TYPE e, TYPE x) { \
+    return abacus::detail::common::step(e, x);    \
   }
-#define DEF2(TYPE, TYPE2)                      \
-  TYPE __abacus_step(TYPE2 e, TYPE x) {        \
-    return abacus::detail::common::step(e, x); \
+#define DEF2(TYPE, TYPE2)                          \
+  TYPE ABACUS_API __abacus_step(TYPE2 e, TYPE x) { \
+    return abacus::detail::common::step(e, x);     \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/cross.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/cross.cpp
@@ -18,7 +18,7 @@
 #include <abacus/abacus_geometric.h>
 
 #define DEF(TYPE)                                  \
-  TYPE __abacus_cross(TYPE x, TYPE y) {            \
+  TYPE ABACUS_API __abacus_cross(TYPE x, TYPE y) { \
     return abacus::detail::geometric::cross(x, y); \
   }
 

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/distance.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/distance.cpp
@@ -17,9 +17,9 @@
 #include <abacus/abacus_detail_geometric.h>
 #include <abacus/abacus_geometric.h>
 
-#define DEF(TYPE)                                                   \
-  TypeTraits<TYPE>::ElementType __abacus_distance(TYPE x, TYPE y) { \
-    return abacus::detail::geometric::distance(x, y);               \
+#define DEF(TYPE)                                                              \
+  TypeTraits<TYPE>::ElementType ABACUS_API __abacus_distance(TYPE x, TYPE y) { \
+    return abacus::detail::geometric::distance(x, y);                          \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/dot.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/dot.cpp
@@ -17,9 +17,9 @@
 #include <abacus/abacus_detail_geometric.h>
 #include <abacus/abacus_geometric.h>
 
-#define DEF(TYPE)                                              \
-  TypeTraits<TYPE>::ElementType __abacus_dot(TYPE x, TYPE y) { \
-    return abacus::detail::geometric::dot(x, y);               \
+#define DEF(TYPE)                                                         \
+  TypeTraits<TYPE>::ElementType ABACUS_API __abacus_dot(TYPE x, TYPE y) { \
+    return abacus::detail::geometric::dot(x, y);                          \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_distance.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_distance.cpp
@@ -17,9 +17,10 @@
 #include <abacus/abacus_detail_geometric.h>
 #include <abacus/abacus_geometric.h>
 
-#define DEF(TYPE)                                                        \
-  TypeTraits<TYPE>::ElementType __abacus_fast_distance(TYPE x, TYPE y) { \
-    return abacus::detail::geometric::fast_distance(x, y);               \
+#define DEF(TYPE)                                                           \
+  TypeTraits<TYPE>::ElementType ABACUS_API __abacus_fast_distance(TYPE x,   \
+                                                                  TYPE y) { \
+    return abacus::detail::geometric::fast_distance(x, y);                  \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_length.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_length.cpp
@@ -17,9 +17,9 @@
 #include <abacus/abacus_detail_geometric.h>
 #include <abacus/abacus_geometric.h>
 
-#define DEF(TYPE)                                              \
-  TypeTraits<TYPE>::ElementType __abacus_fast_length(TYPE x) { \
-    return abacus::detail::geometric::fast_length(x);          \
+#define DEF(TYPE)                                                         \
+  TypeTraits<TYPE>::ElementType ABACUS_API __abacus_fast_length(TYPE x) { \
+    return abacus::detail::geometric::fast_length(x);                     \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_normalize.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_normalize.cpp
@@ -18,7 +18,7 @@
 #include <abacus/abacus_geometric.h>
 
 #define DEF(TYPE)                                        \
-  TYPE __abacus_fast_normalize(TYPE x) {                 \
+  TYPE ABACUS_API __abacus_fast_normalize(TYPE x) {      \
     return abacus::detail::geometric::fast_normalize(x); \
   }
 

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/length.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/length.cpp
@@ -17,9 +17,9 @@
 #include <abacus/abacus_detail_geometric.h>
 #include <abacus/abacus_geometric.h>
 
-#define DEF(TYPE)                                         \
-  TypeTraits<TYPE>::ElementType __abacus_length(TYPE x) { \
-    return abacus::detail::geometric::length(x);          \
+#define DEF(TYPE)                                                    \
+  TypeTraits<TYPE>::ElementType ABACUS_API __abacus_length(TYPE x) { \
+    return abacus::detail::geometric::length(x);                     \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/normalize.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/normalize.cpp
@@ -18,7 +18,7 @@
 #include <abacus/abacus_geometric.h>
 
 #define SCALAR_DEF(TYPE)                                  \
-  TYPE __abacus_normalize(TYPE x) {                       \
+  TYPE ABACUS_API __abacus_normalize(TYPE x) {            \
     if (x == static_cast<TYPE>(0) || __abacus_isnan(x)) { \
       return x;                                           \
     }                                                     \
@@ -26,7 +26,7 @@
   }
 
 #define DEF(TYPE)                                   \
-  TYPE __abacus_normalize(TYPE x) {                 \
+  TYPE ABACUS_API __abacus_normalize(TYPE x) {      \
     return abacus::detail::geometric::normalize(x); \
   }
 

--- a/modules/compiler/builtins/abacus/source/abacus_integer/add_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/add_sat.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                  \
-  TYPE __abacus_add_sat(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::add_sat(x, y); \
+#define DEF(TYPE)                                    \
+  TYPE ABACUS_API __abacus_add_sat(TYPE x, TYPE y) { \
+    return abacus::detail::integer::add_sat(x, y);   \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/clamp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/clamp.cpp
@@ -16,13 +16,13 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                   \
-  TYPE __abacus_clamp(TYPE x, TYPE y, TYPE z) {     \
-    return abacus::detail::integer::clamp(x, y, z); \
+#define DEF(TYPE)                                          \
+  TYPE ABACUS_API __abacus_clamp(TYPE x, TYPE y, TYPE z) { \
+    return abacus::detail::integer::clamp(x, y, z);        \
   }
-#define DEF2(TYPE, TYPE2)                           \
-  TYPE __abacus_clamp(TYPE x, TYPE2 y, TYPE2 z) {   \
-    return abacus::detail::integer::clamp(x, y, z); \
+#define DEF2(TYPE, TYPE2)                                    \
+  TYPE ABACUS_API __abacus_clamp(TYPE x, TYPE2 y, TYPE2 z) { \
+    return abacus::detail::integer::clamp(x, y, z);          \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/hadd.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/hadd.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                               \
-  TYPE __abacus_hadd(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::hadd(x, y); \
+#define DEF(TYPE)                                 \
+  TYPE ABACUS_API __abacus_hadd(TYPE x, TYPE y) { \
+    return abacus::detail::integer::hadd(x, y);   \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad24.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad24.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                   \
-  TYPE __abacus_mad24(TYPE x, TYPE y, TYPE z) {     \
-    return abacus::detail::integer::mad24(x, y, z); \
+#define DEF(TYPE)                                          \
+  TYPE ABACUS_API __abacus_mad24(TYPE x, TYPE y, TYPE z) { \
+    return abacus::detail::integer::mad24(x, y, z);        \
   }
 
 DEF(abacus_int);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad_hi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad_hi.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                    \
-  TYPE __abacus_mad_hi(TYPE x, TYPE y, TYPE z) {     \
-    return abacus::detail::integer::mad_hi(x, y, z); \
+#define DEF(TYPE)                                           \
+  TYPE ABACUS_API __abacus_mad_hi(TYPE x, TYPE y, TYPE z) { \
+    return abacus::detail::integer::mad_hi(x, y, z);        \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
@@ -348,8 +348,10 @@ abacus_ulong16 mad_sat(const abacus_ulong16 x, const abacus_ulong16 y,
 }
 }  // namespace
 
-#define DEF(TYPE) \
-  TYPE __abacus_mad_sat(TYPE x, TYPE y, TYPE z) { return mad_sat<>(x, y, z); }
+#define DEF(TYPE)                                            \
+  TYPE ABACUS_API __abacus_mad_sat(TYPE x, TYPE y, TYPE z) { \
+    return mad_sat<>(x, y, z);                               \
+  }
 
 DEF(abacus_char);
 DEF(abacus_char2);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/max.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/max.cpp
@@ -16,13 +16,13 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                              \
-  TYPE __abacus_max(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::max(x, y); \
+#define DEF(TYPE)                                \
+  TYPE ABACUS_API __abacus_max(TYPE x, TYPE y) { \
+    return abacus::detail::integer::max(x, y);   \
   }
-#define DEF2(TYPE, TYPE2)                      \
-  TYPE __abacus_max(TYPE x, TYPE2 y) {         \
-    return abacus::detail::integer::max(x, y); \
+#define DEF2(TYPE, TYPE2)                         \
+  TYPE ABACUS_API __abacus_max(TYPE x, TYPE2 y) { \
+    return abacus::detail::integer::max(x, y);    \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/min.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/min.cpp
@@ -16,13 +16,13 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                              \
-  TYPE __abacus_min(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::min(x, y); \
+#define DEF(TYPE)                                \
+  TYPE ABACUS_API __abacus_min(TYPE x, TYPE y) { \
+    return abacus::detail::integer::min(x, y);   \
   }
-#define DEF2(TYPE, TYPE2)                      \
-  TYPE __abacus_min(TYPE x, TYPE2 y) {         \
-    return abacus::detail::integer::min(x, y); \
+#define DEF2(TYPE, TYPE2)                         \
+  TYPE ABACUS_API __abacus_min(TYPE x, TYPE2 y) { \
+    return abacus::detail::integer::min(x, y);    \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mul24.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mul24.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                \
-  TYPE __abacus_mul24(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::mul24(x, y); \
+#define DEF(TYPE)                                  \
+  TYPE ABACUS_API __abacus_mul24(TYPE x, TYPE y) { \
+    return abacus::detail::integer::mul24(x, y);   \
   }
 
 DEF(abacus_int);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mul_hi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mul_hi.cpp
@@ -47,7 +47,7 @@ T mul_hi(const T x, const T y) {
 }  // namespace
 
 #define DEF(TYPE) \
-  TYPE __abacus_mul_hi(TYPE x, TYPE y) { return mul_hi<TYPE>(x, y); }
+  TYPE ABACUS_API __abacus_mul_hi(TYPE x, TYPE y) { return mul_hi<TYPE>(x, y); }
 
 DEF(abacus_char);
 DEF(abacus_char2);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/rhadd.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/rhadd.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                \
-  TYPE __abacus_rhadd(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::rhadd(x, y); \
+#define DEF(TYPE)                                  \
+  TYPE ABACUS_API __abacus_rhadd(TYPE x, TYPE y) { \
+    return abacus::detail::integer::rhadd(x, y);   \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/rotate.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/rotate.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                 \
-  TYPE __abacus_rotate(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::rotate(x, y); \
+#define DEF(TYPE)                                   \
+  TYPE ABACUS_API __abacus_rotate(TYPE x, TYPE y) { \
+    return abacus::detail::integer::rotate(x, y);   \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/sub_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/sub_sat.cpp
@@ -16,9 +16,9 @@
 
 #include <abacus/abacus_detail_integer.h>
 
-#define DEF(TYPE)                                  \
-  TYPE __abacus_sub_sat(TYPE x, TYPE y) {          \
-    return abacus::detail::integer::sub_sat(x, y); \
+#define DEF(TYPE)                                    \
+  TYPE ABACUS_API __abacus_sub_sat(TYPE x, TYPE y) { \
+    return abacus::detail::integer::sub_sat(x, y);   \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_integer/upsample.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/upsample.cpp
@@ -17,10 +17,10 @@
 #include <abacus/abacus_detail_integer.h>
 #include <abacus/abacus_type_traits.h>
 
-#define DEF(TYPE)                                     \
-  TypeTraits<TYPE>::LargerType __abacus_upsample(     \
-      TYPE x, TypeTraits<TYPE>::UnsignedType y) {     \
-    return abacus::detail::integer::upsample<>(x, y); \
+#define DEF(TYPE)                                            \
+  TypeTraits<TYPE>::LargerType ABACUS_API __abacus_upsample( \
+      TYPE x, TypeTraits<TYPE>::UnsignedType y) {            \
+    return abacus::detail::integer::upsample<>(x, y);        \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
@@ -115,7 +115,7 @@ static ABACUS_CONSTANT abacus_float intervals[16] = {
     ABACUS_INFINITY, 0.9999f, 0.998f, 0.97f, 0.93f, 0.895f, 0.85f, 0.77f,
     0.71f,           0.62f,   0.53f,  0.42f, 0.35f, 0.25f,  0.16f, 0.07f};
 
-abacus_float __abacus_asin(abacus_float x) {
+abacus_float ABACUS_API __abacus_asin(abacus_float x) {
   if (__abacus_isinf(x)) {
     return __abacus_copysign(ABACUS_NAN, x);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
@@ -120,7 +120,7 @@ static ABACUS_CONSTANT abacus_float intervals[16] = {ABACUS_INFINITY,
                                                      .3f,
                                                      .12f};
 
-abacus_float __abacus_asinh(abacus_float x) {
+abacus_float ABACUS_API __abacus_asinh(abacus_float x) {
   if (__abacus_isftz() && abacus::internal::is_denorm(x)) {
     return x;
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/ceil.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/ceil.cpp
@@ -90,26 +90,28 @@ T ceil(const T x) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_half __abacus_ceil(abacus_half x) { return ceil<>(x); }
-abacus_half2 __abacus_ceil(abacus_half2 x) { return ceil<>(x); }
-abacus_half3 __abacus_ceil(abacus_half3 x) { return ceil<>(x); }
-abacus_half4 __abacus_ceil(abacus_half4 x) { return ceil<>(x); }
-abacus_half8 __abacus_ceil(abacus_half8 x) { return ceil<>(x); }
-abacus_half16 __abacus_ceil(abacus_half16 x) { return ceil<>(x); }
+abacus_half ABACUS_API __abacus_ceil(abacus_half x) { return ceil<>(x); }
+abacus_half2 ABACUS_API __abacus_ceil(abacus_half2 x) { return ceil<>(x); }
+abacus_half3 ABACUS_API __abacus_ceil(abacus_half3 x) { return ceil<>(x); }
+abacus_half4 ABACUS_API __abacus_ceil(abacus_half4 x) { return ceil<>(x); }
+abacus_half8 ABACUS_API __abacus_ceil(abacus_half8 x) { return ceil<>(x); }
+abacus_half16 ABACUS_API __abacus_ceil(abacus_half16 x) { return ceil<>(x); }
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-abacus_float __abacus_ceil(abacus_float x) { return ceil<>(x); }
-abacus_float2 __abacus_ceil(abacus_float2 x) { return ceil<>(x); }
-abacus_float3 __abacus_ceil(abacus_float3 x) { return ceil<>(x); }
-abacus_float4 __abacus_ceil(abacus_float4 x) { return ceil<>(x); }
-abacus_float8 __abacus_ceil(abacus_float8 x) { return ceil<>(x); }
-abacus_float16 __abacus_ceil(abacus_float16 x) { return ceil<>(x); }
+abacus_float ABACUS_API __abacus_ceil(abacus_float x) { return ceil<>(x); }
+abacus_float2 ABACUS_API __abacus_ceil(abacus_float2 x) { return ceil<>(x); }
+abacus_float3 ABACUS_API __abacus_ceil(abacus_float3 x) { return ceil<>(x); }
+abacus_float4 ABACUS_API __abacus_ceil(abacus_float4 x) { return ceil<>(x); }
+abacus_float8 ABACUS_API __abacus_ceil(abacus_float8 x) { return ceil<>(x); }
+abacus_float16 ABACUS_API __abacus_ceil(abacus_float16 x) { return ceil<>(x); }
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-abacus_double __abacus_ceil(abacus_double x) { return ceil<>(x); }
-abacus_double2 __abacus_ceil(abacus_double2 x) { return ceil<>(x); }
-abacus_double3 __abacus_ceil(abacus_double3 x) { return ceil<>(x); }
-abacus_double4 __abacus_ceil(abacus_double4 x) { return ceil<>(x); }
-abacus_double8 __abacus_ceil(abacus_double8 x) { return ceil<>(x); }
-abacus_double16 __abacus_ceil(abacus_double16 x) { return ceil<>(x); }
+abacus_double ABACUS_API __abacus_ceil(abacus_double x) { return ceil<>(x); }
+abacus_double2 ABACUS_API __abacus_ceil(abacus_double2 x) { return ceil<>(x); }
+abacus_double3 ABACUS_API __abacus_ceil(abacus_double3 x) { return ceil<>(x); }
+abacus_double4 ABACUS_API __abacus_ceil(abacus_double4 x) { return ceil<>(x); }
+abacus_double8 ABACUS_API __abacus_ceil(abacus_double8 x) { return ceil<>(x); }
+abacus_double16 ABACUS_API __abacus_ceil(abacus_double16 x) {
+  return ceil<>(x);
+}
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/floor.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/floor.cpp
@@ -86,26 +86,38 @@ T floor(const T x) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_half __abacus_floor(abacus_half x) { return floor<>(x); }
-abacus_half2 __abacus_floor(abacus_half2 x) { return floor<>(x); }
-abacus_half3 __abacus_floor(abacus_half3 x) { return floor<>(x); }
-abacus_half4 __abacus_floor(abacus_half4 x) { return floor<>(x); }
-abacus_half8 __abacus_floor(abacus_half8 x) { return floor<>(x); }
-abacus_half16 __abacus_floor(abacus_half16 x) { return floor<>(x); }
+abacus_half ABACUS_API __abacus_floor(abacus_half x) { return floor<>(x); }
+abacus_half2 ABACUS_API __abacus_floor(abacus_half2 x) { return floor<>(x); }
+abacus_half3 ABACUS_API __abacus_floor(abacus_half3 x) { return floor<>(x); }
+abacus_half4 ABACUS_API __abacus_floor(abacus_half4 x) { return floor<>(x); }
+abacus_half8 ABACUS_API __abacus_floor(abacus_half8 x) { return floor<>(x); }
+abacus_half16 ABACUS_API __abacus_floor(abacus_half16 x) { return floor<>(x); }
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-abacus_float __abacus_floor(abacus_float x) { return floor<>(x); }
-abacus_float2 __abacus_floor(abacus_float2 x) { return floor<>(x); }
-abacus_float3 __abacus_floor(abacus_float3 x) { return floor<>(x); }
-abacus_float4 __abacus_floor(abacus_float4 x) { return floor<>(x); }
-abacus_float8 __abacus_floor(abacus_float8 x) { return floor<>(x); }
-abacus_float16 __abacus_floor(abacus_float16 x) { return floor<>(x); }
+abacus_float ABACUS_API __abacus_floor(abacus_float x) { return floor<>(x); }
+abacus_float2 ABACUS_API __abacus_floor(abacus_float2 x) { return floor<>(x); }
+abacus_float3 ABACUS_API __abacus_floor(abacus_float3 x) { return floor<>(x); }
+abacus_float4 ABACUS_API __abacus_floor(abacus_float4 x) { return floor<>(x); }
+abacus_float8 ABACUS_API __abacus_floor(abacus_float8 x) { return floor<>(x); }
+abacus_float16 ABACUS_API __abacus_floor(abacus_float16 x) {
+  return floor<>(x);
+}
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-abacus_double __abacus_floor(abacus_double x) { return floor<>(x); }
-abacus_double2 __abacus_floor(abacus_double2 x) { return floor<>(x); }
-abacus_double3 __abacus_floor(abacus_double3 x) { return floor<>(x); }
-abacus_double4 __abacus_floor(abacus_double4 x) { return floor<>(x); }
-abacus_double8 __abacus_floor(abacus_double8 x) { return floor<>(x); }
-abacus_double16 __abacus_floor(abacus_double16 x) { return floor<>(x); }
+abacus_double ABACUS_API __abacus_floor(abacus_double x) { return floor<>(x); }
+abacus_double2 ABACUS_API __abacus_floor(abacus_double2 x) {
+  return floor<>(x);
+}
+abacus_double3 ABACUS_API __abacus_floor(abacus_double3 x) {
+  return floor<>(x);
+}
+abacus_double4 ABACUS_API __abacus_floor(abacus_double4 x) {
+  return floor<>(x);
+}
+abacus_double8 ABACUS_API __abacus_floor(abacus_double8 x) {
+  return floor<>(x);
+}
+abacus_double16 ABACUS_API __abacus_floor(abacus_double16 x) {
+  return floor<>(x);
+}
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/fract.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/fract.cpp
@@ -81,68 +81,80 @@ inline T fract_helper_vector(T x, T *out) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_half __abacus_fract(abacus_half x, abacus_half *out_whole_number) {
+abacus_half ABACUS_API __abacus_fract(abacus_half x,
+                                      abacus_half *out_whole_number) {
   return fract_helper_scalar(x, out_whole_number);
 }
-abacus_half2 __abacus_fract(abacus_half2 x, abacus_half2 *out_whole_number) {
+abacus_half2 ABACUS_API __abacus_fract(abacus_half2 x,
+                                       abacus_half2 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_half3 __abacus_fract(abacus_half3 x, abacus_half3 *out_whole_number) {
+abacus_half3 ABACUS_API __abacus_fract(abacus_half3 x,
+                                       abacus_half3 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_half4 __abacus_fract(abacus_half4 x, abacus_half4 *out_whole_number) {
+abacus_half4 ABACUS_API __abacus_fract(abacus_half4 x,
+                                       abacus_half4 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_half8 __abacus_fract(abacus_half8 x, abacus_half8 *out_whole_number) {
+abacus_half8 ABACUS_API __abacus_fract(abacus_half8 x,
+                                       abacus_half8 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_half16 __abacus_fract(abacus_half16 x, abacus_half16 *out_whole_number) {
+abacus_half16 ABACUS_API __abacus_fract(abacus_half16 x,
+                                        abacus_half16 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-abacus_float __abacus_fract(abacus_float x, abacus_float *out_whole_number) {
+abacus_float ABACUS_API __abacus_fract(abacus_float x,
+                                       abacus_float *out_whole_number) {
   return fract_helper_scalar(x, out_whole_number);
 }
-abacus_float2 __abacus_fract(abacus_float2 x, abacus_float2 *out_whole_number) {
+abacus_float2 ABACUS_API __abacus_fract(abacus_float2 x,
+                                        abacus_float2 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_float3 __abacus_fract(abacus_float3 x, abacus_float3 *out_whole_number) {
+abacus_float3 ABACUS_API __abacus_fract(abacus_float3 x,
+                                        abacus_float3 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_float4 __abacus_fract(abacus_float4 x, abacus_float4 *out_whole_number) {
+abacus_float4 ABACUS_API __abacus_fract(abacus_float4 x,
+                                        abacus_float4 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_float8 __abacus_fract(abacus_float8 x, abacus_float8 *out_whole_number) {
+abacus_float8 ABACUS_API __abacus_fract(abacus_float8 x,
+                                        abacus_float8 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_float16 __abacus_fract(abacus_float16 x,
-                              abacus_float16 *out_whole_number) {
+abacus_float16 ABACUS_API __abacus_fract(abacus_float16 x,
+                                         abacus_float16 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-abacus_double __abacus_fract(abacus_double x, abacus_double *out_whole_number) {
+abacus_double ABACUS_API __abacus_fract(abacus_double x,
+                                        abacus_double *out_whole_number) {
   return fract_helper_scalar(x, out_whole_number);
 }
-abacus_double2 __abacus_fract(abacus_double2 x,
-                              abacus_double2 *out_whole_number) {
+abacus_double2 ABACUS_API __abacus_fract(abacus_double2 x,
+                                         abacus_double2 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_double3 __abacus_fract(abacus_double3 x,
-                              abacus_double3 *out_whole_number) {
+abacus_double3 ABACUS_API __abacus_fract(abacus_double3 x,
+                                         abacus_double3 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_double4 __abacus_fract(abacus_double4 x,
-                              abacus_double4 *out_whole_number) {
+abacus_double4 ABACUS_API __abacus_fract(abacus_double4 x,
+                                         abacus_double4 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_double8 __abacus_fract(abacus_double8 x,
-                              abacus_double8 *out_whole_number) {
+abacus_double8 ABACUS_API __abacus_fract(abacus_double8 x,
+                                         abacus_double8 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
-abacus_double16 __abacus_fract(abacus_double16 x,
-                               abacus_double16 *out_whole_number) {
+abacus_double16 ABACUS_API __abacus_fract(abacus_double16 x,
+                                          abacus_double16 *out_whole_number) {
   return fract_helper_vector(x, out_whole_number);
 }
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/frexp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/frexp.cpp
@@ -155,63 +155,63 @@ T frexp(const T x,
 }
 }  // namespace
 
-abacus_float __abacus_frexp(abacus_float x, abacus_int *o) {
+abacus_float ABACUS_API __abacus_frexp(abacus_float x, abacus_int *o) {
   return frexp<>(x, o);
 }
-abacus_float2 __abacus_frexp(abacus_float2 x, abacus_int2 *o) {
+abacus_float2 ABACUS_API __abacus_frexp(abacus_float2 x, abacus_int2 *o) {
   return frexp<>(x, o);
 }
-abacus_float3 __abacus_frexp(abacus_float3 x, abacus_int3 *o) {
+abacus_float3 ABACUS_API __abacus_frexp(abacus_float3 x, abacus_int3 *o) {
   return frexp<>(x, o);
 }
-abacus_float4 __abacus_frexp(abacus_float4 x, abacus_int4 *o) {
+abacus_float4 ABACUS_API __abacus_frexp(abacus_float4 x, abacus_int4 *o) {
   return frexp<>(x, o);
 }
-abacus_float8 __abacus_frexp(abacus_float8 x, abacus_int8 *o) {
+abacus_float8 ABACUS_API __abacus_frexp(abacus_float8 x, abacus_int8 *o) {
   return frexp<>(x, o);
 }
-abacus_float16 __abacus_frexp(abacus_float16 x, abacus_int16 *o) {
+abacus_float16 ABACUS_API __abacus_frexp(abacus_float16 x, abacus_int16 *o) {
   return frexp<>(x, o);
 }
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-abacus_double __abacus_frexp(abacus_double x, abacus_int *o) {
+abacus_double ABACUS_API __abacus_frexp(abacus_double x, abacus_int *o) {
   return frexp<>(x, o);
 }
-abacus_double2 __abacus_frexp(abacus_double2 x, abacus_int2 *o) {
+abacus_double2 ABACUS_API __abacus_frexp(abacus_double2 x, abacus_int2 *o) {
   return frexp<>(x, o);
 }
-abacus_double3 __abacus_frexp(abacus_double3 x, abacus_int3 *o) {
+abacus_double3 ABACUS_API __abacus_frexp(abacus_double3 x, abacus_int3 *o) {
   return frexp<>(x, o);
 }
-abacus_double4 __abacus_frexp(abacus_double4 x, abacus_int4 *o) {
+abacus_double4 ABACUS_API __abacus_frexp(abacus_double4 x, abacus_int4 *o) {
   return frexp<>(x, o);
 }
-abacus_double8 __abacus_frexp(abacus_double8 x, abacus_int8 *o) {
+abacus_double8 ABACUS_API __abacus_frexp(abacus_double8 x, abacus_int8 *o) {
   return frexp<>(x, o);
 }
-abacus_double16 __abacus_frexp(abacus_double16 x, abacus_int16 *o) {
+abacus_double16 ABACUS_API __abacus_frexp(abacus_double16 x, abacus_int16 *o) {
   return frexp<>(x, o);
 }
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
 
-abacus_half __abacus_frexp(abacus_half x, abacus_int *o) {
+abacus_half ABACUS_API __abacus_frexp(abacus_half x, abacus_int *o) {
   return frexp<>(x, o);
 }
-abacus_half2 __abacus_frexp(abacus_half2 x, abacus_int2 *o) {
+abacus_half2 ABACUS_API __abacus_frexp(abacus_half2 x, abacus_int2 *o) {
   return frexp<>(x, o);
 }
-abacus_half3 __abacus_frexp(abacus_half3 x, abacus_int3 *o) {
+abacus_half3 ABACUS_API __abacus_frexp(abacus_half3 x, abacus_int3 *o) {
   return frexp<>(x, o);
 }
-abacus_half4 __abacus_frexp(abacus_half4 x, abacus_int4 *o) {
+abacus_half4 ABACUS_API __abacus_frexp(abacus_half4 x, abacus_int4 *o) {
   return frexp<>(x, o);
 }
-abacus_half8 __abacus_frexp(abacus_half8 x, abacus_int8 *o) {
+abacus_half8 ABACUS_API __abacus_frexp(abacus_half8 x, abacus_int8 *o) {
   return frexp<>(x, o);
 }
-abacus_half16 __abacus_frexp(abacus_half16 x, abacus_int16 *o) {
+abacus_half16 ABACUS_API __abacus_frexp(abacus_half16 x, abacus_int16 *o) {
   return frexp<>(x, o);
 }
 

--- a/modules/compiler/builtins/abacus/source/abacus_math/ilogb.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/ilogb.cpp
@@ -119,7 +119,9 @@ typename ilogb_info<T>::IntType ilogb_helper(const T x) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_int __abacus_ilogb(abacus_half x) { return ilogb_helper_scalar<>(x); }
+abacus_int ABACUS_API __abacus_ilogb(abacus_half x) {
+  return ilogb_helper_scalar<>(x);
+}
 abacus_int2 ABACUS_API __abacus_ilogb(abacus_half2 x) {
   return ilogb_helper<>(x);
 }
@@ -137,7 +139,9 @@ abacus_int16 ABACUS_API __abacus_ilogb(abacus_half16 x) {
 }
 #endif
 
-abacus_int __abacus_ilogb(abacus_float x) { return ilogb_helper_scalar<>(x); }
+abacus_int ABACUS_API __abacus_ilogb(abacus_float x) {
+  return ilogb_helper_scalar<>(x);
+}
 abacus_int2 ABACUS_API __abacus_ilogb(abacus_float2 x) {
   return ilogb_helper<>(x);
 }
@@ -155,7 +159,9 @@ abacus_int16 ABACUS_API __abacus_ilogb(abacus_float16 x) {
 }
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-abacus_int __abacus_ilogb(abacus_double x) { return ilogb_helper_scalar<>(x); }
+abacus_int ABACUS_API __abacus_ilogb(abacus_double x) {
+  return ilogb_helper_scalar<>(x);
+}
 abacus_int2 ABACUS_API __abacus_ilogb(abacus_double2 x) {
   return ilogb_helper<>(x);
 }

--- a/modules/compiler/builtins/abacus/source/abacus_math/ldexp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/ldexp.cpp
@@ -210,52 +210,52 @@ inline T ldexp_double(const T x, const S n) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_half __abacus_ldexp(abacus_half x, abacus_int n) {
+abacus_half ABACUS_API __abacus_ldexp(abacus_half x, abacus_int n) {
   return ldexp_half(x, n);
 }
 
-abacus_half2 __abacus_ldexp(abacus_half2 x, abacus_int2 n) {
+abacus_half2 ABACUS_API __abacus_ldexp(abacus_half2 x, abacus_int2 n) {
   return ldexp_half<>(x, n);
 }
 
-abacus_half3 __abacus_ldexp(abacus_half3 x, abacus_int3 n) {
+abacus_half3 ABACUS_API __abacus_ldexp(abacus_half3 x, abacus_int3 n) {
   return ldexp_half<>(x, n);
 }
 
-abacus_half4 __abacus_ldexp(abacus_half4 x, abacus_int4 n) {
+abacus_half4 ABACUS_API __abacus_ldexp(abacus_half4 x, abacus_int4 n) {
   return ldexp_half<>(x, n);
 }
 
-abacus_half8 __abacus_ldexp(abacus_half8 x, abacus_int8 n) {
+abacus_half8 ABACUS_API __abacus_ldexp(abacus_half8 x, abacus_int8 n) {
   return ldexp_half<>(x, n);
 }
 
-abacus_half16 __abacus_ldexp(abacus_half16 x, abacus_int16 n) {
+abacus_half16 ABACUS_API __abacus_ldexp(abacus_half16 x, abacus_int16 n) {
   return ldexp_half<>(x, n);
 }
 #endif
 
-abacus_float __abacus_ldexp(abacus_float x, abacus_int n) {
+abacus_float ABACUS_API __abacus_ldexp(abacus_float x, abacus_int n) {
   return ldexp_float(x, n);
 }
 
-abacus_float2 __abacus_ldexp(abacus_float2 x, abacus_int2 n) {
+abacus_float2 ABACUS_API __abacus_ldexp(abacus_float2 x, abacus_int2 n) {
   return ldexp_float<>(x, n);
 }
 
-abacus_float3 __abacus_ldexp(abacus_float3 x, abacus_int3 n) {
+abacus_float3 ABACUS_API __abacus_ldexp(abacus_float3 x, abacus_int3 n) {
   return ldexp_float<>(x, n);
 }
 
-abacus_float4 __abacus_ldexp(abacus_float4 x, abacus_int4 n) {
+abacus_float4 ABACUS_API __abacus_ldexp(abacus_float4 x, abacus_int4 n) {
   return ldexp_float<>(x, n);
 }
 
-abacus_float8 __abacus_ldexp(abacus_float8 x, abacus_int8 n) {
+abacus_float8 ABACUS_API __abacus_ldexp(abacus_float8 x, abacus_int8 n) {
   return ldexp_float<>(x, n);
 }
 
-abacus_float16 __abacus_ldexp(abacus_float16 x, abacus_int16 n) {
+abacus_float16 ABACUS_API __abacus_ldexp(abacus_float16 x, abacus_int16 n) {
   return ldexp_float<>(x, n);
 }
 
@@ -263,7 +263,7 @@ abacus_float16 __abacus_ldexp(abacus_float16 x, abacus_int16 n) {
 // We don't use the templated version for scalar doubles because the return
 // types of functions such as isnan are inconsistent for doubles, they return
 // longs for vectors and ints for scalars.
-abacus_double __abacus_ldexp(abacus_double x, abacus_int n) {
+abacus_double ABACUS_API __abacus_ldexp(abacus_double x, abacus_int n) {
   typedef FPShape<abacus_double> Shape;
   const bool is_not_denorm = 0 == abacus::internal::is_denorm(x);
 
@@ -309,23 +309,23 @@ abacus_double __abacus_ldexp(abacus_double x, abacus_int n) {
   return ((x * mul_hi) * mul_lo) * mul_lo_lo;
 }
 
-abacus_double2 __abacus_ldexp(abacus_double2 x, abacus_int2 n) {
+abacus_double2 ABACUS_API __abacus_ldexp(abacus_double2 x, abacus_int2 n) {
   return ldexp_double<>(x, n);
 }
 
-abacus_double3 __abacus_ldexp(abacus_double3 x, abacus_int3 n) {
+abacus_double3 ABACUS_API __abacus_ldexp(abacus_double3 x, abacus_int3 n) {
   return ldexp_double<>(x, n);
 }
 
-abacus_double4 __abacus_ldexp(abacus_double4 x, abacus_int4 n) {
+abacus_double4 ABACUS_API __abacus_ldexp(abacus_double4 x, abacus_int4 n) {
   return ldexp_double<>(x, n);
 }
 
-abacus_double8 __abacus_ldexp(abacus_double8 x, abacus_int8 n) {
+abacus_double8 ABACUS_API __abacus_ldexp(abacus_double8 x, abacus_int8 n) {
   return ldexp_double<>(x, n);
 }
 
-abacus_double16 __abacus_ldexp(abacus_double16 x, abacus_int16 n) {
+abacus_double16 ABACUS_API __abacus_ldexp(abacus_double16 x, abacus_int16 n) {
   return ldexp_double<>(x, n);
 }
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/lgamma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/lgamma.cpp
@@ -87,7 +87,9 @@ T lgamma_scalar(const T x) {
 }  // namespace
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-abacus_half __abacus_lgamma(abacus_half x) { return lgamma_scalar(x); }
+abacus_half ABACUS_API __abacus_lgamma(abacus_half x) {
+  return lgamma_scalar(x);
+}
 abacus_half2 ABACUS_API __abacus_lgamma(abacus_half2 x) {
   return lgamma_vector(x);
 }
@@ -105,7 +107,9 @@ abacus_half16 ABACUS_API __abacus_lgamma(abacus_half16 x) {
 }
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-abacus_float __abacus_lgamma(abacus_float x) { return lgamma_scalar(x); }
+abacus_float ABACUS_API __abacus_lgamma(abacus_float x) {
+  return lgamma_scalar(x);
+}
 abacus_float2 ABACUS_API __abacus_lgamma(abacus_float2 x) {
   return lgamma_vector(x);
 }

--- a/modules/compiler/builtins/abacus/source/abacus_misc/shuffle.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_misc/shuffle.cpp
@@ -49,7 +49,7 @@ R shuffle(const T x, const M m) {
 }  // namespace hidden
 
 #define DEF_WITH_BOTH_SIZES(TYPE, IN_SIZE, OUT_SIZE)                 \
-  TYPE##OUT_SIZE __abacus_shuffle(                                   \
+  TYPE##OUT_SIZE ABACUS_API __abacus_shuffle(                        \
       TYPE##IN_SIZE x, TypeTraits<TYPE##OUT_SIZE>::UnsignedType m) { \
     return hidden::shuffle<TYPE##OUT_SIZE>(x, m);                    \
   }

--- a/modules/compiler/builtins/abacus/source/abacus_misc/shuffle2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_misc/shuffle2.cpp
@@ -49,7 +49,7 @@ R shuffle2(const T x, const T y, const M m) {
 }  // namespace
 
 #define DEF_WITH_BOTH_SIZES(TYPE, IN_SIZE, OUT_SIZE) \
-  TYPE##OUT_SIZE __abacus_shuffle2(                  \
+  TYPE##OUT_SIZE ABACUS_API __abacus_shuffle2(       \
       TYPE##IN_SIZE x, TYPE##IN_SIZE y,              \
       TypeTraits<TYPE##OUT_SIZE>::UnsignedType m) {  \
     return shuffle2<TYPE##OUT_SIZE>(x, y, m);        \

--- a/modules/compiler/builtins/abacus/source/abacus_relational/all.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/all.cpp
@@ -17,8 +17,10 @@
 #include <abacus/abacus_detail_relational.h>
 #include <abacus/abacus_relational.h>
 
-#define DEF(TYPE) \
-  abacus_int __abacus_all(TYPE x) { return abacus::detail::relational::all(x); }
+#define DEF(TYPE)                              \
+  abacus_int ABACUS_API __abacus_all(TYPE x) { \
+    return abacus::detail::relational::all(x); \
+  }
 
 DEF(abacus_char);
 DEF(abacus_char2);

--- a/modules/compiler/builtins/abacus/source/abacus_relational/any.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/any.cpp
@@ -17,8 +17,10 @@
 #include <abacus/abacus_detail_relational.h>
 #include <abacus/abacus_relational.h>
 
-#define DEF(TYPE) \
-  abacus_int __abacus_any(TYPE x) { return abacus::detail::relational::any(x); }
+#define DEF(TYPE)                              \
+  abacus_int ABACUS_API __abacus_any(TYPE x) { \
+    return abacus::detail::relational::any(x); \
+  }
 
 DEF(abacus_char);
 DEF(abacus_char2);

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isequal.cpp
@@ -40,10 +40,10 @@ struct helper<abacus_half> {
 
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isequal(TYPE x, TYPE y) {       \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isequal(x, y));           \
+#define DEF(TYPE)                                                  \
+  helper<TYPE>::type ABACUS_API __abacus_isequal(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(      \
+        abacus::detail::relational::isequal(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isfinite.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isfinite.cpp
@@ -40,7 +40,7 @@ struct helper<abacus_half> {
 }  // namespace
 
 #define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isfinite(TYPE x) {              \
+  helper<TYPE>::type ABACUS_API __abacus_isfinite(TYPE x) {   \
     return abacus::detail::cast::convert<helper<TYPE>::type>( \
         abacus::detail::relational::isfinite(x));             \
   }

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isgreater.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isgreater.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isgreater(TYPE x, TYPE y) {     \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isgreater(x, y));         \
+#define DEF(TYPE)                                                    \
+  helper<TYPE>::type ABACUS_API __abacus_isgreater(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(        \
+        abacus::detail::relational::isgreater(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isgreaterequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isgreaterequal.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                              \
-  helper<TYPE>::type __abacus_isgreaterequal(TYPE x, TYPE y) { \
-    return abacus::detail::cast::convert<helper<TYPE>::type>(  \
-        abacus::detail::relational::isgreaterequal(x, y));     \
+#define DEF(TYPE)                                                         \
+  helper<TYPE>::type ABACUS_API __abacus_isgreaterequal(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(             \
+        abacus::detail::relational::isgreaterequal(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isinf.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isinf.cpp
@@ -40,7 +40,7 @@ struct helper<abacus_half> {
 }  // namespace
 
 #define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isinf(TYPE x) {                 \
+  helper<TYPE>::type ABACUS_API __abacus_isinf(TYPE x) {      \
     return abacus::detail::cast::convert<helper<TYPE>::type>( \
         abacus::detail::relational::isinf(x));                \
   }

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isless.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isless.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isless(TYPE x, TYPE y) {        \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isless(x, y));            \
+#define DEF(TYPE)                                                 \
+  helper<TYPE>::type ABACUS_API __abacus_isless(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(     \
+        abacus::detail::relational::isless(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/islessequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/islessequal.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_islessequal(TYPE x, TYPE y) {   \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::islessequal(x, y));       \
+#define DEF(TYPE)                                                      \
+  helper<TYPE>::type ABACUS_API __abacus_islessequal(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(          \
+        abacus::detail::relational::islessequal(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/islessgreater.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/islessgreater.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_islessgreater(TYPE x, TYPE y) { \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::islessgreater(x, y));     \
+#define DEF(TYPE)                                                        \
+  helper<TYPE>::type ABACUS_API __abacus_islessgreater(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(            \
+        abacus::detail::relational::islessgreater(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnan.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnan.cpp
@@ -40,7 +40,7 @@ struct helper<abacus_half> {
 }  // namespace
 
 #define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isnan(TYPE x) {                 \
+  helper<TYPE>::type ABACUS_API __abacus_isnan(TYPE x) {      \
     return abacus::detail::cast::convert<helper<TYPE>::type>( \
         abacus::detail::relational::isnan(x));                \
   }

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnormal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnormal.cpp
@@ -40,7 +40,7 @@ struct helper<abacus_half> {
 }  // namespace
 
 #define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isnormal(TYPE x) {              \
+  helper<TYPE>::type ABACUS_API __abacus_isnormal(TYPE x) {   \
     return abacus::detail::cast::convert<helper<TYPE>::type>( \
         abacus::detail::relational::isnormal(x));             \
   }

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnotequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnotequal.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isnotequal(TYPE x, TYPE y) {    \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isnotequal(x, y));        \
+#define DEF(TYPE)                                                     \
+  helper<TYPE>::type ABACUS_API __abacus_isnotequal(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(         \
+        abacus::detail::relational::isnotequal(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isordered.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isordered.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isordered(TYPE x, TYPE y) {     \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isordered(x, y));         \
+#define DEF(TYPE)                                                    \
+  helper<TYPE>::type ABACUS_API __abacus_isordered(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(        \
+        abacus::detail::relational::isordered(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isunordered.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isunordered.cpp
@@ -39,10 +39,10 @@ struct helper<abacus_half> {
 #endif
 }  // namespace
 
-#define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_isunordered(TYPE x, TYPE y) {   \
-    return abacus::detail::cast::convert<helper<TYPE>::type>( \
-        abacus::detail::relational::isunordered(x, y));       \
+#define DEF(TYPE)                                                      \
+  helper<TYPE>::type ABACUS_API __abacus_isunordered(TYPE x, TYPE y) { \
+    return abacus::detail::cast::convert<helper<TYPE>::type>(          \
+        abacus::detail::relational::isunordered(x, y));                \
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/select.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/select.cpp
@@ -17,12 +17,14 @@
 #include <abacus/abacus_detail_relational.h>
 #include <abacus/abacus_relational.h>
 
-#define DEF(TYPE)                                                          \
-  TYPE __abacus_select(TYPE x, TYPE y, TypeTraits<TYPE>::SignedType z) {   \
-    return abacus::detail::relational::select(x, y, z);                    \
-  }                                                                        \
-  TYPE __abacus_select(TYPE x, TYPE y, TypeTraits<TYPE>::UnsignedType z) { \
-    return abacus::detail::relational::select(x, y, z);                    \
+#define DEF(TYPE)                                                     \
+  TYPE ABACUS_API __abacus_select(TYPE x, TYPE y,                     \
+                                  TypeTraits<TYPE>::SignedType z) {   \
+    return abacus::detail::relational::select(x, y, z);               \
+  }                                                                   \
+  TYPE ABACUS_API __abacus_select(TYPE x, TYPE y,                     \
+                                  TypeTraits<TYPE>::UnsignedType z) { \
+    return abacus::detail::relational::select(x, y, z);               \
   }
 
 DEF(abacus_char);

--- a/modules/compiler/builtins/abacus/source/abacus_relational/signbit.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/signbit.cpp
@@ -40,7 +40,7 @@ struct helper<abacus_half> {
 }  // namespace
 
 #define DEF(TYPE)                                             \
-  helper<TYPE>::type __abacus_signbit(TYPE x) {               \
+  helper<TYPE>::type ABACUS_API __abacus_signbit(TYPE x) {    \
     return abacus::detail::cast::convert<helper<TYPE>::type>( \
         abacus::detail::relational::signbit(x));              \
   }


### PR DESCRIPTION
# Overview

[NFC] Build Abacus in C++17 mode.

# Reason for change

The previous -std=c++11 for Abacus dated from back when the default mode was C++03, it was to enable new features in Abacus. The project-wide mode now is C++17, and keeping -std=c++11 for Abacus now has the opposite effect where features we can use throughout the project are not available for Abacus. This change makes it so that the whole project uses C++17.

# Description of change

This is a fairly large change because C++17 makes noexcept (including __attribute__((nothrow))) part of the type system, requiring us to be consistent between declaration and definition, we can no longer rely on it being picked up from a previous declaration.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
