### PR TITLE
[NFC] Pick a style for const.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,5 +11,6 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        3
 DerivePointerAlignment: false
+QualifierAlignment: Left
 PointerAlignment: Right
 ...

--- a/modules/cargo/include/cargo/detail/expected.h
+++ b/modules/cargo/include/cargo/detail/expected.h
@@ -594,11 +594,11 @@ template <class T, class E,
 struct expected_default_ctor_base {
   constexpr expected_default_ctor_base() noexcept = default;
   constexpr expected_default_ctor_base(
-      expected_default_ctor_base const &) noexcept = default;
+      const expected_default_ctor_base &) noexcept = default;
   constexpr expected_default_ctor_base(expected_default_ctor_base &&) noexcept =
       default;
   expected_default_ctor_base &operator=(
-      expected_default_ctor_base const &) noexcept = default;
+      const expected_default_ctor_base &) noexcept = default;
   expected_default_ctor_base &operator=(
       expected_default_ctor_base &&) noexcept = default;
 
@@ -610,11 +610,11 @@ template <class T, class E>
 struct expected_default_ctor_base<T, E, false> {
   constexpr expected_default_ctor_base() noexcept = delete;
   constexpr expected_default_ctor_base(
-      expected_default_ctor_base const &) noexcept = default;
+      const expected_default_ctor_base &) noexcept = default;
   constexpr expected_default_ctor_base(expected_default_ctor_base &&) noexcept =
       default;
   expected_default_ctor_base &operator=(
-      expected_default_ctor_base const &) noexcept = default;
+      const expected_default_ctor_base &) noexcept = default;
   expected_default_ctor_base &operator=(
       expected_default_ctor_base &&) noexcept = default;
 

--- a/modules/cargo/include/cargo/expected.h
+++ b/modules/cargo/include/cargo/expected.h
@@ -330,7 +330,7 @@ class expected
   template <class G = E,
             enable_if_t<std::is_constructible<E, const G &>::value> * = nullptr,
             enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
-  constexpr expected(unexpected<G> const &e)
+  constexpr expected(const unexpected<G> &e)
       : impl_base(unexpect, e.value()),
         ctor_base(detail::default_constructor_tag{}) {}
 
@@ -390,8 +390,8 @@ class expected
   /// @param rhs Expected object to copy.
   template <
       class U, class G,
-      enable_if_t<!(std::is_convertible<U const &, T>::value &&
-                    std::is_convertible<G const &, E>::value)> * = nullptr,
+      enable_if_t<!(std::is_convertible<const U &, T>::value &&
+                    std::is_convertible<const G &, E>::value)> * = nullptr,
       detail::expected_enable_from_other<T, E, U, G, const U &, const G &> * =
           nullptr>
   explicit constexpr expected(const expected<U, G> &rhs)
@@ -409,8 +409,8 @@ class expected
   /// @tparam G Type of `rhs'`s unexpected value.
   /// @param rhs Expected object to copy.
   template <class U, class G,
-            enable_if_t<(std::is_convertible<U const &, T>::value &&
-                         std::is_convertible<G const &, E>::value)> * = nullptr,
+            enable_if_t<(std::is_convertible<const U &, T>::value &&
+                         std::is_convertible<const G &, E>::value)> * = nullptr,
             detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
                 * = nullptr>
   constexpr expected(const expected<U, G> &rhs)

--- a/modules/cargo/test/expected.cpp
+++ b/modules/cargo/test/expected.cpp
@@ -916,10 +916,10 @@ TEST(expected, and_then_std_string) { getInt1(); }
 
 cargo::expected<int, int> operation1() { return 42; }
 
