### PR TITLE
[NFC] Suppress clang-tidy warnings.

### DIFF
--- a/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
@@ -27,10 +27,10 @@ inline T horner_polynomial(const T x, const TCoef *p_coef, size_t N) {
   T coef_sum = T(p_coef[N - 1]);
 
   for (size_t n = N - 1; n > 0; n--) {
-    if constexpr (sizeof(typename TypeTraits<T>::ElementType) == 2) {
+    if constexpr (sizeof(typename TypeTraits<T>::ElementType) == 2) {  // NOLINT
       // For half, we need the precision of FMA
       coef_sum = __abacus_fma(coef_sum, x, T(p_coef[n - 1]));
-    } else {
+    } else {  // NOLINT
       coef_sum = T(p_coef[n - 1]) + x * coef_sum;
     }
   }


### PR DESCRIPTION
# Overview

[NFC] Suppress clang-tidy warnings.

# Reason for change

We use clang-tidy 9, which does not understand if constexpr. Until we can upgrade, just suppress the warnings it produces.

# Description of change

This commit merely adds two `// NOLINT` comments to instruct clang-tidy to ignore the code.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
