### PR TITLE
Remove CA_CL_FORCE_PROFILE

### DIFF
--- a/modules/compiler/utils/source/replace_mux_math_decls_pass.cpp
+++ b/modules/compiler/utils/source/replace_mux_math_decls_pass.cpp
@@ -51,11 +51,6 @@ PreservedAnalyses compiler::utils::ReplaceMuxMathDeclsPass::run(
         (0 == (DI.half_capabilities & device_floating_point_capabilities_full));
   }
 
-#ifdef CA_CL_FORCE_PROFILE_STRING
-  is_embedded_profile =
-      cargo::string_view(CA_CL_FORCE_PROFILE_STRING) == "EMBEDDED_PROFILE";
-#endif
-
   const std::array<std::pair<StringRef, const bool>, 3> MuxMathDecls = {
       std::make_pair(MuxBuiltins::isftz, flush_denorms_to_zero),
       std::make_pair(MuxBuiltins ::usefast, UseFast),

--- a/source/cl/CMakeLists.txt
+++ b/source/cl/CMakeLists.txt
@@ -253,17 +253,6 @@ foreach(CL_lib CL CL-static)
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include)
 
-  if(CA_CL_FORCE_PROFILE STREQUAL "full")
-    target_compile_definitions(${CL_lib} PRIVATE
-      CA_CL_FORCE_PROFILE_STRING="FULL_PROFILE")
-  elseif(CA_CL_FORCE_PROFILE STREQUAL "embedded")
-    target_compile_definitions(${CL_lib} PRIVATE
-      CA_CL_FORCE_PROFILE_STRING="EMBEDDED_PROFILE")
-  elseif(CA_CL_FORCE_PROFILE)
-    message(FATAL_ERROR
-      "Invalid CA_CL_FORCE_PROFILE, only 'full' or 'embedded' allowed.")
-  endif()
-
   target_link_libraries(${CL_lib}
     PUBLIC Threads::Threads
     # Optional extra library dependencies set for customer devices

--- a/source/cl/cmake/Options.cmake
+++ b/source/cl/cmake/Options.cmake
@@ -39,18 +39,6 @@ ca_option(CA_CL_LIBRARY_VERSION STRING
         "Version of the OpenCL shared library" "")
 
 #[=======================================================================[.rst:
-.. cmake:variable:: CA_CL_FORCE_PROFILE
-
-  A string CMAke option to force the OpenCL platform to report ``"full"`` or
-  ``"embedded"`` profile.
-
-  Default value
-    ``""``
-#]=======================================================================]
-ca_option(CA_CL_FORCE_PROFILE STRING
-        "Force cl to use 'full' or 'embedded' profile" "")
-
-#[=======================================================================[.rst:
 .. cmake:variable:: CA_CL_PUBLIC_LINK_LIBRARIES
 
   A list of additional libraries that the ``CL`` target should be linked

--- a/source/cl/source/binary/include/cl/binary/binary.h
+++ b/source/cl/source/binary/include/cl/binary/binary.h
@@ -111,8 +111,6 @@ md_hooks getOpenCLMetadataReadHooks();
 ///
 /// @return "FULL_PROFILE" if the device supports the OpenCL specification, or
 /// "EMBEDDED_PROFILE" if the device supports the OpenCL embedded profile. If
-/// CA_CL_FORCE_PROFILE_STRING is set when configuring CMake, then that string
-/// will be returned instead.
 cargo::string_view detectMuxDeviceProfile(cl_bool compiler_available,
                                           mux_device_info_t device);
 

--- a/source/cl/source/binary/source/binary.cpp
+++ b/source/cl/source/binary/source/binary.cpp
@@ -780,15 +780,10 @@ bool deserializeOpenCLProgramInfo(md_ctx ctx,
 
 cargo::string_view detectMuxDeviceProfile(cl_bool compiler_available,
                                           mux_device_info_t device) {
-#ifdef CA_CL_FORCE_PROFILE_STRING
-  (void)device;
-  return CA_CL_FORCE_PROFILE_STRING;
-#else
   if (compiler_available == CL_FALSE) {
     return "EMBEDDED_PROFILE";
   }
   return mux::detectOpenCLProfile(device);
-#endif  // CA_CL_FORCE_PROFILE_STRING
 }
 
 uint32_t detectBuiltinCapabilities(mux_device_info_t device_info) {


### PR DESCRIPTION

# Overview
Remove CA_CL_FORCE_PROFILE_OPTION

# Reason for change

This had been available as a backdoor for testing embedded but this is untested and not documented and embedded is much lower priority now. If needed we should make a target which is effectively embedded, which is a much better way of testing it.

# Description of change

Remove all references of CA_CL_FORCE_PROFILE_OPTION or CA_CL_FORCE_PROFILE_OPTION_STRING
