### PR TITLE
Avoid undefined behavior in FMA.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_math/fma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/fma.cpp
@@ -432,7 +432,7 @@ T ABACUS_API __abacus_fma_unsafe(const T x, const T y, const T z) {
   const SignedType finalExpBiased =
       (((ansAsUint & exp_mask) >> mantissa_bits)) + 2 * ansExp;
 
-  if (finalExpBiased < 1) {
+  if (ans != 0 && finalExpBiased < 1) {
     // The answer is a denormal, find what bits will be cut off and see if it's
     // going to result in a RTE case.
     const UnsignedType rounding_bits = UnsignedType(0x1)


### PR DESCRIPTION
# Overview

Avoid undefined behavior in FMA.

# Reason for change

If the result is zero, the result is not denormal, so we do not need to follow the denormal special case logic. The check
rounding_mask & ansAsUint would always be zero, so it would never do anything, but the calculation of rounding_mask might have had undefined behavior due to an out-of-range exponent.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
