### PR TITLE
Remove unused cargo include from pass_functions.h

### DIFF
--- a/modules/compiler/utils/include/compiler/utils/pass_functions.h
+++ b/modules/compiler/utils/include/compiler/utils/pass_functions.h
@@ -21,7 +21,6 @@
 #ifndef COMPILER_UTILS_PASS_FUNCTIONS_H_INCLUDED
 #define COMPILER_UTILS_PASS_FUNCTIONS_H_INCLUDED
 
-#include <cargo/optional.h>
 #include <llvm/ADT/Twine.h>
 #include <llvm/Analysis/IVDescriptors.h>
 #include <llvm/IR/Constants.h>


### PR DESCRIPTION
# Overview

Remove unused cargo include from pass_functions.h

# Reason for change

Unnecessary and unused dependence on a non-compiler module.

# Description of change

Removed unused header file.
