### PR TITLE
Use llvm.fma in abacus_fma

### DIFF
--- a/doc/modules/compiler/utils.rst
+++ b/doc/modules/compiler/utils.rst
@@ -1026,15 +1026,18 @@ The following builtins are replaced:
 * ``__mux_usefast`` - Whether to use faster, less accurate maths algorithms.
 * ``__mux_isembeddedprofile`` - Whether the mux target implements OpenCL
   embedded profile.
+* ``__mux_hasnativefma`` - Whether the mux target supports a fused multiply-add
+  instruction.
 
 Declarations matching each of these function names are searched for by
 ``ReplaceMuxMathDeclsPass``, and if found, a function body is created returning
 a constant value. These constant return values are set from ``bool`` parameters
 passed by the runtime on pass creation, and may be derived from hardware
-features like denormal support, or from compilation flags like fast-math. Later
-generic optimization passes, such as Dead Code Elimination, should be able
-remove the unused control-flow in kernel code once the definitions of these
-builtins have been inlined.
+features like denormal support, or from compilation flags like fast-math. These
+functions must not be declared with the ``noinline`` attribute: later generic
+optimization passes, such as Dead Code Elimination, should be able remove the
+unused control-flow in kernel code once the definitions of these builtins have
+been inlined.
 
 UniqueOpaqueStructsPass
 -----------------------

--- a/modules/compiler/builtins/abacus/generate/abacus_config/abacus_config.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_config/abacus_config.in
@@ -188,6 +188,7 @@
 extern ABACUS_API bool __abacus_isftz(void);
 extern ABACUS_API bool __abacus_usefast(void);
 extern ABACUS_API bool __abacus_isembeddedprofile(void);