-cargo::expected<std::string, int> operation2(int const) { return "Bananas"; }
+cargo::expected<std::string, int> operation2(const int) { return "Bananas"; }
 
 TEST(expected, and_then_non_constexpr) {
-  auto const intermediate_result = operation1();
+  const auto intermediate_result = operation1();
 
   intermediate_result.and_then(operation2);
 }

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -94,7 +94,7 @@ class ExtInstSetHandler {
   ///
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
-  virtual llvm::Error create(OpExtInst const &opc) = 0;
+  virtual llvm::Error create(const OpExtInst &opc) = 0;
 
  protected:
   /// @brief `spirv_ll::Builder` that owns this object.
@@ -235,13 +235,13 @@ class Builder {
 
   /// @brief Populate the incoming edges/values for the given Phi node
   /// @param op The SpirV Op for the Phi node
-  void populatePhi(OpPhi const &op);
+  void populatePhi(const OpPhi &op);
 
   /// @brief A unification of the four very similar access chain functions
   ///
   /// @param opc The OpCode representing the access chain instruction
   /// being translated
-  void accessChain(OpCode const &opc);
+  void accessChain(const OpCode &opc);
 
   /// @brief Represents a lexical scope, used for debug information.
   struct LexicalScopeTy {

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_debug_info.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_debug_info.h
@@ -45,7 +45,7 @@ class DebugInfoBuilder : public ExtInstSetHandler {
       : ExtInstSetHandler(builder, module), workarounds(workarounds) {}
 
   /// @see ExtInstSetHandler::create
-  virtual llvm::Error create(OpExtInst const &opc) override;
+  virtual llvm::Error create(const OpExtInst &opc) override;
 
   virtual llvm::Error finishModuleProcessing() override;
 
@@ -67,7 +67,7 @@ class DebugInfoBuilder : public ExtInstSetHandler {
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
   template <typename T>
-  llvm::Error create(OpExtInst const &opc);
+  llvm::Error create(const OpExtInst &opc);
 
   /// @brief Returns the LLVM DIBuilder for the given instruction.
   ///

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_glsl.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_glsl.h
@@ -32,7 +32,7 @@ class GLSLBuilder : public ExtInstSetHandler {
       : ExtInstSetHandler(builder, module) {}
 
   /// @see ExtendedInstrSet::create
-  virtual llvm::Error create(OpExtInst const &opc) override;
+  virtual llvm::Error create(const OpExtInst &opc) override;
 
  private:
   /// @brief Create a GLSL extended instruction transformation to LLVM IR.
@@ -43,7 +43,7 @@ class GLSLBuilder : public ExtInstSetHandler {
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
   template <enum GLSLstd450 inst>
-  llvm::Error create(OpExtInst const &opc);
+  llvm::Error create(const OpExtInst &opc);
 };
 
 }  // namespace spirv_ll

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_group_async_copies.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_group_async_copies.h
@@ -41,7 +41,7 @@ class GroupAsyncCopiesBuilder : public ExtInstSetHandler {
   };
 
   /// @see ExtInstSetHandler::create
-  virtual llvm::Error create(OpExtInst const &opc) override;
+  virtual llvm::Error create(const OpExtInst &opc) override;
 
  private:
   /// @brief Create a Codeplay.GroupAsyncCopies extended instruction
@@ -54,7 +54,7 @@ class GroupAsyncCopiesBuilder : public ExtInstSetHandler {
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
   template <Instruction inst>
-  llvm::Error create(OpExtInst const &opc);
+  llvm::Error create(const OpExtInst &opc);
 };
 
 }  // namespace spirv_ll

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_opencl.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_opencl.h
@@ -31,7 +31,7 @@ class OpenCLBuilder : public spirv_ll::ExtInstSetHandler {
       : ExtInstSetHandler(builder, module) {}
 
   /// @see ExtInstSetHandler::create
-  virtual llvm::Error create(OpExtInst const &opc) override;
+  virtual llvm::Error create(const OpExtInst &opc) override;
 
  private:
   /// @brief Create an OpenCL extended instruction transformation to LLVM IR.
@@ -42,7 +42,7 @@ class OpenCLBuilder : public spirv_ll::ExtInstSetHandler {
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
   template <typename T>
-  llvm::Error create(OpExtInst const &opc);
+  llvm::Error create(const OpExtInst &opc);
 
   /// @brief Create a vector OpenCL extended instruction transformation to LLVM
   /// IR.
@@ -53,7 +53,7 @@ class OpenCLBuilder : public spirv_ll::ExtInstSetHandler {
   /// @return Returns an `llvm::Error` object representing either success, or
   /// an error value.
   template <OpenCLLIB::Entrypoints inst>
-  llvm::Error createVec(OpExtInst const &opc);
+  llvm::Error createVec(const OpExtInst &opc);
 };
 
 }  // namespace spirv_ll

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -296,7 +296,7 @@ class Module : public ModuleHeader {
   ///
   /// @param Op `OpResult` object with the ID whose value will be replaced.
   /// @param V `Value` object to replace the old value with.
-  void replaceID(OpResult const *Op, llvm::Value *V);
+  void replaceID(const OpResult *Op, llvm::Value *V);
 
   /// @brief Add a specified execution mode to the module.
   ///
@@ -638,7 +638,7 @@ class Module : public ModuleHeader {
   /// @param[in] T The LLVM value for the given Op.
   ///
   /// @return true on success, false if the ID already exists
-  bool addID(spv::Id id, OpCode const *Op, llvm::Type *T);
+  bool addID(spv::Id id, const OpCode *Op, llvm::Type *T);
 
   /// @brief track the original SPIR-V type ids for the OpFunctionType `func`
   ///
@@ -796,7 +796,7 @@ class Module : public ModuleHeader {
   /// @param[in] V The LLVM value for the given Op.
   ///
   /// @return true on success, false if the ID already exists
-  bool addID(spv::Id id, OpCode const *Op, llvm::Value *V);
+  bool addID(spv::Id id, const OpCode *Op, llvm::Value *V);
 
   /// @brief Get the LLVM Value for the given SPIR-V ID.
   ///
@@ -1082,7 +1082,7 @@ class Module : public ModuleHeader {
     /// @brief Empty constructor, initializes everything to nullptr.
     TypePair() : Op(nullptr), Type(nullptr) {}
     /// @brief Constructor with initializers
-    TypePair(OpCode const *Op, llvm::Type *Type) : Op(Op), Type(Type) {}
+    TypePair(const OpCode *Op, llvm::Type *Type) : Op(Op), Type(Type) {}
     /// @brief Pointer to the SPIR-V Op.
     const OpCode *Op;
     /// @brief Pointer to the LLVM Type defined by the SPIR-V Op.
@@ -1109,7 +1109,7 @@ class Module : public ModuleHeader {
     /// @brief Empty constructor, initializes everything to nullptr.
     ValuePair() : Op(nullptr), Value(nullptr) {}
     /// @brief Constructor with initializers
-    ValuePair(OpCode const *Op, llvm::Value *Value) : Op(Op), Value(Value) {}
+    ValuePair(const OpCode *Op, llvm::Value *Value) : Op(Op), Value(Value) {}
     /// @brief Pointer to the SPIR-V Op.
     const OpCode *Op;
     /// @brief Pointer to the LLVM Value defined by the SPIR-V Op.
@@ -1138,7 +1138,7 @@ class Module : public ModuleHeader {
   llvm::Value *BufferSizeArray;
   /// @brief List of `OpSpecConstantOp` instructions whose translation had to be
   /// deferred.
-  llvm::SmallVector<spirv_ll::OpSpecConstantOp const *, 2>
+  llvm::SmallVector<const spirv_ll::OpSpecConstantOp *, 2>
       deferredSpecConstantOps;
   std::string ModuleProcess;
   /// @brief True if debug scopes should be inferred and generated when

--- a/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
@@ -330,7 +330,7 @@ inline const OpType *dyn_cast(const OpCode *op) {
 class OpResult : public OpCode {
  public:
   /// @brief Constructor from base `OpCode` object.
-  OpResult(OpCode const &other, spv::Op code) : OpCode(other, code) {}
+  OpResult(const OpCode &other, spv::Op code) : OpCode(other, code) {}
 
   /// @brief Return the instruction's result type ID.
   spv::Id IdResultType() const;
@@ -360,7 +360,7 @@ inline const OpResult *dyn_cast(const OpCode *op) {
 class OpDecorateBase : public OpCode {
  public:
   /// @brief Constructor from base `OpCode` object.
-  OpDecorateBase(OpCode const &other, spv::Op code) : OpCode(other, code) {}
+  OpDecorateBase(const OpCode &other, spv::Op code) : OpCode(other, code) {}
 
   /// @brief Return the instruction's decoration operand.
   spv::Decoration getDecoration() const;
@@ -376,19 +376,19 @@ inline const OpDecorateBase *cast(const OpCode *op) {
 
 class OpNop : public OpCode {
  public:
-  OpNop(OpCode const &other) : OpCode(other, spv::OpNop) {}
+  OpNop(const OpCode &other) : OpCode(other, spv::OpNop) {}
   static const spv::Op ClassCode = spv::OpNop;
 };
 
 class OpUndef : public OpResult {
  public:
-  OpUndef(OpCode const &other) : OpResult(other, spv::OpUndef) {}
+  OpUndef(const OpCode &other) : OpResult(other, spv::OpUndef) {}
   static const spv::Op ClassCode = spv::OpUndef;
 };
 
 class OpSourceContinued : public OpCode {
  public:
-  OpSourceContinued(OpCode const &other)
+  OpSourceContinued(const OpCode &other)
       : OpCode(other, spv::OpSourceContinued) {}
   llvm::StringRef ContinuedSource() const;
   static const spv::Op ClassCode = spv::OpSourceContinued;
@@ -396,7 +396,7 @@ class OpSourceContinued : public OpCode {
 
 class OpSource : public OpCode {
  public:
-  OpSource(OpCode const &other) : OpCode(other, spv::OpSource) {}
+  OpSource(const OpCode &other) : OpCode(other, spv::OpSource) {}
   spv::SourceLanguage SourceLanguage() const;
   uint32_t Version() const;
   spv::Id File() const;
@@ -406,7 +406,7 @@ class OpSource : public OpCode {
 
 class OpSourceExtension : public OpCode {
  public:
-  OpSourceExtension(OpCode const &other)
+  OpSourceExtension(const OpCode &other)
       : OpCode(other, spv::OpSourceExtension) {}
   llvm::StringRef Extension() const;
   static const spv::Op ClassCode = spv::OpSourceExtension;
@@ -414,7 +414,7 @@ class OpSourceExtension : public OpCode {
 
 class OpName : public OpCode {
  public:
-  OpName(OpCode const &other) : OpCode(other, spv::OpName) {}
+  OpName(const OpCode &other) : OpCode(other, spv::OpName) {}
   spv::Id Target() const;
   llvm::StringRef Name() const;
   static const spv::Op ClassCode = spv::OpName;
@@ -422,7 +422,7 @@ class OpName : public OpCode {
 
 class OpMemberName : public OpCode {
  public:
-  OpMemberName(OpCode const &other) : OpCode(other, spv::OpMemberName) {}
+  OpMemberName(const OpCode &other) : OpCode(other, spv::OpMemberName) {}
   spv::Id Type() const;
   uint32_t Member() const;
   llvm::StringRef Name() const;
@@ -431,7 +431,7 @@ class OpMemberName : public OpCode {
 
 class OpString : public OpCode {
  public:
-  OpString(OpCode const &other) : OpCode(other, spv::OpString) {}
+  OpString(const OpCode &other) : OpCode(other, spv::OpString) {}
   spv::Id IdResult() const;
   llvm::StringRef String() const;
   static const spv::Op ClassCode = spv::OpString;
@@ -439,7 +439,7 @@ class OpString : public OpCode {
 
 class OpLine : public OpCode {
  public:
-  OpLine(OpCode const &other) : OpCode(other, spv::OpLine) {}
+  OpLine(const OpCode &other) : OpCode(other, spv::OpLine) {}
   spv::Id File() const;
   uint32_t Line() const;
   uint32_t Column() const;
@@ -448,14 +448,14 @@ class OpLine : public OpCode {
 
 class OpExtension : public OpCode {
  public:
-  OpExtension(OpCode const &other) : OpCode(other, spv::OpExtension) {}
+  OpExtension(const OpCode &other) : OpCode(other, spv::OpExtension) {}
   llvm::StringRef Name() const;
   static const spv::Op ClassCode = spv::OpExtension;
 };
 
 class OpExtInstImport : public OpCode {
  public:
-  OpExtInstImport(OpCode const &other) : OpCode(other, spv::OpExtInstImport) {}
+  OpExtInstImport(const OpCode &other) : OpCode(other, spv::OpExtInstImport) {}
   spv::Id IdResult() const;
   llvm::StringRef Name() const;
   static const spv::Op ClassCode = spv::OpExtInstImport;
@@ -463,7 +463,7 @@ class OpExtInstImport : public OpCode {
 
 class OpExtInst : public OpResult {
  public:
-  OpExtInst(OpCode const &other) : OpResult(other, spv::OpExtInst) {}
+  OpExtInst(const OpCode &other) : OpResult(other, spv::OpExtInst) {}
   spv::Id Set() const;
   uint32_t Instruction() const;
   llvm::SmallVector<spv::Id, 8> Operands() const;
@@ -485,7 +485,7 @@ class OpExtInst : public OpResult {
 
 class OpMemoryModel : public OpCode {
  public:
-  OpMemoryModel(OpCode const &other) : OpCode(other, spv::OpMemoryModel) {}
+  OpMemoryModel(const OpCode &other) : OpCode(other, spv::OpMemoryModel) {}
   spv::AddressingModel AddressingModel() const;
   spv::MemoryModel MemoryModel() const;
   static const spv::Op ClassCode = spv::OpMemoryModel;
@@ -493,7 +493,7 @@ class OpMemoryModel : public OpCode {
 
 class OpEntryPoint : public OpCode {
  public:
-  OpEntryPoint(OpCode const &other) : OpCode(other, spv::OpEntryPoint) {}
+  OpEntryPoint(const OpCode &other) : OpCode(other, spv::OpEntryPoint) {}
   spv::ExecutionModel ExecutionModel() const;
   spv::Id EntryPoint() const;
   llvm::StringRef Name() const;
@@ -503,7 +503,7 @@ class OpEntryPoint : public OpCode {
 
 class OpExecutionMode : public OpCode {
  public:
-  OpExecutionMode(OpCode const &other) : OpCode(other, spv::OpExecutionMode) {}
+  OpExecutionMode(const OpCode &other) : OpCode(other, spv::OpExecutionMode) {}
   spv::Id EntryPoint() const;
   spv::ExecutionMode Mode() const;
   static const spv::Op ClassCode = spv::OpExecutionMode;
@@ -511,26 +511,26 @@ class OpExecutionMode : public OpCode {
 
 class OpCapability : public OpCode {
  public:
-  OpCapability(OpCode const &other) : OpCode(other, spv::OpCapability) {}
+  OpCapability(const OpCode &other) : OpCode(other, spv::OpCapability) {}
   spv::Capability Capability() const;
   static const spv::Op ClassCode = spv::OpCapability;
 };
 
 class OpTypeVoid : public OpType {
  public:
-  OpTypeVoid(OpCode const &other) : OpType(other, spv::OpTypeVoid) {}
+  OpTypeVoid(const OpCode &other) : OpType(other, spv::OpTypeVoid) {}
   static const spv::Op ClassCode = spv::OpTypeVoid;
 };
 
 class OpTypeBool : public OpType {
  public:
-  OpTypeBool(OpCode const &other) : OpType(other, spv::OpTypeBool) {}
+  OpTypeBool(const OpCode &other) : OpType(other, spv::OpTypeBool) {}
   static const spv::Op ClassCode = spv::OpTypeBool;
 };
 
 class OpTypeInt : public OpType {
  public:
-  OpTypeInt(OpCode const &other) : OpType(other, spv::OpTypeInt) {}
+  OpTypeInt(const OpCode &other) : OpType(other, spv::OpTypeInt) {}
   uint32_t Width() const;
   uint32_t Signedness() const;
   static const spv::Op ClassCode = spv::OpTypeInt;
@@ -538,14 +538,14 @@ class OpTypeInt : public OpType {
 
 class OpTypeFloat : public OpType {
  public:
-  OpTypeFloat(OpCode const &other) : OpType(other, spv::OpTypeFloat) {}
+  OpTypeFloat(const OpCode &other) : OpType(other, spv::OpTypeFloat) {}
   uint32_t Width() const;
   static const spv::Op ClassCode = spv::OpTypeFloat;
 };
 
 class OpTypeVector : public OpType {
  public:
-  OpTypeVector(OpCode const &other) : OpType(other, spv::OpTypeVector) {}
+  OpTypeVector(const OpCode &other) : OpType(other, spv::OpTypeVector) {}
   spv::Id ComponentType() const;
   uint32_t ComponentCount() const;
   static const spv::Op ClassCode = spv::OpTypeVector;
@@ -553,7 +553,7 @@ class OpTypeVector : public OpType {
 
 class OpTypeMatrix : public OpType {
  public:
-  OpTypeMatrix(OpCode const &other) : OpType(other, spv::OpTypeMatrix) {}
+  OpTypeMatrix(const OpCode &other) : OpType(other, spv::OpTypeMatrix) {}
   spv::Id ColumnType() const;
   uint32_t ColumnCount() const;
   static const spv::Op ClassCode = spv::OpTypeMatrix;
@@ -561,7 +561,7 @@ class OpTypeMatrix : public OpType {
 
 class OpTypeImage : public OpType {
  public:
-  OpTypeImage(OpCode const &other) : OpType(other, spv::OpTypeImage) {}
+  OpTypeImage(const OpCode &other) : OpType(other, spv::OpTypeImage) {}
   spv::Id SampledType() const;
   spv::Dim Dim() const;
   uint32_t Depth() const;
@@ -575,13 +575,13 @@ class OpTypeImage : public OpType {
 
 class OpTypeSampler : public OpType {
  public:
-  OpTypeSampler(OpCode const &other) : OpType(other, spv::OpTypeSampler) {}
+  OpTypeSampler(const OpCode &other) : OpType(other, spv::OpTypeSampler) {}
   static const spv::Op ClassCode = spv::OpTypeSampler;
 };
 
 class OpTypeSampledImage : public OpType {
  public:
-  OpTypeSampledImage(OpCode const &other)
+  OpTypeSampledImage(const OpCode &other)
       : OpType(other, spv::OpTypeSampledImage) {}
   spv::Id ImageType() const;
   static const spv::Op ClassCode = spv::OpTypeSampledImage;
@@ -589,7 +589,7 @@ class OpTypeSampledImage : public OpType {
 
 class OpTypeArray : public OpType {
  public:
-  OpTypeArray(OpCode const &other) : OpType(other, spv::OpTypeArray) {}
+  OpTypeArray(const OpCode &other) : OpType(other, spv::OpTypeArray) {}
   spv::Id ElementType() const;
   spv::Id Length() const;
   static const spv::Op ClassCode = spv::OpTypeArray;
@@ -597,7 +597,7 @@ class OpTypeArray : public OpType {
 
 class OpTypeRuntimeArray : public OpType {
  public:
-  OpTypeRuntimeArray(OpCode const &other)
+  OpTypeRuntimeArray(const OpCode &other)
       : OpType(other, spv::OpTypeRuntimeArray) {}
   spv::Id ElementType() const;
   static const spv::Op ClassCode = spv::OpTypeRuntimeArray;
@@ -605,21 +605,21 @@ class OpTypeRuntimeArray : public OpType {
 
 class OpTypeStruct : public OpType {
  public:
-  OpTypeStruct(OpCode const &other) : OpType(other, spv::OpTypeStruct) {}
+  OpTypeStruct(const OpCode &other) : OpType(other, spv::OpTypeStruct) {}
   llvm::SmallVector<spv::Id, 8> MemberTypes() const;
   static const spv::Op ClassCode = spv::OpTypeStruct;
 };
 
 class OpTypeOpaque : public OpType {
  public:
-  OpTypeOpaque(OpCode const &other) : OpType(other, spv::OpTypeOpaque) {}
+  OpTypeOpaque(const OpCode &other) : OpType(other, spv::OpTypeOpaque) {}
   llvm::StringRef Name() const;
   static const spv::Op ClassCode = spv::OpTypeOpaque;
 };
 
 class OpTypePointer : public OpType {
  public:
-  OpTypePointer(OpCode const &other) : OpType(other, spv::OpTypePointer) {}
+  OpTypePointer(const OpCode &other) : OpType(other, spv::OpTypePointer) {}
   uint32_t StorageClass() const;
   spv::Id Type() const;
   static const spv::Op ClassCode = spv::OpTypePointer;
@@ -627,7 +627,7 @@ class OpTypePointer : public OpType {
 
 class OpTypeFunction : public OpType {
  public:
-  OpTypeFunction(OpCode const &other) : OpType(other, spv::OpTypeFunction) {}
+  OpTypeFunction(const OpCode &other) : OpType(other, spv::OpTypeFunction) {}
   spv::Id ReturnType() const;
   llvm::SmallVector<spv::Id, 8> ParameterTypes() const;
   static const spv::Op ClassCode = spv::OpTypeFunction;
@@ -635,39 +635,39 @@ class OpTypeFunction : public OpType {
 
 class OpTypeEvent : public OpType {
  public:
-  OpTypeEvent(OpCode const &other) : OpType(other, spv::OpTypeEvent) {}
+  OpTypeEvent(const OpCode &other) : OpType(other, spv::OpTypeEvent) {}
   static const spv::Op ClassCode = spv::OpTypeEvent;
 };
 
 class OpTypeDeviceEvent : public OpType {
  public:
-  OpTypeDeviceEvent(OpCode const &other)
+  OpTypeDeviceEvent(const OpCode &other)
       : OpType(other, spv::OpTypeDeviceEvent) {}
   static const spv::Op ClassCode = spv::OpTypeDeviceEvent;
 };
 
 class OpTypeReserveId : public OpType {
  public:
-  OpTypeReserveId(OpCode const &other) : OpType(other, spv::OpTypeReserveId) {}
+  OpTypeReserveId(const OpCode &other) : OpType(other, spv::OpTypeReserveId) {}
   static const spv::Op ClassCode = spv::OpTypeReserveId;
 };
 
 class OpTypeQueue : public OpType {
  public:
-  OpTypeQueue(OpCode const &other) : OpType(other, spv::OpTypeQueue) {}
+  OpTypeQueue(const OpCode &other) : OpType(other, spv::OpTypeQueue) {}
   static const spv::Op ClassCode = spv::OpTypeQueue;
 };
 
 class OpTypePipe : public OpType {
  public:
-  OpTypePipe(OpCode const &other) : OpType(other, spv::OpTypePipe) {}
+  OpTypePipe(const OpCode &other) : OpType(other, spv::OpTypePipe) {}
   spv::AccessQualifier Qualifier() const;
   static const spv::Op ClassCode = spv::OpTypePipe;
 };
 
 class OpTypeForwardPointer : public OpType {
  public:
-  OpTypeForwardPointer(OpCode const &other)
+  OpTypeForwardPointer(const OpCode &other)
       : OpType(other, spv::OpTypeForwardPointer) {}
   spv::Id PointerType() const;
   spv::StorageClass StorageClass() const;
@@ -676,20 +676,20 @@ class OpTypeForwardPointer : public OpType {
 
 class OpConstantTrue : public OpResult {
  public:
-  OpConstantTrue(OpCode const &other) : OpResult(other, spv::OpConstantTrue) {}
+  OpConstantTrue(const OpCode &other) : OpResult(other, spv::OpConstantTrue) {}
   static const spv::Op ClassCode = spv::OpConstantTrue;
 };
 
 class OpConstantFalse : public OpResult {
  public:
-  OpConstantFalse(OpCode const &other)
+  OpConstantFalse(const OpCode &other)
       : OpResult(other, spv::OpConstantFalse) {}
   static const spv::Op ClassCode = spv::OpConstantFalse;
 };
 
 class OpConstant : public OpResult {
  public:
-  OpConstant(OpCode const &other) : OpResult(other, spv::OpConstant) {}
+  OpConstant(const OpCode &other) : OpResult(other, spv::OpConstant) {}
   uint32_t Value32() const;
   uint64_t Value64() const;
   static const spv::Op ClassCode = spv::OpConstant;
@@ -697,7 +697,7 @@ class OpConstant : public OpResult {
 
 class OpConstantComposite : public OpResult {
  public:
-  OpConstantComposite(OpCode const &other)
+  OpConstantComposite(const OpCode &other)
       : OpResult(other, spv::OpConstantComposite) {}
   llvm::SmallVector<spv::Id, 8> Constituents() const;
   static const spv::Op ClassCode = spv::OpConstantComposite;
@@ -705,7 +705,7 @@ class OpConstantComposite : public OpResult {
 
 class OpConstantSampler : public OpResult {
  public:
-  OpConstantSampler(OpCode const &other)
+  OpConstantSampler(const OpCode &other)
       : OpResult(other, spv::OpConstantSampler) {}
   spv::SamplerAddressingMode SamplerAddressingMode() const;
   uint32_t Param() const;
@@ -715,27 +715,27 @@ class OpConstantSampler : public OpResult {
 
 class OpConstantNull : public OpResult {
  public:
-  OpConstantNull(OpCode const &other) : OpResult(other, spv::OpConstantNull) {}
+  OpConstantNull(const OpCode &other) : OpResult(other, spv::OpConstantNull) {}
   static const spv::Op ClassCode = spv::OpConstantNull;
 };
 
 class OpSpecConstantTrue : public OpResult {
  public:
-  OpSpecConstantTrue(OpCode const &other)
+  OpSpecConstantTrue(const OpCode &other)
       : OpResult(other, spv::OpSpecConstantTrue) {}
   static const spv::Op ClassCode = spv::OpSpecConstantTrue;
 };
 
 class OpSpecConstantFalse : public OpResult {
  public:
-  OpSpecConstantFalse(OpCode const &other)
+  OpSpecConstantFalse(const OpCode &other)
       : OpResult(other, spv::OpSpecConstantFalse) {}
   static const spv::Op ClassCode = spv::OpSpecConstantFalse;
 };
 
 class OpSpecConstant : public OpResult {
  public:
-  OpSpecConstant(OpCode const &other) : OpResult(other, spv::OpSpecConstant) {}
+  OpSpecConstant(const OpCode &other) : OpResult(other, spv::OpSpecConstant) {}
   uint32_t Value32() const;
   uint64_t Value64() const;
   static const spv::Op ClassCode = spv::OpSpecConstant;
@@ -743,7 +743,7 @@ class OpSpecConstant : public OpResult {
 
 class OpSpecConstantComposite : public OpResult {
  public:
-  OpSpecConstantComposite(OpCode const &other)
+  OpSpecConstantComposite(const OpCode &other)
       : OpResult(other, spv::OpSpecConstantComposite) {}
   llvm::SmallVector<spv::Id, 8> Constituents() const;
   static const spv::Op ClassCode = spv::OpSpecConstantComposite;
@@ -751,7 +751,7 @@ class OpSpecConstantComposite : public OpResult {
 
 class OpSpecConstantOp : public OpResult {
  public:
-  OpSpecConstantOp(OpCode const &other)
+  OpSpecConstantOp(const OpCode &other)
       : OpResult(other, spv::OpSpecConstantOp) {}
   uint32_t Opcode() const;
   static const spv::Op ClassCode = spv::OpSpecConstantOp;
@@ -759,7 +759,7 @@ class OpSpecConstantOp : public OpResult {
 
 class OpFunction : public OpResult {
  public:
-  OpFunction(OpCode const &other) : OpResult(other, spv::OpFunction) {}
+  OpFunction(const OpCode &other) : OpResult(other, spv::OpFunction) {}
   uint32_t FunctionControl() const;
   spv::Id FunctionType() const;
   static const spv::Op ClassCode = spv::OpFunction;
@@ -767,20 +767,20 @@ class OpFunction : public OpResult {
 
 class OpFunctionParameter : public OpResult {
  public:
-  OpFunctionParameter(OpCode const &other)
+  OpFunctionParameter(const OpCode &other)
       : OpResult(other, spv::OpFunctionParameter) {}
   static const spv::Op ClassCode = spv::OpFunctionParameter;
 };
 
 class OpFunctionEnd : public OpCode {
  public:
-  OpFunctionEnd(OpCode const &other) : OpCode(other, spv::OpFunctionEnd) {}
+  OpFunctionEnd(const OpCode &other) : OpCode(other, spv::OpFunctionEnd) {}
   static const spv::Op ClassCode = spv::OpFunctionEnd;
 };
 
 class OpFunctionCall : public OpResult {
  public:
-  OpFunctionCall(OpCode const &other) : OpResult(other, spv::OpFunctionCall) {}
+  OpFunctionCall(const OpCode &other) : OpResult(other, spv::OpFunctionCall) {}
   spv::Id Function() const;
   llvm::SmallVector<spv::Id, 8> Arguments() const;
   static const spv::Op ClassCode = spv::OpFunctionCall;
@@ -788,7 +788,7 @@ class OpFunctionCall : public OpResult {
 
 class OpVariable : public OpResult {
  public:
-  OpVariable(OpCode const &other) : OpResult(other, spv::OpVariable) {}
+  OpVariable(const OpCode &other) : OpResult(other, spv::OpVariable) {}
   uint32_t StorageClass() const;
   spv::Id Initializer() const;
   static const spv::Op ClassCode = spv::OpVariable;
@@ -796,7 +796,7 @@ class OpVariable : public OpResult {
 
 class OpImageTexelPointer : public OpResult {
  public:
-  OpImageTexelPointer(OpCode const &other)
+  OpImageTexelPointer(const OpCode &other)
       : OpResult(other, spv::OpImageTexelPointer) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
@@ -806,7 +806,7 @@ class OpImageTexelPointer : public OpResult {
 
 class OpLoad : public OpResult {
  public:
-  OpLoad(OpCode const &other) : OpResult(other, spv::OpLoad) {}
+  OpLoad(const OpCode &other) : OpResult(other, spv::OpLoad) {}
   spv::Id Pointer() const;
   uint32_t MemoryAccess() const;
   static const spv::Op ClassCode = spv::OpLoad;
@@ -814,7 +814,7 @@ class OpLoad : public OpResult {
 
 class OpStore : public OpCode {
  public:
-  OpStore(OpCode const &other) : OpCode(other, spv::OpStore) {}
+  OpStore(const OpCode &other) : OpCode(other, spv::OpStore) {}
   spv::Id Pointer() const;
   spv::Id Object() const;
   uint32_t MemoryAccess() const;
@@ -823,7 +823,7 @@ class OpStore : public OpCode {
 
 class OpCopyMemory : public OpCode {
  public:
-  OpCopyMemory(OpCode const &other) : OpCode(other, spv::OpCopyMemory) {}
+  OpCopyMemory(const OpCode &other) : OpCode(other, spv::OpCopyMemory) {}
   spv::Id Target() const;
   spv::Id Source() const;
   uint32_t MemoryAccess() const;
@@ -832,7 +832,7 @@ class OpCopyMemory : public OpCode {
 
 class OpCopyMemorySized : public OpCode {
  public:
-  OpCopyMemorySized(OpCode const &other)
+  OpCopyMemorySized(const OpCode &other)
       : OpCode(other, spv::OpCopyMemorySized) {}
   spv::Id Target() const;
   spv::Id Source() const;
@@ -843,7 +843,7 @@ class OpCopyMemorySized : public OpCode {
 
 class OpAccessChain : public OpResult {
  public:
-  OpAccessChain(OpCode const &other) : OpResult(other, spv::OpAccessChain) {}
+  OpAccessChain(const OpCode &other) : OpResult(other, spv::OpAccessChain) {}
   spv::Id Base() const;
   llvm::SmallVector<spv::Id, 8> Indexes() const;
   static const spv::Op ClassCode = spv::OpAccessChain;
@@ -851,7 +851,7 @@ class OpAccessChain : public OpResult {
 
 class OpInBoundsAccessChain : public OpResult {
  public:
-  OpInBoundsAccessChain(OpCode const &other)
+  OpInBoundsAccessChain(const OpCode &other)
       : OpResult(other, spv::OpInBoundsAccessChain) {}
   spv::Id Base() const;
   llvm::SmallVector<spv::Id, 8> Indexes() const;
@@ -860,7 +860,7 @@ class OpInBoundsAccessChain : public OpResult {
 
 class OpPtrAccessChain : public OpResult {
  public:
-  OpPtrAccessChain(OpCode const &other)
+  OpPtrAccessChain(const OpCode &other)
       : OpResult(other, spv::OpPtrAccessChain) {}
   spv::Id Base() const;
   spv::Id Element() const;
@@ -870,7 +870,7 @@ class OpPtrAccessChain : public OpResult {
 
 class OpArrayLength : public OpResult {
  public:
-  OpArrayLength(OpCode const &other) : OpResult(other, spv::OpArrayLength) {}
+  OpArrayLength(const OpCode &other) : OpResult(other, spv::OpArrayLength) {}
   spv::Id Structure() const;
   uint32_t Arraymember() const;
   static const spv::Op ClassCode = spv::OpArrayLength;
@@ -878,7 +878,7 @@ class OpArrayLength : public OpResult {
 
 class OpGenericPtrMemSemantics : public OpResult {
  public:
-  OpGenericPtrMemSemantics(OpCode const &other)
+  OpGenericPtrMemSemantics(const OpCode &other)
       : OpResult(other, spv::OpGenericPtrMemSemantics) {}
   spv::Id Pointer() const;
   static const spv::Op ClassCode = spv::OpGenericPtrMemSemantics;
@@ -886,7 +886,7 @@ class OpGenericPtrMemSemantics : public OpResult {
 
 class OpInBoundsPtrAccessChain : public OpResult {
  public:
-  OpInBoundsPtrAccessChain(OpCode const &other)
+  OpInBoundsPtrAccessChain(const OpCode &other)
       : OpResult(other, spv::OpInBoundsPtrAccessChain) {}
   spv::Id Base() const;
   spv::Id Element() const;
@@ -896,7 +896,7 @@ class OpInBoundsPtrAccessChain : public OpResult {
 
 class OpDecorate : public OpDecorateBase {
  public:
-  OpDecorate(OpCode const &other) : OpDecorateBase(other, spv::OpDecorate) {}
+  OpDecorate(const OpCode &other) : OpDecorateBase(other, spv::OpDecorate) {}
   spv::Id Target() const;
   spv::Decoration Decoration() const;
   const char *getDecorationString() const;
@@ -905,7 +905,7 @@ class OpDecorate : public OpDecorateBase {
 
 class OpMemberDecorate : public OpDecorateBase {
  public:
-  OpMemberDecorate(OpCode const &other)
+  OpMemberDecorate(const OpCode &other)
       : OpDecorateBase(other, spv::OpMemberDecorate) {}
   spv::Id StructureType() const;
   uint32_t Member() const;
@@ -915,7 +915,7 @@ class OpMemberDecorate : public OpDecorateBase {
 
 class OpDecorationGroup : public OpCode {
  public:
-  OpDecorationGroup(OpCode const &other)
+  OpDecorationGroup(const OpCode &other)
       : OpCode(other, spv::OpDecorationGroup) {}
   spv::Id IdResult() const;
   static const spv::Op ClassCode = spv::OpDecorationGroup;
@@ -923,7 +923,7 @@ class OpDecorationGroup : public OpCode {
 
 class OpGroupDecorate : public OpCode {
  public:
-  OpGroupDecorate(OpCode const &other) : OpCode(other, spv::OpGroupDecorate) {}
+  OpGroupDecorate(const OpCode &other) : OpCode(other, spv::OpGroupDecorate) {}
   spv::Id DecorationGroup() const;
   llvm::SmallVector<spv::Id, 8> Targets() const;
   static const spv::Op ClassCode = spv::OpGroupDecorate;
@@ -931,7 +931,7 @@ class OpGroupDecorate : public OpCode {
 
 class OpGroupMemberDecorate : public OpCode {
  public:
-  OpGroupMemberDecorate(OpCode const &other)
+  OpGroupMemberDecorate(const OpCode &other)
       : OpCode(other, spv::OpGroupMemberDecorate) {}
   spv::Id DecorationGroup() const;
   struct TargetsT {
@@ -944,7 +944,7 @@ class OpGroupMemberDecorate : public OpCode {
 
 class OpVectorExtractDynamic : public OpResult {
  public:
-  OpVectorExtractDynamic(OpCode const &other)
+  OpVectorExtractDynamic(const OpCode &other)
       : OpResult(other, spv::OpVectorExtractDynamic) {}
   spv::Id Vector() const;
   spv::Id Index() const;
@@ -953,7 +953,7 @@ class OpVectorExtractDynamic : public OpResult {
 
 class OpVectorInsertDynamic : public OpResult {
  public:
-  OpVectorInsertDynamic(OpCode const &other)
+  OpVectorInsertDynamic(const OpCode &other)
       : OpResult(other, spv::OpVectorInsertDynamic) {}
   spv::Id Vector() const;
   spv::Id Component() const;
@@ -963,7 +963,7 @@ class OpVectorInsertDynamic : public OpResult {
 
 class OpVectorShuffle : public OpResult {
  public:
-  OpVectorShuffle(OpCode const &other)
+  OpVectorShuffle(const OpCode &other)
       : OpResult(other, spv::OpVectorShuffle) {}
   spv::Id Vector1() const;
   spv::Id Vector2() const;
@@ -973,7 +973,7 @@ class OpVectorShuffle : public OpResult {
 
 class OpCompositeConstruct : public OpResult {
  public:
-  OpCompositeConstruct(OpCode const &other)
+  OpCompositeConstruct(const OpCode &other)
       : OpResult(other, spv::OpCompositeConstruct) {}
   llvm::SmallVector<spv::Id, 8> Constituents() const;
   static const spv::Op ClassCode = spv::OpCompositeConstruct;
@@ -981,7 +981,7 @@ class OpCompositeConstruct : public OpResult {
 
 class OpCompositeExtract : public OpResult {
  public:
-  OpCompositeExtract(OpCode const &other)
+  OpCompositeExtract(const OpCode &other)
       : OpResult(other, spv::OpCompositeExtract) {}
   spv::Id Composite() const;
   llvm::SmallVector<uint32_t, 4> Indexes() const;
@@ -990,7 +990,7 @@ class OpCompositeExtract : public OpResult {
 
 class OpCompositeInsert : public OpResult {
  public:
-  OpCompositeInsert(OpCode const &other)
+  OpCompositeInsert(const OpCode &other)
       : OpResult(other, spv::OpCompositeInsert) {}
   spv::Id Object() const;
   spv::Id Composite() const;
@@ -1000,21 +1000,21 @@ class OpCompositeInsert : public OpResult {
 
 class OpCopyObject : public OpResult {
  public:
-  OpCopyObject(OpCode const &other) : OpResult(other, spv::OpCopyObject) {}
+  OpCopyObject(const OpCode &other) : OpResult(other, spv::OpCopyObject) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpCopyObject;
 };
 
 class OpTranspose : public OpResult {
  public:
-  OpTranspose(OpCode const &other) : OpResult(other, spv::OpTranspose) {}
+  OpTranspose(const OpCode &other) : OpResult(other, spv::OpTranspose) {}
   spv::Id Matrix() const;
   static const spv::Op ClassCode = spv::OpTranspose;
 };
 
 class OpSampledImage : public OpResult {
  public:
-  OpSampledImage(OpCode const &other) : OpResult(other, spv::OpSampledImage) {}
+  OpSampledImage(const OpCode &other) : OpResult(other, spv::OpSampledImage) {}
   spv::Id Image() const;
   spv::Id Sampler() const;
   static const spv::Op ClassCode = spv::OpSampledImage;
@@ -1022,7 +1022,7 @@ class OpSampledImage : public OpResult {
 
 class OpImageSampleImplicitLod : public OpResult {
  public:
-  OpImageSampleImplicitLod(OpCode const &other)
+  OpImageSampleImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1032,7 +1032,7 @@ class OpImageSampleImplicitLod : public OpResult {
 
 class OpImageSampleExplicitLod : public OpResult {
  public:
-  OpImageSampleExplicitLod(OpCode const &other)
+  OpImageSampleExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1042,7 +1042,7 @@ class OpImageSampleExplicitLod : public OpResult {
 
 class OpImageSampleDrefImplicitLod : public OpResult {
  public:
-  OpImageSampleDrefImplicitLod(OpCode const &other)
+  OpImageSampleDrefImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleDrefImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1053,7 +1053,7 @@ class OpImageSampleDrefImplicitLod : public OpResult {
 
 class OpImageSampleDrefExplicitLod : public OpResult {
  public:
-  OpImageSampleDrefExplicitLod(OpCode const &other)
+  OpImageSampleDrefExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleDrefExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1064,7 +1064,7 @@ class OpImageSampleDrefExplicitLod : public OpResult {
 
 class OpImageSampleProjImplicitLod : public OpResult {
  public:
-  OpImageSampleProjImplicitLod(OpCode const &other)
+  OpImageSampleProjImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleProjImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1074,7 +1074,7 @@ class OpImageSampleProjImplicitLod : public OpResult {
 
 class OpImageSampleProjExplicitLod : public OpResult {
  public:
-  OpImageSampleProjExplicitLod(OpCode const &other)
+  OpImageSampleProjExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleProjExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1084,7 +1084,7 @@ class OpImageSampleProjExplicitLod : public OpResult {
 
 class OpImageSampleProjDrefImplicitLod : public OpResult {
  public:
-  OpImageSampleProjDrefImplicitLod(OpCode const &other)
+  OpImageSampleProjDrefImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleProjDrefImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1095,7 +1095,7 @@ class OpImageSampleProjDrefImplicitLod : public OpResult {
 
 class OpImageSampleProjDrefExplicitLod : public OpResult {
  public:
-  OpImageSampleProjDrefExplicitLod(OpCode const &other)
+  OpImageSampleProjDrefExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSampleProjDrefExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1106,7 +1106,7 @@ class OpImageSampleProjDrefExplicitLod : public OpResult {
 
 class OpImageFetch : public OpResult {
  public:
-  OpImageFetch(OpCode const &other) : OpResult(other, spv::OpImageFetch) {}
+  OpImageFetch(const OpCode &other) : OpResult(other, spv::OpImageFetch) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
   uint32_t ImageOperands() const;
@@ -1115,7 +1115,7 @@ class OpImageFetch : public OpResult {
 
 class OpImageGather : public OpResult {
  public:
-  OpImageGather(OpCode const &other) : OpResult(other, spv::OpImageGather) {}
+  OpImageGather(const OpCode &other) : OpResult(other, spv::OpImageGather) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
   spv::Id Component() const;
@@ -1125,7 +1125,7 @@ class OpImageGather : public OpResult {
 
 class OpImageDrefGather : public OpResult {
  public:
-  OpImageDrefGather(OpCode const &other)
+  OpImageDrefGather(const OpCode &other)
       : OpResult(other, spv::OpImageDrefGather) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1136,7 +1136,7 @@ class OpImageDrefGather : public OpResult {
 
 class OpImageRead : public OpResult {
  public:
-  OpImageRead(OpCode const &other) : OpResult(other, spv::OpImageRead) {}
+  OpImageRead(const OpCode &other) : OpResult(other, spv::OpImageRead) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
   uint32_t ImageOperands() const;
@@ -1145,7 +1145,7 @@ class OpImageRead : public OpResult {
 
 class OpImageWrite : public OpCode {
  public:
-  OpImageWrite(OpCode const &other) : OpCode(other, spv::OpImageWrite) {}
+  OpImageWrite(const OpCode &other) : OpCode(other, spv::OpImageWrite) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
   spv::Id Texel() const;
@@ -1155,14 +1155,14 @@ class OpImageWrite : public OpCode {
 
 class OpImage : public OpResult {
  public:
-  OpImage(OpCode const &other) : OpResult(other, spv::OpImage) {}
+  OpImage(const OpCode &other) : OpResult(other, spv::OpImage) {}
   spv::Id SampledImage() const;
   static const spv::Op ClassCode = spv::OpImage;
 };
 
 class OpImageQueryFormat : public OpResult {
  public:
-  OpImageQueryFormat(OpCode const &other)
+  OpImageQueryFormat(const OpCode &other)
       : OpResult(other, spv::OpImageQueryFormat) {}
   spv::Id Image() const;
   static const spv::Op ClassCode = spv::OpImageQueryFormat;
@@ -1170,7 +1170,7 @@ class OpImageQueryFormat : public OpResult {
 
 class OpImageQueryOrder : public OpResult {
  public:
-  OpImageQueryOrder(OpCode const &other)
+  OpImageQueryOrder(const OpCode &other)
       : OpResult(other, spv::OpImageQueryOrder) {}
   spv::Id Image() const;
   static const spv::Op ClassCode = spv::OpImageQueryOrder;
@@ -1178,7 +1178,7 @@ class OpImageQueryOrder : public OpResult {
 
 class OpImageQuerySizeLod : public OpResult {
  public:
-  OpImageQuerySizeLod(OpCode const &other)
+  OpImageQuerySizeLod(const OpCode &other)
       : OpResult(other, spv::OpImageQuerySizeLod) {}
   spv::Id Image() const;
   spv::Id LevelofDetail() const;
@@ -1187,7 +1187,7 @@ class OpImageQuerySizeLod : public OpResult {
 
 class OpImageQuerySize : public OpResult {
  public:
-  OpImageQuerySize(OpCode const &other)
+  OpImageQuerySize(const OpCode &other)
       : OpResult(other, spv::OpImageQuerySize) {}
   spv::Id Image() const;
   static const spv::Op ClassCode = spv::OpImageQuerySize;
@@ -1195,7 +1195,7 @@ class OpImageQuerySize : public OpResult {
 
 class OpImageQueryLod : public OpResult {
  public:
-  OpImageQueryLod(OpCode const &other)
+  OpImageQueryLod(const OpCode &other)
       : OpResult(other, spv::OpImageQueryLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -1204,7 +1204,7 @@ class OpImageQueryLod : public OpResult {
 
 class OpImageQueryLevels : public OpResult {
  public:
-  OpImageQueryLevels(OpCode const &other)
+  OpImageQueryLevels(const OpCode &other)
       : OpResult(other, spv::OpImageQueryLevels) {}
   spv::Id Image() const;
   static const spv::Op ClassCode = spv::OpImageQueryLevels;
@@ -1212,7 +1212,7 @@ class OpImageQueryLevels : public OpResult {
 
 class OpImageQuerySamples : public OpResult {
  public:
-  OpImageQuerySamples(OpCode const &other)
+  OpImageQuerySamples(const OpCode &other)
       : OpResult(other, spv::OpImageQuerySamples) {}
   spv::Id Image() const;
   static const spv::Op ClassCode = spv::OpImageQuerySamples;
@@ -1220,56 +1220,56 @@ class OpImageQuerySamples : public OpResult {
 
 class OpConvertFToU : public OpResult {
  public:
-  OpConvertFToU(OpCode const &other) : OpResult(other, spv::OpConvertFToU) {}
+  OpConvertFToU(const OpCode &other) : OpResult(other, spv::OpConvertFToU) {}
   spv::Id FloatValue() const;
   static const spv::Op ClassCode = spv::OpConvertFToU;
 };
 
 class OpConvertFToS : public OpResult {
  public:
-  OpConvertFToS(OpCode const &other) : OpResult(other, spv::OpConvertFToS) {}
+  OpConvertFToS(const OpCode &other) : OpResult(other, spv::OpConvertFToS) {}
   spv::Id FloatValue() const;
   static const spv::Op ClassCode = spv::OpConvertFToS;
 };
 
 class OpConvertSToF : public OpResult {
  public:
-  OpConvertSToF(OpCode const &other) : OpResult(other, spv::OpConvertSToF) {}
+  OpConvertSToF(const OpCode &other) : OpResult(other, spv::OpConvertSToF) {}
   spv::Id SignedValue() const;
   static const spv::Op ClassCode = spv::OpConvertSToF;
 };
 
 class OpConvertUToF : public OpResult {
  public:
-  OpConvertUToF(OpCode const &other) : OpResult(other, spv::OpConvertUToF) {}
+  OpConvertUToF(const OpCode &other) : OpResult(other, spv::OpConvertUToF) {}
   spv::Id UnsignedValue() const;
   static const spv::Op ClassCode = spv::OpConvertUToF;
 };
 
 class OpUConvert : public OpResult {
  public:
-  OpUConvert(OpCode const &other) : OpResult(other, spv::OpUConvert) {}
+  OpUConvert(const OpCode &other) : OpResult(other, spv::OpUConvert) {}
   spv::Id UnsignedValue() const;
   static const spv::Op ClassCode = spv::OpUConvert;
 };
 
 class OpSConvert : public OpResult {
  public:
-  OpSConvert(OpCode const &other) : OpResult(other, spv::OpSConvert) {}
+  OpSConvert(const OpCode &other) : OpResult(other, spv::OpSConvert) {}
   spv::Id SignedValue() const;
   static const spv::Op ClassCode = spv::OpSConvert;
 };
 
 class OpFConvert : public OpResult {
  public:
-  OpFConvert(OpCode const &other) : OpResult(other, spv::OpFConvert) {}
+  OpFConvert(const OpCode &other) : OpResult(other, spv::OpFConvert) {}
   spv::Id FloatValue() const;
   static const spv::Op ClassCode = spv::OpFConvert;
 };
 
 class OpQuantizeToF16 : public OpResult {
  public:
-  OpQuantizeToF16(OpCode const &other)
+  OpQuantizeToF16(const OpCode &other)
       : OpResult(other, spv::OpQuantizeToF16) {}
   spv::Id Value() const;
   static const spv::Op ClassCode = spv::OpQuantizeToF16;
@@ -1277,7 +1277,7 @@ class OpQuantizeToF16 : public OpResult {
 
 class OpConvertPtrToU : public OpResult {
  public:
-  OpConvertPtrToU(OpCode const &other)
+  OpConvertPtrToU(const OpCode &other)
       : OpResult(other, spv::OpConvertPtrToU) {}
   spv::Id Pointer() const;
   static const spv::Op ClassCode = spv::OpConvertPtrToU;
@@ -1285,7 +1285,7 @@ class OpConvertPtrToU : public OpResult {
 
 class OpSatConvertSToU : public OpResult {
  public:
-  OpSatConvertSToU(OpCode const &other)
+  OpSatConvertSToU(const OpCode &other)
       : OpResult(other, spv::OpSatConvertSToU) {}
   spv::Id SignedValue() const;
   static const spv::Op ClassCode = spv::OpSatConvertSToU;
@@ -1293,7 +1293,7 @@ class OpSatConvertSToU : public OpResult {
 
 class OpSatConvertUToS : public OpResult {
  public:
-  OpSatConvertUToS(OpCode const &other)
+  OpSatConvertUToS(const OpCode &other)
       : OpResult(other, spv::OpSatConvertUToS) {}
   spv::Id UnsignedValue() const;
   static const spv::Op ClassCode = spv::OpSatConvertUToS;
@@ -1301,7 +1301,7 @@ class OpSatConvertUToS : public OpResult {
 
 class OpConvertUToPtr : public OpResult {
  public:
-  OpConvertUToPtr(OpCode const &other)
+  OpConvertUToPtr(const OpCode &other)
       : OpResult(other, spv::OpConvertUToPtr) {}
   spv::Id IntegerValue() const;
   static const spv::Op ClassCode = spv::OpConvertUToPtr;
@@ -1309,7 +1309,7 @@ class OpConvertUToPtr : public OpResult {
 
 class OpPtrCastToGeneric : public OpResult {
  public:
-  OpPtrCastToGeneric(OpCode const &other)
+  OpPtrCastToGeneric(const OpCode &other)
       : OpResult(other, spv::OpPtrCastToGeneric) {}
   spv::Id Pointer() const;
   static const spv::Op ClassCode = spv::OpPtrCastToGeneric;
@@ -1317,7 +1317,7 @@ class OpPtrCastToGeneric : public OpResult {
 
 class OpGenericCastToPtr : public OpResult {
  public:
-  OpGenericCastToPtr(OpCode const &other)
+  OpGenericCastToPtr(const OpCode &other)
       : OpResult(other, spv::OpGenericCastToPtr) {}
   spv::Id Pointer() const;
   static const spv::Op ClassCode = spv::OpGenericCastToPtr;
@@ -1325,7 +1325,7 @@ class OpGenericCastToPtr : public OpResult {
 
 class OpGenericCastToPtrExplicit : public OpResult {
  public:
-  OpGenericCastToPtrExplicit(OpCode const &other)
+  OpGenericCastToPtrExplicit(const OpCode &other)
       : OpResult(other, spv::OpGenericCastToPtrExplicit) {}
   spv::Id Pointer() const;
   spv::StorageClass Storage() const;
@@ -1334,28 +1334,28 @@ class OpGenericCastToPtrExplicit : public OpResult {
 
 class OpBitcast : public OpResult {
  public:
-  OpBitcast(OpCode const &other) : OpResult(other, spv::OpBitcast) {}
+  OpBitcast(const OpCode &other) : OpResult(other, spv::OpBitcast) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpBitcast;
 };
 
 class OpSNegate : public OpResult {
  public:
-  OpSNegate(OpCode const &other) : OpResult(other, spv::OpSNegate) {}
+  OpSNegate(const OpCode &other) : OpResult(other, spv::OpSNegate) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpSNegate;
 };
 
 class OpFNegate : public OpResult {
  public:
-  OpFNegate(OpCode const &other) : OpResult(other, spv::OpFNegate) {}
+  OpFNegate(const OpCode &other) : OpResult(other, spv::OpFNegate) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpFNegate;
 };
 
 class OpIAdd : public OpResult {
  public:
-  OpIAdd(OpCode const &other) : OpResult(other, spv::OpIAdd) {}
+  OpIAdd(const OpCode &other) : OpResult(other, spv::OpIAdd) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpIAdd;
@@ -1363,7 +1363,7 @@ class OpIAdd : public OpResult {
 
 class OpFAdd : public OpResult {
  public:
-  OpFAdd(OpCode const &other) : OpResult(other, spv::OpFAdd) {}
+  OpFAdd(const OpCode &other) : OpResult(other, spv::OpFAdd) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFAdd;
@@ -1371,7 +1371,7 @@ class OpFAdd : public OpResult {
 
 class OpISub : public OpResult {
  public:
-  OpISub(OpCode const &other) : OpResult(other, spv::OpISub) {}
+  OpISub(const OpCode &other) : OpResult(other, spv::OpISub) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpISub;
@@ -1379,7 +1379,7 @@ class OpISub : public OpResult {
 
 class OpFSub : public OpResult {
  public:
-  OpFSub(OpCode const &other) : OpResult(other, spv::OpFSub) {}
+  OpFSub(const OpCode &other) : OpResult(other, spv::OpFSub) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFSub;
@@ -1387,7 +1387,7 @@ class OpFSub : public OpResult {
 
 class OpIMul : public OpResult {
  public:
-  OpIMul(OpCode const &other) : OpResult(other, spv::OpIMul) {}
+  OpIMul(const OpCode &other) : OpResult(other, spv::OpIMul) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpIMul;
@@ -1395,7 +1395,7 @@ class OpIMul : public OpResult {
 
 class OpFMul : public OpResult {
  public:
-  OpFMul(OpCode const &other) : OpResult(other, spv::OpFMul) {}
+  OpFMul(const OpCode &other) : OpResult(other, spv::OpFMul) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFMul;
@@ -1403,7 +1403,7 @@ class OpFMul : public OpResult {
 
 class OpUDiv : public OpResult {
  public:
-  OpUDiv(OpCode const &other) : OpResult(other, spv::OpUDiv) {}
+  OpUDiv(const OpCode &other) : OpResult(other, spv::OpUDiv) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpUDiv;
@@ -1411,7 +1411,7 @@ class OpUDiv : public OpResult {
 
 class OpSDiv : public OpResult {
  public:
-  OpSDiv(OpCode const &other) : OpResult(other, spv::OpSDiv) {}
+  OpSDiv(const OpCode &other) : OpResult(other, spv::OpSDiv) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSDiv;
@@ -1419,7 +1419,7 @@ class OpSDiv : public OpResult {
 
 class OpFDiv : public OpResult {
  public:
-  OpFDiv(OpCode const &other) : OpResult(other, spv::OpFDiv) {}
+  OpFDiv(const OpCode &other) : OpResult(other, spv::OpFDiv) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFDiv;
@@ -1427,7 +1427,7 @@ class OpFDiv : public OpResult {
 
 class OpUMod : public OpResult {
  public:
-  OpUMod(OpCode const &other) : OpResult(other, spv::OpUMod) {}
+  OpUMod(const OpCode &other) : OpResult(other, spv::OpUMod) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpUMod;
@@ -1435,7 +1435,7 @@ class OpUMod : public OpResult {
 
 class OpSRem : public OpResult {
  public:
-  OpSRem(OpCode const &other) : OpResult(other, spv::OpSRem) {}
+  OpSRem(const OpCode &other) : OpResult(other, spv::OpSRem) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSRem;
@@ -1443,7 +1443,7 @@ class OpSRem : public OpResult {
 
 class OpSMod : public OpResult {
  public:
-  OpSMod(OpCode const &other) : OpResult(other, spv::OpSMod) {}
+  OpSMod(const OpCode &other) : OpResult(other, spv::OpSMod) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSMod;
@@ -1451,7 +1451,7 @@ class OpSMod : public OpResult {
 
 class OpFRem : public OpResult {
  public:
-  OpFRem(OpCode const &other) : OpResult(other, spv::OpFRem) {}
+  OpFRem(const OpCode &other) : OpResult(other, spv::OpFRem) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFRem;
@@ -1459,7 +1459,7 @@ class OpFRem : public OpResult {
 
 class OpFMod : public OpResult {
  public:
-  OpFMod(OpCode const &other) : OpResult(other, spv::OpFMod) {}
+  OpFMod(const OpCode &other) : OpResult(other, spv::OpFMod) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFMod;
@@ -1467,7 +1467,7 @@ class OpFMod : public OpResult {
 
 class OpVectorTimesScalar : public OpResult {
  public:
-  OpVectorTimesScalar(OpCode const &other)
+  OpVectorTimesScalar(const OpCode &other)
       : OpResult(other, spv::OpVectorTimesScalar) {}
   spv::Id Vector() const;
   spv::Id Scalar() const;
@@ -1476,7 +1476,7 @@ class OpVectorTimesScalar : public OpResult {
 
 class OpMatrixTimesScalar : public OpResult {
  public:
-  OpMatrixTimesScalar(OpCode const &other)
+  OpMatrixTimesScalar(const OpCode &other)
       : OpResult(other, spv::OpMatrixTimesScalar) {}
   spv::Id Matrix() const;
   spv::Id Scalar() const;
@@ -1485,7 +1485,7 @@ class OpMatrixTimesScalar : public OpResult {
 
 class OpVectorTimesMatrix : public OpResult {
  public:
-  OpVectorTimesMatrix(OpCode const &other)
+  OpVectorTimesMatrix(const OpCode &other)
       : OpResult(other, spv::OpVectorTimesMatrix) {}
   spv::Id Vector() const;
   spv::Id Matrix() const;
@@ -1494,7 +1494,7 @@ class OpVectorTimesMatrix : public OpResult {
 
 class OpMatrixTimesVector : public OpResult {
  public:
-  OpMatrixTimesVector(OpCode const &other)
+  OpMatrixTimesVector(const OpCode &other)
       : OpResult(other, spv::OpMatrixTimesVector) {}
   spv::Id Matrix() const;
   spv::Id Vector() const;
@@ -1503,7 +1503,7 @@ class OpMatrixTimesVector : public OpResult {
 
 class OpMatrixTimesMatrix : public OpResult {
  public:
-  OpMatrixTimesMatrix(OpCode const &other)
+  OpMatrixTimesMatrix(const OpCode &other)
       : OpResult(other, spv::OpMatrixTimesMatrix) {}
   spv::Id LeftMatrix() const;
   spv::Id RightMatrix() const;
@@ -1512,7 +1512,7 @@ class OpMatrixTimesMatrix : public OpResult {
 
 class OpOuterProduct : public OpResult {
  public:
-  OpOuterProduct(OpCode const &other) : OpResult(other, spv::OpOuterProduct) {}
+  OpOuterProduct(const OpCode &other) : OpResult(other, spv::OpOuterProduct) {}
   spv::Id Vector1() const;
   spv::Id Vector2() const;
   static const spv::Op ClassCode = spv::OpOuterProduct;
@@ -1520,7 +1520,7 @@ class OpOuterProduct : public OpResult {
 
 class OpDot : public OpResult {
  public:
-  OpDot(OpCode const &other) : OpResult(other, spv::OpDot) {}
+  OpDot(const OpCode &other) : OpResult(other, spv::OpDot) {}
   spv::Id Vector1() const;
   spv::Id Vector2() const;
   static const spv::Op ClassCode = spv::OpDot;
@@ -1528,7 +1528,7 @@ class OpDot : public OpResult {
 
 class OpIAddCarry : public OpResult {
  public:
-  OpIAddCarry(OpCode const &other) : OpResult(other, spv::OpIAddCarry) {}
+  OpIAddCarry(const OpCode &other) : OpResult(other, spv::OpIAddCarry) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpIAddCarry;
@@ -1536,7 +1536,7 @@ class OpIAddCarry : public OpResult {
 
 class OpISubBorrow : public OpResult {
  public:
-  OpISubBorrow(OpCode const &other) : OpResult(other, spv::OpISubBorrow) {}
+  OpISubBorrow(const OpCode &other) : OpResult(other, spv::OpISubBorrow) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpISubBorrow;
@@ -1544,7 +1544,7 @@ class OpISubBorrow : public OpResult {
 
 class OpUMulExtended : public OpResult {
  public:
-  OpUMulExtended(OpCode const &other) : OpResult(other, spv::OpUMulExtended) {}
+  OpUMulExtended(const OpCode &other) : OpResult(other, spv::OpUMulExtended) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpUMulExtended;
@@ -1552,7 +1552,7 @@ class OpUMulExtended : public OpResult {
 
 class OpSMulExtended : public OpResult {
  public:
-  OpSMulExtended(OpCode const &other) : OpResult(other, spv::OpSMulExtended) {}
+  OpSMulExtended(const OpCode &other) : OpResult(other, spv::OpSMulExtended) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSMulExtended;
@@ -1560,56 +1560,56 @@ class OpSMulExtended : public OpResult {
 
 class OpAny : public OpResult {
  public:
-  OpAny(OpCode const &other) : OpResult(other, spv::OpAny) {}
+  OpAny(const OpCode &other) : OpResult(other, spv::OpAny) {}
   spv::Id Vector() const;
   static const spv::Op ClassCode = spv::OpAny;
 };
 
 class OpAll : public OpResult {
  public:
-  OpAll(OpCode const &other) : OpResult(other, spv::OpAll) {}
+  OpAll(const OpCode &other) : OpResult(other, spv::OpAll) {}
   spv::Id Vector() const;
   static const spv::Op ClassCode = spv::OpAll;
 };
 
 class OpIsNan : public OpResult {
  public:
-  OpIsNan(OpCode const &other) : OpResult(other, spv::OpIsNan) {}
+  OpIsNan(const OpCode &other) : OpResult(other, spv::OpIsNan) {}
   spv::Id x() const;
   static const spv::Op ClassCode = spv::OpIsNan;
 };
 
 class OpIsInf : public OpResult {
  public:
-  OpIsInf(OpCode const &other) : OpResult(other, spv::OpIsInf) {}
+  OpIsInf(const OpCode &other) : OpResult(other, spv::OpIsInf) {}
   spv::Id x() const;
   static const spv::Op ClassCode = spv::OpIsInf;
 };
 
 class OpIsFinite : public OpResult {
  public:
-  OpIsFinite(OpCode const &other) : OpResult(other, spv::OpIsFinite) {}
+  OpIsFinite(const OpCode &other) : OpResult(other, spv::OpIsFinite) {}
   spv::Id x() const;
   static const spv::Op ClassCode = spv::OpIsFinite;
 };
 
 class OpIsNormal : public OpResult {
  public:
-  OpIsNormal(OpCode const &other) : OpResult(other, spv::OpIsNormal) {}
+  OpIsNormal(const OpCode &other) : OpResult(other, spv::OpIsNormal) {}
   spv::Id x() const;
   static const spv::Op ClassCode = spv::OpIsNormal;
 };
 
 class OpSignBitSet : public OpResult {
  public:
-  OpSignBitSet(OpCode const &other) : OpResult(other, spv::OpSignBitSet) {}
+  OpSignBitSet(const OpCode &other) : OpResult(other, spv::OpSignBitSet) {}
   spv::Id x() const;
   static const spv::Op ClassCode = spv::OpSignBitSet;
 };
 
 class OpLessOrGreater : public OpResult {
  public:
-  OpLessOrGreater(OpCode const &other)
+  OpLessOrGreater(const OpCode &other)
       : OpResult(other, spv::OpLessOrGreater) {}
   spv::Id x() const;
   spv::Id y() const;
@@ -1618,7 +1618,7 @@ class OpLessOrGreater : public OpResult {
 
 class OpOrdered : public OpResult {
  public:
-  OpOrdered(OpCode const &other) : OpResult(other, spv::OpOrdered) {}
+  OpOrdered(const OpCode &other) : OpResult(other, spv::OpOrdered) {}
   spv::Id x() const;
   spv::Id y() const;
   static const spv::Op ClassCode = spv::OpOrdered;
@@ -1626,7 +1626,7 @@ class OpOrdered : public OpResult {
 
 class OpUnordered : public OpResult {
  public:
-  OpUnordered(OpCode const &other) : OpResult(other, spv::OpUnordered) {}
+  OpUnordered(const OpCode &other) : OpResult(other, spv::OpUnordered) {}
   spv::Id x() const;
   spv::Id y() const;
   static const spv::Op ClassCode = spv::OpUnordered;
@@ -1634,7 +1634,7 @@ class OpUnordered : public OpResult {
 
 class OpLogicalEqual : public OpResult {
  public:
-  OpLogicalEqual(OpCode const &other) : OpResult(other, spv::OpLogicalEqual) {}
+  OpLogicalEqual(const OpCode &other) : OpResult(other, spv::OpLogicalEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpLogicalEqual;
@@ -1642,7 +1642,7 @@ class OpLogicalEqual : public OpResult {
 
 class OpLogicalNotEqual : public OpResult {
  public:
-  OpLogicalNotEqual(OpCode const &other)
+  OpLogicalNotEqual(const OpCode &other)
       : OpResult(other, spv::OpLogicalNotEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1651,7 +1651,7 @@ class OpLogicalNotEqual : public OpResult {
 
 class OpLogicalOr : public OpResult {
  public:
-  OpLogicalOr(OpCode const &other) : OpResult(other, spv::OpLogicalOr) {}
+  OpLogicalOr(const OpCode &other) : OpResult(other, spv::OpLogicalOr) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpLogicalOr;
@@ -1659,7 +1659,7 @@ class OpLogicalOr : public OpResult {
 
 class OpLogicalAnd : public OpResult {
  public:
-  OpLogicalAnd(OpCode const &other) : OpResult(other, spv::OpLogicalAnd) {}
+  OpLogicalAnd(const OpCode &other) : OpResult(other, spv::OpLogicalAnd) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpLogicalAnd;
@@ -1667,14 +1667,14 @@ class OpLogicalAnd : public OpResult {
 
 class OpLogicalNot : public OpResult {
  public:
-  OpLogicalNot(OpCode const &other) : OpResult(other, spv::OpLogicalNot) {}
+  OpLogicalNot(const OpCode &other) : OpResult(other, spv::OpLogicalNot) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpLogicalNot;
 };
 
 class OpSelect : public OpResult {
  public:
-  OpSelect(OpCode const &other) : OpResult(other, spv::OpSelect) {}
+  OpSelect(const OpCode &other) : OpResult(other, spv::OpSelect) {}
   spv::Id Condition() const;
   spv::Id Object1() const;
   spv::Id Object2() const;
@@ -1683,7 +1683,7 @@ class OpSelect : public OpResult {
 
 class OpIEqual : public OpResult {
  public:
-  OpIEqual(OpCode const &other) : OpResult(other, spv::OpIEqual) {}
+  OpIEqual(const OpCode &other) : OpResult(other, spv::OpIEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpIEqual;
@@ -1691,7 +1691,7 @@ class OpIEqual : public OpResult {
 
 class OpINotEqual : public OpResult {
  public:
-  OpINotEqual(OpCode const &other) : OpResult(other, spv::OpINotEqual) {}
+  OpINotEqual(const OpCode &other) : OpResult(other, spv::OpINotEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpINotEqual;
@@ -1699,7 +1699,7 @@ class OpINotEqual : public OpResult {
 
 class OpUGreaterThan : public OpResult {
  public:
-  OpUGreaterThan(OpCode const &other) : OpResult(other, spv::OpUGreaterThan) {}
+  OpUGreaterThan(const OpCode &other) : OpResult(other, spv::OpUGreaterThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpUGreaterThan;
@@ -1707,7 +1707,7 @@ class OpUGreaterThan : public OpResult {
 
 class OpSGreaterThan : public OpResult {
  public:
-  OpSGreaterThan(OpCode const &other) : OpResult(other, spv::OpSGreaterThan) {}
+  OpSGreaterThan(const OpCode &other) : OpResult(other, spv::OpSGreaterThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSGreaterThan;
@@ -1715,7 +1715,7 @@ class OpSGreaterThan : public OpResult {
 
 class OpUGreaterThanEqual : public OpResult {
  public:
-  OpUGreaterThanEqual(OpCode const &other)
+  OpUGreaterThanEqual(const OpCode &other)
       : OpResult(other, spv::OpUGreaterThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1724,7 +1724,7 @@ class OpUGreaterThanEqual : public OpResult {
 
 class OpSGreaterThanEqual : public OpResult {
  public:
-  OpSGreaterThanEqual(OpCode const &other)
+  OpSGreaterThanEqual(const OpCode &other)
       : OpResult(other, spv::OpSGreaterThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1733,7 +1733,7 @@ class OpSGreaterThanEqual : public OpResult {
 
 class OpULessThan : public OpResult {
  public:
-  OpULessThan(OpCode const &other) : OpResult(other, spv::OpULessThan) {}
+  OpULessThan(const OpCode &other) : OpResult(other, spv::OpULessThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpULessThan;
@@ -1741,7 +1741,7 @@ class OpULessThan : public OpResult {
 
 class OpSLessThan : public OpResult {
  public:
-  OpSLessThan(OpCode const &other) : OpResult(other, spv::OpSLessThan) {}
+  OpSLessThan(const OpCode &other) : OpResult(other, spv::OpSLessThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpSLessThan;
@@ -1749,7 +1749,7 @@ class OpSLessThan : public OpResult {
 
 class OpULessThanEqual : public OpResult {
  public:
-  OpULessThanEqual(OpCode const &other)
+  OpULessThanEqual(const OpCode &other)
       : OpResult(other, spv::OpULessThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1758,7 +1758,7 @@ class OpULessThanEqual : public OpResult {
 
 class OpSLessThanEqual : public OpResult {
  public:
-  OpSLessThanEqual(OpCode const &other)
+  OpSLessThanEqual(const OpCode &other)
       : OpResult(other, spv::OpSLessThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1767,7 +1767,7 @@ class OpSLessThanEqual : public OpResult {
 
 class OpFOrdEqual : public OpResult {
  public:
-  OpFOrdEqual(OpCode const &other) : OpResult(other, spv::OpFOrdEqual) {}
+  OpFOrdEqual(const OpCode &other) : OpResult(other, spv::OpFOrdEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFOrdEqual;
@@ -1775,7 +1775,7 @@ class OpFOrdEqual : public OpResult {
 
 class OpFUnordEqual : public OpResult {
  public:
-  OpFUnordEqual(OpCode const &other) : OpResult(other, spv::OpFUnordEqual) {}
+  OpFUnordEqual(const OpCode &other) : OpResult(other, spv::OpFUnordEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFUnordEqual;
@@ -1783,7 +1783,7 @@ class OpFUnordEqual : public OpResult {
 
 class OpFOrdNotEqual : public OpResult {
  public:
-  OpFOrdNotEqual(OpCode const &other) : OpResult(other, spv::OpFOrdNotEqual) {}
+  OpFOrdNotEqual(const OpCode &other) : OpResult(other, spv::OpFOrdNotEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFOrdNotEqual;
@@ -1791,7 +1791,7 @@ class OpFOrdNotEqual : public OpResult {
 
 class OpFUnordNotEqual : public OpResult {
  public:
-  OpFUnordNotEqual(OpCode const &other)
+  OpFUnordNotEqual(const OpCode &other)
       : OpResult(other, spv::OpFUnordNotEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1800,7 +1800,7 @@ class OpFUnordNotEqual : public OpResult {
 
 class OpFOrdLessThan : public OpResult {
  public:
-  OpFOrdLessThan(OpCode const &other) : OpResult(other, spv::OpFOrdLessThan) {}
+  OpFOrdLessThan(const OpCode &other) : OpResult(other, spv::OpFOrdLessThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpFOrdLessThan;
@@ -1808,7 +1808,7 @@ class OpFOrdLessThan : public OpResult {
 
 class OpFUnordLessThan : public OpResult {
  public:
-  OpFUnordLessThan(OpCode const &other)
+  OpFUnordLessThan(const OpCode &other)
       : OpResult(other, spv::OpFUnordLessThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1817,7 +1817,7 @@ class OpFUnordLessThan : public OpResult {
 
 class OpFOrdGreaterThan : public OpResult {
  public:
-  OpFOrdGreaterThan(OpCode const &other)
+  OpFOrdGreaterThan(const OpCode &other)
       : OpResult(other, spv::OpFOrdGreaterThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1826,7 +1826,7 @@ class OpFOrdGreaterThan : public OpResult {
 
 class OpFUnordGreaterThan : public OpResult {
  public:
-  OpFUnordGreaterThan(OpCode const &other)
+  OpFUnordGreaterThan(const OpCode &other)
       : OpResult(other, spv::OpFUnordGreaterThan) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1835,7 +1835,7 @@ class OpFUnordGreaterThan : public OpResult {
 
 class OpFOrdLessThanEqual : public OpResult {
  public:
-  OpFOrdLessThanEqual(OpCode const &other)
+  OpFOrdLessThanEqual(const OpCode &other)
       : OpResult(other, spv::OpFOrdLessThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1844,7 +1844,7 @@ class OpFOrdLessThanEqual : public OpResult {
 
 class OpFUnordLessThanEqual : public OpResult {
  public:
-  OpFUnordLessThanEqual(OpCode const &other)
+  OpFUnordLessThanEqual(const OpCode &other)
       : OpResult(other, spv::OpFUnordLessThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1853,7 +1853,7 @@ class OpFUnordLessThanEqual : public OpResult {
 
 class OpFOrdGreaterThanEqual : public OpResult {
  public:
-  OpFOrdGreaterThanEqual(OpCode const &other)
+  OpFOrdGreaterThanEqual(const OpCode &other)
       : OpResult(other, spv::OpFOrdGreaterThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1862,7 +1862,7 @@ class OpFOrdGreaterThanEqual : public OpResult {
 
 class OpFUnordGreaterThanEqual : public OpResult {
  public:
-  OpFUnordGreaterThanEqual(OpCode const &other)
+  OpFUnordGreaterThanEqual(const OpCode &other)
       : OpResult(other, spv::OpFUnordGreaterThanEqual) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
@@ -1871,7 +1871,7 @@ class OpFUnordGreaterThanEqual : public OpResult {
 
 class OpShiftRightLogical : public OpResult {
  public:
-  OpShiftRightLogical(OpCode const &other)
+  OpShiftRightLogical(const OpCode &other)
       : OpResult(other, spv::OpShiftRightLogical) {}
   spv::Id Base() const;
   spv::Id Shift() const;
@@ -1880,7 +1880,7 @@ class OpShiftRightLogical : public OpResult {
 
 class OpShiftRightArithmetic : public OpResult {
  public:
-  OpShiftRightArithmetic(OpCode const &other)
+  OpShiftRightArithmetic(const OpCode &other)
       : OpResult(other, spv::OpShiftRightArithmetic) {}
   spv::Id Base() const;
   spv::Id Shift() const;
@@ -1889,7 +1889,7 @@ class OpShiftRightArithmetic : public OpResult {
 
 class OpShiftLeftLogical : public OpResult {
  public:
-  OpShiftLeftLogical(OpCode const &other)
+  OpShiftLeftLogical(const OpCode &other)
       : OpResult(other, spv::OpShiftLeftLogical) {}
   spv::Id Base() const;
   spv::Id Shift() const;
@@ -1898,7 +1898,7 @@ class OpShiftLeftLogical : public OpResult {
 
 class OpBitwiseOr : public OpResult {
  public:
-  OpBitwiseOr(OpCode const &other) : OpResult(other, spv::OpBitwiseOr) {}
+  OpBitwiseOr(const OpCode &other) : OpResult(other, spv::OpBitwiseOr) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpBitwiseOr;
@@ -1906,7 +1906,7 @@ class OpBitwiseOr : public OpResult {
 
 class OpBitwiseXor : public OpResult {
  public:
-  OpBitwiseXor(OpCode const &other) : OpResult(other, spv::OpBitwiseXor) {}
+  OpBitwiseXor(const OpCode &other) : OpResult(other, spv::OpBitwiseXor) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpBitwiseXor;
@@ -1914,7 +1914,7 @@ class OpBitwiseXor : public OpResult {
 
 class OpBitwiseAnd : public OpResult {
  public:
-  OpBitwiseAnd(OpCode const &other) : OpResult(other, spv::OpBitwiseAnd) {}
+  OpBitwiseAnd(const OpCode &other) : OpResult(other, spv::OpBitwiseAnd) {}
   spv::Id Operand1() const;
   spv::Id Operand2() const;
   static const spv::Op ClassCode = spv::OpBitwiseAnd;
@@ -1922,14 +1922,14 @@ class OpBitwiseAnd : public OpResult {
 
 class OpNot : public OpResult {
  public:
-  OpNot(OpCode const &other) : OpResult(other, spv::OpNot) {}
+  OpNot(const OpCode &other) : OpResult(other, spv::OpNot) {}
   spv::Id Operand() const;
   static const spv::Op ClassCode = spv::OpNot;
 };
 
 class OpBitFieldInsert : public OpResult {
  public:
-  OpBitFieldInsert(OpCode const &other)
+  OpBitFieldInsert(const OpCode &other)
       : OpResult(other, spv::OpBitFieldInsert) {}
   spv::Id Base() const;
   spv::Id Insert() const;
@@ -1940,7 +1940,7 @@ class OpBitFieldInsert : public OpResult {
 
 class OpBitFieldSExtract : public OpResult {
  public:
-  OpBitFieldSExtract(OpCode const &other)
+  OpBitFieldSExtract(const OpCode &other)
       : OpResult(other, spv::OpBitFieldSExtract) {}
   spv::Id Base() const;
   spv::Id Offset() const;
@@ -1950,7 +1950,7 @@ class OpBitFieldSExtract : public OpResult {
 
 class OpBitFieldUExtract : public OpResult {
  public:
-  OpBitFieldUExtract(OpCode const &other)
+  OpBitFieldUExtract(const OpCode &other)
       : OpResult(other, spv::OpBitFieldUExtract) {}
   spv::Id Base() const;
   spv::Id Offset() const;
@@ -1960,96 +1960,96 @@ class OpBitFieldUExtract : public OpResult {
 
 class OpBitReverse : public OpResult {
  public:
-  OpBitReverse(OpCode const &other) : OpResult(other, spv::OpBitReverse) {}
+  OpBitReverse(const OpCode &other) : OpResult(other, spv::OpBitReverse) {}
   spv::Id Base() const;
   static const spv::Op ClassCode = spv::OpBitReverse;
 };
 
 class OpBitCount : public OpResult {
  public:
-  OpBitCount(OpCode const &other) : OpResult(other, spv::OpBitCount) {}
+  OpBitCount(const OpCode &other) : OpResult(other, spv::OpBitCount) {}
   spv::Id Base() const;
   static const spv::Op ClassCode = spv::OpBitCount;
 };
 
 class OpDPdx : public OpResult {
  public:
-  OpDPdx(OpCode const &other) : OpResult(other, spv::OpDPdx) {}
+  OpDPdx(const OpCode &other) : OpResult(other, spv::OpDPdx) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdx;
 };
 
 class OpDPdy : public OpResult {
  public:
-  OpDPdy(OpCode const &other) : OpResult(other, spv::OpDPdy) {}
+  OpDPdy(const OpCode &other) : OpResult(other, spv::OpDPdy) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdy;
 };
 
 class OpFwidth : public OpResult {
  public:
-  OpFwidth(OpCode const &other) : OpResult(other, spv::OpFwidth) {}
+  OpFwidth(const OpCode &other) : OpResult(other, spv::OpFwidth) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpFwidth;
 };
 
 class OpDPdxFine : public OpResult {
  public:
-  OpDPdxFine(OpCode const &other) : OpResult(other, spv::OpDPdxFine) {}
+  OpDPdxFine(const OpCode &other) : OpResult(other, spv::OpDPdxFine) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdxFine;
 };
 
 class OpDPdyFine : public OpResult {
  public:
-  OpDPdyFine(OpCode const &other) : OpResult(other, spv::OpDPdyFine) {}
+  OpDPdyFine(const OpCode &other) : OpResult(other, spv::OpDPdyFine) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdyFine;
 };
 
 class OpFwidthFine : public OpResult {
  public:
-  OpFwidthFine(OpCode const &other) : OpResult(other, spv::OpFwidthFine) {}
+  OpFwidthFine(const OpCode &other) : OpResult(other, spv::OpFwidthFine) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpFwidthFine;
 };
 
 class OpDPdxCoarse : public OpResult {
  public:
-  OpDPdxCoarse(OpCode const &other) : OpResult(other, spv::OpDPdxCoarse) {}
+  OpDPdxCoarse(const OpCode &other) : OpResult(other, spv::OpDPdxCoarse) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdxCoarse;
 };
 
 class OpDPdyCoarse : public OpResult {
  public:
-  OpDPdyCoarse(OpCode const &other) : OpResult(other, spv::OpDPdyCoarse) {}
+  OpDPdyCoarse(const OpCode &other) : OpResult(other, spv::OpDPdyCoarse) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpDPdyCoarse;
 };
 
 class OpFwidthCoarse : public OpResult {
  public:
-  OpFwidthCoarse(OpCode const &other) : OpResult(other, spv::OpFwidthCoarse) {}
+  OpFwidthCoarse(const OpCode &other) : OpResult(other, spv::OpFwidthCoarse) {}
   spv::Id P() const;
   static const spv::Op ClassCode = spv::OpFwidthCoarse;
 };
 
 class OpEmitVertex : public OpCode {
  public:
-  OpEmitVertex(OpCode const &other) : OpCode(other, spv::OpEmitVertex) {}
+  OpEmitVertex(const OpCode &other) : OpCode(other, spv::OpEmitVertex) {}
   static const spv::Op ClassCode = spv::OpEmitVertex;
 };
 
 class OpEndPrimitive : public OpCode {
  public:
-  OpEndPrimitive(OpCode const &other) : OpCode(other, spv::OpEndPrimitive) {}
+  OpEndPrimitive(const OpCode &other) : OpCode(other, spv::OpEndPrimitive) {}
   static const spv::Op ClassCode = spv::OpEndPrimitive;
 };
 
 class OpEmitStreamVertex : public OpCode {
  public:
-  OpEmitStreamVertex(OpCode const &other)
+  OpEmitStreamVertex(const OpCode &other)
       : OpCode(other, spv::OpEmitStreamVertex) {}
   spv::Id Stream() const;
   static const spv::Op ClassCode = spv::OpEmitStreamVertex;
@@ -2057,7 +2057,7 @@ class OpEmitStreamVertex : public OpCode {
 
 class OpEndStreamPrimitive : public OpCode {
  public:
-  OpEndStreamPrimitive(OpCode const &other)
+  OpEndStreamPrimitive(const OpCode &other)
       : OpCode(other, spv::OpEndStreamPrimitive) {}
   spv::Id Stream() const;
   static const spv::Op ClassCode = spv::OpEndStreamPrimitive;
@@ -2065,7 +2065,7 @@ class OpEndStreamPrimitive : public OpCode {
 
 class OpControlBarrier : public OpCode {
  public:
-  OpControlBarrier(OpCode const &other)
+  OpControlBarrier(const OpCode &other)
       : OpCode(other, spv::OpControlBarrier) {}
   spv::Id Execution() const;
   spv::Id Memory() const;
@@ -2075,7 +2075,7 @@ class OpControlBarrier : public OpCode {
 
 class OpMemoryBarrier : public OpCode {
  public:
-  OpMemoryBarrier(OpCode const &other) : OpCode(other, spv::OpMemoryBarrier) {}
+  OpMemoryBarrier(const OpCode &other) : OpCode(other, spv::OpMemoryBarrier) {}
   spv::Id Memory() const;
   spv::Id Semantics() const;
   static const spv::Op ClassCode = spv::OpMemoryBarrier;
@@ -2083,7 +2083,7 @@ class OpMemoryBarrier : public OpCode {
 
 class OpAtomicLoad : public OpResult {
  public:
-  OpAtomicLoad(OpCode const &other) : OpResult(other, spv::OpAtomicLoad) {}
+  OpAtomicLoad(const OpCode &other) : OpResult(other, spv::OpAtomicLoad) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2092,7 +2092,7 @@ class OpAtomicLoad : public OpResult {
 
 class OpAtomicStore : public OpCode {
  public:
-  OpAtomicStore(OpCode const &other) : OpCode(other, spv::OpAtomicStore) {}
+  OpAtomicStore(const OpCode &other) : OpCode(other, spv::OpAtomicStore) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2102,7 +2102,7 @@ class OpAtomicStore : public OpCode {
 
 class OpAtomicExchange : public OpResult {
  public:
-  OpAtomicExchange(OpCode const &other)
+  OpAtomicExchange(const OpCode &other)
       : OpResult(other, spv::OpAtomicExchange) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2113,7 +2113,7 @@ class OpAtomicExchange : public OpResult {
 
 class OpAtomicCompareExchange : public OpResult {
  public:
-  OpAtomicCompareExchange(OpCode const &other)
+  OpAtomicCompareExchange(const OpCode &other)
       : OpResult(other, spv::OpAtomicCompareExchange) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2126,7 +2126,7 @@ class OpAtomicCompareExchange : public OpResult {
 
 class OpAtomicCompareExchangeWeak : public OpResult {
  public:
-  OpAtomicCompareExchangeWeak(OpCode const &other)
+  OpAtomicCompareExchangeWeak(const OpCode &other)
       : OpResult(other, spv::OpAtomicCompareExchangeWeak) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2139,7 +2139,7 @@ class OpAtomicCompareExchangeWeak : public OpResult {
 
 class OpAtomicIIncrement : public OpResult {
  public:
-  OpAtomicIIncrement(OpCode const &other)
+  OpAtomicIIncrement(const OpCode &other)
       : OpResult(other, spv::OpAtomicIIncrement) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2149,7 +2149,7 @@ class OpAtomicIIncrement : public OpResult {
 
 class OpAtomicIDecrement : public OpResult {
  public:
-  OpAtomicIDecrement(OpCode const &other)
+  OpAtomicIDecrement(const OpCode &other)
       : OpResult(other, spv::OpAtomicIDecrement) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2159,7 +2159,7 @@ class OpAtomicIDecrement : public OpResult {
 
 class OpAtomicIAdd : public OpResult {
  public:
-  OpAtomicIAdd(OpCode const &other) : OpResult(other, spv::OpAtomicIAdd) {}
+  OpAtomicIAdd(const OpCode &other) : OpResult(other, spv::OpAtomicIAdd) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2169,7 +2169,7 @@ class OpAtomicIAdd : public OpResult {
 
 class OpAtomicISub : public OpResult {
  public:
-  OpAtomicISub(OpCode const &other) : OpResult(other, spv::OpAtomicISub) {}
+  OpAtomicISub(const OpCode &other) : OpResult(other, spv::OpAtomicISub) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2179,7 +2179,7 @@ class OpAtomicISub : public OpResult {
 
 class OpAtomicSMin : public OpResult {
  public:
-  OpAtomicSMin(OpCode const &other) : OpResult(other, spv::OpAtomicSMin) {}
+  OpAtomicSMin(const OpCode &other) : OpResult(other, spv::OpAtomicSMin) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2189,7 +2189,7 @@ class OpAtomicSMin : public OpResult {
 
 class OpAtomicUMin : public OpResult {
  public:
-  OpAtomicUMin(OpCode const &other) : OpResult(other, spv::OpAtomicUMin) {}
+  OpAtomicUMin(const OpCode &other) : OpResult(other, spv::OpAtomicUMin) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2199,7 +2199,7 @@ class OpAtomicUMin : public OpResult {
 
 class OpAtomicSMax : public OpResult {
  public:
-  OpAtomicSMax(OpCode const &other) : OpResult(other, spv::OpAtomicSMax) {}
+  OpAtomicSMax(const OpCode &other) : OpResult(other, spv::OpAtomicSMax) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2209,7 +2209,7 @@ class OpAtomicSMax : public OpResult {
 
 class OpAtomicUMax : public OpResult {
  public:
-  OpAtomicUMax(OpCode const &other) : OpResult(other, spv::OpAtomicUMax) {}
+  OpAtomicUMax(const OpCode &other) : OpResult(other, spv::OpAtomicUMax) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2219,7 +2219,7 @@ class OpAtomicUMax : public OpResult {
 
 class OpAtomicFAddEXT : public OpResult {
  public:
-  OpAtomicFAddEXT(OpCode const &other)
+  OpAtomicFAddEXT(const OpCode &other)
       : OpResult(other, spv::OpAtomicFAddEXT) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2230,7 +2230,7 @@ class OpAtomicFAddEXT : public OpResult {
 
 class OpAtomicFMinEXT : public OpResult {
  public:
-  OpAtomicFMinEXT(OpCode const &other)
+  OpAtomicFMinEXT(const OpCode &other)
       : OpResult(other, spv::OpAtomicFMinEXT) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2241,7 +2241,7 @@ class OpAtomicFMinEXT : public OpResult {
 
 class OpAtomicFMaxEXT : public OpResult {
  public:
-  OpAtomicFMaxEXT(OpCode const &other)
+  OpAtomicFMaxEXT(const OpCode &other)
       : OpResult(other, spv::OpAtomicFMaxEXT) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -2252,7 +2252,7 @@ class OpAtomicFMaxEXT : public OpResult {
 
 class OpAtomicAnd : public OpResult {
  public:
-  OpAtomicAnd(OpCode const &other) : OpResult(other, spv::OpAtomicAnd) {}
+  OpAtomicAnd(const OpCode &other) : OpResult(other, spv::OpAtomicAnd) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2262,7 +2262,7 @@ class OpAtomicAnd : public OpResult {
 
 class OpAtomicOr : public OpResult {
  public:
-  OpAtomicOr(OpCode const &other) : OpResult(other, spv::OpAtomicOr) {}
+  OpAtomicOr(const OpCode &other) : OpResult(other, spv::OpAtomicOr) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2272,7 +2272,7 @@ class OpAtomicOr : public OpResult {
 
 class OpAtomicXor : public OpResult {
  public:
-  OpAtomicXor(OpCode const &other) : OpResult(other, spv::OpAtomicXor) {}
+  OpAtomicXor(const OpCode &other) : OpResult(other, spv::OpAtomicXor) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
   spv::Id Semantics() const;
@@ -2282,7 +2282,7 @@ class OpAtomicXor : public OpResult {
 
 class OpPhi : public OpResult {
  public:
-  OpPhi(OpCode const &other) : OpResult(other, spv::OpPhi) {}
+  OpPhi(const OpCode &other) : OpResult(other, spv::OpPhi) {}
   struct VariableParentT {
     spv::Id Variable;
     spv::Id Parent;
@@ -2293,7 +2293,7 @@ class OpPhi : public OpResult {
 
 class OpLoopMerge : public OpCode {
  public:
-  OpLoopMerge(OpCode const &other) : OpCode(other, spv::OpLoopMerge) {}
+  OpLoopMerge(const OpCode &other) : OpCode(other, spv::OpLoopMerge) {}
   spv::Id MergeBlock() const;
   spv::Id ContinueTarget() const;
   uint32_t LoopControl() const;
@@ -2302,7 +2302,7 @@ class OpLoopMerge : public OpCode {
 
 class OpSelectionMerge : public OpCode {
  public:
-  OpSelectionMerge(OpCode const &other)
+  OpSelectionMerge(const OpCode &other)
       : OpCode(other, spv::OpSelectionMerge) {}
   spv::Id MergeBlock() const;
   uint32_t SelectionControl() const;
@@ -2311,21 +2311,21 @@ class OpSelectionMerge : public OpCode {
 
 class OpLabel : public OpCode {
  public:
-  OpLabel(OpCode const &other) : OpCode(other, spv::OpLabel) {}
+  OpLabel(const OpCode &other) : OpCode(other, spv::OpLabel) {}
   spv::Id IdResult() const;
   static const spv::Op ClassCode = spv::OpLabel;
 };
 
 class OpBranch : public OpCode {
  public:
-  OpBranch(OpCode const &other) : OpCode(other, spv::OpBranch) {}
+  OpBranch(const OpCode &other) : OpCode(other, spv::OpBranch) {}
   spv::Id TargetLabel() const;
   static const spv::Op ClassCode = spv::OpBranch;
 };
 
 class OpBranchConditional : public OpCode {
  public:
-  OpBranchConditional(OpCode const &other)
+  OpBranchConditional(const OpCode &other)
       : OpCode(other, spv::OpBranchConditional) {}
   spv::Id Condition() const;
   spv::Id TrueLabel() const;
@@ -2336,7 +2336,7 @@ class OpBranchConditional : public OpCode {
 
 class OpSwitch : public OpCode {
  public:
-  OpSwitch(OpCode const &other) : OpCode(other, spv::OpSwitch) {}
+  OpSwitch(const OpCode &other) : OpCode(other, spv::OpSwitch) {}
   spv::Id Selector() const;
   spv::Id Default() const;
   struct TargetT {
@@ -2349,32 +2349,32 @@ class OpSwitch : public OpCode {
 
 class OpKill : public OpCode {
  public:
-  OpKill(OpCode const &other) : OpCode(other, spv::OpKill) {}
+  OpKill(const OpCode &other) : OpCode(other, spv::OpKill) {}
   static const spv::Op ClassCode = spv::OpKill;
 };
 
 class OpReturn : public OpCode {
  public:
-  OpReturn(OpCode const &other) : OpCode(other, spv::OpReturn) {}
+  OpReturn(const OpCode &other) : OpCode(other, spv::OpReturn) {}
   static const spv::Op ClassCode = spv::OpReturn;
 };
 
 class OpReturnValue : public OpCode {
  public:
-  OpReturnValue(OpCode const &other) : OpCode(other, spv::OpReturnValue) {}
+  OpReturnValue(const OpCode &other) : OpCode(other, spv::OpReturnValue) {}
   spv::Id Value() const;
   static const spv::Op ClassCode = spv::OpReturnValue;
 };
 
 class OpUnreachable : public OpCode {
  public:
-  OpUnreachable(OpCode const &other) : OpCode(other, spv::OpUnreachable) {}
+  OpUnreachable(const OpCode &other) : OpCode(other, spv::OpUnreachable) {}
   static const spv::Op ClassCode = spv::OpUnreachable;
 };
 
 class OpLifetimeStart : public OpCode {
  public:
-  OpLifetimeStart(OpCode const &other) : OpCode(other, spv::OpLifetimeStart) {}
+  OpLifetimeStart(const OpCode &other) : OpCode(other, spv::OpLifetimeStart) {}
   spv::Id Pointer() const;
   uint32_t Size() const;
   static const spv::Op ClassCode = spv::OpLifetimeStart;
@@ -2382,7 +2382,7 @@ class OpLifetimeStart : public OpCode {
 
 class OpLifetimeStop : public OpCode {
  public:
-  OpLifetimeStop(OpCode const &other) : OpCode(other, spv::OpLifetimeStop) {}
+  OpLifetimeStop(const OpCode &other) : OpCode(other, spv::OpLifetimeStop) {}
   spv::Id Pointer() const;
   uint32_t Size() const;
   static const spv::Op ClassCode = spv::OpLifetimeStop;
@@ -2390,7 +2390,7 @@ class OpLifetimeStop : public OpCode {
 
 class OpGroupAsyncCopy : public OpResult {
  public:
-  OpGroupAsyncCopy(OpCode const &other)
+  OpGroupAsyncCopy(const OpCode &other)
       : OpResult(other, spv::OpGroupAsyncCopy) {}
   spv::Id Execution() const;
   spv::Id Destination() const;
@@ -2403,7 +2403,7 @@ class OpGroupAsyncCopy : public OpResult {
 
 class OpGroupWaitEvents : public OpCode {
  public:
-  OpGroupWaitEvents(OpCode const &other)
+  OpGroupWaitEvents(const OpCode &other)
       : OpCode(other, spv::OpGroupWaitEvents) {}
   spv::Id Execution() const;
   spv::Id NumEvents() const;
@@ -2413,7 +2413,7 @@ class OpGroupWaitEvents : public OpCode {
 
 class OpGroupAll : public OpResult {
  public:
-  OpGroupAll(OpCode const &other) : OpResult(other, spv::OpGroupAll) {}
+  OpGroupAll(const OpCode &other) : OpResult(other, spv::OpGroupAll) {}
   spv::Id Execution() const;
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpGroupAll;
@@ -2421,7 +2421,7 @@ class OpGroupAll : public OpResult {
 
 class OpGroupAny : public OpResult {
  public:
-  OpGroupAny(OpCode const &other) : OpResult(other, spv::OpGroupAny) {}
+  OpGroupAny(const OpCode &other) : OpResult(other, spv::OpGroupAny) {}
   spv::Id Execution() const;
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpGroupAny;
@@ -2429,7 +2429,7 @@ class OpGroupAny : public OpResult {
 
 class OpGroupBroadcast : public OpResult {
  public:
-  OpGroupBroadcast(OpCode const &other)
+  OpGroupBroadcast(const OpCode &other)
       : OpResult(other, spv::OpGroupBroadcast) {}
   spv::Id Execution() const;
   spv::Id Value() const;
@@ -2440,7 +2440,7 @@ class OpGroupBroadcast : public OpResult {
 template <enum spv::Op opcode>
 class OpGroupOperation : public OpResult {
  public:
-  OpGroupOperation(OpCode const &other) : OpResult(other, opcode) {}
+  OpGroupOperation(const OpCode &other) : OpResult(other, opcode) {}
   spv::Id Execution() const { return getValueAtOffset(3); }
   spv::GroupOperation Operation() const {
     return static_cast<spv::GroupOperation>(getValueAtOffset(4));
@@ -2451,86 +2451,86 @@ class OpGroupOperation : public OpResult {
 
 class OpGroupIAdd : public OpGroupOperation<spv::OpGroupIAdd> {
  public:
-  OpGroupIAdd(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupIAdd(const OpCode &other) : OpGroupOperation(other) {}
 };
 class OpGroupFAdd : public OpGroupOperation<spv::OpGroupFAdd> {
  public:
-  OpGroupFAdd(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupFAdd(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupFMin : public OpGroupOperation<spv::OpGroupFMin> {
  public:
-  OpGroupFMin(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupFMin(const OpCode &other) : OpGroupOperation(other) {}
 };
 class OpGroupUMin : public OpGroupOperation<spv::OpGroupUMin> {
  public:
-  OpGroupUMin(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupUMin(const OpCode &other) : OpGroupOperation(other) {}
 };
 class OpGroupSMin : public OpGroupOperation<spv::OpGroupSMin> {
  public:
-  OpGroupSMin(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupSMin(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupFMax : public OpGroupOperation<spv::OpGroupFMax> {
  public:
-  OpGroupFMax(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupFMax(const OpCode &other) : OpGroupOperation(other) {}
 };
 class OpGroupUMax : public OpGroupOperation<spv::OpGroupUMax> {
  public:
-  OpGroupUMax(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupUMax(const OpCode &other) : OpGroupOperation(other) {}
 };
 class OpGroupSMax : public OpGroupOperation<spv::OpGroupSMax> {
  public:
-  OpGroupSMax(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupSMax(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupIMulKHR : public OpGroupOperation<spv::OpGroupIMulKHR> {
  public:
-  OpGroupIMulKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupIMulKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupFMulKHR : public OpGroupOperation<spv::OpGroupFMulKHR> {
  public:
-  OpGroupFMulKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupFMulKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupBitwiseAndKHR
     : public OpGroupOperation<spv::OpGroupBitwiseAndKHR> {
  public:
-  OpGroupBitwiseAndKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupBitwiseAndKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupBitwiseOrKHR : public OpGroupOperation<spv::OpGroupBitwiseOrKHR> {
  public:
-  OpGroupBitwiseOrKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupBitwiseOrKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupBitwiseXorKHR
     : public OpGroupOperation<spv::OpGroupBitwiseXorKHR> {
  public:
-  OpGroupBitwiseXorKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupBitwiseXorKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupLogicalAndKHR
     : public OpGroupOperation<spv::OpGroupLogicalAndKHR> {
  public:
-  OpGroupLogicalAndKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupLogicalAndKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupLogicalOrKHR : public OpGroupOperation<spv::OpGroupLogicalOrKHR> {
  public:
-  OpGroupLogicalOrKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupLogicalOrKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpGroupLogicalXorKHR
     : public OpGroupOperation<spv::OpGroupLogicalXorKHR> {
  public:
-  OpGroupLogicalXorKHR(OpCode const &other) : OpGroupOperation(other) {}
+  OpGroupLogicalXorKHR(const OpCode &other) : OpGroupOperation(other) {}
 };
 
 class OpSubgroupShuffle : public OpResult {
  public:
-  OpSubgroupShuffle(OpCode const &other)
+  OpSubgroupShuffle(const OpCode &other)
       : OpResult(other, spv::OpSubgroupShuffleINTEL) {}
   spv::Id Data() const { return getValueAtOffset(3); }
   spv::Id InvocationId() const { return getValueAtOffset(4); }
@@ -2539,7 +2539,7 @@ class OpSubgroupShuffle : public OpResult {
 
 class OpSubgroupShuffleUp : public OpResult {
  public:
-  OpSubgroupShuffleUp(OpCode const &other)
+  OpSubgroupShuffleUp(const OpCode &other)
       : OpResult(other, spv::OpSubgroupShuffleUpINTEL) {}
   spv::Id Previous() const { return getValueAtOffset(3); }
   spv::Id Current() const { return getValueAtOffset(4); }
@@ -2549,7 +2549,7 @@ class OpSubgroupShuffleUp : public OpResult {
 
 class OpSubgroupShuffleDown : public OpResult {
  public:
-  OpSubgroupShuffleDown(OpCode const &other)
+  OpSubgroupShuffleDown(const OpCode &other)
       : OpResult(other, spv::OpSubgroupShuffleDownINTEL) {}
   spv::Id Current() const { return getValueAtOffset(3); }
   spv::Id Next() const { return getValueAtOffset(4); }
@@ -2559,7 +2559,7 @@ class OpSubgroupShuffleDown : public OpResult {
 
 class OpSubgroupShuffleXor : public OpResult {
  public:
-  OpSubgroupShuffleXor(OpCode const &other)
+  OpSubgroupShuffleXor(const OpCode &other)
       : OpResult(other, spv::OpSubgroupShuffleXorINTEL) {}
   spv::Id Data() const { return getValueAtOffset(3); }
   spv::Id Value() const { return getValueAtOffset(4); }
@@ -2568,7 +2568,7 @@ class OpSubgroupShuffleXor : public OpResult {
 
 class OpReadPipe : public OpResult {
  public:
-  OpReadPipe(OpCode const &other) : OpResult(other, spv::OpReadPipe) {}
+  OpReadPipe(const OpCode &other) : OpResult(other, spv::OpReadPipe) {}
   spv::Id Pipe() const;
   spv::Id Pointer() const;
   spv::Id PacketSize() const;
@@ -2578,7 +2578,7 @@ class OpReadPipe : public OpResult {
 
 class OpWritePipe : public OpResult {
  public:
-  OpWritePipe(OpCode const &other) : OpResult(other, spv::OpWritePipe) {}
+  OpWritePipe(const OpCode &other) : OpResult(other, spv::OpWritePipe) {}
   spv::Id Pipe() const;
   spv::Id Pointer() const;
   spv::Id PacketSize() const;
@@ -2588,7 +2588,7 @@ class OpWritePipe : public OpResult {
 
 class OpReservedReadPipe : public OpResult {
  public:
-  OpReservedReadPipe(OpCode const &other)
+  OpReservedReadPipe(const OpCode &other)
       : OpResult(other, spv::OpReservedReadPipe) {}
   spv::Id Pipe() const;
   spv::Id ReserveId() const;
@@ -2601,7 +2601,7 @@ class OpReservedReadPipe : public OpResult {
 
 class OpReservedWritePipe : public OpResult {
  public:
-  OpReservedWritePipe(OpCode const &other)
+  OpReservedWritePipe(const OpCode &other)
       : OpResult(other, spv::OpReservedWritePipe) {}
   spv::Id Pipe() const;
   spv::Id ReserveId() const;
@@ -2614,7 +2614,7 @@ class OpReservedWritePipe : public OpResult {
 
 class OpReserveReadPipePackets : public OpResult {
  public:
-  OpReserveReadPipePackets(OpCode const &other)
+  OpReserveReadPipePackets(const OpCode &other)
       : OpResult(other, spv::OpReserveReadPipePackets) {}
   spv::Id Pipe() const;
   spv::Id NumPackets() const;
@@ -2625,7 +2625,7 @@ class OpReserveReadPipePackets : public OpResult {
 
 class OpReserveWritePipePackets : public OpResult {
  public:
-  OpReserveWritePipePackets(OpCode const &other)
+  OpReserveWritePipePackets(const OpCode &other)
       : OpResult(other, spv::OpReserveWritePipePackets) {}
   spv::Id Pipe() const;
   spv::Id NumPackets() const;
@@ -2636,7 +2636,7 @@ class OpReserveWritePipePackets : public OpResult {
 
 class OpCommitReadPipe : public OpCode {
  public:
-  OpCommitReadPipe(OpCode const &other)
+  OpCommitReadPipe(const OpCode &other)
       : OpCode(other, spv::OpCommitReadPipe) {}
   spv::Id Pipe() const;
   spv::Id ReserveId() const;
@@ -2647,7 +2647,7 @@ class OpCommitReadPipe : public OpCode {
 
 class OpCommitWritePipe : public OpCode {
  public:
-  OpCommitWritePipe(OpCode const &other)
+  OpCommitWritePipe(const OpCode &other)
       : OpCode(other, spv::OpCommitWritePipe) {}
   spv::Id Pipe() const;
   spv::Id ReserveId() const;
@@ -2658,7 +2658,7 @@ class OpCommitWritePipe : public OpCode {
 
 class OpIsValidReserveId : public OpResult {
  public:
-  OpIsValidReserveId(OpCode const &other)
+  OpIsValidReserveId(const OpCode &other)
       : OpResult(other, spv::OpIsValidReserveId) {}
   spv::Id ReserveId() const;
   static const spv::Op ClassCode = spv::OpIsValidReserveId;
@@ -2666,7 +2666,7 @@ class OpIsValidReserveId : public OpResult {
 
 class OpGetNumPipePackets : public OpResult {
  public:
-  OpGetNumPipePackets(OpCode const &other)
+  OpGetNumPipePackets(const OpCode &other)
       : OpResult(other, spv::OpGetNumPipePackets) {}
   spv::Id Pipe() const;
   spv::Id PacketSize() const;
@@ -2676,7 +2676,7 @@ class OpGetNumPipePackets : public OpResult {
 
 class OpGetMaxPipePackets : public OpResult {
  public:
-  OpGetMaxPipePackets(OpCode const &other)
+  OpGetMaxPipePackets(const OpCode &other)
       : OpResult(other, spv::OpGetMaxPipePackets) {}
   spv::Id Pipe() const;
   spv::Id PacketSize() const;
@@ -2686,7 +2686,7 @@ class OpGetMaxPipePackets : public OpResult {
 
 class OpGroupReserveReadPipePackets : public OpResult {
  public:
-  OpGroupReserveReadPipePackets(OpCode const &other)
+  OpGroupReserveReadPipePackets(const OpCode &other)
       : OpResult(other, spv::OpGroupReserveReadPipePackets) {}
   spv::Id Execution() const;
   spv::Id Pipe() const;
@@ -2698,7 +2698,7 @@ class OpGroupReserveReadPipePackets : public OpResult {
 
 class OpGroupReserveWritePipePackets : public OpResult {
  public:
-  OpGroupReserveWritePipePackets(OpCode const &other)
+  OpGroupReserveWritePipePackets(const OpCode &other)
       : OpResult(other, spv::OpGroupReserveWritePipePackets) {}
   spv::Id Execution() const;
   spv::Id Pipe() const;
@@ -2710,7 +2710,7 @@ class OpGroupReserveWritePipePackets : public OpResult {
 
 class OpGroupCommitReadPipe : public OpCode {
  public:
-  OpGroupCommitReadPipe(OpCode const &other)
+  OpGroupCommitReadPipe(const OpCode &other)
       : OpCode(other, spv::OpGroupCommitReadPipe) {}
   spv::Id Execution() const;
   spv::Id Pipe() const;
@@ -2722,7 +2722,7 @@ class OpGroupCommitReadPipe : public OpCode {
 
 class OpGroupCommitWritePipe : public OpCode {
  public:
-  OpGroupCommitWritePipe(OpCode const &other)
+  OpGroupCommitWritePipe(const OpCode &other)
       : OpCode(other, spv::OpGroupCommitWritePipe) {}
   spv::Id Execution() const;
   spv::Id Pipe() const;
@@ -2734,7 +2734,7 @@ class OpGroupCommitWritePipe : public OpCode {
 
 class OpEnqueueMarker : public OpResult {
  public:
-  OpEnqueueMarker(OpCode const &other)
+  OpEnqueueMarker(const OpCode &other)
       : OpResult(other, spv::OpEnqueueMarker) {}
   spv::Id Queue() const;
   spv::Id NumEvents() const;
@@ -2745,7 +2745,7 @@ class OpEnqueueMarker : public OpResult {
 
 class OpEnqueueKernel : public OpResult {
  public:
-  OpEnqueueKernel(OpCode const &other)
+  OpEnqueueKernel(const OpCode &other)
       : OpResult(other, spv::OpEnqueueKernel) {}
   spv::Id Queue() const;
   spv::Id Flags() const;
@@ -2763,7 +2763,7 @@ class OpEnqueueKernel : public OpResult {
 
 class OpGetKernelNDrangeSubGroupCount : public OpResult {
  public:
-  OpGetKernelNDrangeSubGroupCount(OpCode const &other)
+  OpGetKernelNDrangeSubGroupCount(const OpCode &other)
       : OpResult(other, spv::OpGetKernelNDrangeSubGroupCount) {}
   spv::Id NDRange() const;
   spv::Id Invoke() const;
@@ -2775,7 +2775,7 @@ class OpGetKernelNDrangeSubGroupCount : public OpResult {
 
 class OpGetKernelNDrangeMaxSubGroupSize : public OpResult {
  public:
-  OpGetKernelNDrangeMaxSubGroupSize(OpCode const &other)
+  OpGetKernelNDrangeMaxSubGroupSize(const OpCode &other)
       : OpResult(other, spv::OpGetKernelNDrangeMaxSubGroupSize) {}
   spv::Id NDRange() const;
   spv::Id Invoke() const;
@@ -2787,7 +2787,7 @@ class OpGetKernelNDrangeMaxSubGroupSize : public OpResult {
 
 class OpGetKernelWorkGroupSize : public OpResult {
  public:
-  OpGetKernelWorkGroupSize(OpCode const &other)
+  OpGetKernelWorkGroupSize(const OpCode &other)
       : OpResult(other, spv::OpGetKernelWorkGroupSize) {}
   spv::Id Invoke() const;
   spv::Id Param() const;
@@ -2798,7 +2798,7 @@ class OpGetKernelWorkGroupSize : public OpResult {
 
 class OpGetKernelPreferredWorkGroupSizeMultiple : public OpResult {
  public:
-  OpGetKernelPreferredWorkGroupSizeMultiple(OpCode const &other)
+  OpGetKernelPreferredWorkGroupSizeMultiple(const OpCode &other)
       : OpResult(other, spv::OpGetKernelPreferredWorkGroupSizeMultiple) {}
   spv::Id Invoke() const;
   spv::Id Param() const;
@@ -2810,35 +2810,35 @@ class OpGetKernelPreferredWorkGroupSizeMultiple : public OpResult {
 
 class OpRetainEvent : public OpCode {
  public:
-  OpRetainEvent(OpCode const &other) : OpCode(other, spv::OpRetainEvent) {}
+  OpRetainEvent(const OpCode &other) : OpCode(other, spv::OpRetainEvent) {}
   spv::Id Event() const;
   static const spv::Op ClassCode = spv::OpRetainEvent;
 };
 
 class OpReleaseEvent : public OpCode {
  public:
-  OpReleaseEvent(OpCode const &other) : OpCode(other, spv::OpReleaseEvent) {}
+  OpReleaseEvent(const OpCode &other) : OpCode(other, spv::OpReleaseEvent) {}
   spv::Id Event() const;
   static const spv::Op ClassCode = spv::OpReleaseEvent;
 };
 
 class OpCreateUserEvent : public OpResult {
  public:
-  OpCreateUserEvent(OpCode const &other)
+  OpCreateUserEvent(const OpCode &other)
       : OpResult(other, spv::OpCreateUserEvent) {}
   static const spv::Op ClassCode = spv::OpCreateUserEvent;
 };
 
 class OpIsValidEvent : public OpResult {
  public:
-  OpIsValidEvent(OpCode const &other) : OpResult(other, spv::OpIsValidEvent) {}
+  OpIsValidEvent(const OpCode &other) : OpResult(other, spv::OpIsValidEvent) {}
   spv::Id Event() const;
   static const spv::Op ClassCode = spv::OpIsValidEvent;
 };
 
 class OpSetUserEventStatus : public OpCode {
  public:
-  OpSetUserEventStatus(OpCode const &other)
+  OpSetUserEventStatus(const OpCode &other)
       : OpCode(other, spv::OpSetUserEventStatus) {}
   spv::Id Event() const;
   spv::Id Status() const;
@@ -2847,7 +2847,7 @@ class OpSetUserEventStatus : public OpCode {
 
 class OpCaptureEventProfilingInfo : public OpCode {
  public:
-  OpCaptureEventProfilingInfo(OpCode const &other)
+  OpCaptureEventProfilingInfo(const OpCode &other)
       : OpCode(other, spv::OpCaptureEventProfilingInfo) {}
   spv::Id Event() const;
   spv::Id ProfilingInfo() const;
@@ -2857,14 +2857,14 @@ class OpCaptureEventProfilingInfo : public OpCode {
 
 class OpGetDefaultQueue : public OpResult {
  public:
-  OpGetDefaultQueue(OpCode const &other)
+  OpGetDefaultQueue(const OpCode &other)
       : OpResult(other, spv::OpGetDefaultQueue) {}
   static const spv::Op ClassCode = spv::OpGetDefaultQueue;
 };
 
 class OpBuildNDRange : public OpResult {
  public:
-  OpBuildNDRange(OpCode const &other) : OpResult(other, spv::OpBuildNDRange) {}
+  OpBuildNDRange(const OpCode &other) : OpResult(other, spv::OpBuildNDRange) {}
   spv::Id GlobalWorkSize() const;
   spv::Id LocalWorkSize() const;
   spv::Id GlobalWorkOffset() const;
@@ -2873,7 +2873,7 @@ class OpBuildNDRange : public OpResult {
 
 class OpGetKernelLocalSizeForSubgroupCount : public OpResult {
  public:
-  OpGetKernelLocalSizeForSubgroupCount(OpCode const &other)
+  OpGetKernelLocalSizeForSubgroupCount(const OpCode &other)
       : OpResult(other, spv::OpGetKernelLocalSizeForSubgroupCount) {}
   spv::Id SubgroupCount() const;
   spv::Id Invoke() const;
@@ -2885,7 +2885,7 @@ class OpGetKernelLocalSizeForSubgroupCount : public OpResult {
 
 class OpGetKernelMaxNumSubgroups : public OpResult {
  public:
-  OpGetKernelMaxNumSubgroups(OpCode const &other)
+  OpGetKernelMaxNumSubgroups(const OpCode &other)
       : OpResult(other, spv::OpGetKernelMaxNumSubgroups) {}
   spv::Id Invoke() const;
   spv::Id Param() const;
@@ -2896,7 +2896,7 @@ class OpGetKernelMaxNumSubgroups : public OpResult {
 
 class OpImageSparseSampleImplicitLod : public OpResult {
  public:
-  OpImageSparseSampleImplicitLod(OpCode const &other)
+  OpImageSparseSampleImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2906,7 +2906,7 @@ class OpImageSparseSampleImplicitLod : public OpResult {
 
 class OpImageSparseSampleExplicitLod : public OpResult {
  public:
-  OpImageSparseSampleExplicitLod(OpCode const &other)
+  OpImageSparseSampleExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2916,7 +2916,7 @@ class OpImageSparseSampleExplicitLod : public OpResult {
 
 class OpImageSparseSampleDrefImplicitLod : public OpResult {
  public:
-  OpImageSparseSampleDrefImplicitLod(OpCode const &other)
+  OpImageSparseSampleDrefImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleDrefImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2927,7 +2927,7 @@ class OpImageSparseSampleDrefImplicitLod : public OpResult {
 
 class OpImageSparseSampleDrefExplicitLod : public OpResult {
  public:
-  OpImageSparseSampleDrefExplicitLod(OpCode const &other)
+  OpImageSparseSampleDrefExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleDrefExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2938,7 +2938,7 @@ class OpImageSparseSampleDrefExplicitLod : public OpResult {
 
 class OpImageSparseSampleProjImplicitLod : public OpResult {
  public:
-  OpImageSparseSampleProjImplicitLod(OpCode const &other)
+  OpImageSparseSampleProjImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleProjImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2948,7 +2948,7 @@ class OpImageSparseSampleProjImplicitLod : public OpResult {
 
 class OpImageSparseSampleProjExplicitLod : public OpResult {
  public:
-  OpImageSparseSampleProjExplicitLod(OpCode const &other)
+  OpImageSparseSampleProjExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleProjExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2958,7 +2958,7 @@ class OpImageSparseSampleProjExplicitLod : public OpResult {
 
 class OpImageSparseSampleProjDrefImplicitLod : public OpResult {
  public:
-  OpImageSparseSampleProjDrefImplicitLod(OpCode const &other)
+  OpImageSparseSampleProjDrefImplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleProjDrefImplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2969,7 +2969,7 @@ class OpImageSparseSampleProjDrefImplicitLod : public OpResult {
 
 class OpImageSparseSampleProjDrefExplicitLod : public OpResult {
  public:
-  OpImageSparseSampleProjDrefExplicitLod(OpCode const &other)
+  OpImageSparseSampleProjDrefExplicitLod(const OpCode &other)
       : OpResult(other, spv::OpImageSparseSampleProjDrefExplicitLod) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -2980,7 +2980,7 @@ class OpImageSparseSampleProjDrefExplicitLod : public OpResult {
 
 class OpImageSparseFetch : public OpResult {
  public:
-  OpImageSparseFetch(OpCode const &other)
+  OpImageSparseFetch(const OpCode &other)
       : OpResult(other, spv::OpImageSparseFetch) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
@@ -2990,7 +2990,7 @@ class OpImageSparseFetch : public OpResult {
 
 class OpImageSparseGather : public OpResult {
  public:
-  OpImageSparseGather(OpCode const &other)
+  OpImageSparseGather(const OpCode &other)
       : OpResult(other, spv::OpImageSparseGather) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -3001,7 +3001,7 @@ class OpImageSparseGather : public OpResult {
 
 class OpImageSparseDrefGather : public OpResult {
  public:
-  OpImageSparseDrefGather(OpCode const &other)
+  OpImageSparseDrefGather(const OpCode &other)
       : OpResult(other, spv::OpImageSparseDrefGather) {}
   spv::Id SampledImage() const;
   spv::Id Coordinate() const;
@@ -3012,7 +3012,7 @@ class OpImageSparseDrefGather : public OpResult {
 
 class OpImageSparseTexelsResident : public OpResult {
  public:
-  OpImageSparseTexelsResident(OpCode const &other)
+  OpImageSparseTexelsResident(const OpCode &other)
       : OpResult(other, spv::OpImageSparseTexelsResident) {}
   spv::Id ResidentCode() const;
   static const spv::Op ClassCode = spv::OpImageSparseTexelsResident;
@@ -3020,13 +3020,13 @@ class OpImageSparseTexelsResident : public OpResult {
 
 class OpNoLine : public OpCode {
  public:
-  OpNoLine(OpCode const &other) : OpCode(other, spv::OpNoLine) {}
+  OpNoLine(const OpCode &other) : OpCode(other, spv::OpNoLine) {}
   static const spv::Op ClassCode = spv::OpNoLine;
 };
 
 class OpModuleProcessed : public OpCode {
  public:
-  OpModuleProcessed(OpCode const &other)
+  OpModuleProcessed(const OpCode &other)
       : OpCode(other, spv::OpModuleProcessed) {}
   llvm::StringRef Process() const;
   static const spv::Op ClassCode = spv::OpModuleProcessed;
@@ -3034,7 +3034,7 @@ class OpModuleProcessed : public OpCode {
 
 class OpAtomicFlagTestAndSet : public OpResult {
  public:
-  OpAtomicFlagTestAndSet(OpCode const &other)
+  OpAtomicFlagTestAndSet(const OpCode &other)
       : OpResult(other, spv::OpAtomicFlagTestAndSet) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -3044,7 +3044,7 @@ class OpAtomicFlagTestAndSet : public OpResult {
 
 class OpAtomicFlagClear : public OpCode {
  public:
-  OpAtomicFlagClear(OpCode const &other)
+  OpAtomicFlagClear(const OpCode &other)
       : OpCode(other, spv::OpAtomicFlagClear) {}
   spv::Id Pointer() const;
   spv::Id Scope() const;
@@ -3054,7 +3054,7 @@ class OpAtomicFlagClear : public OpCode {
 
 class OpImageSparseRead : public OpResult {
  public:
-  OpImageSparseRead(OpCode const &other)
+  OpImageSparseRead(const OpCode &other)
       : OpResult(other, spv::OpImageSparseRead) {}
   spv::Id Image() const;
   spv::Id Coordinate() const;
@@ -3064,7 +3064,7 @@ class OpImageSparseRead : public OpResult {
 
 class OpSubgroupBallotKHR : public OpResult {
  public:
-  OpSubgroupBallotKHR(OpCode const &other)
+  OpSubgroupBallotKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupBallotKHR) {}
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpSubgroupBallotKHR;
@@ -3072,7 +3072,7 @@ class OpSubgroupBallotKHR : public OpResult {
 
 class OpSubgroupFirstInvocationKHR : public OpResult {
  public:
-  OpSubgroupFirstInvocationKHR(OpCode const &other)
+  OpSubgroupFirstInvocationKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupFirstInvocationKHR) {}
   spv::Id Value() const;
   static const spv::Op ClassCode = spv::OpSubgroupFirstInvocationKHR;
@@ -3080,7 +3080,7 @@ class OpSubgroupFirstInvocationKHR : public OpResult {
 
 class OpSubgroupAllKHR : public OpResult {
  public:
-  OpSubgroupAllKHR(OpCode const &other)
+  OpSubgroupAllKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupAllKHR) {}
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpSubgroupAllKHR;
@@ -3088,7 +3088,7 @@ class OpSubgroupAllKHR : public OpResult {
 
 class OpSubgroupAnyKHR : public OpResult {
  public:
-  OpSubgroupAnyKHR(OpCode const &other)
+  OpSubgroupAnyKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupAnyKHR) {}
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpSubgroupAnyKHR;
@@ -3096,7 +3096,7 @@ class OpSubgroupAnyKHR : public OpResult {
 
 class OpSubgroupAllEqualKHR : public OpResult {
  public:
-  OpSubgroupAllEqualKHR(OpCode const &other)
+  OpSubgroupAllEqualKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupAllEqualKHR) {}
   spv::Id Predicate() const;
   static const spv::Op ClassCode = spv::OpSubgroupAllEqualKHR;
@@ -3104,7 +3104,7 @@ class OpSubgroupAllEqualKHR : public OpResult {
 
 class OpSubgroupReadInvocationKHR : public OpResult {
  public:
-  OpSubgroupReadInvocationKHR(OpCode const &other)
+  OpSubgroupReadInvocationKHR(const OpCode &other)
       : OpResult(other, spv::OpSubgroupReadInvocationKHR) {}
   spv::Id Value() const;
   spv::Id Index() const;
@@ -3164,70 +3164,70 @@ class ExtInst;
 template <>
 class ExtInst<DEGREES> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id degrees() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<INTERPOLANT> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id interpolant() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<NANCODE> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id nanCode() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<P> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id p() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<RADIANS> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id radians() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<V> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id v() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<VALUE> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id value() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<X> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<Y_OVER_X> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id yOverX() const { return getOpExtInstOperand(0); }
 };
 
 template <>
 class ExtInst<EDGE, X> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id edge() const { return getOpExtInstOperand(0); }
   spv::Id x() const { return getOpExtInstOperand(1); }
 };
@@ -3235,7 +3235,7 @@ class ExtInst<EDGE, X> : public OpExtInst {
 template <>
 class ExtInst<HI, LO> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id hi() const { return getOpExtInstOperand(0); }
   spv::Id lo() const { return getOpExtInstOperand(1); }
 };
@@ -3243,7 +3243,7 @@ class ExtInst<HI, LO> : public OpExtInst {
 template <>
 class ExtInst<I, N> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id i() const { return getOpExtInstOperand(0); }
   spv::Id n() const { return getOpExtInstOperand(1); }
 };
@@ -3251,7 +3251,7 @@ class ExtInst<I, N> : public OpExtInst {
 template <>
 class ExtInst<INTERPOLANT, OFFSET> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id interpolant() const { return getOpExtInstOperand(0); }
   spv::Id offset() const { return getOpExtInstOperand(1); }
 };
@@ -3259,7 +3259,7 @@ class ExtInst<INTERPOLANT, OFFSET> : public OpExtInst {
 template <>
 class ExtInst<INTERPOLANT, SAMPLER> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id interpolant() const { return getOpExtInstOperand(0); }
   spv::Id sampler() const { return getOpExtInstOperand(1); }
 };
@@ -3267,7 +3267,7 @@ class ExtInst<INTERPOLANT, SAMPLER> : public OpExtInst {
 template <>
 class ExtInst<OFFSET, P> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id offset() const { return getOpExtInstOperand(0); }
   spv::Id p() const { return getOpExtInstOperand(1); }
 };
@@ -3275,7 +3275,7 @@ class ExtInst<OFFSET, P> : public OpExtInst {
 template <>
 class ExtInst<P0, P1> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id p0() const { return getOpExtInstOperand(0); }
   spv::Id p1() const { return getOpExtInstOperand(1); }
 };
@@ -3283,7 +3283,7 @@ class ExtInst<P0, P1> : public OpExtInst {
 template <>
 class ExtInst<PTR, NUM_ELEMENTS> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id ptr() const { return getOpExtInstOperand(0); }
   spv::Id numElements() const { return getOpExtInstOperand(1); }
 };
@@ -3291,7 +3291,7 @@ class ExtInst<PTR, NUM_ELEMENTS> : public OpExtInst {
 template <>
 class ExtInst<V, I> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id v() const { return getOpExtInstOperand(0); }
   spv::Id i() const { return getOpExtInstOperand(1); }
 };
@@ -3299,7 +3299,7 @@ class ExtInst<V, I> : public OpExtInst {
 template <>
 class ExtInst<X, COSVAL> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id cosVal() const { return getOpExtInstOperand(1); }
 };
@@ -3307,7 +3307,7 @@ class ExtInst<X, COSVAL> : public OpExtInst {
 template <>
 class ExtInst<X, EXP> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id exp() const { return getOpExtInstOperand(1); }
 };
@@ -3315,7 +3315,7 @@ class ExtInst<X, EXP> : public OpExtInst {
 template <>
 class ExtInst<X, I> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id i() const { return getOpExtInstOperand(1); }
 };
@@ -3323,7 +3323,7 @@ class ExtInst<X, I> : public OpExtInst {
 template <>
 class ExtInst<X, IPTR> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id iPtr() const { return getOpExtInstOperand(1); }
 };
@@ -3331,7 +3331,7 @@ class ExtInst<X, IPTR> : public OpExtInst {
 template <>
 class ExtInst<X, K> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id k() const { return getOpExtInstOperand(1); }
 };
@@ -3339,7 +3339,7 @@ class ExtInst<X, K> : public OpExtInst {
 template <>
 class ExtInst<X, PTR> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id ptr() const { return getOpExtInstOperand(1); }
 };
@@ -3347,7 +3347,7 @@ class ExtInst<X, PTR> : public OpExtInst {
 template <>
 class ExtInst<X, SHUFFLEMASK> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id shuffleMask() const { return getOpExtInstOperand(1); }
 };
@@ -3355,7 +3355,7 @@ class ExtInst<X, SHUFFLEMASK> : public OpExtInst {
 template <>
 class ExtInst<X, SIGNP> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id signp() const { return getOpExtInstOperand(1); }
 };
@@ -3363,7 +3363,7 @@ class ExtInst<X, SIGNP> : public OpExtInst {
 template <>
 class ExtInst<X, Y> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id y() const { return getOpExtInstOperand(1); }
 };
@@ -3371,7 +3371,7 @@ class ExtInst<X, Y> : public OpExtInst {
 template <>
 class ExtInst<Y, X> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id y() const { return getOpExtInstOperand(0); }
   spv::Id x() const { return getOpExtInstOperand(1); }
 };
@@ -3379,7 +3379,7 @@ class ExtInst<Y, X> : public OpExtInst {
 template <>
 class ExtInst<A, B, C> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id a() const { return getOpExtInstOperand(0); }
   spv::Id b() const { return getOpExtInstOperand(1); }
   spv::Id c() const { return getOpExtInstOperand(2); }
@@ -3388,7 +3388,7 @@ class ExtInst<A, B, C> : public OpExtInst {
 template <>
 class ExtInst<DATA, OFFSET, P> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id data() const { return getOpExtInstOperand(0); }
   spv::Id offset() const { return getOpExtInstOperand(1); }
   spv::Id p() const { return getOpExtInstOperand(2); }
@@ -3397,7 +3397,7 @@ class ExtInst<DATA, OFFSET, P> : public OpExtInst {
 template <>
 class ExtInst<EDGE0, EDGE1, X> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id edge0() const { return getOpExtInstOperand(0); }
   spv::Id edge1() const { return getOpExtInstOperand(1); }
   spv::Id x() const { return getOpExtInstOperand(2); }
@@ -3406,7 +3406,7 @@ class ExtInst<EDGE0, EDGE1, X> : public OpExtInst {
 template <>
 class ExtInst<I, N, ETA> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id i() const { return getOpExtInstOperand(0); }
   spv::Id n() const { return getOpExtInstOperand(1); }
   spv::Id eta() const { return getOpExtInstOperand(2); }
@@ -3415,7 +3415,7 @@ class ExtInst<I, N, ETA> : public OpExtInst {
 template <>
 class ExtInst<N, I, NREF> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id n() const { return getOpExtInstOperand(0); }
   spv::Id i() const { return getOpExtInstOperand(1); }
   spv::Id nRef() const { return getOpExtInstOperand(2); }
@@ -3424,7 +3424,7 @@ class ExtInst<N, I, NREF> : public OpExtInst {
 template <>
 class ExtInst<OFFSET, P, N> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id offset() const { return getOpExtInstOperand(0); }
   spv::Id p() const { return getOpExtInstOperand(1); }
   spv::Id n() const { return getOpExtInstOperand(2); }
@@ -3433,7 +3433,7 @@ class ExtInst<OFFSET, P, N> : public OpExtInst {
 template <>
 class ExtInst<X, MINVAL, MAXVAL> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id minVal() const { return getOpExtInstOperand(1); }
   spv::Id maxVal() const { return getOpExtInstOperand(2); }
@@ -3442,7 +3442,7 @@ class ExtInst<X, MINVAL, MAXVAL> : public OpExtInst {
 template <>
 class ExtInst<X, Y, A> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id y() const { return getOpExtInstOperand(1); }
   spv::Id a() const { return getOpExtInstOperand(2); }
@@ -3451,7 +3451,7 @@ class ExtInst<X, Y, A> : public OpExtInst {
 template <>
 class ExtInst<X, Y, QUO> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id y() const { return getOpExtInstOperand(1); }
   spv::Id quo() const { return getOpExtInstOperand(2); }
@@ -3460,7 +3460,7 @@ class ExtInst<X, Y, QUO> : public OpExtInst {
 template <>
 class ExtInst<X, Y, SHUFFLEMASK> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id y() const { return getOpExtInstOperand(1); }
   spv::Id shuffleMask() const { return getOpExtInstOperand(2); }
@@ -3469,7 +3469,7 @@ class ExtInst<X, Y, SHUFFLEMASK> : public OpExtInst {
 template <>
 class ExtInst<X, Y, Z> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id x() const { return getOpExtInstOperand(0); }
   spv::Id y() const { return getOpExtInstOperand(1); }
   spv::Id z() const { return getOpExtInstOperand(2); }
@@ -3478,7 +3478,7 @@ class ExtInst<X, Y, Z> : public OpExtInst {
 template <>
 class ExtInst<DATA, OFFSET, P, MODE> : public OpExtInst {
  public:
-  ExtInst(OpCode const &other) : OpExtInst(other) {}
+  ExtInst(const OpCode &other) : OpExtInst(other) {}
   spv::Id data() const { return getOpExtInstOperand(0); }
   spv::Id offset() const { return getOpExtInstOperand(1); }
   spv::Id p() const { return getOpExtInstOperand(2); }
@@ -3488,13 +3488,13 @@ class ExtInst<DATA, OFFSET, P, MODE> : public OpExtInst {
 };
 class OpAssumeTrueKHR : public OpCode {
  public:
-  OpAssumeTrueKHR(OpCode const &other) : OpCode(other, spv::OpAssumeTrueKHR) {}
+  OpAssumeTrueKHR(const OpCode &other) : OpCode(other, spv::OpAssumeTrueKHR) {}
   spv::Id Condition() const;
   static const spv::Op ClassCode = spv::OpAssumeTrueKHR;
 };
 class OpExpectKHR : public OpResult {
  public:
-  OpExpectKHR(OpCode const &other) : OpResult(other, spv::OpExpectKHR) {}
+  OpExpectKHR(const OpCode &other) : OpResult(other, spv::OpExpectKHR) {}
   spv::Id Value() const;
   spv::Id ExpectedValue() const;
   static const spv::Op ClassCode = spv::OpExpectKHR;

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1258,7 +1258,7 @@ std::string spirv_ll::Builder::getMangledTypeName(
         mangleInfo && module.get<OpType>(mangleInfo->id)->isPointerType(),
         "Parameter is not a pointer");
 
-    auto const spvPointeeTy =
+    const auto spvPointeeTy =
         module.get<OpType>(mangleInfo->id)->getTypePointer()->Type();
     auto *const elementTy = module.getLLVMType(spvPointeeTy);
     std::string mangled = getMangledPointerPrefix(ty, mangleInfo->typeQuals);

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -2317,9 +2317,9 @@ std::string retrieveArgTyMetadata(spirv_ll::Module &module, llvm::Type *argTy,
   }
   if (argTy->isVectorTy()) {
     auto *const elemTy = multi_llvm::getVectorElementType(argTy);
-    auto const opElem = module.getFromLLVMTy<OpCode>(elemTy);
-    auto const name = getScalarTypeName(elemTy, opElem);
-    auto const numElements =
+    const auto opElem = module.getFromLLVMTy<OpCode>(elemTy);
+    const auto name = getScalarTypeName(elemTy, opElem);
+    const auto numElements =
         std::to_string(multi_llvm::getVectorNumElements(argTy));
     return isBaseTyName
                ? name + " __attribute__((ext_vector_type(" + numElements + ")))"
@@ -5594,8 +5594,8 @@ llvm::Error Builder::create<OpControlBarrier>(const OpControlBarrier *op) {
   // The mux enumeration values for 'scope' and 'semantics' are identical to
   // the SPIR-V ones, so we can just pass operands straight through.
 
-  auto const wgBarrierName = "__mux_work_group_barrier";
-  auto const sgBarrierName = "__mux_sub_group_barrier";
+  const auto wgBarrierName = "__mux_work_group_barrier";
+  const auto sgBarrierName = "__mux_sub_group_barrier";
   // If it's constant (which is most likely is) emit the right barrier
   // directly.
   if (auto *exe_const = dyn_cast<llvm::ConstantInt>(execution)) {
@@ -5959,7 +5959,7 @@ llvm::Error Builder::create<OpPhi>(const OpPhi *op) {
   return llvm::Error::success();
 }
 
-void Builder::populatePhi(OpPhi const &op) {
+void Builder::populatePhi(const OpPhi &op) {
   llvm::Value *value = module.getValue(op.IdResult());
   SPIRV_LL_ASSERT_PTR(value);
   llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(value);

--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -324,7 +324,7 @@ llvm::Expected<std::optional<uint64_t>> DebugInfoBuilder::getConstantIntValue(
 
 class DebugCompilationUnit : public OpExtInst {
  public:
-  DebugCompilationUnit(OpCode const &other) : OpExtInst(other) {}
+  DebugCompilationUnit(const OpCode &other) : OpExtInst(other) {}
   uint32_t Version() const { return getOpExtInstOperand(0); }
   uint32_t DWARFVersion() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -388,7 +388,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugSource : public OpExtInst {
  public:
-  DebugSource(OpCode const &other) : OpExtInst(other) {}
+  DebugSource(const OpCode &other) : OpExtInst(other) {}
   spv::Id File() const { return getOpExtInstOperand(0); }
   std::optional<spv::Id> Text() const {
     return 1 < opExtInstOperandCount() ? getOpExtInstOperand(1)
@@ -443,7 +443,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeBasic : public OpExtInst {
  public:
-  DebugTypeBasic(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeBasic(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Size() const { return getOpExtInstOperand(1); }
   uint32_t Encoding() const { return getOpExtInstOperand(2); }
@@ -480,7 +480,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypePointer : public OpExtInst {
  public:
-  DebugTypePointer(OpCode const &other) : OpExtInst(other) {}
+  DebugTypePointer(const OpCode &other) : OpExtInst(other) {}
   spv::Id BaseType() const { return getOpExtInstOperand(0); }
   uint32_t StorageClass() const {
     return static_cast<spv::StorageClass>(getOpExtInstOperand(1));
@@ -534,7 +534,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeQualifier : public OpExtInst {
  public:
-  DebugTypeQualifier(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeQualifier(const OpCode &other) : OpExtInst(other) {}
   spv::Id BaseType() const { return getOpExtInstOperand(0); }
   uint32_t TypeQualifier() const { return getOpExtInstOperand(1); }
 };
@@ -565,7 +565,7 @@ static uint64_t getDerivedSizeInBits(const llvm::DIType *Ty) {
 
 class DebugTypeArray : public OpExtInst {
  public:
-  DebugTypeArray(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeArray(const OpCode &other) : OpExtInst(other) {}
   spv::Id BaseType() const { return getOpExtInstOperand(0); }
 
   llvm::SmallVector<std::pair<spv::Id, spv::Id>, 4> ComponentCounts() const {
@@ -629,7 +629,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeVector : public OpExtInst {
  public:
-  DebugTypeVector(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeVector(const OpCode &other) : OpExtInst(other) {}
   spv::Id BaseType() const { return getOpExtInstOperand(0); }
   uint32_t ComponentCount() const { return getOpExtInstOperand(1); }
 };
@@ -660,7 +660,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypedef : public OpExtInst {
  public:
-  DebugTypedef(OpCode const &other) : OpExtInst(other) {}
+  DebugTypedef(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id BaseType() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -702,7 +702,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeFunction : public OpExtInst {
  public:
-  DebugTypeFunction(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeFunction(const OpCode &other) : OpExtInst(other) {}
   uint32_t Flags() const { return getOpExtInstOperand(0); }
   spv::Id ReturnType() const { return getOpExtInstOperand(1); }
   llvm::SmallVector<spv::Id, 4> ParameterTypes() const {
@@ -736,7 +736,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeEnum : public OpExtInst {
  public:
-  DebugTypeEnum(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeEnum(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id UnderlyingType() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -825,7 +825,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeComposite : public OpExtInst {
  public:
-  DebugTypeComposite(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeComposite(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   uint32_t Tag() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -936,7 +936,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeMember : public OpExtInst {
  public:
-  DebugTypeMember(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeMember(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Type() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1032,7 +1032,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeInheritance : public OpExtInst {
  public:
-  DebugTypeInheritance(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeInheritance(const OpCode &other) : OpExtInst(other) {}
   spv::Id Child() const { return getOpExtInstOperand(0); }
   static constexpr size_t ParentIdx = 1;
   spv::Id Parent() const { return getOpExtInstOperand(ParentIdx); }
@@ -1074,7 +1074,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypePtrToMember : public OpExtInst {
  public:
-  DebugTypePtrToMember(OpCode const &other) : OpExtInst(other) {}
+  DebugTypePtrToMember(const OpCode &other) : OpExtInst(other) {}
   spv::Id MemberType() const { return getOpExtInstOperand(0); }
   static constexpr size_t ParentIdx = 1;
   spv::Id Parent() const { return getOpExtInstOperand(ParentIdx); }
@@ -1102,7 +1102,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeTemplate : public OpExtInst {
  public:
-  DebugTypeTemplate(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeTemplate(const OpCode &other) : OpExtInst(other) {}
   spv::Id Target() const { return getOpExtInstOperand(0); }
   llvm::SmallVector<spv::Id, 4> Parameters() const {
     llvm::SmallVector<spv::Id, 4> parameters;
@@ -1158,7 +1158,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeTemplateParameter : public OpExtInst {
  public:
-  DebugTypeTemplateParameter(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeTemplateParameter(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id ActualType() const { return getOpExtInstOperand(1); }
   spv::Id Value() const { return getOpExtInstOperand(2); }
@@ -1205,7 +1205,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeTemplateTemplateParameter : public OpExtInst {
  public:
-  DebugTypeTemplateTemplateParameter(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeTemplateTemplateParameter(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id TemplateName() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1243,7 +1243,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugTypeTemplateParameterPack : public OpExtInst {
  public:
-  DebugTypeTemplateParameterPack(OpCode const &other) : OpExtInst(other) {}
+  DebugTypeTemplateParameterPack(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Source() const { return getOpExtInstOperand(1); }
   uint32_t Line() const { return getOpExtInstOperand(2); }
@@ -1295,7 +1295,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugGlobalVariable : public OpExtInst {
  public:
-  DebugGlobalVariable(OpCode const &other) : OpExtInst(other) {}
+  DebugGlobalVariable(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Type() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1387,7 +1387,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugFunctionDeclaration : public OpExtInst {
  public:
-  DebugFunctionDeclaration(OpCode const &other) : OpExtInst(other) {}
+  DebugFunctionDeclaration(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Type() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1487,7 +1487,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugFunction : public OpExtInst {
  public:
-  DebugFunction(OpCode const &other) : OpExtInst(other) {}
+  DebugFunction(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Type() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1606,7 +1606,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugLexicalBlock : public OpExtInst {
  public:
-  DebugLexicalBlock(OpCode const &other) : OpExtInst(other) {}
+  DebugLexicalBlock(const OpCode &other) : OpExtInst(other) {}
   spv::Id Source() const { return getOpExtInstOperand(0); }
   uint32_t Line() const { return getOpExtInstOperand(1); }
   uint32_t Column() const { return getOpExtInstOperand(2); }
@@ -1650,7 +1650,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugLexicalBlockDiscriminator : public OpExtInst {
  public:
-  DebugLexicalBlockDiscriminator(OpCode const &other) : OpExtInst(other) {}
+  DebugLexicalBlockDiscriminator(const OpCode &other) : OpExtInst(other) {}
   spv::Id Source() const { return getOpExtInstOperand(0); }
   uint32_t Discriminator() const { return getOpExtInstOperand(1); }
   static constexpr size_t ScopeIdx = 2;
@@ -1682,7 +1682,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugScope : public OpExtInst {
  public:
-  DebugScope(OpCode const &other) : OpExtInst(other) {}
+  DebugScope(const OpCode &other) : OpExtInst(other) {}
   static constexpr size_t ScopeIdx = 0;
   spv::Id Scope() const { return getOpExtInstOperand(ScopeIdx); }
   std::optional<spv::Id> InlinedAt() const {
@@ -1692,7 +1692,7 @@ class DebugScope : public OpExtInst {
 };
 
 template <>
-llvm::Error DebugInfoBuilder::create<DebugScope>(OpExtInst const &opc) {
+llvm::Error DebugInfoBuilder::create<DebugScope>(const OpExtInst &opc) {
   auto *op = module.create<DebugScope>(opc);
 
   // Close any current scope.
@@ -1728,18 +1728,18 @@ llvm::Error DebugInfoBuilder::create<DebugScope>(OpExtInst const &opc) {
 
 class DebugNoScope : public OpExtInst {
  public:
-  DebugNoScope(OpCode const &other) : OpExtInst(other) {}
+  DebugNoScope(const OpCode &other) : OpExtInst(other) {}
 };
 
 template <>
-llvm::Error DebugInfoBuilder::create<DebugNoScope>(OpExtInst const &) {
+llvm::Error DebugInfoBuilder::create<DebugNoScope>(const OpExtInst &) {
   builder.closeCurrentLexicalScope(/*closing_line_range*/ false);
   return llvm::Error::success();
 }
 
 class DebugInlinedAt : public OpExtInst {
  public:
-  DebugInlinedAt(OpCode const &other) : OpExtInst(other) {}
+  DebugInlinedAt(const OpCode &other) : OpExtInst(other) {}
   uint32_t Line() const { return getOpExtInstOperand(0); }
   static constexpr size_t ScopeIdx = 1;
   spv::Id Scope() const { return getOpExtInstOperand(ScopeIdx); }
@@ -1784,7 +1784,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugLocalVariable : public OpExtInst {
  public:
-  DebugLocalVariable(OpCode const &other) : OpExtInst(other) {}
+  DebugLocalVariable(const OpCode &other) : OpExtInst(other) {}
   spv::Id Name() const { return getOpExtInstOperand(0); }
   spv::Id Type() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -1859,14 +1859,14 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 
 class DebugDeclare : public OpExtInst {
  public:
-  DebugDeclare(OpCode const &other) : OpExtInst(other) {}
+  DebugDeclare(const OpCode &other) : OpExtInst(other) {}
   spv::Id LocalVariable() const { return getOpExtInstOperand(0); }
   spv::Id Variable() const { return getOpExtInstOperand(1); }
   spv::Id Expression() const { return getOpExtInstOperand(2); }
 };
 
 template <>
-llvm::Error DebugInfoBuilder::create<DebugDeclare>(OpExtInst const &opc) {
+llvm::Error DebugInfoBuilder::create<DebugDeclare>(const OpExtInst &opc) {
   auto *op = module.create<DebugDeclare>(opc);
 
   llvm::Value *variable = module.getValue(op->Variable());
@@ -1920,7 +1920,7 @@ llvm::Error DebugInfoBuilder::create<DebugDeclare>(OpExtInst const &opc) {
 
 class DebugValue : public OpExtInst {
  public:
-  DebugValue(OpCode const &other) : OpExtInst(other) {}
+  DebugValue(const OpCode &other) : OpExtInst(other) {}
   spv::Id LocalVariable() const { return getOpExtInstOperand(0); }
   spv::Id Variable() const { return getOpExtInstOperand(1); }
   spv::Id Expression() const { return getOpExtInstOperand(2); }
@@ -1934,7 +1934,7 @@ class DebugValue : public OpExtInst {
 };
 
 template <>
-llvm::Error DebugInfoBuilder::create<DebugValue>(OpExtInst const &opc) {
+llvm::Error DebugInfoBuilder::create<DebugValue>(const OpExtInst &opc) {
   auto *op = module.create<DebugValue>(opc);
   llvm::Value *variable = module.getValue(op->Variable());
   if (!variable) {
@@ -1984,7 +1984,7 @@ llvm::Error DebugInfoBuilder::create<DebugValue>(OpExtInst const &opc) {
 
 class DebugOperation : public OpExtInst {
  public:
-  DebugOperation(OpCode const &other) : OpExtInst(other) {}
+  DebugOperation(const OpCode &other) : OpExtInst(other) {}
   spv::Id Operation() const { return getOpExtInstOperand(0); }
   llvm::SmallVector<spv::Id, 4> Operands() const {
     llvm::SmallVector<uint32_t, 4> operands;
@@ -1997,7 +1997,7 @@ class DebugOperation : public OpExtInst {
 
 class DebugExpression : public OpExtInst {
  public:
-  DebugExpression(OpCode const &other) : OpExtInst(other) {}
+  DebugExpression(const OpCode &other) : OpExtInst(other) {}
   llvm::SmallVector<spv::Id, 4> Operation() const {
     llvm::SmallVector<spv::Id, 4> operations;
     for (uint16_t i = 0, e = opExtInstOperandCount(); i != e; i++) {
@@ -2041,7 +2041,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
 // skipping it, depending on the number of operands in the instruction.
 class DebugImportedEntity : public OpExtInst {
  public:
-  DebugImportedEntity(OpCode const &other) : OpExtInst(other) {
+  DebugImportedEntity(const OpCode &other) : OpExtInst(other) {
     dummy_offset = opExtInstOperandCount() == 7 ? 0 : 1;
   }
   spv::Id Name() const { return getOpExtInstOperand(0); }
@@ -2060,7 +2060,7 @@ class DebugImportedEntity : public OpExtInst {
 
 template <>
 llvm::Error DebugInfoBuilder::create<DebugImportedEntity>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<DebugImportedEntity>(opc);
   uint32_t line = op->Line();
 
@@ -2305,7 +2305,7 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translateDebugInstImpl(
 // All other nodes are visited through the process of creating these above
 // nodes. They are visited through the 'translateDebugInst' API, and are
 // cached as they may be multiply referenced.
-llvm::Error DebugInfoBuilder::create(OpExtInst const &opc) {
+llvm::Error DebugInfoBuilder::create(const OpExtInst &opc) {
   // Most of this code *should* work for the DebugInfo instruction set, with a
   // few tweaks to account for the differences. However, we haven't thoroughly
   // tested that instruction set as there is a dearth of producers and test

--- a/modules/compiler/spirv-ll/source/builder_glsl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_glsl.cpp
@@ -111,7 +111,7 @@ using NClamp = ExtInst<X, MINVAL, MAXVAL>;
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Round>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -130,7 +130,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Round>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::RoundEven>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -149,7 +149,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450RoundEven>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Trunc>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -168,7 +168,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Trunc>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FAbs>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -187,7 +187,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FAbs>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SAbs>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -206,7 +206,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SAbs>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FSign>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -225,7 +225,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FSign>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SSign>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -271,7 +271,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SSign>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Floor>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -290,7 +290,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Floor>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Ceil>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -309,7 +309,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ceil>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Fract>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -343,7 +343,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fract>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Radians>(opc);
 
   llvm::Value *degrees = module.getValue(op->degrees());
@@ -362,7 +362,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Radians>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Degrees>(opc);
 
   llvm::Value *radians = module.getValue(op->radians());
@@ -380,7 +380,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Degrees>(
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Sin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -398,7 +398,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sin>(OpExtInst const &opc) {
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Cos>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -416,7 +416,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cos>(OpExtInst const &opc) {
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Tan>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -435,7 +435,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tan>(OpExtInst const &opc) {
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Asin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -454,7 +454,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asin>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Acos>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -473,7 +473,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acos>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Atan>(opc);
 
   llvm::Value *yOverX = module.getValue(op->yOverX());
@@ -493,7 +493,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Sinh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -512,7 +512,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sinh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Cosh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -531,7 +531,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cosh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Tanh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -550,7 +550,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Tanh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Asinh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -569,7 +569,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Asinh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Acosh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -588,7 +588,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Acosh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Atanh>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -607,7 +607,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atanh>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Atan2>(opc);
 
   llvm::Value *y = module.getValue(op->y());
@@ -628,7 +628,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Atan2>(
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Pow>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -649,7 +649,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Pow>(OpExtInst const &opc) {
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Exp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -667,7 +667,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp>(OpExtInst const &opc) {
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Log>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -686,7 +686,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log>(OpExtInst const &opc) {
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Exp2>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -705,7 +705,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Exp2>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Log2>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -724,7 +724,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Log2>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Sqrt>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -743,7 +743,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Sqrt>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::InverseSqrt>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -762,7 +762,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InverseSqrt>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Determinant>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Determinant>(opc);
 
   // Builtin not yet implemented!
@@ -773,7 +773,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Determinant>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450MatrixInverse>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::MatrixInverse>(opc);
 
   // Builtin not yet implemented!
@@ -784,7 +784,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450MatrixInverse>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Modf>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -806,7 +806,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Modf>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FrexpStruct>(opc);
 
   auto *x = module.getValue(op->x());
@@ -844,7 +844,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450ModfStruct>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FMin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -866,7 +866,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMin>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UMin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -888,7 +888,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMin>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SMin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -910,7 +910,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMin>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FMax>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -932,7 +932,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMax>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UMax>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -954,7 +954,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UMax>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SMax>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -976,7 +976,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SMax>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1002,7 +1002,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FClamp>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1028,7 +1028,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UClamp>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1054,7 +1054,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SClamp>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FMix>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1080,7 +1080,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FMix>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450IMix>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::IMix>(opc);
 
   // Builtin not yet implemented!
@@ -1091,7 +1091,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450IMix>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Step>(opc);
 
   llvm::Value *edge = module.getValue(op->edge());
@@ -1113,7 +1113,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Step>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::SmoothStep>(opc);
 
   llvm::Value *edge0 = module.getValue(op->edge0());
@@ -1138,7 +1138,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450SmoothStep>(
 }
 
 template <>
-llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Fma>(opc);
 
   llvm::Value *a = module.getValue(op->a());
@@ -1165,7 +1165,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Fma>(OpExtInst const &opc) {
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Frexp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1200,7 +1200,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Frexp>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FrexpStruct>(opc);
 
   auto *x = module.getValue(op->x());
@@ -1244,7 +1244,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FrexpStruct>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Ldexp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1270,7 +1270,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Ldexp>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackSnorm4x8>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1288,7 +1288,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm4x8>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackUnorm4x8>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1306,7 +1306,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm4x8>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackSnorm2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1324,7 +1324,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackSnorm2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackUnorm2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1342,7 +1342,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackUnorm2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackHalf2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1360,7 +1360,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackHalf2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::PackDouble2x32>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1377,7 +1377,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450PackDouble2x32>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackSnorm2x16>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1395,7 +1395,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackUnorm2x16>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1413,7 +1413,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackHalf2x16>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1431,7 +1431,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackHalf2x16>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackSnorm4x8>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1449,7 +1449,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackSnorm4x8>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackUnorm4x8>(opc);
 
   llvm::Value *p = module.getValue(op->p());
@@ -1467,7 +1467,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackUnorm4x8>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::UnpackDouble2x32>(opc);
 
   llvm::Value *v = module.getValue(op->v());
@@ -1484,7 +1484,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450UnpackDouble2x32>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Length>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Length>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1503,7 +1503,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Length>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Distance>(opc);
 
   llvm::Value *p0 = module.getValue(op->p0());
@@ -1525,7 +1525,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Distance>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Cross>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1547,7 +1547,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Cross>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Normalize>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1566,7 +1566,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Normalize>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FaceForward>(opc);
 
   llvm::Value *n = module.getValue(op->n());
@@ -1593,7 +1593,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FaceForward>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Reflect>(opc);
 
   llvm::Value *i = module.getValue(op->i());
@@ -1616,7 +1616,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Reflect>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::Refract>(opc);
 
   llvm::Value *i = module.getValue(op->i());
@@ -1642,7 +1642,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450Refract>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FindILsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1661,7 +1661,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindILsb>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FindSMsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1681,7 +1681,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindSMsb>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::FindUMsb>(opc);
 
   llvm::Value *value = module.getValue(op->value());
@@ -1700,7 +1700,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450FindUMsb>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtCentroid>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtCentroid>(opc);
 
   // Builtin not yet implemented!
@@ -1711,7 +1711,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtCentroid>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtSample>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtSample>(opc);
 
   // Builtin not yet implemented!
@@ -1722,7 +1722,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtSample>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtOffset>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::InterpolateAtOffset>(opc);
 
   // Builtin not yet implemented!
@@ -1733,7 +1733,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450InterpolateAtOffset>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::NMin>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1755,7 +1755,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMin>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::NMax>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1777,7 +1777,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NMax>(
 
 template <>
 llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<GLSLstd450::NClamp>(opc);
 
   llvm::Value *x = module.getValue(op->x());
@@ -1805,7 +1805,7 @@ llvm::Error spirv_ll::GLSLBuilder::create<GLSLstd450NClamp>(
   case ExtInst:       \
     return create<ExtInst>(opc);
 
-llvm::Error spirv_ll::GLSLBuilder::create(OpExtInst const &opc) {
+llvm::Error spirv_ll::GLSLBuilder::create(const OpExtInst &opc) {
   switch (opc.Instruction()) {
     CASE(GLSLstd450Round)
     CASE(GLSLstd450RoundEven)

--- a/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
+++ b/modules/compiler/spirv-ll/source/builder_group_async_copies.cpp
@@ -19,7 +19,7 @@
 
 namespace spirv_ll {
 struct GroupAsyncCopy2D2D : OpExtInst {
-  GroupAsyncCopy2D2D(OpCode const &opc) : OpExtInst(opc) {}
+  GroupAsyncCopy2D2D(const OpCode &opc) : OpExtInst(opc) {}
   spv::Id Destination() const { return getOpExtInstOperand(0); }
   spv::Id DestinationOffset() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -33,7 +33,7 @@ struct GroupAsyncCopy2D2D : OpExtInst {
 };
 
 struct GroupAsyncCopy3D3D : OpExtInst {
-  GroupAsyncCopy3D3D(OpCode const &opc) : OpExtInst(opc) {}
+  GroupAsyncCopy3D3D(const OpCode &opc) : OpExtInst(opc) {}
   spv::Id Destination() const { return getOpExtInstOperand(0); }
   spv::Id DestinationOffset() const { return getOpExtInstOperand(1); }
   spv::Id Source() const { return getOpExtInstOperand(2); }
@@ -52,7 +52,7 @@ struct GroupAsyncCopy3D3D : OpExtInst {
 template <>
 llvm::Error
 GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy2D2D>(opc);
 
   llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
@@ -121,7 +121,7 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy2D2D>(
 template <>
 llvm::Error
 GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<spirv_ll::GroupAsyncCopy3D3D>(opc);
 
   llvm::Type *eventTy = module.getLLVMType(op->IdResultType());
@@ -196,7 +196,7 @@ GroupAsyncCopiesBuilder::create<GroupAsyncCopiesBuilder::GroupAsyncCopy3D3D>(
   return llvm::Error::success();
 }
 
-llvm::Error GroupAsyncCopiesBuilder::create(OpExtInst const &opc) {
+llvm::Error GroupAsyncCopiesBuilder::create(const OpExtInst &opc) {
   switch (opc.Instruction()) {
     case GroupAsyncCopy2D2D:
       return create<GroupAsyncCopy2D2D>(opc);

--- a/modules/compiler/spirv-ll/source/builder_opencl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_opencl.cpp
@@ -187,7 +187,7 @@ using Prefetch = ExtInst<PTR, NUM_ELEMENTS>;
 
 class Printf : public OpExtInst {
  public:
-  Printf(OpCode const &other) : OpExtInst(other) {}
+  Printf(const OpCode &other) : OpExtInst(other) {}
   spv::Id format() const { return getOpExtInstOperand(0); }
   llvm::SmallVector<spv::Id, 8> AdditionalArguments() const {
     llvm::SmallVector<spv::Id, 8> additionalArguments;
@@ -200,7 +200,7 @@ class Printf : public OpExtInst {
 
 }  // namespace OpenCLstd
 
-static llvm::Error createPrintf(OpExtInst const &opc, Module &module,
+static llvm::Error createPrintf(const OpExtInst &opc, Module &module,
                                 Builder &builder) {
   auto *op = module.create<OpenCLstd::Printf>(opc);
 
@@ -243,7 +243,7 @@ static llvm::Error createPrintf(OpExtInst const &opc, Module &module,
 }
 
 template <>
-llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X>>(const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -256,7 +256,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X>>(OpExtInst const &opc) {
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, Y>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -269,7 +269,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, Z>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, Y, Z>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -282,7 +282,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, Z>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, PTR>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, PTR>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -295,7 +295,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, PTR>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, EXP>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, EXP>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -308,7 +308,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, EXP>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, K>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, K>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -321,7 +321,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, K>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SIGNP>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, SIGNP>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -334,7 +334,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SIGNP>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<Y, X>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<Y, X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -347,7 +347,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<Y, X>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<A, B, C>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<A, B, C>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -360,7 +360,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<A, B, C>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, IPTR>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, IPTR>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -373,7 +373,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, IPTR>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<NANCODE>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<NANCODE>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -386,7 +386,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<NANCODE>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, QUO>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, Y, QUO>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -399,7 +399,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, QUO>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, COSVAL>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, COSVAL>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -412,7 +412,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, COSVAL>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, MINVAL, MAXVAL>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, MINVAL, MAXVAL>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -425,7 +425,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, MINVAL, MAXVAL>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<V, I>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<V, I>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -438,7 +438,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<V, I>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<HI, LO>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<HI, LO>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -451,7 +451,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<HI, LO>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DEGREES>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<DEGREES>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -464,7 +464,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DEGREES>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<RADIANS>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<RADIANS>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -477,7 +477,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<RADIANS>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, A>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, Y, A>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -489,7 +489,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, A>>(
 }
 
 template <>
-llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P>>(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P>>(const OpExtInst &opc) {
   auto *op = module.create<ExtInst<P>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -502,7 +502,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P>>(OpExtInst const &opc) {
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P0, P1>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<P0, P1>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -515,7 +515,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<P0, P1>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE, X>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<EDGE, X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -528,7 +528,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE, X>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE0, EDGE1, X>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<EDGE0, EDGE1, X>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -541,7 +541,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<EDGE0, EDGE1, X>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SHUFFLEMASK>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, SHUFFLEMASK>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -554,7 +554,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, SHUFFLEMASK>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, SHUFFLEMASK>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<X, Y, SHUFFLEMASK>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -567,7 +567,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<X, Y, SHUFFLEMASK>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<PTR, NUM_ELEMENTS>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<PTR, NUM_ELEMENTS>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -580,7 +580,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<PTR, NUM_ELEMENTS>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<OFFSET, P, N>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -593,7 +593,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P, N>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<OFFSET, P, N>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -606,7 +606,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<OFFSET, P, N>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<DATA, OFFSET, P>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -619,7 +619,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P>>(
 
 template <>
 llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P, MODE>>(
-    OpExtInst const &opc) {
+    const OpExtInst &opc) {
   auto *op = module.create<ExtInst<DATA, OFFSET, P, MODE>>(opc);
 
   auto *const result = builder.createOCLBuiltinCall(
@@ -635,7 +635,7 @@ llvm::Error spirv_ll::OpenCLBuilder::create<ExtInst<DATA, OFFSET, P, MODE>>(
   case Opcode:                \
     return create<ExtInst>(opc);
 
-llvm::Error spirv_ll::OpenCLBuilder::create(OpExtInst const &opc) {
+llvm::Error spirv_ll::OpenCLBuilder::create(const OpExtInst &opc) {
   switch (opc.Instruction()) {
     CASE(OpenCLLIB::Acos, OpenCLstd::Acos)
     CASE(OpenCLLIB::Acosh, OpenCLstd::Acosh)

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -141,7 +141,7 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
   llvm::SmallVector<IRInsertPoint, 8> IPStack;
   // Store the branch instructions found in the current function, as we need to
   // generate them after all the basic blocks have been generated.
-  using OpIRLocTy = std::pair<OpCode const, IRInsertPoint>;
+  using OpIRLocTy = std::pair<const OpCode, IRInsertPoint>;
   // Store the Phi nodes in order to add the values after all the basic blocks
   // have been generated
   llvm::SmallVector<OpIRLocTy, 8> Phis;

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -133,7 +133,7 @@ const spirv_ll::OpEntryPoint *spirv_ll::Module::getEntryPoint(
   return found != EntryPoints.end() ? found->getSecond() : nullptr;
 }
 
-void spirv_ll::Module::replaceID(OpResult const *Op, llvm::Value *V) {
+void spirv_ll::Module::replaceID(const OpResult *Op, llvm::Value *V) {
   auto found = Values.find(Op->IdResult());
   if (found != Values.end()) {
     Values.erase(found);
@@ -474,7 +474,7 @@ llvm::Type *spirv_ll::Module::getBlockType(const spv::Id id) const {
   }
 }
 
-bool spirv_ll::Module::addID(spv::Id id, OpCode const *Op, llvm::Value *V) {
+bool spirv_ll::Module::addID(spv::Id id, const OpCode *Op, llvm::Value *V) {
   // If the ID has a name attached to it, try to set it here if it wasn't
   // already set. reference might not have been able to take a name (e.g., if
   // it was a undef/poison constant).
@@ -668,7 +668,7 @@ spirv_ll::Module::SampledImage spirv_ll::Module::getSampledImage(
   return SampledImagesMap.lookup(id);
 }
 
-bool spirv_ll::Module::addID(spv::Id id, OpCode const *Op, llvm::Type *T) {
+bool spirv_ll::Module::addID(spv::Id id, const OpCode *Op, llvm::Type *T) {
   // SSA form forbids the reassignment of IDs
   auto existing = Types.find(id);
   if (existing != Types.end() && existing->second.Type != nullptr) {

--- a/modules/compiler/spirv-ll/source/opcodes.cpp
+++ b/modules/compiler/spirv-ll/source/opcodes.cpp
@@ -362,7 +362,7 @@ spv::Decoration OpDecorateBase::getDecoration() const {
 }
 
 llvm::StringRef OpSourceContinued::ContinuedSource() const {
-  return reinterpret_cast<char const *>(data + 1);
+  return reinterpret_cast<const char *>(data + 1);
 }
 
 spv::SourceLanguage OpSource::SourceLanguage() const {
@@ -374,17 +374,17 @@ uint32_t OpSource::Version() const { return getValueAtOffset(2); }
 spv::Id OpSource::File() const { return getValueAtOffset(3); }
 
 llvm::StringRef OpSource::Source() const {
-  return reinterpret_cast<char const *>(data + 4);
+  return reinterpret_cast<const char *>(data + 4);
 }
 
 llvm::StringRef OpSourceExtension::Extension() const {
-  return reinterpret_cast<char const *>(data + 1);
+  return reinterpret_cast<const char *>(data + 1);
 }
 
 spv::Id OpName::Target() const { return getValueAtOffset(1); }
 
 llvm::StringRef OpName::Name() const {
-  return reinterpret_cast<char const *>(data + 2);
+  return reinterpret_cast<const char *>(data + 2);
 }
 
 spv::Id OpMemberName::Type() const { return getValueAtOffset(1); }
@@ -392,13 +392,13 @@ spv::Id OpMemberName::Type() const { return getValueAtOffset(1); }
 uint32_t OpMemberName::Member() const { return getValueAtOffset(2); }
 
 llvm::StringRef OpMemberName::Name() const {
-  return reinterpret_cast<char const *>(data + 3);
+  return reinterpret_cast<const char *>(data + 3);
 }
 
 spv::Id OpString::IdResult() const { return getValueAtOffset(1); }
 
 llvm::StringRef OpString::String() const {
-  return reinterpret_cast<char const *>(data + 2);
+  return reinterpret_cast<const char *>(data + 2);
 }
 
 spv::Id OpLine::File() const { return getValueAtOffset(1); }
@@ -408,17 +408,17 @@ uint32_t OpLine::Line() const { return getValueAtOffset(2); }
 uint32_t OpLine::Column() const { return getValueAtOffset(3); }
 
 llvm::StringRef OpModuleProcessed::Process() const {
-  return reinterpret_cast<char const *>(data + 1);
+  return reinterpret_cast<const char *>(data + 1);
 }
 
 llvm::StringRef OpExtension::Name() const {
-  return reinterpret_cast<char const *>(data + 1);
+  return reinterpret_cast<const char *>(data + 1);
 }
 
 spv::Id OpExtInstImport::IdResult() const { return getValueAtOffset(1); }
 
 llvm::StringRef OpExtInstImport::Name() const {
-  return reinterpret_cast<char const *>(data + 2);
+  return reinterpret_cast<const char *>(data + 2);
 }
 
 spv::Id OpExtInst::Set() const { return getValueAtOffset(3); }
@@ -458,7 +458,7 @@ spv::ExecutionModel OpEntryPoint::ExecutionModel() const {
 spv::Id OpEntryPoint::EntryPoint() const { return getValueAtOffset(2); }
 
 llvm::StringRef OpEntryPoint::Name() const {
-  return reinterpret_cast<char const *>(data + 3);
+  return reinterpret_cast<const char *>(data + 3);
 }
 
 llvm::SmallVector<spv::Id, 8> OpEntryPoint::Interface() const {
@@ -535,7 +535,7 @@ llvm::SmallVector<spv::Id, 8> OpTypeStruct::MemberTypes() const {
 }
 
 llvm::StringRef OpTypeOpaque::Name() const {
-  return reinterpret_cast<char const *>(data + 2);
+  return reinterpret_cast<const char *>(data + 2);
 }
 
 uint32_t OpTypePointer::StorageClass() const {

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -175,8 +175,8 @@ HostKernel::querySubGroupSizeForLocalSize(size_t local_size_x,
 cargo::expected<std::array<size_t, 3>, compiler::Result>
 HostKernel::queryLocalSizeForSubGroupCount(size_t sub_group_count) {
   // Try to compile something and see what subgroup size we get
-  auto const &info = *target.getCompilerInfo()->device_info;
-  size_t const max_local_size_x = info.max_work_group_size_x;
+  const auto &info = *target.getCompilerInfo()->device_info;
+  const size_t max_local_size_x = info.max_work_group_size_x;
   auto optimized_kernel =
       lookupOrCreateOptimizedKernel({max_local_size_x, 1, 1});
   if (!optimized_kernel) {
@@ -185,7 +185,7 @@ HostKernel::queryLocalSizeForSubGroupCount(size_t sub_group_count) {
 
   // If we've compiled with degenerate sub-groups, the work-group size is the
   // sub-group size.
-  auto const sub_group_size = optimized_kernel->binary_kernel->sub_group_size;
+  const auto sub_group_size = optimized_kernel->binary_kernel->sub_group_size;
   if (sub_group_size == 0) {
     // FIXME: For degenerate sub-groups, the local size could be anything up to
     // the maximum local size. For any other sub-group count, we should ensure
@@ -200,7 +200,7 @@ HostKernel::queryLocalSizeForSubGroupCount(size_t sub_group_count) {
     }
   }
 
-  auto const local_size = sub_group_count * sub_group_size;
+  const auto local_size = sub_group_count * sub_group_size;
   if (local_size <= max_local_size_x) {
     return {{local_size, 1, 1}};
   }

--- a/modules/compiler/test/group_ops.cpp
+++ b/modules/compiler/test/group_ops.cpp
@@ -395,7 +395,7 @@ define void @test_wrapper(i32 %i, float %f, i32 %sg_lid, i64 %lid_x, i64 %lid_y,
     // order as the group operations we generated earlier.
     unsigned GroupOpIdx = 0;
     for (auto &I : BB) {
-      auto const *CI = dyn_cast<CallInst>(&I);
+      const auto *CI = dyn_cast<CallInst>(&I);
       if (!CI) {
         continue;
       }

--- a/modules/compiler/utils/include/compiler/utils/attributes.h
+++ b/modules/compiler/utils/include/compiler/utils/attributes.h
@@ -160,7 +160,7 @@ void setBarrierSchedule(llvm::CallInst &CI, BarrierSchedule Sched);
 ///
 /// @param[in] CI the barrier call instruction
 /// @return the execution schedule for this barrier
-BarrierSchedule getBarrierSchedule(llvm::CallInst const &CI);
+BarrierSchedule getBarrierSchedule(const llvm::CallInst &CI);
 
 /// @brief Marks a kernel's subgroups as degenerate
 ///

--- a/modules/compiler/utils/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/utils/include/compiler/utils/barrier_regions.h
@@ -150,7 +150,7 @@ class Barrier {
   // TODO CA-1115 llvm.dbg.declare is being deprecated
   using debug_intrinsics_t =
       llvm::SmallVector<std::pair<llvm::DbgDeclareInst *, unsigned>, 4>;
-  debug_intrinsics_t const &getDebugIntrinsics() const {
+  const debug_intrinsics_t &getDebugIntrinsics() const {
     return debug_intrinsics_;
   }
 
@@ -160,7 +160,7 @@ class Barrier {
 
   /// @brief struct to help retrieval of values from the barrier struct
   struct LiveValuesHelper {
-    Barrier const &barrier;
+    const Barrier &barrier;
     /// @brief A cache of queried live-values addresses (inside the live
     /// variables struct), stored by the pair (value, member_idx).
     llvm::DenseMap<std::pair<const llvm::Value *, unsigned>, llvm::Value *>
@@ -170,10 +170,10 @@ class Barrier {
     llvm::Value *barrier_struct = nullptr;
     llvm::Value *vscale = nullptr;
 
-    LiveValuesHelper(Barrier const &b, llvm::Instruction *i, llvm::Value *s)
+    LiveValuesHelper(const Barrier &b, llvm::Instruction *i, llvm::Value *s)
         : barrier(b), gepBuilder(i), barrier_struct(s) {}
 
-    LiveValuesHelper(Barrier const &b, llvm::BasicBlock *bb, llvm::Value *s)
+    LiveValuesHelper(const Barrier &b, llvm::BasicBlock *bb, llvm::Value *s)
         : barrier(b), gepBuilder(bb), barrier_struct(s) {}
 
     /// @brief Return a GEP instruction pointing to the given value/idx pair in

--- a/modules/compiler/utils/include/compiler/utils/builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/builtin_info.h
@@ -228,11 +228,11 @@ enum BuiltinProperties : int32_t {
 /// @brief struct to hold information about a builtin function
 struct Builtin {
   /// @brief the builtin Function
-  llvm::Function const &function;
+  const llvm::Function &function;
   /// @brief ID for internal use
-  BuiltinID const ID;
+  const BuiltinID ID;
   /// @brief the Builtin Properties
-  BuiltinProperties const properties;
+  const BuiltinProperties properties;
   /// @brief list of types used in overloading this builtin (only relevant for
   /// overloadable mux builtins)
   std::vector<llvm::Type *> mux_overload_info = {};
@@ -247,12 +247,12 @@ struct Builtin {
 /// @brief struct to hold information about a builtin function call
 struct BuiltinCall : public Builtin {
   /// @brief the call instruction
-  llvm::CallInst const &call;
+  const llvm::CallInst &call;
   /// @brief the uniformity of the builtin call
-  BuiltinUniformity const uniformity;
+  const BuiltinUniformity uniformity;
 
   /// @brief constructor
-  BuiltinCall(Builtin const &B, llvm::CallInst const &CI, BuiltinUniformity U)
+  BuiltinCall(const Builtin &B, const llvm::CallInst &CI, BuiltinUniformity U)
       : Builtin(B), call(CI), uniformity(U) {}
 };
 
@@ -362,12 +362,12 @@ class BuiltinInfo {
   /// @brief Determine general properties for the given builtin function.
   /// @param[in] F Function to analyze.
   /// @return Analyzed properties for the builtin.
-  Builtin analyzeBuiltin(llvm::Function const &F) const;
+  Builtin analyzeBuiltin(const llvm::Function &F) const;
 
   /// @brief Determine general properties for the given builtin function.
   /// @param[in] CI Call instruction to analyze.
   /// @return Analyzed properties for the builtin call.
-  BuiltinCall analyzeBuiltinCall(llvm::CallInst const &CI,
+  BuiltinCall analyzeBuiltinCall(const llvm::CallInst &CI,
                                  unsigned SimdDimIdx) const;
 
   /// @brief Try to find a builtin function that is a vector equivalent of the
@@ -377,7 +377,7 @@ class BuiltinInfo {
   /// @param[in] M Optional module where the vector equivalent should be
   /// declared.
   /// @return Equivalent vector builtin function on success.
-  llvm::Function *getVectorEquivalent(Builtin const &B, unsigned Width,
+  llvm::Function *getVectorEquivalent(const Builtin &B, unsigned Width,
                                       llvm::Module *M = nullptr);
 
   /// @brief Try to find a builtin function that is a scalar equivalent of the
@@ -386,7 +386,7 @@ class BuiltinInfo {
   /// @param[in] M Optional module where the vector equivalent should be
   /// declared.
   /// @return Equivalent scalar builtin function on success.
-  llvm::Function *getScalarEquivalent(Builtin const &B, llvm::Module *M);
+  llvm::Function *getScalarEquivalent(const Builtin &B, llvm::Module *M);
 
   /// @brief Emit an inline implementation of the builtin function F.
   /// @param[in] Builtin Builtin function to emit an implementation for.
@@ -650,7 +650,7 @@ class BuiltinInfo {
   /// @return Valid builtin ID if the name was identified, as well as any types
   /// required to overload the builtin ID.
   std::pair<BuiltinID, std::vector<llvm::Type *>> identifyMuxBuiltin(
-      llvm::Function const &F) const;
+      const llvm::Function &F) const;
 
   /// @brief Determine whether the given builtin function returns uniform values
   /// or not. An optional call instruction can be passed for more accuracy.
@@ -658,7 +658,7 @@ class BuiltinInfo {
   /// @param[in] CI Optional argument list from a call instruction.
   /// @param[in] SimdDimIdx Index of current vectorization dimension.
   /// @return Uniformity value for the builtin.
-  BuiltinUniformity isBuiltinUniform(Builtin const &B, const llvm::CallInst *CI,
+  BuiltinUniformity isBuiltinUniform(const Builtin &B, const llvm::CallInst *CI,
                                      unsigned SimdDimIdx) const;
 
   std::unique_ptr<BIMuxInfoConcept> MuxImpl;
@@ -792,16 +792,16 @@ class BILangInfoConcept {
   /// @see BuiltinInfo::getBuiltinsModule
   virtual llvm::Module *getBuiltinsModule() { return nullptr; }
   /// @see BuiltinInfo::analyzeBuiltin
-  virtual Builtin analyzeBuiltin(llvm::Function const &F) const = 0;
+  virtual Builtin analyzeBuiltin(const llvm::Function &F) const = 0;
   /// @see BuiltinInfo::isBuiltinUniform
-  virtual BuiltinUniformity isBuiltinUniform(Builtin const &B,
+  virtual BuiltinUniformity isBuiltinUniform(const Builtin &B,
                                              const llvm::CallInst *,
                                              unsigned) const = 0;
   /// @see BuiltinInfo::getVectorEquivalent
-  virtual llvm::Function *getVectorEquivalent(Builtin const &B, unsigned Width,
+  virtual llvm::Function *getVectorEquivalent(const Builtin &B, unsigned Width,
                                               llvm::Module *M = nullptr) = 0;
   /// @see BuiltinInfo::getScalarEquivalent
-  virtual llvm::Function *getScalarEquivalent(Builtin const &B,
+  virtual llvm::Function *getScalarEquivalent(const Builtin &B,
                                               llvm::Module *M) = 0;
   /// @see BuiltinInfo::emitBuiltinInline
   virtual llvm::Value *emitBuiltinInline(

--- a/modules/compiler/utils/include/compiler/utils/cl_builtin_info.h
+++ b/modules/compiler/utils/include/compiler/utils/cl_builtin_info.h
@@ -87,16 +87,16 @@ class CLBuiltinInfo : public BILangInfoConcept {
   llvm::Module *getBuiltinsModule() override;
 
   /// @see BuiltinInfo::isBuiltinUniform
-  BuiltinUniformity isBuiltinUniform(Builtin const &B, const llvm::CallInst *CI,
+  BuiltinUniformity isBuiltinUniform(const Builtin &B, const llvm::CallInst *CI,
                                      unsigned SimdDimIdx) const override;
 
   /// @see BuiltinInfo::analyzeBuiltin
-  Builtin analyzeBuiltin(llvm::Function const &F) const override;
+  Builtin analyzeBuiltin(const llvm::Function &F) const override;
   /// @see BuiltinInfo::getVectorEquivalent
-  llvm::Function *getVectorEquivalent(Builtin const &B, unsigned Width,
+  llvm::Function *getVectorEquivalent(const Builtin &B, unsigned Width,
                                       llvm::Module *M = nullptr) override;
   /// @see BuiltinInfo::getScalarEquivalent
-  llvm::Function *getScalarEquivalent(Builtin const &B,
+  llvm::Function *getScalarEquivalent(const Builtin &B,
                                       llvm::Module *M) override;
   /// @see BuiltinInfo::emitBuiltinInline
   llvm::Value *emitBuiltinInline(llvm::Function *Builtin, llvm::IRBuilder<> &B,
@@ -109,7 +109,7 @@ class CLBuiltinInfo : public BILangInfoConcept {
   BuiltinID getPrintfBuiltin() const override;
 
  private:
-  BuiltinID identifyBuiltin(llvm::Function const &) const;
+  BuiltinID identifyBuiltin(const llvm::Function &) const;
 
   llvm::Function *materializeBuiltin(
       llvm::StringRef BuiltinName, llvm::Module *DestM = nullptr,

--- a/modules/compiler/utils/source/add_scheduling_parameters_pass.cpp
+++ b/modules/compiler/utils/source/add_scheduling_parameters_pass.cpp
@@ -73,7 +73,7 @@ PreservedAnalyses compiler::utils::AddSchedulingParametersPass::run(
     if (!F.isDeclaration() || F.isIntrinsic()) {
       continue;
     }
-    auto const B = BI.analyzeBuiltin(F);
+    const auto B = BI.analyzeBuiltin(F);
     if (B.isUnknown() || !B.isValid()) {
       continue;
     }

--- a/modules/compiler/utils/source/attributes.cpp
+++ b/modules/compiler/utils/source/attributes.cpp
@@ -174,7 +174,7 @@ void setBarrierSchedule(CallInst &CI, BarrierSchedule Sched) {
   CI.addFnAttr(Attr);
 }
 
-BarrierSchedule getBarrierSchedule(CallInst const &CI) {
+BarrierSchedule getBarrierSchedule(const CallInst &CI) {
   Attribute Attr = CI.getFnAttr(BarrierScheduleAttrName);
   if (Attr.isValid()) {
     return StringSwitch<BarrierSchedule>(Attr.getValueAsString())

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -164,7 +164,7 @@ inline bool CheckValidUse(Value *v) {
 bool IsRematerializableBuiltinCall(Value *v, compiler::utils::BuiltinInfo &bi) {
   if (auto *call = dyn_cast<CallInst>(v)) {
     assert(call->getCalledFunction() && "Could not get called function");
-    auto const B = bi.analyzeBuiltin(*call->getCalledFunction());
+    const auto B = bi.analyzeBuiltin(*call->getCalledFunction());
     if (B.properties & compiler::utils::eBuiltinPropertyRematerializable) {
       for (auto &op : call->operands()) {
         if (isa<Instruction>(op.get())) {
@@ -329,7 +329,7 @@ Value *compiler::utils::Barrier::LiveValuesHelper::getGEP(const Value *live,
                                        Twine("live_gep_") + live->getName());
   } else if (auto field_it = barrier.live_variable_scalables_map_.find(key);
              field_it != barrier.live_variable_scalables_map_.end()) {
-    unsigned const field_offset = field_it->second;
+    const unsigned field_offset = field_it->second;
     Value *scaled_offset = nullptr;
 
     LLVMContext &context = barrier.module_.getContext();
@@ -521,7 +521,7 @@ void compiler::utils::Barrier::FindBarriers() {
       if (CallInst *call_inst = dyn_cast<CallInst>(&bi)) {
         Function *callee = call_inst->getCalledFunction();
         if (callee != nullptr) {
-          auto const B = bi_->analyzeBuiltin(*callee);
+          const auto B = bi_->analyzeBuiltin(*callee);
           if (BuiltinInfo::isMuxBuiltinWithWGBarrierID(B.ID)) {
             unsigned id = ~0u;
             auto *const id_param = call_inst->getOperand(0);
@@ -536,7 +536,7 @@ void compiler::utils::Barrier::FindBarriers() {
   }
 
   std::sort(orderedBarriers.begin(), orderedBarriers.end());
-  for (auto const &barrier : orderedBarriers) {
+  for (const auto &barrier : orderedBarriers) {
     barriers_.push_back(barrier.second);
   }
 }
@@ -1062,14 +1062,14 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
 
   // If we have a work group collective call, we need to create a new argument
   // so that the result can be passed in.
-  bool const collective =
+  const bool collective =
       getWorkGroupCollectiveCall(region.barrier_inst, *bi_).has_value();
   if (collective) {
     new_func_params.push_back(region.barrier_inst->getType());
   }
 
   // Add live variables' parameter as last if there are any.
-  bool const hasBarrierStruct = !whole_live_variables_set_.empty() &&
+  const bool hasBarrierStruct = !whole_live_variables_set_.empty() &&
                                 region.schedule != BarrierSchedule::Once;
   if (hasBarrierStruct) {
     PointerType *pty = PointerType::get(live_var_mem_ty_, 0);

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -44,7 +44,7 @@ Module *BuiltinInfo::getBuiltinsModule() {
 }
 
 std::pair<BuiltinID, std::vector<Type *>> BuiltinInfo::identifyMuxBuiltin(
-    Function const &F) const {
+    const Function &F) const {
   StringRef Name = F.getName();
   auto ID =
       StringSwitch<BuiltinID>(Name)
@@ -123,7 +123,7 @@ std::pair<BuiltinID, std::vector<Type *>> BuiltinInfo::identifyMuxBuiltin(
 
   // Most group operations have one argument, except for broadcasts. Despite
   // that, we don't mangle the indices as they're fixed.
-  unsigned const NumExpectedMangledArgs = 1;
+  const unsigned NumExpectedMangledArgs = 1;
 
   if (Name.consume_front("any")) {
     ID = SCOPED_GROUP_OP(Any);
@@ -271,7 +271,7 @@ std::pair<BuiltinID, std::vector<Type *>> BuiltinInfo::identifyMuxBuiltin(
 #undef SCOPED_GROUP_OP
 }
 
-BuiltinUniformity BuiltinInfo::isBuiltinUniform(Builtin const &B,
+BuiltinUniformity BuiltinInfo::isBuiltinUniform(const Builtin &B,
                                                 const CallInst *CI,
                                                 unsigned SimdDimIdx) const {
   switch (B.ID) {
@@ -328,7 +328,7 @@ BuiltinUniformity BuiltinInfo::isBuiltinUniform(Builtin const &B,
   return eBuiltinUniformityUnknown;
 }
 
-Builtin BuiltinInfo::analyzeBuiltin(Function const &F) const {
+Builtin BuiltinInfo::analyzeBuiltin(const Function &F) const {
   // Handle LLVM intrinsics.
   if (F.isIntrinsic()) {
     int32_t Properties = eBuiltinPropertyNone;
@@ -485,16 +485,16 @@ Builtin BuiltinInfo::analyzeBuiltin(Function const &F) const {
   return Builtin{F, ID, (BuiltinProperties)Properties, OverloadInfo};
 }
 
-BuiltinCall BuiltinInfo::analyzeBuiltinCall(CallInst const &CI,
+BuiltinCall BuiltinInfo::analyzeBuiltinCall(const CallInst &CI,
                                             unsigned SimdDimIdx) const {
   auto *const callee = CI.getCalledFunction();
   assert(callee && "Call instruction with no callee");
-  auto const B = analyzeBuiltin(*callee);
-  auto const U = isBuiltinUniform(B, &CI, SimdDimIdx);
+  const auto B = analyzeBuiltin(*callee);
+  const auto U = isBuiltinUniform(B, &CI, SimdDimIdx);
   return BuiltinCall{B, CI, U};
 }
 
-Function *BuiltinInfo::getVectorEquivalent(Builtin const &B, unsigned Width,
+Function *BuiltinInfo::getVectorEquivalent(const Builtin &B, unsigned Width,
                                            Module *M) {
   // We don't handle LLVM intrinsics here
   if (B.function.isIntrinsic()) {
@@ -507,12 +507,12 @@ Function *BuiltinInfo::getVectorEquivalent(Builtin const &B, unsigned Width,
   return nullptr;
 }
 
-Function *BuiltinInfo::getScalarEquivalent(Builtin const &B, Module *M) {
+Function *BuiltinInfo::getScalarEquivalent(const Builtin &B, Module *M) {
   // We will first check to see if this is an LLVM intrinsic that has a scalar
   // equivalent.
   if (B.function.isIntrinsic()) {
     // Analyze the builtin. Some functions have no scalar equivalent.
-    auto const Props = B.properties;
+    const auto Props = B.properties;
     if (!(Props & eBuiltinPropertyVectorEquivalent)) {
       return nullptr;
     }

--- a/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
+++ b/modules/compiler/utils/source/degenerate_sub_group_pass.cpp
@@ -247,7 +247,7 @@ PreservedAnalyses compiler::utils::DegenerateSubGroupPass::run(
         continue;
       }
 
-      auto const local_sizes = compiler::utils::getLocalSizeMetadata(F);
+      const auto local_sizes = compiler::utils::getLocalSizeMetadata(F);
       if (!local_sizes) {
         // If we don't know the local size at compile time, we can't guarantee
         // safety of non-degenerate subgroups, so we clone the kernel and defer
@@ -267,11 +267,11 @@ PreservedAnalyses compiler::utils::DegenerateSubGroupPass::run(
         // avoid the need for degenerate sub-groups, but we can't rely on it,
         // therefore if the local size is not a power of two, we only go by the
         // maximum width supported by the device. TODO DDK-75
-        uint32_t const local_size = local_sizes ? (*local_sizes)[0] : 0;
+        const uint32_t local_size = local_sizes ? (*local_sizes)[0] : 0;
         if (!isPowerOf2_32(local_size)) {
-          auto const &DI =
+          const auto &DI =
               AM.getResult<compiler::utils::DeviceInfoAnalysis>(*F.getParent());
-          auto const max_work_width = DI.max_work_width;
+          const auto max_work_width = DI.max_work_width;
           if (local_size % max_work_width != 0) {
             // Flag the presence of degenerate sub-groups in this kernel.
             // There might not be any sub-group builtins, in which case it's
@@ -337,7 +337,7 @@ PreservedAnalyses compiler::utils::DegenerateSubGroupPass::run(
   SmallVector<Function *, 8> worklist;
   SmallVector<Function *, 8> nonDegenerateUsers;
   for (auto *const K : kernels) {
-    bool const subgroups = usesSubgroups.contains(K);
+    const bool subgroups = usesSubgroups.contains(K);
     if (!subgroups) {
       // No need to clone kernels that don't use any subgroup functions.
       kernelsToClone.erase(K);
@@ -454,7 +454,7 @@ PreservedAnalyses compiler::utils::DegenerateSubGroupPass::run(
 
     StringRef BaseName = getBaseFnNameOrFnName(*F);
 
-    auto const ChangeType = CloneFunctionChangeType::LocalChangesOnly;
+    const auto ChangeType = CloneFunctionChangeType::LocalChangesOnly;
     SmallVector<ReturnInst *, 1> Returns;
     CloneFunctionInto(NewF, F, VMap, ChangeType, Returns);
 

--- a/modules/compiler/utils/source/metadata.cpp
+++ b/modules/compiler/utils/source/metadata.cpp
@@ -29,9 +29,9 @@ uint32_t getOpenCLVersion(const llvm::Module &m) {
     if (md->getNumOperands() == 1) {
       auto *const op = md->getOperand(0);
       if (op->getNumOperands() == 2) {
-        auto const major =
+        const auto major =
             mdconst::extract<ConstantInt>(op->getOperand(0))->getZExtValue();
-        auto const minor =
+        const auto minor =
             mdconst::extract<ConstantInt>(op->getOperand(1))->getZExtValue();
         return (major * 100 + minor) * 1000;
       }

--- a/modules/compiler/utils/source/mux_builtin_info.cpp
+++ b/modules/compiler/utils/source/mux_builtin_info.cpp
@@ -1314,7 +1314,7 @@ std::optional<llvm::ConstantRange> BIMuxInfoConcept::getBuiltinRange(
       // ID builtins range [0,size) (exclusive), and size builtins [1,size]
       // (inclusive). Thus offset the range by 1 at each low/high end when
       // returning the range for a size builtin.
-      int const SizeAdjust = ID == eMuxBuiltinGetLocalSize ||
+      const int SizeAdjust = ID == eMuxBuiltinGetLocalSize ||
                              ID == eMuxBuiltinGetEnqueuedLocalSize ||
                              ID == eMuxBuiltinGetGlobalSize;
       return ConstantRange::getNonEmpty(

--- a/modules/compiler/utils/source/pass_functions.cpp
+++ b/modules/compiler/utils/source/pass_functions.cpp
@@ -52,7 +52,7 @@ uint64_t computeApproximatePrivateMemoryUsage(const llvm::Function &fn) {
       continue;
     }
     const auto &alloca_inst = llvm::cast<llvm::AllocaInst>(inst);
-    auto const *type = alloca_inst.getType();
+    const auto *type = alloca_inst.getType();
     if (type->getAddressSpace() != AddressSpace::Private) {
       continue;
     }
@@ -275,7 +275,7 @@ bool cloneFunctionsAddArg(
   // Preserve the value map across all function clones
   llvm::ValueToValueMapTy vmap;
 
-  ParamTypeAttrsPair const paramInfo = paramTypeFunc(module);
+  const ParamTypeAttrsPair paramInfo = paramTypeFunc(module);
 
   // For each function we run the function toBeCloned to set the bools
   // doCloneNoBody and doCloneWithBody

--- a/modules/compiler/utils/source/prepare_barriers_pass.cpp
+++ b/modules/compiler/utils/source/prepare_barriers_pass.cpp
@@ -41,7 +41,7 @@ PreservedAnalyses compiler::utils::PrepareBarriersPass::run(
   SmallPtrSet<Function *, 4> FuncsWithBarriers;
 
   for (Function &F : M) {
-    auto const B = BI.analyzeBuiltin(F);
+    const auto B = BI.analyzeBuiltin(F);
     // If the function does not have a barrier id.
     if (!BI.isMuxBuiltinWithBarrierID(B.ID)) {
       continue;

--- a/modules/compiler/utils/source/replace_address_space_qualifier_functions_pass.cpp
+++ b/modules/compiler/utils/source/replace_address_space_qualifier_functions_pass.cpp
@@ -58,7 +58,7 @@ compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass::run(
 
       auto &call = cast<CallInst>(inst);
       Function *const callee = call.getCalledFunction();
-      auto const name = callee->getName();
+      const auto name = callee->getName();
       if (auto *const ASQ = replaceAddressSpaceQualifierFunction(call, name)) {
         call.replaceAllUsesWith(ASQ);
         call.eraseFromParent();

--- a/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
+++ b/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
@@ -244,7 +244,7 @@ void replaceFetchKey(CallInst *C11FetchKey) {
   auto KeyEndIndex = BuiltinName.find('_', KeyStartIndex);
   auto Key = BuiltinName.substr(KeyStartIndex, KeyEndIndex - KeyStartIndex);
 
-  bool const IsFloat = C11FetchKey->getType()->isFloatingPointTy();
+  const bool IsFloat = C11FetchKey->getType()->isFloatingPointTy();
   AtomicRMWInst::BinOp KeyOpCode{IsFloat
                                      ? StringSwitch<AtomicRMWInst::BinOp>(Key)
                                            .Case("add", AtomicRMWInst::FAdd)

--- a/modules/compiler/utils/source/replace_wgc_pass.cpp
+++ b/modules/compiler/utils/source/replace_wgc_pass.cpp
@@ -514,7 +514,7 @@ void emitWorkGroupScanBody(Function &F,
                                      IsInclusive, WGC.IsLogical, BI);
   assert(SubScan && "Invalid subgroup scan");
 
-  bool const NeedsIdentityFix =
+  const bool NeedsIdentityFix =
       !IsInclusive &&
       (WGC.Recurrence == RecurKind::FAdd || WGC.Recurrence == RecurKind::FMin ||
        WGC.Recurrence == RecurKind::FMax);

--- a/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
+++ b/modules/compiler/utils/source/verify_reqd_sub_group_size_pass.cpp
@@ -69,7 +69,7 @@ PreservedAnalyses VerifyReqdSubGroupSizeLegalPass::run(
   auto &DI = AM.getResult<DeviceInfoAnalysis>(M);
   const auto &SGSizes = DI.reqd_sub_group_sizes;
   for (auto &F : M) {
-    auto const ReqdSGSize = getReqdSubgroupSize(F);
+    const auto ReqdSGSize = getReqdSubgroupSize(F);
     if (!ReqdSGSize) {
       continue;
     }
@@ -92,7 +92,7 @@ PreservedAnalyses VerifyReqdSubGroupSizeSatisfiedPass::run(
       continue;
     }
 
-    auto const ReqdSGSize = getReqdSubgroupSize(F);
+    const auto ReqdSGSize = getReqdSubgroupSize(F);
     if (!ReqdSGSize) {
       continue;
     }

--- a/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
@@ -40,7 +40,7 @@ bool analyzeMemOp(MemOp &Op) {
   return analyzeType(Op.getDataType());
 }
 
-bool analyzeCall(VectorizationContext const &Ctx, CallInst *CI) {
+bool analyzeCall(const VectorizationContext &Ctx, CallInst *CI) {
   Function *Callee = CI->getCalledFunction();
   VECZ_FAIL_IF(!Callee);
 
@@ -63,7 +63,7 @@ bool analyzeCall(VectorizationContext const &Ctx, CallInst *CI) {
     return true;
   }
 
-  auto const Props = Ctx.builtins().analyzeBuiltin(*Callee).properties;
+  const auto Props = Ctx.builtins().analyzeBuiltin(*Callee).properties;
 
   // Intrinsics without side-effects can be safely instantiated.
   if (Callee->isIntrinsic() &&
@@ -88,7 +88,7 @@ bool analyzeCall(VectorizationContext const &Ctx, CallInst *CI) {
   return analyzeType(CI->getType());
 }
 
-bool analyzeAlloca(VectorizationContext const &Ctx, AllocaInst *alloca) {
+bool analyzeAlloca(const VectorizationContext &Ctx, AllocaInst *alloca) {
   // Possibly, we could packetize by creating a wider array, but for now let's
   // just let instantiation deal with it.
   if (alloca->isArrayAllocation()) {
@@ -100,14 +100,14 @@ bool analyzeAlloca(VectorizationContext const &Ctx, AllocaInst *alloca) {
   // have to be sure it divides the type allocation size, otherwise only the
   // first vector element would necessarily be correctly aligned.
   auto *const dataTy = alloca->getAllocatedType();
-  uint64_t const memSize = Ctx.dataLayout()->getTypeAllocSize(dataTy);
-  uint64_t const align = alloca->getAlign().value();
+  const uint64_t memSize = Ctx.dataLayout()->getTypeAllocSize(dataTy);
+  const uint64_t align = alloca->getAlign().value();
   return (align != 0 && (memSize % align) != 0);
 }
 }  // namespace
 
 namespace vecz {
-bool needsInstantiation(VectorizationContext const &Ctx, Instruction &I) {
+bool needsInstantiation(const VectorizationContext &Ctx, Instruction &I) {
   if (CallInst *CI = dyn_cast<CallInst>(&I)) {
     return analyzeCall(Ctx, CI);
   } else if (LoadInst *Load = dyn_cast<LoadInst>(&I)) {

--- a/modules/compiler/vecz/source/analysis/packetization_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/packetization_analysis.cpp
@@ -107,7 +107,7 @@ void PacketizationAnalysisResult::markForPacketization(Value *V) {
   if (mo) {
     auto *const ptr = mo->getPointerOperand();
     if (ptr && UVR.isVarying(ptr)) {
-      auto const *info = SAR.getInfo(ptr);
+      const auto *info = SAR.getInfo(ptr);
       assert(info && "markForPacketization: Unable to obtain stride info");
 
       bool hasValidStride = info->hasStride();
@@ -123,7 +123,7 @@ void PacketizationAnalysisResult::markForPacketization(Value *V) {
           // No interleaved memops exist for vector element types or pointer
           // types. We can only vectorize pointer loads/stores or widen vector
           // load/stores if they are contiguous.
-          auto const stride = info->getConstantMemoryStride(
+          const auto stride = info->getConstantMemoryStride(
               eltTy, &F.getParent()->getDataLayout());
           if (stride != 1) {
             hasValidStride = false;
@@ -152,7 +152,7 @@ void PacketizationAnalysisResult::markForPacketization(Value *V) {
   }
 
   if (auto *const intrinsic = dyn_cast<llvm::IntrinsicInst>(I)) {
-    auto const intrinsicID = intrinsic->getIntrinsicID();
+    const auto intrinsicID = intrinsic->getIntrinsicID();
     if (intrinsicID == llvm::Intrinsic::lifetime_end ||
         intrinsicID == llvm::Intrinsic::lifetime_start) {
       // We don't trace through lifetime intrinsics.

--- a/modules/compiler/vecz/source/analysis/simd_width_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/simd_width_analysis.cpp
@@ -55,7 +55,7 @@ bool definedOrUsedInLoop(Value *V, Loop *L) {
     return true;
   }
 
-  auto const *const I = dyn_cast<Instruction>(V);
+  const auto *const I = dyn_cast<Instruction>(V);
   if (I && L->contains(I)) {
     // It's defined in the current loop.
     return true;
@@ -65,8 +65,8 @@ bool definedOrUsedInLoop(Value *V, Loop *L) {
   // Values defined outwith the loop, but used only by a PHI node within it must
   // be loop-carried variable initial values. If these are not otherwise used
   // directly within the loop, then they are not really live inside the loop.
-  for (auto const *const U : V->users()) {
-    auto const *const I = dyn_cast<Instruction>(U);
+  for (const auto *const U : V->users()) {
+    const auto *const I = dyn_cast<Instruction>(U);
     if (I && !isa<PHINode>(I) && L->contains(I)) {
       return true;
     }

--- a/modules/compiler/vecz/source/analysis/stride_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/stride_analysis.cpp
@@ -35,7 +35,7 @@ using namespace llvm;
 llvm::AnalysisKey StrideAnalysis::Key;
 
 OffsetInfo &StrideAnalysisResult::analyze(Value *V) {
-  auto const find = analyzed.find(V);
+  const auto find = analyzed.find(V);
   if (find != analyzed.end()) {
     return find->second;
   }
@@ -44,7 +44,7 @@ OffsetInfo &StrideAnalysisResult::analyze(Value *V) {
   // the constructor itself can create more things in the map and constructing
   // it in-place could result in the storage being re-allocated while the
   // constructor is still running.
-  auto const OI = OffsetInfo(*this, V);
+  const auto OI = OffsetInfo(*this, V);
   return analyzed.try_emplace(V, OI).first->second;
 }
 
@@ -67,7 +67,7 @@ StrideAnalysisResult::StrideAnalysisResult(llvm::Function &f,
 }
 
 void StrideAnalysisResult::manifestAll(IRBuilder<> &B) {
-  auto const saved = B.GetInsertPoint();
+  const auto saved = B.GetInsertPoint();
   for (auto &info : analyzed) {
     info.second.manifest(B, *this);
   }

--- a/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
@@ -156,7 +156,7 @@ void UniformValueResult::findVectorLeaves(
           // uniform then add it to the leaves
           if (!Callee->isIntrinsic() && CI->use_empty()) {
             // Try to identify the called function
-            auto const Builtin = BI.analyzeBuiltin(*Callee);
+            const auto Builtin = BI.analyzeBuiltin(*Callee);
             if (!Builtin.isValid()) {
               Leaves.push_back(CI);
             }
@@ -218,8 +218,8 @@ void UniformValueResult::findVectorRoots(std::vector<Value *> &Roots) const {
       if (!CI || !CI->getCalledFunction()) {
         continue;
       }
-      auto const Builtin = BI.analyzeBuiltinCall(*CI, dimension);
-      auto const Uniformity = Builtin.uniformity;
+      const auto Builtin = BI.analyzeBuiltinCall(*CI, dimension);
+      const auto Uniformity = Builtin.uniformity;
       if (Uniformity == compiler::utils::eBuiltinUniformityInstanceID ||
           Uniformity == compiler::utils::eBuiltinUniformityMaybeInstanceID) {
         // Calls to `get_global_id`/`get_local_id` are roots.
@@ -280,8 +280,8 @@ void UniformValueResult::markVaryingValues(Value *V, Value *From) {
     Function *Callee = CI->getCalledFunction();
     if (Callee) {
       compiler::utils::BuiltinInfo &BI = Ctx.builtins();
-      auto const Builtin = BI.analyzeBuiltinCall(*CI, dimension);
-      auto const Uniformity = Builtin.uniformity;
+      const auto Builtin = BI.analyzeBuiltinCall(*CI, dimension);
+      const auto Uniformity = Builtin.uniformity;
       if (Uniformity == compiler::utils::eBuiltinUniformityAlways) {
         return;
       }
@@ -405,7 +405,7 @@ Value *UniformValueResult::extractMemBase(Value *Address) {
       // If it's a simple loop iterator, the base can be analyzed from the
       // initial value.
       if (GEP->getPointerOperand() == Phi) {
-        for (auto const &index : GEP->indices()) {
+        for (const auto &index : GEP->indices()) {
           if (isVarying(index.get())) {
             return nullptr;
           }
@@ -455,7 +455,7 @@ UniformValueResult UniformValueAnalysis::run(
       // The same goes for the atomic builtins as well
       if (CallInst *CI = dyn_cast<CallInst>(&I)) {
         if (Function *Callee = CI->getCalledFunction()) {
-          auto const Builtin = BI.analyzeBuiltin(*Callee);
+          const auto Builtin = BI.analyzeBuiltin(*Callee);
           if (Builtin.properties & compiler::utils::eBuiltinPropertyAtomic) {
             Res.markVaryingValues(&I);
             continue;

--- a/modules/compiler/vecz/source/analysis/vectorizable_function_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/vectorizable_function_analysis.cpp
@@ -73,7 +73,7 @@ bool canVectorize(const Instruction &I, const VectorizationContext &Ctx) {
       // All builtins should be vectorizable, in principle. "Invalid builtins"
       // correspond to user functions.
       const compiler::utils::BuiltinInfo &BI = Ctx.builtins();
-      auto const Builtin = BI.analyzeBuiltin(*Callee);
+      const auto Builtin = BI.analyzeBuiltin(*Callee);
       if (!Builtin.isValid()) {
         // If it is a user function missing a definition, we cannot safely
         // instantiate it. For example, what if it contains calls to
@@ -100,7 +100,7 @@ bool canVectorize(const Instruction &I, const VectorizationContext &Ctx) {
 ///
 /// @return the Instruction that prevents the function from vectorizing, or
 /// nullptr if the function can be vectorized.
-Value const *canVectorize(const Function &F, const VectorizationContext &Ctx) {
+const Value *canVectorize(const Function &F, const VectorizationContext &Ctx) {
   // Look for things that are not (yet?) supported.
   for (const BasicBlock &BB : F) {
     for (const Instruction &I : BB) {

--- a/modules/compiler/vecz/source/control_flow_boscc.cpp
+++ b/modules/compiler/vecz/source/control_flow_boscc.cpp
@@ -140,8 +140,8 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformRegions() {
     }
     std::sort(predicatedBlockIndices.begin(), predicatedBlockIndices.end());
 
-    for (auto const index : predicatedBlockIndices) {
-      auto const &BTag = DR->getBlockTag(index);
+    for (const auto index : predicatedBlockIndices) {
+      const auto &BTag = DR->getBlockTag(index);
       auto *const B = BTag.BB;
       auto *const LTag = BTag.loop;
 
@@ -200,7 +200,7 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformRegions() {
 
   // Fix the duplicated instructions arguments.
   for (BasicBlock *B : newBlocks) {
-    bool const notHeader = !DR->getTag(B).isLoopHeader();
+    const bool notHeader = !DR->getTag(B).isLoopHeader();
 
     for (Instruction &I : *B) {
       RemapInstruction(&I, VMap,
@@ -235,7 +235,7 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformRegions() {
 }
 
 bool ControlFlowConversionState::BOSCCGadget::duplicateUniformLoops(Loop *L) {
-  LoopTag const &LTag = DR->getTag(L);
+  const LoopTag &LTag = DR->getTag(L);
   Loop *const uniformL = LI->AllocateLoop();
 
   // Either add 'uniformL' as a child of a loop or as a top level loop.
@@ -286,9 +286,9 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformLoops(Loop *L) {
 }
 
 bool ControlFlowConversionState::BOSCCGadget::createUniformRegions(
-    DenseSet<BasicBlock *> const &noDuplicateBlocks) {
+    const DenseSet<BasicBlock *> &noDuplicateBlocks) {
   auto discardRegion =
-      [&noDuplicateBlocks](UniformRegion const &region) -> bool {
+      [&noDuplicateBlocks](const UniformRegion &region) -> bool {
     // To determine if it is worth it to duplicate the uniform region, we must
     // take several elements into account:
     // - The length of the duplicated code
@@ -412,11 +412,11 @@ bool ControlFlowConversionState::BOSCCGadget::createUniformRegions(
   };
 
   // Collect all the blocks in the worklist
-  auto const &DCBI = DR->getBlockOrdering();
-  size_t const numBlocks = DCBI.size();
+  const auto &DCBI = DR->getBlockOrdering();
+  const size_t numBlocks = DCBI.size();
   SmallVector<SESEInfo, 16> SESE;
   SESE.reserve(numBlocks);
-  for (auto const &BBTag : DCBI) {
+  for (const auto &BBTag : DCBI) {
     SESE.emplace_back();
     SESE.back().BB = BBTag.BB;
   }
@@ -436,7 +436,7 @@ bool ControlFlowConversionState::BOSCCGadget::createUniformRegions(
 
     uniformRegions.emplace_back();
     auto &region = uniformRegions.back();
-    size_t const entryPos = i;
+    const size_t entryPos = i;
     size_t exitPos = 0u;
     size_t firstPredicated = numBlocks;
 
@@ -447,11 +447,11 @@ bool ControlFlowConversionState::BOSCCGadget::createUniformRegions(
 
     // If we are in a divergent loop, then the whole loop needs a uniform
     // version.
-    auto const *const entryLoopTag = DR->getTag(info.BB).loop;
+    const auto *const entryLoopTag = DR->getTag(info.BB).loop;
     if (entryLoopTag && entryLoopTag->isLoopDivergent()) {
       auto *const loop = entryLoopTag->loop;
       for (BasicBlock *loopB : loop->blocks()) {
-        size_t const pos = DR->getTagIndex(loopB);
+        const size_t pos = DR->getTagIndex(loopB);
         firstPredicated = std::min(firstPredicated, pos);
         SESE[pos].predicated = true;
         region.predicatedBlocks.insert(loopB);
@@ -467,7 +467,7 @@ bool ControlFlowConversionState::BOSCCGadget::createUniformRegions(
     while (!stack.empty()) {
       auto *const cur = SESE[stack.pop_back_val()].BB;
       for (BasicBlock *succ : successors(cur)) {
-        size_t const succPos = DR->getTagIndex(succ);
+        const size_t succPos = DR->getTagIndex(succ);
 
         auto *const succLoopTag = DR->getBlockTag(succPos).loop;
         if ((!succLoopTag || !succLoopTag->isLoopDivergent()) &&
@@ -582,7 +582,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectBOSCCRegions() {
       }
     }
 
-    auto const &LTag = DR->getTag(L);
+    const auto &LTag = DR->getTag(L);
     BasicBlock *preheader = LTag.preheader;
     if (!VMap.count(preheader)) {
       auto *T = preheader->getTerminator();
@@ -624,7 +624,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectBOSCCRegions() {
 
   // If a uniform block targets a predicated block, the latter needs its
   // operands that have a uniform and predicated version blended.
-  for (auto const &predicatedBTag : DR->getBlockOrdering()) {
+  for (const auto &predicatedBTag : DR->getBlockOrdering()) {
     if (BasicBlock *uniformB = getBlock(predicatedBTag.BB)) {
       for (BasicBlock *succ : successors(uniformB)) {
         // We've found a uniform block that targets a predicated block prior
@@ -780,7 +780,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
 
   BasicBlock *connectionPoint = target;
 
-  auto const *const LTag = DR->getTag(predicatedB).loop;
+  const auto *const LTag = DR->getTag(predicatedB).loop;
   const bool needsStore = LTag && LMap.count(LTag->loop);
   if (needsStore) {
     // 'store' is a block that will contain all the uniform versions of the
@@ -856,7 +856,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
 
 bool ControlFlowConversionState::BOSCCGadget::blendConnectionPoint(
     BasicBlock *CP, const std::pair<BasicBlock *, BasicBlock *> &incoming) {
-  auto const *const CPLTag = DR->getTag(CP).loop;
+  const auto *const CPLTag = DR->getTag(CP).loop;
   for (auto &region : uniformRegions) {
     // Create blend instructions at each blend point following 'CP'.
     if (region.contains(CP) || (CP == region.exitBlock) ||
@@ -964,7 +964,7 @@ bool ControlFlowConversionState::BOSCCGadget::blendFinalize() {
     }
   }
 
-  for (auto const &tag : DR->getBlockOrdering()) {
+  for (const auto &tag : DR->getBlockOrdering()) {
     BasicBlock *blendPoint = tag.BB;
     if (blendBlocks.count(blendPoint) == 0) {
       continue;
@@ -1124,7 +1124,7 @@ Loop *ControlFlowConversionState::BOSCCGadget::getLoop(Loop *L) {
 
 void ControlFlowConversionState::BOSCCGadget::getUnduplicatedEntryBlocks(
     SmallVectorImpl<BasicBlock *> &blocks) const {
-  for (auto const &region : uniformRegions) {
+  for (const auto &region : uniformRegions) {
     if (VMap.count(region.entryBlock) == 0) {
       blocks.push_back(region.entryBlock);
     }
@@ -1192,7 +1192,7 @@ void ControlFlowConversionState::BOSCCGadget::updateValue(Value *from,
 }
 
 bool ControlFlowConversionState::BOSCCGadget::linkMasks() {
-  for (auto const &BTag : DR->getBlockOrdering()) {
+  for (const auto &BTag : DR->getBlockOrdering()) {
     auto *const BB = BTag.BB;
     if (auto *const uniformB = getBlock(BB)) {
       // Both sets of masks had better exist by this point.
@@ -1287,7 +1287,7 @@ bool ControlFlowConversionState::BOSCCGadget::updateLoopBlendValues(
 
 bool ControlFlowConversionState::BOSCCGadget::computeBlockOrdering() {
   // Create a map from entry blocks to their uniform regions
-  DenseMap<BasicBlock *, UniformRegion const *> entryMap;
+  DenseMap<BasicBlock *, const UniformRegion *> entryMap;
   unsigned maxUBlocks = 0;
   for (const auto &region : uniformRegions) {
     if (!region.uniformBlocks.empty()) {
@@ -1302,11 +1302,11 @@ bool ControlFlowConversionState::BOSCCGadget::computeBlockOrdering() {
   // Also note that we can't use pointers to BasicBlockTags here since
   // `PassState.computeBlockOrdering()` re-orders the tags vector.
   SmallVector<BasicBlock *, 16> filtered;
-  for (auto const &tag : DR->getBlockOrdering()) {
+  for (const auto &tag : DR->getBlockOrdering()) {
     filtered.push_back(tag.BB);
-    auto const found = entryMap.find(tag.BB);
+    const auto found = entryMap.find(tag.BB);
     if (found != entryMap.end()) {
-      auto const *const region = found->second;
+      const auto *const region = found->second;
       filtered.resize(filtered.size() + region->uniformBlocks.size());
     }
   }
@@ -1320,17 +1320,17 @@ bool ControlFlowConversionState::BOSCCGadget::computeBlockOrdering() {
   for (auto it = filtered.begin(), ie = filtered.end(); it != ie;) {
     auto *const BB = *it;
 
-    auto const found = entryMap.find(BB);
+    const auto found = entryMap.find(BB);
     if (found != entryMap.end()) {
       // If the entry block of the region is NOT duplicated, add the uniform
       // blocks after it.
-      bool const entryDupe = getBlock(BB);
+      const bool entryDupe = getBlock(BB);
       if (!entryDupe) {
         ++it;
       }
 
       // Gather the indices of the uniform blocks and sort them.
-      auto const &region = *found->second;
+      const auto &region = *found->second;
       uniformBlocks.clear();
       for (auto *const uBB : region.uniformBlocks) {
         uniformBlocks.push_back(DR->getTagIndex(uBB));
@@ -1338,7 +1338,7 @@ bool ControlFlowConversionState::BOSCCGadget::computeBlockOrdering() {
       std::sort(uniformBlocks.begin(), uniformBlocks.end());
 
       // Insert the uniform blocks into the gap.
-      for (auto const uBBi : uniformBlocks) {
+      for (const auto uBBi : uniformBlocks) {
         (*it++) = DR->getBlockTag(uBBi).BB;
       }
 

--- a/modules/compiler/vecz/source/include/analysis/divergence_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/divergence_analysis.h
@@ -95,7 +95,7 @@ struct BlockQueue {
   using index_type = uint32_t;
   using index_list = std::vector<index_type>;
 
-  DivergenceResult const &DR;
+  const DivergenceResult &DR;
 
   /// @brief The DCBI indices of the blocks in the queue, in min-heap order.
   /// Since we can easily retrieve the BasicBlockTag from the DCBI ordered
@@ -105,11 +105,11 @@ struct BlockQueue {
   index_list indices;
 
   /// @brief Constructs an empty BlockQueue
-  BlockQueue(DivergenceResult const &dr) : DR(dr){};
+  BlockQueue(const DivergenceResult &dr) : DR(dr){};
 
   /// @brief Constructs a BlockQueue from a set of blocks.
-  BlockQueue(DivergenceResult const &dr,
-             llvm::DenseSet<llvm::BasicBlock *> const &blocks);
+  BlockQueue(const DivergenceResult &dr,
+             const llvm::DenseSet<llvm::BasicBlock *> &blocks);
 
   /// @brief Returns the number of blocks in the queue.
   size_t size() const { return indices.size(); }
@@ -122,7 +122,7 @@ struct BlockQueue {
 
   /// @brief Pushes a block on the queue by pointer.
   /// Prefer `push(size_t)` if the tag index is available.
-  void push(llvm::BasicBlock const *bb);
+  void push(const llvm::BasicBlock *bb);
 
   /// @brief Pops a block from the queue and returns it.
   const BasicBlockTag &pop();
@@ -178,7 +178,7 @@ struct BasicBlockTag {
   /// @brief Deleted address-of operator
   BasicBlockTag *operator&() = delete;
   /// @brief Deleted const address-of operator
-  BasicBlockTag const *operator&() const = delete;
+  const BasicBlockTag *operator&() const = delete;
 
   BlockDivergenceFlag divergenceFlag = BlockDivergenceFlag::eBlockHasNoFlag;
 
@@ -236,7 +236,7 @@ class DivergenceResult {
   /// @brief Gets a BasicBlockTag by its DCBI index
   /// @param[in] index the DCBI index
   /// @returns reference to the BasicBlockTag
-  BasicBlockTag const &getBlockTag(size_t index) const {
+  const BasicBlockTag &getBlockTag(size_t index) const {
     return basicBlockTags[index];
   }
 
@@ -259,7 +259,7 @@ class DivergenceResult {
     return basicBlockTags[getTagIndex(BB)];
   }
 
-  BasicBlockTag const &getTag(const llvm::BasicBlock *BB) const {
+  const BasicBlockTag &getTag(const llvm::BasicBlock *BB) const {
     return basicBlockTags[getTagIndex(BB)];
   }
 
@@ -375,7 +375,7 @@ class DivergenceResult {
                    bool allowLatch = false) const;
 
   /// @brief List of blocks having a divergent branch.
-  std::vector<llvm::BasicBlock *> const &getDivCausingBlocks() const {
+  const std::vector<llvm::BasicBlock *> &getDivCausingBlocks() const {
     return divCausingBlocks;
   }
 
@@ -417,8 +417,8 @@ class DivergenceResult {
   /// @param[in] src Divergent branch
   /// @param[in] L Divergent loop
   /// @return List of exit blocks some work-item may leave through.
-  llvm::DenseSet<llvm::BasicBlock *> escapePoints(llvm::BasicBlock const &src,
-                                                  llvm::Loop const &L) const;
+  llvm::DenseSet<llvm::BasicBlock *> escapePoints(const llvm::BasicBlock &src,
+                                                  const llvm::Loop &L) const;
 
   /// @brief the Function the analysis was run on
   llvm::Function &F;

--- a/modules/compiler/vecz/source/include/analysis/instantiation_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/instantiation_analysis.h
@@ -30,7 +30,7 @@ class VectorizationContext;
 /// @param[in] I Instruction to analyze.
 ///
 /// @return true iff the instruction requires instantiation.
-bool needsInstantiation(VectorizationContext const &Ctx, llvm::Instruction &I);
+bool needsInstantiation(const VectorizationContext &Ctx, llvm::Instruction &I);
 };  // namespace vecz
 
 #endif  // VECZ_ANALYSIS_INSTANTIATION_ANALYSIS_H_INCLUDED

--- a/modules/compiler/vecz/source/include/analysis/stride_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/stride_analysis.h
@@ -57,13 +57,13 @@ class StrideAnalysisResult {
 
   /// @brief gets a pointer to the info struct for this value's analysis.
   OffsetInfo *getInfo(llvm::Value *V) {
-    auto const find = analyzed.find(V);
+    const auto find = analyzed.find(V);
     return (find != analyzed.end()) ? &find->second : nullptr;
   }
 
   /// @brief gets a pointer to the info struct for this value's analysis.
-  OffsetInfo const *getInfo(llvm::Value *V) const {
-    auto const find = analyzed.find(V);
+  const OffsetInfo *getInfo(llvm::Value *V) const {
+    const auto find = analyzed.find(V);
     return (find != analyzed.end()) ? &find->second : nullptr;
   }
 
@@ -75,8 +75,8 @@ class StrideAnalysisResult {
   /// not allowed to construct them during an analysis pass. However, note that
   /// information about manifested stride `Value`s will survive until the
   /// analysis is invalidated.
-  OffsetInfo const &manifest(llvm::IRBuilder<> &B, llvm::Value *V) {
-    auto const find = analyzed.find(V);
+  const OffsetInfo &manifest(llvm::IRBuilder<> &B, llvm::Value *V) {
+    const auto find = analyzed.find(V);
     assert(find != analyzed.end() &&
            "Trying to manifest unanalyzed OffsetInfo");
     return find->second.manifest(B, *this);

--- a/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
@@ -42,7 +42,7 @@ class VectorizableFunctionAnalysis
 
     /// @brief If the function can not be vectorized, the value (if any) that
     /// is the cause of the problem.
-    llvm::Value const *failedAt = nullptr;
+    const llvm::Value *failedAt = nullptr;
 
    public:
     /// @brief Handle invalidation events from the new pass manager.

--- a/modules/compiler/vecz/source/include/control_flow_boscc.h
+++ b/modules/compiler/vecz/source/include/control_flow_boscc.h
@@ -221,7 +221,7 @@ class ControlFlowConversionState::BOSCCGadget final {
   /// @brief Create uniform regions
   /// @return true if no problem occurred, false otherwise.
   bool createUniformRegions(
-      llvm::DenseSet<llvm::BasicBlock *> const &noDuplicateBlocks);
+      const llvm::DenseSet<llvm::BasicBlock *> &noDuplicateBlocks);
   /// @brief Duplicate a loop, creating a new looptag and updating all the
   ///        relevant information.
   /// @param[in] L The loop to duplicate

--- a/modules/compiler/vecz/source/include/offset_info.h
+++ b/modules/compiler/vecz/source/include/offset_info.h
@@ -124,7 +124,7 @@ struct OffsetInfo {
   /// @return The memory stride as number of elements.
 
   uint64_t getConstantMemoryStride(llvm::Type *PtrEleTy,
-                                   llvm::DataLayout const *DL) const;
+                                   const llvm::DataLayout *DL) const;
 
   /// @brief Convert the bytewise stride into an element-wise stride based on
   /// the data type and data layout, building instructions where needed. Note
@@ -135,7 +135,7 @@ struct OffsetInfo {
   /// @param[in] DL The Data Layout.
   /// @return The memory stride as number of elements.
   llvm::Value *buildMemoryStride(llvm::IRBuilder<> &B, llvm::Type *PtrEleTy,
-                                 llvm::DataLayout const *DL) const;
+                                 const llvm::DataLayout *DL) const;
 
   /// @brief Create Values that represent or compute strides.
   ///

--- a/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
+++ b/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
@@ -121,7 +121,7 @@ class ControlFlowConversionState {
   /// @param[in] BB the BasicBlock
   /// @returns a reference to the MaskInfo
   const MaskInfo &getMaskInfo(llvm::BasicBlock *BB) const {
-    auto const found = MaskInfos.find(BB);
+    const auto found = MaskInfos.find(BB);
     assert(found != MaskInfos.end() &&
            "Mask Info not constructed for Basic Block!");
     return found->second;

--- a/modules/compiler/vecz/source/include/vectorization_context.h
+++ b/modules/compiler/vecz/source/include/vectorization_context.h
@@ -268,13 +268,13 @@ class VectorizationContext {
   /// @param[in] F The empty (declaration only) function to emit the body in
   /// @param[in] Desc The MemOpDesc for the memory operation
   /// @returns true on success, false otherwise
-  bool emitMaskedMemOpBody(llvm::Function &F, MemOpDesc const &Desc) const;
+  bool emitMaskedMemOpBody(llvm::Function &F, const MemOpDesc &Desc) const;
   /// @brief Emit the body for the interleaved load or store internal builtins
   ///
   /// @param[in] F The empty (declaration only) function to emit the body in
   /// @param[in] Desc The MemOpDesc for the memory operation
   /// @returns true on success, false otherwise
-  bool emitInterleavedMemOpBody(llvm::Function &F, MemOpDesc const &Desc) const;
+  bool emitInterleavedMemOpBody(llvm::Function &F, const MemOpDesc &Desc) const;
   /// @brief Emit the body for the masked interleaved load/store internal
   /// builtins
   ///
@@ -282,21 +282,21 @@ class VectorizationContext {
   /// @param[in] Desc The MemOpDesc for the memory operation
   /// @returns true on success, false otherwise
   bool emitMaskedInterleavedMemOpBody(llvm::Function &F,
-                                      MemOpDesc const &Desc) const;
+                                      const MemOpDesc &Desc) const;
   /// @brief Emit the body for the scatter or gather internal builtins
   ///
   /// @param[in] F The empty (declaration only) function to emit the body in
   /// @param[in] Desc The MemOpDesc for the memory operation
   /// @returns true on success, false otherwise
   bool emitScatterGatherMemOpBody(llvm::Function &F,
-                                  MemOpDesc const &Desc) const;
+                                  const MemOpDesc &Desc) const;
   /// @brief Emit the body for the masked scatter or gather internal builtins
   ///
   /// @param[in] F The empty (declaration only) function to emit the body in
   /// @param[in] Desc The MemOpDesc for the memory operation
   /// @returns true on success, false otherwise
   bool emitMaskedScatterGatherMemOpBody(llvm::Function &F,
-                                        MemOpDesc const &Desc) const;
+                                        const MemOpDesc &Desc) const;
   /// @brief Add the masked function to the tracking set
   ///
   /// @param[in] F The function to add

--- a/modules/compiler/vecz/source/include/vectorization_helpers.h
+++ b/modules/compiler/vecz/source/include/vectorization_helpers.h
@@ -62,12 +62,12 @@ decodeVectorizedFunctionName(llvm::StringRef Name);
 /// @param[in] VU the Vectorization Unit of the scalar function to clone.
 ///
 /// @return The cloned function.
-llvm::Function *cloneFunctionToVector(VectorizationUnit const &VU);
+llvm::Function *cloneFunctionToVector(const VectorizationUnit &VU);
 
 /// @brief Create a copy of the scalar functions debug info metatadata
 //         nodes and set the scope of the copied DI to the vectorized
 //         function.
-void cloneDebugInfo(VectorizationUnit const &VU);
+void cloneDebugInfo(const VectorizationUnit &VU);
 
 /// @brief Clone OpenCL related metadata from the scalar kernel to the
 /// vectorized one.
@@ -76,7 +76,7 @@ void cloneDebugInfo(VectorizationUnit const &VU);
 /// 'opencl.kernel_wg_size_info' metadata from the scalar kernel to the
 /// vectorized one. Obviously, the kernel itself has to be cloned before
 /// calling this function.
-void cloneOpenCLMetadata(VectorizationUnit const &VU);
+void cloneOpenCLMetadata(const VectorizationUnit &VU);
 }  // namespace vecz
 
 #endif  // VECZ_VECTORIZATION_HELPERS_H_INCLUDED

--- a/modules/compiler/vecz/source/pass.cpp
+++ b/modules/compiler/vecz/source/pass.cpp
@@ -106,7 +106,7 @@ PreservedAnalyses RunVeczPass::run(Module &M, ModuleAnalysisManager &MAM) {
   PM.addPass(
       RequireAnalysisPass<compiler::utils::DeviceInfoAnalysis, Module>());
 
-  bool const Check = VeczPassPipeline.empty();
+  const bool Check = VeczPassPipeline.empty();
   if (Check) {
     if (!buildPassPipeline(PM)) {
       return PreservedAnalyses::all();
@@ -305,7 +305,7 @@ std::optional<VeczPassOptions> getAutoSubgroupSizeOpts(
 
   // Now try and choose the best width.
   std::optional<unsigned> best_width;
-  auto const mux_sub_group_size = compiler::utils::getMuxSubgroupSize(F);
+  const auto mux_sub_group_size = compiler::utils::getMuxSubgroupSize(F);
 
   auto can_produce_legal_width = [&mux_sub_group_size](unsigned size) {
     // We only support vectorization widths where there's a clean multiple, and
@@ -318,7 +318,7 @@ std::optional<VeczPassOptions> getAutoSubgroupSizeOpts(
     if (!can_produce_legal_width(size)) {
       continue;
     }
-    unsigned const candidate_width = size / mux_sub_group_size;
+    const unsigned candidate_width = size / mux_sub_group_size;
     // Try and choose at least one width.
     if (!best_width) {
       best_width = candidate_width;
@@ -335,8 +335,8 @@ std::optional<VeczPassOptions> getAutoSubgroupSizeOpts(
     // with that.
     if (auto wgs = compiler::utils::parseRequiredWGSMetadata(F)) {
       uint64_t local_size_x = wgs.value()[0];
-      bool const best_fits = !(local_size_x % *best_width);
-      bool const cand_fits = !(local_size_x % candidate_width);
+      const bool best_fits = !(local_size_x % *best_width);
+      const bool cand_fits = !(local_size_x % candidate_width);
       if (!best_fits && cand_fits) {
         best_width = candidate_width;
         continue;

--- a/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
+++ b/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
@@ -61,7 +61,7 @@ Value *processCallSite(CallInst *CI, bool &NeedLLVMInline,
 
   // Emit builtins inline when they have no vector/scalar equivalent.
   IRBuilder<> B(CI);
-  auto const Builtin = BI.analyzeBuiltin(*Callee);
+  const auto Builtin = BI.analyzeBuiltin(*Callee);
   if (Builtin.properties &
       compiler::utils::eBuiltinPropertyInlinePostVectorization) {
     SmallVector<Value *, 4> Args(CI->args());

--- a/modules/compiler/vecz/source/transform/instantiation_pass.cpp
+++ b/modules/compiler/vecz/source/transform/instantiation_pass.cpp
@@ -139,9 +139,9 @@ PacketRange InstantiationPass::instantiateCall(CallInst *CI) {
   unsigned SimdWidth = packetizer.width().getFixedValue();
   // Handle special call instructions that return a lane ID.
   compiler::utils::BuiltinInfo &BI = Ctx.builtins();
-  auto const Builtin = BI.analyzeBuiltinCall(*CI, packetizer.dimension());
+  const auto Builtin = BI.analyzeBuiltinCall(*CI, packetizer.dimension());
   if (Builtin.properties & compiler::utils::eBuiltinPropertyWorkItem) {
-    auto const Uniformity = Builtin.uniformity;
+    const auto Uniformity = Builtin.uniformity;
     if (Uniformity == compiler::utils::eBuiltinUniformityNever) {
       // can't handle these (global/local linear ID probably)
       VECZ_FAIL();

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -61,7 +61,7 @@ inline Type *getWideType(Type *ty, ElementCount factor) {
     }
     return VectorType::get(ty, factor);
   }
-  bool const isScalable = isa<ScalableVectorType>(ty);
+  const bool isScalable = isa<ScalableVectorType>(ty);
   assert((!factor.isScalable() || !isScalable) &&
          "Can't widen a scalable vector by a scalable amount");
   auto *vecTy = cast<llvm::VectorType>(ty);
@@ -179,9 +179,9 @@ Value *createOptimalShuffle(IRBuilder<> &B, Value *srcA, Value *srcB,
     // We can absorb one or two unary shuffles into the new shuffle..
     auto *const shuffleAsrc = shuffleA ? shuffleA->getOperand(0) : srcA;
     auto *const shuffleBsrc = shuffleB ? shuffleB->getOperand(0) : srcB;
-    auto const srcASize =
+    const auto srcASize =
         cast<FixedVectorType>(shuffleAsrc->getType())->getNumElements();
-    auto const srcBSize =
+    const auto srcBSize =
         cast<FixedVectorType>(shuffleBsrc->getType())->getNumElements();
     if (srcASize == srcBSize) {
       Constant *srcMaskA = nullptr;
@@ -332,7 +332,7 @@ Value *getGatherIndicesVector(IRBuilder<> &B, Value *Indices, Type *Ty,
                               unsigned FixedVecElts, const Twine &N) {
   auto *const Steps = B.CreateStepVector(Ty);
 
-  auto const EltCount = multi_llvm::getVectorElementCount(Ty);
+  const auto EltCount = multi_llvm::getVectorElementCount(Ty);
   auto *const ElTy = multi_llvm::getVectorElementType(Ty);
 
   auto *const FixedVecEltsSplat =
@@ -512,7 +512,7 @@ PacketRange Packetizer::Result::getAsPacket(unsigned width) const {
 
 void Packetizer::Result::getPacketValues(SmallVectorImpl<Value *> &vals) const {
   assert(info && "No packet info for this packetization result");
-  auto const width = info->numInstances;
+  const auto width = info->numInstances;
   if (width != 0) {
     return getPacketValues(width, vals);
   }
@@ -647,7 +647,7 @@ Value *scalableBroadcastHelper(Value *subvec, ElementCount factor,
                                const vecz::TargetInfo &TI, IRBuilder<> &B,
                                bool URem) {
   auto *ty = subvec->getType();
-  auto const subVecEltCount = multi_llvm::getVectorElementCount(ty);
+  const auto subVecEltCount = multi_llvm::getVectorElementCount(ty);
   assert(subVecEltCount.isScalable() ^ factor.isScalable() &&
          "Must either broadcast fixed vector by scalable factor or scalable "
          "vector by fixed factor");

--- a/modules/compiler/vecz/source/transform/scalarization_pass.cpp
+++ b/modules/compiler/vecz/source/transform/scalarization_pass.cpp
@@ -228,7 +228,7 @@ PreservedAnalyses ScalarizationPass::run(llvm::Function &F,
     // operands, scalarization can produce dead code, which will get removed
     // by later cleanup optimizations. Reductions are generally much better
     // off scalarized.
-    bool const scalable = VU.width().isScalable();
+    const bool scalable = VU.width().isScalable();
 
     OperandTracer tracer(UVR, scalable);
     for (Instruction *Leaf : Leaves) {

--- a/modules/compiler/vecz/source/transform/scalarizer.cpp
+++ b/modules/compiler/vecz/source/transform/scalarizer.cpp
@@ -225,7 +225,7 @@ Value *Scalarizer::scalarizeOperands(Instruction *I) {
     if (!Callee->isIntrinsic()) {
       // Check if this is indeed a printf call
       compiler::utils::BuiltinInfo &BI = Ctx.builtins();
-      auto const ID = BI.analyzeBuiltin(*Callee).ID;
+      const auto ID = BI.analyzeBuiltin(*Callee).ID;
       if (ID == BI.getPrintfBuiltin()) {
         return scalarizeOperandsPrintf(CI);
       }
@@ -272,7 +272,7 @@ Value *Scalarizer::scalarizeOperandsPrintf(CallInst *CI) {
   // Gather the operands for the new printf call, taking care to scalarize
   // any vector operands.
   llvm::SmallVector<Value *, 16> NewOps;
-  for (Use const &Op : CI->args()) {
+  for (const Use &Op : CI->args()) {
     // The first operand is the new format string
     if (Op == *CI->arg_begin()) {
       Constant *Zero = B.getInt32(0);
@@ -1304,12 +1304,12 @@ SimdPacket *Scalarizer::scalarizeCall(CallInst *CI, PacketMask PM) {
     Callee = originalFunc;
   }
 
-  auto const Builtin = BI.analyzeBuiltin(*Callee);
+  const auto Builtin = BI.analyzeBuiltin(*Callee);
   Function *ScalarEquiv = BI.getScalarEquivalent(Builtin, F.getParent());
   VECZ_STAT_FAIL_IF(!ScalarEquiv, VeczScalarizeFailBuiltin);
 
   IRBuilder<> B(CI);
-  auto const Props = Builtin.properties;
+  const auto Props = Builtin.properties;
   // Ignore the mask if present
   unsigned NumArgs = VectorCallMask ? CI->arg_size() - 1 : CI->arg_size();
   SmallVector<SimdPacket *, 4> OpPackets(NumArgs);
@@ -1535,8 +1535,8 @@ SimdPacket *Scalarizer::scalarizeGEP(GetElementPtrInst *GEP, PacketMask PM) {
   }
 
   IRBuilder<> B(GEP);
-  bool const inBounds = GEP->isInBounds();
-  auto const name = GEP->getName();
+  const bool inBounds = GEP->isInBounds();
+  const auto name = GEP->getName();
   SimdPacket *const P = getPacket(GEP, simdWidth);
   for (unsigned i = 0; i < simdWidth; i++) {
     if (!PM.isEnabled(i) || P->at(i)) {

--- a/modules/compiler/vecz/source/transform/ternary_transform_pass.cpp
+++ b/modules/compiler/vecz/source/transform/ternary_transform_pass.cpp
@@ -36,7 +36,7 @@ namespace {
 /// memory op and there are no other users to GEP.
 /// Additionally, we reject various cases where the tranform would not result
 /// in better code.
-bool shouldTransform(SelectInst *Select, StrideAnalysisResult const &SAR) {
+bool shouldTransform(SelectInst *Select, const StrideAnalysisResult &SAR) {
   // The transform only applies to pointer selects.
   if (!Select->getType()->isPointerTy()) {
     return false;
@@ -50,7 +50,7 @@ bool shouldTransform(SelectInst *Select, StrideAnalysisResult const &SAR) {
   {
     // If the select itself is a strided pointer, we don't gain anything by
     // transforming it into a pair of masked memops.
-    auto const *info = SAR.getInfo(Select);
+    const auto *info = SAR.getInfo(Select);
     if (info && info->hasStride()) {
       return false;
     }
@@ -66,8 +66,8 @@ bool shouldTransform(SelectInst *Select, StrideAnalysisResult const &SAR) {
   // only scalar Mask Varying memops, instead of vector memops.
   if (SAR.UVR.isVarying(VecTrue) || SAR.UVR.isVarying(VecFalse)) {
     // Both pointers must be either strided or uniform (i.e. not divergent).
-    auto const *infoT = SAR.getInfo(VecTrue);
-    auto const *infoF = SAR.getInfo(VecFalse);
+    const auto *infoT = SAR.getInfo(VecTrue);
+    const auto *infoF = SAR.getInfo(VecFalse);
     if (!infoT || !infoF || infoT->mayDiverge() || infoF->mayDiverge()) {
       return false;
     }
@@ -97,7 +97,7 @@ bool shouldTransform(SelectInst *Select, StrideAnalysisResult const &SAR) {
 
     // Validate the GEP indices
     for (Value *idx : GEP->indices()) {
-      auto const *info = SAR.getInfo(idx);
+      const auto *info = SAR.getInfo(idx);
       if (!info || info->mayDiverge()) {
         return false;
       }
@@ -205,7 +205,7 @@ void Transform(SelectInst *Select, VectorizationContext &Ctx) {
 
 PreservedAnalyses TernaryTransformPass::run(llvm::Function &F,
                                             llvm::FunctionAnalysisManager &AM) {
-  auto const &SAR = AM.getResult<StrideAnalysis>(F);
+  const auto &SAR = AM.getResult<StrideAnalysis>(F);
 
   // Find selects that can be transformed
   SmallVector<SelectInst *, 4> Selects;

--- a/modules/compiler/vecz/source/transform/uniform_reassociation_pass.cpp
+++ b/modules/compiler/vecz/source/transform/uniform_reassociation_pass.cpp
@@ -155,7 +155,7 @@ bool Reassociator::reassociate(llvm::BinaryOperator &Op) {
     return false;
   }
 
-  auto const Opcode = Op.getOpcode();
+  const auto Opcode = Op.getOpcode();
   auto *const LHS = Op.getOperand(0);
   auto *const RHS = Op.getOperand(1);
 
@@ -232,7 +232,7 @@ bool Reassociator::run(llvm::Function &F, llvm::FunctionAnalysisManager &AM) {
     for (auto Iit = BB->begin(); Iit != BB->end();) {
       auto &I = *(Iit++);
       if (auto *BinOp = dyn_cast<BinaryOperator>(&I)) {
-        auto const form = canonicalizeBinOp(*BinOp);
+        const auto form = canonicalizeBinOp(*BinOp);
         if (form == OpForm::Varying || form == OpForm::Mixed) {
           reassociate(*BinOp);
         }

--- a/modules/compiler/vecz/source/vector_target_info.cpp
+++ b/modules/compiler/vecz/source/vector_target_info.cpp
@@ -92,7 +92,7 @@ Value *TargetInfo::createLoad(IRBuilder<> &B, Type *Ty, Value *Ptr,
   if (CIntStride && CIntStride->getSExtValue() == 1) {
     if (EVL) {
       const Function *F = B.GetInsertBlock()->getParent();
-      auto const Legality = isVPLoadLegal(F, Ty, Alignment);
+      const auto Legality = isVPLoadLegal(F, Ty, Alignment);
       if (!Legality.isVPLegal()) {
         emitVeczRemarkMissed(F,
                              "Could not create a VP load as the target "
@@ -160,7 +160,7 @@ Value *TargetInfo::createStore(IRBuilder<> &B, Value *Data, Value *Ptr,
     Value *VecPtr = B.CreateBitCast(Ptr, VecPtrTy);
     if (EVL) {
       const Function *F = B.GetInsertBlock()->getParent();
-      auto const Legality = isVPStoreLegal(F, VecTy, Alignment);
+      const auto Legality = isVPStoreLegal(F, VecTy, Alignment);
       if (!Legality.isVPLegal()) {
         emitVeczRemarkMissed(F,
                              "Could not create a VP store as the target "
@@ -232,7 +232,7 @@ Value *TargetInfo::createMaskedLoad(IRBuilder<> &B, Type *Ty, Value *Ptr,
     PtrTy = Ty->getPointerTo(PtrTy->getAddressSpace());
     Ptr = B.CreateBitCast(Ptr, PtrTy);
     const Function *F = B.GetInsertBlock()->getParent();
-    auto const Legality = isVPLoadLegal(F, Ty, Alignment);
+    const auto Legality = isVPLoadLegal(F, Ty, Alignment);
     if (EVL && Legality.isVPLegal()) {
       SmallVector<llvm::Value *, 2> Args = {Ptr, Mask, EVL};
       SmallVector<llvm::Type *, 2> Tys = {Ty, PtrTy};
@@ -249,7 +249,7 @@ Value *TargetInfo::createMaskedLoad(IRBuilder<> &B, Type *Ty, Value *Ptr,
     }
   }
 
-  unsigned const Width = 1;
+  const unsigned Width = 1;
 
   LLVMContext &Ctx = B.getContext();
   BasicBlock *Entry = B.GetInsertBlock();
@@ -339,7 +339,7 @@ Value *TargetInfo::createMaskedStore(IRBuilder<> &B, Value *Data, Value *Ptr,
     PtrTy = DataTy->getPointerTo(PtrTy->getAddressSpace());
     Ptr = B.CreateBitCast(Ptr, PtrTy);
     const Function *F = B.GetInsertBlock()->getParent();
-    auto const Legality = isVPStoreLegal(F, DataTy, Alignment);
+    const auto Legality = isVPStoreLegal(F, DataTy, Alignment);
     if (EVL && Legality.isVPLegal()) {
       SmallVector<llvm::Value *, 3> Args = {Data, Ptr, Mask, EVL};
       SmallVector<llvm::Type *, 2> Tys = {Data->getType(), PtrTy};
@@ -356,7 +356,7 @@ Value *TargetInfo::createMaskedStore(IRBuilder<> &B, Value *Data, Value *Ptr,
     }
   }
 
-  unsigned const Width = 1;
+  const unsigned Width = 1;
 
   LLVMContext &Ctx = B.getContext();
   BasicBlock *Entry = B.GetInsertBlock();
@@ -498,7 +498,7 @@ Value *TargetInfo::createMaskedGatherLoad(IRBuilder<> &B, Type *Ty, Value *Ptr,
   Constant *DefaultEleData = UndefValue::get(EleTy);
 
   if (Ty->isVectorTy()) {
-    auto const Legality = isVPGatherLegal(F, Ty, Alignment);
+    const auto Legality = isVPGatherLegal(F, Ty, Alignment);
     if (EVL && Legality.isVPLegal()) {
       SmallVector<llvm::Value *, 2> Args = {Ptr, Mask, EVL};
       SmallVector<llvm::Type *, 2> Tys = {Ty, VecPtrTy};
@@ -596,7 +596,7 @@ Value *TargetInfo::createMaskedScatterStore(IRBuilder<> &B, Value *Data,
   if (DataTy->isVectorTy()) {
     auto *VecPtrTy = dyn_cast<VectorType>(Ptr->getType());
     VECZ_FAIL_IF(!VecPtrTy);
-    auto const Legality = isVPScatterLegal(F, DataTy, Alignment);
+    const auto Legality = isVPScatterLegal(F, DataTy, Alignment);
     if (EVL && Legality.isVPLegal()) {
       SmallVector<llvm::Value *, 3> Args = {Data, Ptr, Mask, EVL};
       SmallVector<llvm::Type *, 2> Tys = {Data->getType(), VecPtrTy};
@@ -671,7 +671,7 @@ Value *TargetInfo::createScalableExtractElement(IRBuilder<> &B,
                                                 Type *narrowTy, Value *src,
                                                 Value *index, Value *VL) const {
   (void)VL;
-  auto const *origSrc = extract->getOperand(0);
+  const auto *origSrc = extract->getOperand(0);
   auto *eltTy = src->getType()->getScalarType();
 
   auto *wideTy = src->getType();
@@ -695,7 +695,7 @@ Value *TargetInfo::createScalableExtractElement(IRBuilder<> &B,
   auto *const bcastalloc =
       B.CreatePointerBitCastOrAddrSpaceCast(alloc, eltptrTy, "bcast.alloc");
 
-  unsigned const fixedVecElts =
+  const unsigned fixedVecElts =
       multi_llvm::getVectorNumElements(origSrc->getType());
 
   Value *load = nullptr;
@@ -796,8 +796,8 @@ Value *TargetInfo::createBroadcastIndexVector(IRBuilder<> &B, Type *ty,
                                               ElementCount factor, bool URem,
                                               const llvm::Twine &N) {
   auto *const steps = B.CreateStepVector(ty, "idx0");
-  auto const tyEC = multi_llvm::getVectorElementCount(ty);
-  unsigned const factorMinVal = factor.getKnownMinValue();
+  const auto tyEC = multi_llvm::getVectorElementCount(ty);
+  const unsigned factorMinVal = factor.getKnownMinValue();
 
   unsigned fixedAmt;
   Instruction::BinaryOps Opc;
@@ -842,7 +842,7 @@ Value *TargetInfo::createScalableInsertElement(IRBuilder<> &B,
   auto *const bcastalloc =
       B.CreatePointerBitCastOrAddrSpaceCast(alloc, eltptrTy, "bcast.alloc");
 
-  unsigned const fixedVecElts =
+  const unsigned fixedVecElts =
       multi_llvm::getVectorNumElements(insert->getOperand(0)->getType());
 
   // Construct the index, either by packetizing if (if varying) or by
@@ -907,7 +907,7 @@ TargetInfo::VPMemOpLegality TargetInfo::checkMemOpLegality(
         Checker,
     Type *Ty, unsigned Alignment) const {
   assert(Ty->isVectorTy() && "Expected a vector type");
-  bool const isMaskLegal =
+  const bool isMaskLegal =
       !(isa<ScalableVectorType>(Ty) && TM_) ||
       Checker(TM_->getTargetTransformInfo(*F), Ty, Alignment);
   // Assuming a pointer bit width of 64
@@ -966,8 +966,8 @@ llvm::Value *TargetInfo::createVectorShuffle(llvm::IRBuilder<> &B,
   // The alloca must be inserted at the beginning of the function.
   auto *const curBlock = B.GetInsertBlock();
   auto &entryBlock = curBlock->getParent()->getEntryBlock();
-  auto const allocaIt = entryBlock.getFirstInsertionPt();
-  auto const it = B.GetInsertPoint();
+  const auto allocaIt = entryBlock.getFirstInsertionPt();
+  const auto it = B.GetInsertPoint();
 
   B.SetInsertPoint(&entryBlock, allocaIt);
   auto *const alloc = B.CreateAlloca(srcTy, nullptr);
@@ -988,14 +988,14 @@ llvm::Value *TargetInfo::createVectorShuffle(llvm::IRBuilder<> &B,
   // Index into the allocation.
   auto *const gep = B.CreateInBoundsGEP(eltTy, bcastalloc, mask, "vec.alloc");
 
-  auto const eltCount = maskTy->getElementCount();
+  const auto eltCount = maskTy->getElementCount();
   auto *const dstTy = VectorType::get(eltTy, eltCount);
-  auto const alignment =
+  const auto alignment =
       MaybeAlign(eltTy->getScalarSizeInBits() / 8).valueOrOne();
 
   Value *gatherMask = nullptr;
   if (evl) {
-    auto const EC = srcTy->getElementCount();
+    const auto EC = srcTy->getElementCount();
     auto *const IndexTy = VectorType::get(evl->getType(), EC);
     auto *const step = B.CreateStepVector(IndexTy);
     gatherMask = B.CreateICmpULT(step, B.CreateVectorSplat(EC, evl));
@@ -1016,10 +1016,10 @@ llvm::Value *TargetInfo::createVectorSlideUp(llvm::IRBuilder<> &B,
          "TargetInfo::createVectorShuffle: source must have vector type");
 
   auto *const undef = UndefValue::get(srcTy);
-  auto const EC = srcTy->getElementCount();
+  const auto EC = srcTy->getElementCount();
   if (!EC.isScalable()) {
     // Special case for fixed-width vectors
-    auto const width = EC.getFixedValue();
+    const auto width = EC.getFixedValue();
     SmallVector<int, 16> mask(width);
     auto it = mask.begin();
     *it++ = 0;
@@ -1291,7 +1291,7 @@ unsigned TargetInfo::estimateSimdWidth(const TargetTransformInfo &TTI,
             ? TM_->getPointerSizeInBits(Ty->getPointerAddressSpace())
             : VI->getType()->getPrimitiveSizeInBits();
   }
-  unsigned const MaxBits = MaxVecRegBitWidth * NumVecRegs;
+  const unsigned MaxBits = MaxVecRegBitWidth * NumVecRegs;
   while (VaryingUsage * width > MaxBits) {
     width >>= 1;
   }

--- a/modules/compiler/vecz/source/vectorization_helpers.cpp
+++ b/modules/compiler/vecz/source/vectorization_helpers.cpp
@@ -37,9 +37,9 @@ using namespace vecz;
 
 namespace {
 
-Function *declareFunction(VectorizationUnit const &VU) {
+Function *declareFunction(const VectorizationUnit &VU) {
   Module &Module = VU.context().module();
-  Function const *const ScalarFn = VU.scalarFunction();
+  const Function *const ScalarFn = VU.scalarFunction();
   ElementCount SimdWidth = VU.width();
 
   // For kernels, the vectorized function type is is the same as the original
@@ -66,7 +66,7 @@ Function *declareFunction(VectorizationUnit const &VU) {
 /// searches for the node that contains the scalar kernel, and copies all its
 /// metadata, which the exception of the Function itself, which is replaced by
 /// the vectorized kernel.
-void cloneOpenCLNamedMetadataHelper(VectorizationUnit const &VU,
+void cloneOpenCLNamedMetadataHelper(const VectorizationUnit &VU,
                                     const std::string &NodeName) {
   Module &M = VU.context().module();
 
@@ -121,10 +121,10 @@ void cloneOpenCLNamedMetadataHelper(VectorizationUnit const &VU,
 ///
 /// @param[in,out] ValueMap Map to update with the arguments.
 SmallVector<Instruction *, 2> createArgumentPlaceholders(
-    VectorizationUnit const &VU, Function *VecFunc,
+    const VectorizationUnit &VU, Function *VecFunc,
     ValueToValueMapTy &ValueMap) {
   SmallVector<Instruction *, 2> Placeholders;
-  auto const &Arguments = VU.arguments();
+  const auto &Arguments = VU.arguments();
   unsigned i = 0u;
   for (Argument &DstArg : VecFunc->args()) {
     Argument *SrcArg = Arguments[i++].OldArg;
@@ -192,7 +192,7 @@ decodeVectorizedFunctionName(StringRef Name) {
   return std::make_tuple(Name.str(), VF, Choices);
 }
 
-Function *cloneFunctionToVector(VectorizationUnit const &VU) {
+Function *cloneFunctionToVector(const VectorizationUnit &VU) {
   auto *const VectorizedFn = declareFunction(VU);
   VECZ_ERROR_IF(!VectorizedFn, "declareFunction failed to initialize");
 
@@ -266,7 +266,7 @@ static DILocation *getDILocation(unsigned Line, unsigned Column, MDNode *Scope,
                          /*ImplicitCode*/ false);
 }
 
-void cloneDebugInfo(VectorizationUnit const &VU) {
+void cloneDebugInfo(const VectorizationUnit &VU) {
   DISubprogram *const ScalarDI = VU.scalarFunction()->getSubprogram();
   // We don't have debug info
   if (!ScalarDI) {
@@ -430,7 +430,7 @@ void cloneDebugInfo(VectorizationUnit const &VU) {
   return;
 }
 
-void cloneOpenCLMetadata(VectorizationUnit const &VU) {
+void cloneOpenCLMetadata(const VectorizationUnit &VU) {
   cloneOpenCLNamedMetadataHelper(VU, "opencl.kernels");
   cloneOpenCLNamedMetadataHelper(VU, "opencl.kernel_wg_size_info");
 }

--- a/modules/compiler/vecz/source/vectorization_heuristics.cpp
+++ b/modules/compiler/vecz/source/vectorization_heuristics.cpp
@@ -163,7 +163,7 @@ Heuristics::BrClauseKind Heuristics::shouldVectorizeVisitCmpOperands(
 const Value *Heuristics::shouldVectorizeVisitCmpOperand(
     const Value *Val, const CmpInst *Cmp,
     DenseMap<const Value *, const Value *> &Cache) const {
-  auto const It = Cache.find(Val);
+  const auto It = Cache.find(Val);
   if (It != Cache.end()) {
     return It->second;
   }
@@ -209,7 +209,7 @@ const Value *Heuristics::shouldVectorizeVisitCmpOperand(
   if (const CallInst *CI = dyn_cast<const CallInst>(Val)) {
     // We only care if the CallInst does involve a call to a work-item builtin.
     compiler::utils::BuiltinInfo &BI = Ctx.builtins();
-    auto const Uniformity = BI.analyzeBuiltinCall(*CI, SimdDimIdx).uniformity;
+    const auto Uniformity = BI.analyzeBuiltinCall(*CI, SimdDimIdx).uniformity;
     if (Uniformity == compiler::utils::eBuiltinUniformityInstanceID ||
         Uniformity == compiler::utils::eBuiltinUniformityMaybeInstanceID) {
       return (Cache[Val] = CI);

--- a/modules/compiler/vecz/source/vectorizer.cpp
+++ b/modules/compiler/vecz/source/vectorizer.cpp
@@ -316,7 +316,7 @@ void vecz::trackVeczSuccessFailure(VectorizationUnit &VU) {
   collectStatistics(VU, Fn, vectorizedFn);
 
   if (VeczDumpReport) {
-    auto const VF = VU.width();
+    const auto VF = VU.width();
     auto FnName = Fn->getName();
     if (vectorizedFn) {
       errs() << "vecz: Vectorization succeeded for kernel '" << FnName
@@ -341,8 +341,8 @@ bool vecz::createVectorizedFunctionMetadata(VectorizationUnit &vu) {
     // kernels.
     cloneOpenCLMetadata(vu);
   }
-  auto const vf = vu.width();
-  auto const dim = vu.dimension();
+  const auto vf = vu.width();
+  const auto dim = vu.dimension();
 
   // emit output metadata based on vectorization result
   auto finalVF = compiler::utils::VectorizationFactor(vf.getKnownMinValue(),

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -170,7 +170,7 @@ static vecz::VeczPassOptions getDefaultPassOptions() {
     llvm::EnableStatistics(true);
   }
 
-  auto const factor = SIMDWidth ? SIMDWidth : 4;
+  const auto factor = SIMDWidth ? SIMDWidth : 4;
   auto VF = compiler::utils::VectorizationFactor::getFixedWidth(factor);
   if (VeczSimdWidth) {
     VF.setKnownMin(VeczSimdWidth);

--- a/modules/kts/include/kts/arguments_shared.h
+++ b/modules/kts/include/kts/arguments_shared.h
@@ -122,7 +122,7 @@ class Reference1D {
   Reference1D() : Ref(nullptr), Type(Empty) {}
   /// @brief Copy constructor
   /// @param Other The reference to copy
-  Reference1D(Reference1D const &Other) : Ref(Other.Ref), Type(Other.Type) {}
+  Reference1D(const Reference1D &Other) : Ref(Other.Ref), Type(Other.Type) {}
   /// @brief Copy constructor
   /// @param Other The reference to copy
   Reference1D(Reference1D &Other) : Ref(Other.Ref), Type(Other.Type) {}
@@ -137,7 +137,7 @@ class Reference1D {
   /// @brief Copy assignment
   /// @param Other The reference to copy
   /// @return `*this`
-  Reference1D &operator=(Reference1D const &Other) {
+  Reference1D &operator=(const Reference1D &Other) {
     if (this != &Other) {
       Ref = Other.Ref;
       Type = Other.Type;

--- a/modules/mux/targets/host/source/queue.cpp
+++ b/modules/mux/targets/host/source/queue.cpp
@@ -125,7 +125,7 @@ void commandCopyBuffer(host::command_info_s *info) {
 
 void commandReadImage(host::command_info_s *info) {
 #ifdef HOST_IMAGE_SUPPORT
-  host::command_info_read_image_s const &read = info->read_image_command;
+  const host::command_info_read_image_s &read = info->read_image_command;
 
   auto image = static_cast<host::image_s *>(read.image);
   const size_t origin[3] = {read.offset.x, read.offset.y, read.offset.z};
@@ -143,7 +143,7 @@ void commandReadImage(host::command_info_s *info) {
 
 void commandWriteImage(host::command_info_s *info) {
 #ifdef HOST_IMAGE_SUPPORT
-  host::command_info_write_image_s const &write = info->write_image_command;
+  const host::command_info_write_image_s &write = info->write_image_command;
 
   auto image = static_cast<host::image_s *>(write.image);
   size_t origin[3] = {write.offset.x, write.offset.y, write.offset.z};
@@ -161,7 +161,7 @@ void commandWriteImage(host::command_info_s *info) {
 
 void commandFillImage(host::command_info_s *info) {
 #ifdef HOST_IMAGE_SUPPORT
-  host::command_info_fill_image_s const &fill = info->fill_image_command;
+  const host::command_info_fill_image_s &fill = info->fill_image_command;
 
   auto image = static_cast<host::image_s *>(fill.image);
 
@@ -194,7 +194,7 @@ void commandCopyImage(host::command_info_s *info) {
 
 void commandCopyImageToBuffer(host::command_info_s *info) {
 #ifdef HOST_IMAGE_SUPPORT
-  host::command_info_copy_image_to_buffer_s const &copy =
+  const host::command_info_copy_image_to_buffer_s &copy =
       info->copy_image_to_buffer_command;
 
   auto srcImage = static_cast<host::image_s *>(copy.src_image);

--- a/source/cl/source/context.cpp
+++ b/source/cl/source/context.cpp
@@ -211,7 +211,7 @@ cl_int parseProperties(const cl_context_properties *properties,
   cl_platform_id platformid = nullptr;
 
   uint32_t length = 0;
-  cl_context_properties const *property = properties;
+  const cl_context_properties *property = properties;
   while (0 != property[0]) {
     switch (property[0]) {
       case CL_CONTEXT_PLATFORM:

--- a/source/cl/test/UnitCL/include/kts/generator.h
+++ b/source/cl/test/UnitCL/include/kts/generator.h
@@ -189,7 +189,7 @@ void InputGenerator::GenerateFiniteFloatData(std::vector<T> &buffer, T low,
   // other than the sign bit, if the sign bit is set. This gives us an
   // equivalent range over signed integers. Inverting the sign bit then converts
   // that to a range over unsigned integers.
-  auto const sign_bit = TypeInfo<T>::sign_bit;
+  const auto sign_bit = TypeInfo<T>::sign_bit;
 
   UInt iMin = cargo::bit_cast<UInt>(low);
   iMin ^= (iMin & sign_bit) ? ~UInt(0) : sign_bit;

--- a/source/cl/test/UnitCL/include/kts/precision.h
+++ b/source/cl/test/UnitCL/include/kts/precision.h
@@ -84,10 +84,10 @@ inline std::ostream &operator<<(std::ostream &out, const RoundingMode &mode) {
 template <typename T, typename Parameter>
 class NamedType {
  public:
-  explicit NamedType(T const &value) : value_(value) {}
+  explicit NamedType(const T &value) : value_(value) {}
   explicit NamedType(T &&value) : value_(std::move(value)) {}
   T &get() { return value_; }
-  T const &get() const { return value_; }
+  const T &get() const { return value_; }
 
   using WrappedT = T;
 

--- a/source/cl/test/UnitCL/include/ucl/types.h
+++ b/source/cl/test/UnitCL/include/ucl/types.h
@@ -246,7 +246,7 @@ struct VectorType {
   /// @brief Construct from a std::vector of values.
   ///
   /// @param[in] buffer Vector of values to construct from.
-  VectorType(std::vector<value_type> const &buffer) {
+  VectorType(const std::vector<value_type> &buffer) {
     UCL_ASSERT(buffer.size() == N, "invalid vector size");
     std::copy(std::begin(buffer), std::end(buffer), std::begin(*this));
   }

--- a/source/cl/test/UnitCL/source/ktst_vecz_tasks_task_10.cpp
+++ b/source/cl/test/UnitCL/source/ktst_vecz_tasks_task_10.cpp
@@ -113,7 +113,7 @@ TEST_P(OneArgRelationals, Task_10_04_OneArg_Relationals) {
 
   // Determine the output based on the function being tested
   AddMacro("FUNC", Function);
-  cl_int const *Out = nullptr;
+  const cl_int *Out = nullptr;
 
   if (Function == "isfinite") {
     Out = OutIsFinite;

--- a/source/cl/test/UnitCL/source/sub_groups.cpp
+++ b/source/cl/test/UnitCL/source/sub_groups.cpp
@@ -43,7 +43,7 @@ void GenerateOrderIndependentFloatData(std::vector<cl_float> &input_data) {
   // range of integers, which are guaranteed not to lose any bits of precision
   // during addition, and the sum will be exact regardless of
   // ordering.
-  auto const data_size = input_data.size();
+  const auto data_size = input_data.size();
   std::vector<cl_int> input_ints(data_size);
   ucl::Environment::instance->GetInputGenerator().GenerateIntData<cl_int>(
       input_ints, -65536, 65536);


### PR DESCRIPTION
# Overview

[NFC] Pick a style for const.

# Reason for change

This PR prepares for updating our clang-tidy, which wants us to add many more instances of const.

# Description of change

In cases where const may appear before or after the type, LLVM style is to place it before the type, and we have many more instances ourselves where we place it before the type than we do where we place it after. This commit sets that style in .clang-format and does a reformat across the code base.

# Anything else we should know?

I have no opinion on whether `const` is better to place before or after the type. If we want it after the type, consistently, I can update this PR to do so.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
