### PR TITLE
[compiler] Revert use of FMA in horner polynomial

### DIFF
--- a/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
@@ -27,7 +27,12 @@ inline T horner_polynomial(const T x, const TCoef *p_coef, size_t N) {
   T coef_sum = T(p_coef[N - 1]);
 
   for (size_t n = N - 1; n > 0; n--) {
-    coef_sum = __abacus_fma(coef_sum, x, T(p_coef[n - 1]));
+    if constexpr (sizeof(typename TypeTraits<T>::ElementType) == 2) {
+      // For half, we need the precision of FMA
+      coef_sum = __abacus_fma(coef_sum, x, T(p_coef[n - 1]));
+    } else {
+      coef_sum = T(p_coef[n - 1]) + x * coef_sum;
+    }
   }
 
   return coef_sum;


### PR DESCRIPTION
This is unnecessarily precise for float and double types, and causes a lot of code bloat in the builtins library, which slowed down benchmarks.

We hope to improve the handling and performance of `__abacus_fma` in the short term, so we might revisit this when we've done that.