+extern ABACUS_API bool __abacus_hasnativefma(void);
 #else
 // by default we just assume flush to zero
 inline bool __abacus_isftz(void) {
@@ -201,6 +202,11 @@ inline bool __abacus_usefast(void) {
 
 // assume full profile by default
 inline bool __abacus_isembeddedprofile(void) {
+  return false;
+}
+
+// do not make assumptions about FMA support on host
+inline bool __abacus_hasnativefma(void) {
   return false;
 }
 #endif

--- a/modules/compiler/builtins/abacus/source/abacus_math/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/source/abacus_math/CMakeLists.txt
@@ -117,8 +117,10 @@ set(abacus_math_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/tgamma.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/trunc.cpp)
 set(abacus_math_sources_host ${abacus_math_sources}
+  ${CMAKE_CURRENT_SOURCE_DIR}/inplace_fma.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/inplace_sqrt.cpp
   PARENT_SCOPE)
 set(abacus_math_sources_device ${abacus_math_sources}
+  ${CMAKE_CURRENT_SOURCE_DIR}/inplace_fma.ll.in
   ${CMAKE_CURRENT_SOURCE_DIR}/inplace_sqrt.ll.in
   PARENT_SCOPE)

--- a/modules/compiler/builtins/abacus/source/abacus_math/fma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/fma.cpp
@@ -24,6 +24,13 @@
 #include <abacus/internal/ldexp_unsafe.h>
 #include <abacus/internal/multiply_exact.h>
 
+namespace abacus {
+namespace detail {
+template <typename T>
+void inplace_fma(T &, T &, T &);
+}  // namespace detail
+}  // namespace abacus
+
 namespace {
 
 template <typename T>
@@ -531,8 +538,13 @@ struct fma_select<T, abacus_double, true> {
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
 
 template <typename T>
-inline T fma_helper(const T x, const T y, const T z) {
-  return fma_select<T>::fma(x, y, z);
+inline T fma_helper(T x, T y, T z) {
+  if (__abacus_hasnativefma()) {
+    abacus::detail::inplace_fma(x, y, z);
+    return x;
+  } else {
+    return fma_select<T>::fma(x, y, z);
+  }
 }
 }  // namespace
 #ifdef __CA_BUILTINS_HALF_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/inplace_fma.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/inplace_fma.cpp
@@ -1,0 +1,77 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <abacus/abacus_config.h>
+#include <abacus/abacus_type_traits.h>
+
+#include <cmath>
+
+namespace abacus {
+namespace detail {
+template <typename T>
+void inplace_fma(T &a, T &b, T &c) {
+  using ET = typename TypeTraits<T>::ElementType;
+  for (ET *p = reinterpret_cast<ET *>(&a), *q = reinterpret_cast<ET *>(&b),
+          *r = reinterpret_cast<ET *>(&c), *e = reinterpret_cast<ET *>(&a + 1);
+       p != e; ++p, ++q, ++r) {
+    *p = std::fma(*p, *q, *r);
+  }
+}
+}  // namespace detail
+}  // namespace abacus
+
+#ifdef __CA_BUILTINS_HALF_SUPPORT
+template void abacus::detail::inplace_fma(abacus_half &, abacus_half &,
+                                          abacus_half &);
+template void abacus::detail::inplace_fma(abacus_half2 &, abacus_half2 &,
+                                          abacus_half2 &);
+template void abacus::detail::inplace_fma(abacus_half3 &, abacus_half3 &,
+                                          abacus_half3 &);
+template void abacus::detail::inplace_fma(abacus_half4 &, abacus_half4 &,
+                                          abacus_half4 &);
+template void abacus::detail::inplace_fma(abacus_half8 &, abacus_half8 &,
+                                          abacus_half8 &);
+template void abacus::detail::inplace_fma(abacus_half16 &, abacus_half16 &,
+                                          abacus_half16 &);
+#endif  // __CA_BUILTINS_HALF_SUPPORT
+
+template void abacus::detail::inplace_fma(abacus_float &, abacus_float &,
+                                          abacus_float &);
+template void abacus::detail::inplace_fma(abacus_float2 &, abacus_float2 &,
+                                          abacus_float2 &);
+template void abacus::detail::inplace_fma(abacus_float3 &, abacus_float3 &,
+                                          abacus_float3 &);
+template void abacus::detail::inplace_fma(abacus_float4 &, abacus_float4 &,
+                                          abacus_float4 &);
+template void abacus::detail::inplace_fma(abacus_float8 &, abacus_float8 &,
+                                          abacus_float8 &);
+template void abacus::detail::inplace_fma(abacus_float16 &, abacus_float16 &,
+                                          abacus_float16 &);
+
+#ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+template void abacus::detail::inplace_fma(abacus_double &, abacus_double &,
+                                          abacus_double &);
+template void abacus::detail::inplace_fma(abacus_double2 &, abacus_double2 &,
+                                          abacus_double2 &);
+template void abacus::detail::inplace_fma(abacus_double3 &, abacus_double3 &,
+                                          abacus_double3 &);
+template void abacus::detail::inplace_fma(abacus_double4 &, abacus_double4 &,
+                                          abacus_double4 &);
+template void abacus::detail::inplace_fma(abacus_double8 &, abacus_double8 &,
+                                          abacus_double8 &);
+template void abacus::detail::inplace_fma(abacus_double16 &, abacus_double16 &,
+                                          abacus_double16 &);
+#endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_math/inplace_fma.ll.in
+++ b/modules/compiler/builtins/abacus/source/abacus_math/inplace_fma.ll.in
@@ -1,0 +1,218 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+@target@
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDF16_EEvRT_S3_S3_(ptr dereferenceable(2) %0, ptr dereferenceable(2) %1, ptr dereferenceable(2) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load half, ptr %0
+  %4 = load half, ptr %1
+  %5 = load half, ptr %2
+  %6 = call half @llvm.fma.f16(half %3, half %4, half %5)
+  store half %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv2_DF16_EEvRT_S4_S4_(ptr dereferenceable(4) %0, ptr dereferenceable(4) %1, ptr dereferenceable(4) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <2 x half>, ptr %0
+  %4 = load <2 x half>, ptr %1
+  %5 = load <2 x half>, ptr %2
+  %6 = call <2 x half> @llvm.fma.v2f16(<2 x half> %3, <2 x half> %4, <2 x half> %5)
+  store <2 x half> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv3_DF16_EEvRT_S4_S4_(ptr dereferenceable(6) %0, ptr dereferenceable(6) %1, ptr dereferenceable(6) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <3 x half>, ptr %0
+  %4 = load <3 x half>, ptr %1
+  %5 = load <3 x half>, ptr %2
+  %6 = call <3 x half> @llvm.fma.v3f16(<3 x half> %3, <3 x half> %4, <3 x half> %5)
+  store <3 x half> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv4_DF16_EEvRT_S4_S4_(ptr dereferenceable(8) %0, ptr dereferenceable(8) %1, ptr dereferenceable(8) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <4 x half>, ptr %0
+  %4 = load <4 x half>, ptr %1
+  %5 = load <4 x half>, ptr %2
+  %6 = call <4 x half> @llvm.fma.v4f16(<4 x half> %3, <4 x half> %4, <4 x half> %5)
+  store <4 x half> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv8_DF16_EEvRT_S4_S4_(ptr dereferenceable(16) %0, ptr dereferenceable(16) %1, ptr dereferenceable(16) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <8 x half>, ptr %0
+  %4 = load <8 x half>, ptr %1
+  %5 = load <8 x half>, ptr %2
+  %6 = call <8 x half> @llvm.fma.v8f16(<8 x half> %3, <8 x half> %4, <8 x half> %5)
+  store <8 x half> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv16_DF16_EEvRT_S4_S4_(ptr dereferenceable(32) %0, ptr dereferenceable(32) %1, ptr dereferenceable(32) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <16 x half>, ptr %0
+  %4 = load <16 x half>, ptr %1
+  %5 = load <16 x half>, ptr %2
+  %6 = call <16 x half> @llvm.fma.v16f16(<16 x half> %3, <16 x half> %4, <16 x half> %5)
+  store <16 x half> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIfEEvRT_S3_S3_(ptr dereferenceable(4) %0, ptr dereferenceable(4) %1, ptr dereferenceable(4) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load float, ptr %0
+  %4 = load float, ptr %1
+  %5 = load float, ptr %2
+  %6 = call float @llvm.fma.f32(float %3, float %4, float %5)
+  store float %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv2_fEEvRT_S4_S4_(ptr dereferenceable(8) %0, ptr dereferenceable(8) %1, ptr dereferenceable(8) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <2 x float>, ptr %0
+  %4 = load <2 x float>, ptr %1
+  %5 = load <2 x float>, ptr %2
+  %6 = call <2 x float> @llvm.fma.v2f32(<2 x float> %3, <2 x float> %4, <2 x float> %5)
+  store <2 x float> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv3_fEEvRT_S4_S4_(ptr dereferenceable(12) %0, ptr dereferenceable(12) %1, ptr dereferenceable(12) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <3 x float>, ptr %0
+  %4 = load <3 x float>, ptr %1
+  %5 = load <3 x float>, ptr %2
+  %6 = call <3 x float> @llvm.fma.v3f32(<3 x float> %3, <3 x float> %4, <3 x float> %5)
+  store <3 x float> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv4_fEEvRT_S4_S4_(ptr dereferenceable(16) %0, ptr dereferenceable(16) %1, ptr dereferenceable(16) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <4 x float>, ptr %0
+  %4 = load <4 x float>, ptr %1
+  %5 = load <4 x float>, ptr %2
+  %6 = call <4 x float> @llvm.fma.v4f32(<4 x float> %3, <4 x float> %4, <4 x float> %5)
+  store <4 x float> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv8_fEEvRT_S4_S4_(ptr dereferenceable(32) %0, ptr dereferenceable(32) %1, ptr dereferenceable(32) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <8 x float>, ptr %0
+  %4 = load <8 x float>, ptr %1
+  %5 = load <8 x float>, ptr %2
+  %6 = call <8 x float> @llvm.fma.v8f32(<8 x float> %3, <8 x float> %4, <8 x float> %5)
+  store <8 x float> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv16_fEEvRT_S4_S4_(ptr dereferenceable(64) %0, ptr dereferenceable(64) %1, ptr dereferenceable(64) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <16 x float>, ptr %0
+  %4 = load <16 x float>, ptr %1
+  %5 = load <16 x float>, ptr %2
+  %6 = call <16 x float> @llvm.fma.v16f32(<16 x float> %3, <16 x float> %4, <16 x float> %5)
+  store <16 x float> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIdEEvRT_S3_S3_(ptr dereferenceable(8) %0, ptr dereferenceable(8) %1, ptr dereferenceable(8) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load double, ptr %0
+  %4 = load double, ptr %1
+  %5 = load double, ptr %2
+  %6 = call double @llvm.fma.f64(double %3, double %4, double %5)
+  store double %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv2_dEEvRT_S4_S4_(ptr dereferenceable(16) %0, ptr dereferenceable(16) %1, ptr dereferenceable(16) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <2 x double>, ptr %0
+  %4 = load <2 x double>, ptr %1
+  %5 = load <2 x double>, ptr %2
+  %6 = call <2 x double> @llvm.fma.v2f64(<2 x double> %3, <2 x double> %4, <2 x double> %5)
+  store <2 x double> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv3_dEEvRT_S4_S4_(ptr dereferenceable(24) %0, ptr dereferenceable(24) %1, ptr dereferenceable(24) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <3 x double>, ptr %0
+  %4 = load <3 x double>, ptr %1
+  %5 = load <3 x double>, ptr %2
+  %6 = call <3 x double> @llvm.fma.v3f64(<3 x double> %3, <3 x double> %4, <3 x double> %5)
+  store <3 x double> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv4_dEEvRT_S4_S4_(ptr dereferenceable(32) %0, ptr dereferenceable(32) %1, ptr dereferenceable(32) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <4 x double>, ptr %0
+  %4 = load <4 x double>, ptr %1
+  %5 = load <4 x double>, ptr %2
+  %6 = call <4 x double> @llvm.fma.v4f64(<4 x double> %3, <4 x double> %4, <4 x double> %5)
+  store <4 x double> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv8_dEEvRT_S4_S4_(ptr dereferenceable(64) %0, ptr dereferenceable(64) %1, ptr dereferenceable(64) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <8 x double>, ptr %0
+  %4 = load <8 x double>, ptr %1
+  %5 = load <8 x double>, ptr %2
+  %6 = call <8 x double> @llvm.fma.v8f64(<8 x double> %3, <8 x double> %4, <8 x double> %5)
+  store <8 x double> %6, ptr %0
+  ret void
+}
+
+define hidden spir_func void @_ZN6abacus6detail11inplace_fmaIDv16_dEEvRT_S4_S4_(ptr dereferenceable(128) %0, ptr dereferenceable(128) %1, ptr dereferenceable(128) %2) local_unnamed_addr mustprogress nounwind alwaysinline {
+entry:
+  %3 = load <16 x double>, ptr %0
+  %4 = load <16 x double>, ptr %1
+  %5 = load <16 x double>, ptr %2
+  %6 = call <16 x double> @llvm.fma.v16f64(<16 x double> %3, <16 x double> %4, <16 x double> %5)
+  store <16 x double> %6, ptr %0
+  ret void
+}
+
+declare half @llvm.fma.f16(half, half, half)
+declare <2 x half> @llvm.fma.v2f16(<2 x half>, <2 x half>, <2 x half>)
+declare <3 x half> @llvm.fma.v3f16(<3 x half>, <3 x half>, <3 x half>)
+declare <4 x half> @llvm.fma.v4f16(<4 x half>, <4 x half>, <4 x half>)
+declare <8 x half> @llvm.fma.v8f16(<8 x half>, <8 x half>, <8 x half>)
+declare <16 x half> @llvm.fma.v16f16(<16 x half>, <16 x half>, <16 x half>)
+
+declare float @llvm.fma.f32(float, float, float)
+declare <2 x float> @llvm.fma.v2f32(<2 x float>, <2 x float>, <2 x float>)
+declare <3 x float> @llvm.fma.v3f32(<3 x float>, <3 x float>, <3 x float>)
+declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
+declare <8 x float> @llvm.fma.v8f32(<8 x float>, <8 x float>, <8 x float>)
+declare <16 x float> @llvm.fma.v16f32(<16 x float>, <16 x float>, <16 x float>)
+
+declare double @llvm.fma.f64(double, double, double)
+declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>)
+declare <3 x double> @llvm.fma.v3f64(<3 x double>, <3 x double>, <3 x double>)
+declare <4 x double> @llvm.fma.v4f64(<4 x double>, <4 x double>, <4 x double>)
+declare <8 x double> @llvm.fma.v8f64(<8 x double>, <8 x double>, <8 x double>)
+declare <16 x double> @llvm.fma.v16f64(<16 x double>, <16 x double>, <16 x double>)

--- a/modules/compiler/builtins/include/builtins/clbuiltins.h
+++ b/modules/compiler/builtins/include/builtins/clbuiltins.h
@@ -36,11 +36,15 @@
 extern bool __attribute__((const)) __mux_isftz(void);
 extern bool __attribute__((const)) __mux_usefast(void);
 extern bool __attribute__((const)) __mux_isembeddedprofile(void);
+extern bool __attribute__((const)) __mux_hasnativefma(void);
 
 bool __CL_CONST_ATTRIBUTES __abacus_isftz() { return __mux_isftz(); }
 bool __CL_CONST_ATTRIBUTES __abacus_usefast() { return __mux_usefast(); }
 bool __CL_CONST_ATTRIBUTES __abacus_isembeddedprofile() {
   return __mux_isembeddedprofile();
+}
+bool __CL_CONST_ATTRIBUTES __abacus_hasnativefma() {
+  return __mux_hasnativefma();
 }
 
 #endif  // OCL_CLBUILTINS_H_INCLUDED

--- a/modules/compiler/source/base/source/pass_pipelines.cpp
+++ b/modules/compiler/source/base/source/pass_pipelines.cpp
@@ -70,6 +70,9 @@ void addPreVeczPasses(ModulePassManager &PM,
   // associated with each other. To do so, the Prepare Barriers Pass also gives
   // each barrier a unique ID in metadata.
   PM.addPass(compiler::utils::PrepareBarriersPass());
+
+  PM.addPass(compiler::utils::ReplaceMuxMathDeclsPass(
+      tuner.options.unsafe_math_optimizations));
 }
 
 void addLateBuiltinsPasses(ModulePassManager &PM,

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -73,6 +73,7 @@ enum BaseBuiltinID {
   eMuxBuiltinGetEnqueuedLocalSize,
   eMuxBuiltinGetSubGroupSize,
   eMuxBuiltinGetSubGroupLocalId,
+  eMuxBuiltinHasNativeFMA,
   // Synchronization builtins
   eMuxBuiltinMemBarrier,
   eMuxBuiltinSubGroupBarrier,
@@ -260,6 +261,7 @@ namespace MuxBuiltins {
 constexpr const char isftz[] = "__mux_isftz";
 constexpr const char usefast[] = "__mux_usefast";
 constexpr const char isembeddedprofile[] = "__mux_isembeddedprofile";
+constexpr const char has_native_fma[] = "__mux_hasnativefma";
 constexpr const char get_global_size[] = "__mux_get_global_size";
 constexpr const char get_global_id[] = "__mux_get_global_id";
 constexpr const char get_global_offset[] = "__mux_get_global_offset";


### PR DESCRIPTION
# Overview

Use llvm.fma in abacus_fma

# Reason for change

Targets that have FMA instructions see a speedup when we use that instead of our custom `__abacus_fma` implementation. We know this helps ARM and RISC-V.

# Description of change

We add a new `__mux_hasnativefma()` builtin which, for now, only returns `true` on ARM and RISC-V (to be improved later). In `__abacus_fma`, if `__mux_hasnativefma()`, we use the `@llvm.fma` intrinsic, if not, we use our old implementation. This avoids problems on X86, where `@llvm.fma` needs libcalls which we do not expose.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
