### PR TITLE
USM testing rework for better USM support

### DIFF
--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_enqueue.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_enqueue.cpp
@@ -22,39 +22,15 @@ struct USMCommandQueueTest : public cl_intel_unified_shared_memory_Test {
   void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(cl_intel_unified_shared_memory_Test::SetUp());
 
-    cl_device_unified_shared_memory_capabilities_intel host_capabilities;
-    ASSERT_SUCCESS(clGetDeviceInfo(
-        device, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL,
-        sizeof(host_capabilities), &host_capabilities, nullptr));
+    initPointers(bytes, align);
 
     cl_int err;
-    if (host_capabilities) {
-      host_ptr = clHostMemAllocINTEL(context, nullptr, bytes, align, &err);
-      ASSERT_SUCCESS(err);
-      ASSERT_TRUE(host_ptr != nullptr);
-    }
-
-    device_ptr =
-        clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
-    ASSERT_SUCCESS(err);
-    ASSERT_TRUE(device_ptr != nullptr);
-
     queue = clCreateCommandQueue(context, device, 0, &err);
     ASSERT_TRUE(queue != nullptr);
     ASSERT_SUCCESS(err);
   }
 
   void TearDown() override {
-    if (device_ptr) {
-      cl_int err = clMemBlockingFreeINTEL(context, device_ptr);
-      EXPECT_SUCCESS(err);
-    }
-
-    if (host_ptr) {
-      cl_int err = clMemBlockingFreeINTEL(context, host_ptr);
-      EXPECT_SUCCESS(err);
-    }
-
     if (queue) {
       EXPECT_SUCCESS(clReleaseCommandQueue(queue));
     }
@@ -65,108 +41,105 @@ struct USMCommandQueueTest : public cl_intel_unified_shared_memory_Test {
   static const size_t bytes = 512;
   static const cl_uint align = 4;
 
-  void *host_ptr = nullptr;
-  void *device_ptr = nullptr;
-
   cl_command_queue queue = nullptr;
 };
 
 // Test for invalid API usage of clEnqueueMemFillINTEL()
 TEST_F(USMCommandQueueTest, MemFill_InvalidUsage) {
-  const cl_int pattern[1] = {CL_INT_MAX};
-  const cl_ulong16 vec_pattern[2] = {
-      {{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD,
-        0xE, 0xF}},
-      {{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD,
-        0xE, 0xF}}};
+  for (auto ptr : allPointers()) {
+    const cl_int pattern[1] = {CL_INT_MAX};
+    const cl_ulong16 vec_pattern[2] = {
+        {{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD,
+          0xE, 0xF}},
+        {{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD,
+          0xE, 0xF}}};
 
-  // Null command queue argument
-  cl_int err =
-      clEnqueueMemFillINTEL(nullptr, device_ptr, pattern, sizeof(pattern),
-                            sizeof(pattern), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
+    // Null command queue argument
+    cl_int err = clEnqueueMemFillINTEL(nullptr, ptr, pattern, sizeof(pattern),
+                                       sizeof(pattern), 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
 
-  cl_context other_context =
-      clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
-  ASSERT_TRUE(other_context);
-  ASSERT_SUCCESS(err);
+    cl_context other_context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    ASSERT_TRUE(other_context);
+    ASSERT_SUCCESS(err);
 
-  // Mismatch between context of event and command queue
-  cl_event event = clCreateUserEvent(other_context, &err);
-  err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern), 1, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
+    // Mismatch between context of event and command queue
+    cl_event event = clCreateUserEvent(other_context, &err);
+    err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern),
+                                sizeof(pattern), 1, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
 
-  EXPECT_SUCCESS(clReleaseContext(other_context));
+    EXPECT_SUCCESS(clReleaseContext(other_context));
 
-  // Null pointer passed for dst_ptr
-  err = clEnqueueMemFillINTEL(queue, nullptr, pattern, sizeof(pattern),
-                              sizeof(pattern), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // Null pointer passed for dst_ptr
+    err = clEnqueueMemFillINTEL(queue, nullptr, pattern, sizeof(pattern),
+                                sizeof(pattern), 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // Null pointer passed for pattern
-  err = clEnqueueMemFillINTEL(queue, device_ptr, nullptr, sizeof(pattern),
-                              sizeof(pattern), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // Null pointer passed for pattern
+    err = clEnqueueMemFillINTEL(queue, ptr, nullptr, sizeof(pattern),
+                                sizeof(pattern), 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // Pattern sizes must be powers of two, we omit 1 here since offsets
-  // from it will always have valid alignment/sizes.
-  const std::array<size_t, 7> valid_pattern_sizes{2, 4, 8, 16, 32, 64, 128};
-  for (size_t pattern_size : valid_pattern_sizes) {
-    // dst_ptr not aligned to pattern_size
-    void *offset_device_ptr = getPointerOffset(device_ptr, 1);
-    err = clEnqueueMemFillINTEL(queue, offset_device_ptr, pattern, pattern_size,
-                                pattern_size, 0, nullptr, nullptr);
-    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
-        << "pattern size: " << pattern_size;
-
-    // dst_ptr not aligned to pattern_size
-    if (reinterpret_cast<uintptr_t>(device_ptr) % pattern_size != 0) {
-      err = clEnqueueMemFillINTEL(queue, device_ptr, vec_pattern, pattern_size,
+    // Pattern sizes must be powers of two, we omit 1 here since offsets
+    // from it will always have valid alignment/sizes.
+    const std::array<size_t, 7> valid_pattern_sizes{2, 4, 8, 16, 32, 64, 128};
+    for (size_t pattern_size : valid_pattern_sizes) {
+      // dst_ptr not aligned to pattern_size
+      void *offset_ptr = getPointerOffset(ptr, 1);
+      err = clEnqueueMemFillINTEL(queue, offset_ptr, pattern, pattern_size,
                                   pattern_size, 0, nullptr, nullptr);
+      EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
+          << "pattern size: " << pattern_size;
+
+      // dst_ptr not aligned to pattern_size
+      if (reinterpret_cast<uintptr_t>(ptr) % pattern_size != 0) {
+        err = clEnqueueMemFillINTEL(queue, ptr, vec_pattern, pattern_size,
+                                    pattern_size, 0, nullptr, nullptr);
+        EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
+            << "pattern size: " << pattern_size;
+      }
+
+      // size not a multiple of pattern_size
+      err = clEnqueueMemFillINTEL(queue, ptr, pattern, pattern_size,
+                                  pattern_size + (pattern_size / 2), 0, nullptr,
+                                  nullptr);
+      EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
+          << "pattern size: " << pattern_size;
+
+      // Prefer even value when testing non power of two
+      const size_t non_pow_two =
+          pattern_size > 4 ? pattern_size - 2 : pattern_size + 1;
+      // pattern_size not aligned to power-of-two
+      err = clEnqueueMemFillINTEL(queue, ptr, pattern, non_pow_two, non_pow_two,
+                                  0, nullptr, nullptr);
       EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
           << "pattern size: " << pattern_size;
     }
 
-    // size not a multiple of pattern_size
-    err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, pattern_size,
-                                pattern_size + (pattern_size / 2), 0, nullptr,
-                                nullptr);
-    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
-        << "pattern size: " << pattern_size;
+    // pattern_size greater than the size of the largest integer supported by
+    err = clEnqueueMemFillINTEL(queue, ptr, vec_pattern, sizeof(vec_pattern),
+                                sizeof(vec_pattern), 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-    // Prefer even value when testing non power of two
-    const size_t non_pow_two =
-        pattern_size > 4 ? pattern_size - 2 : pattern_size + 1;
-    // pattern_size not aligned to power-of-two
-    err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, non_pow_two,
-                                non_pow_two, 0, nullptr, nullptr);
-    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE)
-        << "pattern size: " << pattern_size;
+    // Zero value for size
+    err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern), 0, 0,
+                                nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+
+    // null wait list with non-zero num_events_in_wait_list
+    err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern),
+                                sizeof(pattern), 1, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+
+    // wait list with zero num_events_in_wait_list
+    err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern),
+                                sizeof(pattern), 0, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+
+    EXPECT_SUCCESS(clReleaseEvent(event));
   }
-
-  // pattern_size greater than the size of the largest integer supported by
-  err =
-      clEnqueueMemFillINTEL(queue, device_ptr, vec_pattern, sizeof(vec_pattern),
-                            sizeof(vec_pattern), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
-
-  // Zero value for size
-  err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, sizeof(pattern), 0, 0,
-                              nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
-
-  // null wait list with non-zero num_events_in_wait_list
-  err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern), 1, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
-
-  // wait list with zero num_events_in_wait_list
-  err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern), 0, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
-
-  EXPECT_SUCCESS(clReleaseEvent(event));
 }
 
 // Test for valid API usage of clEnqueueMemFillINTEL()
@@ -181,159 +154,135 @@ TEST_F(USMCommandQueueTest, MemFill_ValidUsage) {
   // Pattern sizes must be powers of two
   const std::array<size_t, 8> valid_pattern_sizes{1, 2, 4, 8, 16, 32, 64, 128};
 
-  if (host_ptr) {
+  for (auto ptr : allPointers()) {
     for (size_t pattern_size : valid_pattern_sizes) {
       // Check if allocation already aligned, or we need a new aligned
       // allocation
-      if (reinterpret_cast<uintptr_t>(host_ptr) % pattern_size == 0) {
-        err = clEnqueueMemFillINTEL(queue, host_ptr, vec_pattern, pattern_size,
+      if (reinterpret_cast<uintptr_t>(ptr) % pattern_size == 0) {
+        err = clEnqueueMemFillINTEL(queue, ptr, vec_pattern, pattern_size,
                                     pattern_size, 0, nullptr, nullptr);
         EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
 
-        err = clEnqueueMemFillINTEL(queue, host_ptr, vec_pattern, pattern_size,
+        err = clEnqueueMemFillINTEL(queue, ptr, vec_pattern, pattern_size,
                                     pattern_size * 3, 0, nullptr, nullptr);
         EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
       } else {
-        void *aligned_host_ptr = clHostMemAllocINTEL(context, nullptr, bytes,
-                                                     sizeof(vec_pattern), &err);
+        void *aligned_ptr = nullptr;
+        if (ptr == device_ptr) {
+          aligned_ptr = clDeviceMemAllocINTEL(context, device, nullptr, bytes,
+                                              sizeof(vec_pattern), &err);
+        } else if (ptr == host_ptr) {
+          aligned_ptr = clHostMemAllocINTEL(context, nullptr, bytes,
+                                            sizeof(vec_pattern), &err);
+        } else if (ptr == shared_ptr) {
+          aligned_ptr = clSharedMemAllocINTEL(context, device, nullptr, bytes,
+                                              sizeof(vec_pattern), &err);
+        }
         ASSERT_SUCCESS(err) << "Pattern Size " << pattern_size;
-        ASSERT_TRUE(aligned_host_ptr != nullptr)
-            << "Pattern Size " << pattern_size;
+        ASSERT_TRUE(aligned_ptr != nullptr) << "Pattern Size " << pattern_size;
 
-        err = clEnqueueMemFillINTEL(queue, aligned_host_ptr, vec_pattern,
+        err = clEnqueueMemFillINTEL(queue, aligned_ptr, vec_pattern,
                                     sizeof(vec_pattern), sizeof(vec_pattern), 0,
                                     nullptr, nullptr);
         EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
 
-        err = clMemBlockingFreeINTEL(context, aligned_host_ptr);
+        err = clMemBlockingFreeINTEL(context, aligned_ptr);
         ASSERT_SUCCESS(err) << "Pattern Size " << pattern_size;
       }
     }
   }
 
-  for (size_t pattern_size : valid_pattern_sizes) {
-    // Check if allocation already aligned, or we need a new aligned allocation
-    if (reinterpret_cast<uintptr_t>(device_ptr) % pattern_size == 0) {
-      err = clEnqueueMemFillINTEL(queue, device_ptr, vec_pattern, pattern_size,
-                                  pattern_size, 0, nullptr, nullptr);
-      EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
+  std::array<cl_event, MAX_NUM_POINTERS> wait_events;
+  size_t num_events = 0;
 
-      err = clEnqueueMemFillINTEL(queue, device_ptr, vec_pattern, pattern_size,
-                                  pattern_size * 3, 0, nullptr, nullptr);
-      EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
-    } else {
-      void *aligned_device_ptr = clDeviceMemAllocINTEL(
-          context, device, nullptr, bytes, sizeof(vec_pattern), &err);
-      ASSERT_SUCCESS(err) << "Pattern Size " << pattern_size;
-      ASSERT_TRUE(aligned_device_ptr != nullptr)
-          << "Pattern Size " << pattern_size;
-
-      err = clEnqueueMemFillINTEL(queue, aligned_device_ptr, vec_pattern,
-                                  sizeof(vec_pattern), sizeof(vec_pattern), 0,
-                                  nullptr, nullptr);
-      EXPECT_SUCCESS(err) << "Pattern Size " << pattern_size;
-
-      err = clMemBlockingFreeINTEL(context, aligned_device_ptr);
-      ASSERT_SUCCESS(err) << "Pattern Size " << pattern_size;
-    }
+  for (auto ptr : allPointers()) {
+    err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern),
+                                sizeof(pattern) * 2, 0, nullptr,
+                                &wait_events[num_events]);
+    EXPECT_SUCCESS(err);
+    num_events++;
   }
 
-  std::array<cl_event, 2> wait_events;
-  err = clEnqueueMemFillINTEL(queue, device_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern) * 2, 0, nullptr, &wait_events[0]);
-  EXPECT_SUCCESS(err);
-
-  if (host_ptr) {
-    err =
-        clEnqueueMemFillINTEL(queue, host_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern) * 2, 0, nullptr, &wait_events[1]);
-    EXPECT_SUCCESS(err);
-
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
-    err =
-        clEnqueueMemFillINTEL(queue, offset_host_ptr, pattern, sizeof(pattern),
-                              sizeof(pattern), 2, wait_events.data(), nullptr);
+  for (auto ptr : allPointers()) {
+    void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int));
+    err = clEnqueueMemFillINTEL(queue, offset_ptr, pattern, sizeof(pattern),
+                                sizeof(pattern), num_events, wait_events.data(),
+                                nullptr);
     EXPECT_SUCCESS(err);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
-  err = clEnqueueMemFillINTEL(
-      queue, offset_device_ptr, pattern, sizeof(pattern), sizeof(pattern),
-      host_ptr == nullptr ? 1 : 2, wait_events.data(), nullptr);
-  EXPECT_SUCCESS(err);
-
-  EXPECT_SUCCESS(clReleaseEvent(wait_events[0]));
-  if (host_ptr) {
-    EXPECT_SUCCESS(clReleaseEvent(wait_events[1]));
+  for (size_t i = 0; i < num_events; i++) {
+    EXPECT_SUCCESS(clReleaseEvent(wait_events[i]));
   }
 }
 
 // Test for invalid API usage of clEnqueueMemcpyINTEL()
 TEST_F(USMCommandQueueTest, Memcpy_InvalidUsage) {
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int) * 4);
+  for (auto ptr : allPointers()) {
+    void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int) * 4);
 
-  // No command queue
-  cl_int err =
-      clEnqueueMemcpyINTEL(nullptr, CL_TRUE, device_ptr, offset_device_ptr,
-                           sizeof(cl_int), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
+    // No command queue
+    cl_int err = clEnqueueMemcpyINTEL(nullptr, CL_TRUE, ptr, offset_ptr,
+                                      sizeof(cl_int), 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
 
-  cl_context other_context =
-      clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
-  ASSERT_TRUE(other_context);
-  ASSERT_SUCCESS(err);
+    cl_context other_context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    ASSERT_TRUE(other_context);
+    ASSERT_SUCCESS(err);
 
-  // Context of event different from context of queue
-  cl_event other_event = clCreateUserEvent(other_context, &err);
-  ASSERT_SUCCESS(err);
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, offset_device_ptr,
-                             sizeof(cl_int), 1, &other_event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
-  EXPECT_SUCCESS(clReleaseContext(other_context));
+    // Context of event different from context of queue
+    cl_event other_event = clCreateUserEvent(other_context, &err);
+    ASSERT_SUCCESS(err);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, offset_ptr, sizeof(cl_int),
+                               1, &other_event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
+    EXPECT_SUCCESS(clReleaseContext(other_context));
 
-  // NULL dst_ptr
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, nullptr, device_ptr,
-                             sizeof(cl_int), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // NULL dst_ptr
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, nullptr, ptr, sizeof(cl_int), 0,
+                               nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // NULL src_ptr
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, nullptr,
-                             sizeof(cl_int), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // NULL src_ptr
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, nullptr, sizeof(cl_int), 0,
+                               nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // Overlapping copy
-  void *overlap_device_ptr = getPointerOffset(device_ptr, 1);
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, overlap_device_ptr,
-                             sizeof(cl_int), 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_MEM_COPY_OVERLAP);
+    // Overlapping copy
+    void *overlap_ptr = getPointerOffset(ptr, 1);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, overlap_ptr, sizeof(cl_int),
+                               0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_MEM_COPY_OVERLAP);
 
-  // Non-zero num_wait_events with NULL wait events
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, offset_device_ptr,
-                             sizeof(cl_int), 1, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Non-zero num_wait_events with NULL wait events
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, offset_ptr, sizeof(cl_int),
+                               1, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  // Zero num_wait_events with non-NULL wait_event
-  cl_event event = clCreateUserEvent(context, &err);
-  ASSERT_SUCCESS(err);
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, offset_device_ptr,
-                             sizeof(cl_int), 0, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Zero num_wait_events with non-NULL wait_event
+    cl_event event = clCreateUserEvent(context, &err);
+    ASSERT_SUCCESS(err);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, offset_ptr, sizeof(cl_int),
+                               0, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  // blocking set to CL_TRUE with an event in the wait list which has failed,
-  // i.e has a negative integer event execution status
-  ASSERT_SUCCESS(clSetUserEventStatus(event, -1));
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, offset_device_ptr,
-                             sizeof(cl_int), 1, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
+    // blocking set to CL_TRUE with an event in the wait list which has failed,
+    // i.e has a negative integer event execution status
+    ASSERT_SUCCESS(clSetUserEventStatus(event, -1));
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, offset_ptr, sizeof(cl_int),
+                               1, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
 
-  // blocking set to CL_FALSE with an event in the wait list which has failed,
-  // i.e has a negative integer event execution status.
-  err = clEnqueueMemcpyINTEL(queue, CL_FALSE, device_ptr, offset_device_ptr,
-                             sizeof(cl_int), 1, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // blocking set to CL_FALSE with an event in the wait list which has failed,
+    // i.e has a negative integer event execution status.
+    err = clEnqueueMemcpyINTEL(queue, CL_FALSE, ptr, offset_ptr, sizeof(cl_int),
+                               1, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  EXPECT_SUCCESS(clReleaseEvent(event));
-  EXPECT_SUCCESS(clReleaseEvent(other_event));
+    EXPECT_SUCCESS(clReleaseEvent(event));
+    EXPECT_SUCCESS(clReleaseEvent(other_event));
+  }
 }
 
 // Test for valid API usage of clEnqueueMemcpyINTEL()
@@ -344,178 +293,156 @@ TEST_F(USMCommandQueueTest, Memcpy_ValidUsage) {
                            sizeof(cl_int), 0, nullptr, nullptr);
   EXPECT_SUCCESS(err);
 
-  if (host_ptr) {
+  cl_uchar user_data[64] = {0};
+  std::array<std::pair<void *, void *>, 3> pairs = {{
+      {(void *)&user_data, device_ptr},
+      {host_ptr, device_ptr},
+      {host_ptr, shared_ptr},
+  }};
+
+  for (auto pair : pairs) {
+    auto *ptr_a = pair.first;
+    auto *ptr_b = pair.second;
+    if (!ptr_a || !ptr_b) {
+      continue;
+    }
+    void *offset_ptr_a = getPointerOffset(ptr_a, sizeof(cl_int));
+    void *offset_ptr_b = getPointerOffset(ptr_b, sizeof(cl_int));
+
     cl_event event;
-    err = clEnqueueMemcpyINTEL(queue, CL_FALSE, device_ptr, host_ptr,
-                               sizeof(cl_int), 0, nullptr, &event);
+    err = clEnqueueMemcpyINTEL(queue, CL_FALSE, ptr_a, ptr_b, sizeof(cl_int), 0,
+                               nullptr, &event);
     EXPECT_SUCCESS(err);
 
-    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, host_ptr, device_ptr,
-                               sizeof(cl_int), 1, &event, nullptr);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr_b, ptr_a, sizeof(cl_int), 1,
+                               &event, nullptr);
     EXPECT_SUCCESS(err);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
-    err =
-        clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_host_ptr, offset_device_ptr,
-                             sizeof(cl_int), 0, nullptr, nullptr);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_ptr_b, offset_ptr_a,
+                               sizeof(cl_int), 0, nullptr, nullptr);
     EXPECT_SUCCESS(err);
-    err =
-        clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_device_ptr, offset_host_ptr,
-                             sizeof(cl_int), 0, nullptr, nullptr);
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_ptr_a, offset_ptr_b,
+                               sizeof(cl_int), 0, nullptr, nullptr);
     EXPECT_SUCCESS(err);
 
-    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_host_ptr, host_ptr,
+    err = clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_ptr_b, ptr_b,
                                sizeof(cl_int), 0, nullptr, nullptr);
     EXPECT_SUCCESS(err);
 
     EXPECT_SUCCESS(clReleaseEvent(event));
   }
-
-  // Copying from & to arbitrary host data is permitted by the spec
-  cl_uchar user_data[64] = {0};
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, user_data,
-                             sizeof(user_data), 0, nullptr, nullptr);
-  EXPECT_SUCCESS(err);
-
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, user_data, device_ptr,
-                             sizeof(user_data), 0, nullptr, nullptr);
-  EXPECT_SUCCESS(err);
-
-  cl_uchar *offset_user_ptr = user_data + sizeof(cl_ulong);
-  err = clEnqueueMemcpyINTEL(queue, CL_TRUE, offset_user_ptr, user_data,
-                             sizeof(cl_ulong), 0, nullptr, nullptr);
-  EXPECT_SUCCESS(err);
 }
 
 // Test for invalid API usage of clEnqueueMigrateMemINTEL()
 TEST_F(USMCommandQueueTest, MigrateMem_InvalidUsage) {
-  // Null queue
-  cl_int err =
-      clEnqueueMigrateMemINTEL(nullptr, device_ptr, bytes,
-                               CL_MIGRATE_MEM_OBJECT_HOST, 0, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
+  for (auto ptr : allPointers()) {
+    // Null queue
+    cl_int err = clEnqueueMigrateMemINTEL(
+        nullptr, ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
 
-  // Context mismatch  between event and queue device
-  cl_context other_context =
-      clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
-  ASSERT_TRUE(other_context);
-  ASSERT_SUCCESS(err);
+    // Context mismatch  between event and queue device
+    cl_context other_context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    ASSERT_TRUE(other_context);
+    ASSERT_SUCCESS(err);
 
-  cl_event event = clCreateUserEvent(other_context, &err);
-  err = clEnqueueMigrateMemINTEL(
-      queue, device_ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 1, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
-  EXPECT_SUCCESS(clReleaseContext(other_context));
+    cl_event event = clCreateUserEvent(other_context, &err);
+    err = clEnqueueMigrateMemINTEL(
+        queue, ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 1, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
+    EXPECT_SUCCESS(clReleaseContext(other_context));
 
-  // Flags is zero
-  err = clEnqueueMigrateMemINTEL(queue, device_ptr, bytes, 0, 0, nullptr,
-                                 nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // Flags is zero
+    err = clEnqueueMigrateMemINTEL(queue, ptr, bytes, 0, 0, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // Invalid Flags
-  cl_mem_migration_flags bad_flags = ~cl_mem_migration_flags(0);
-  err = clEnqueueMigrateMemINTEL(queue, device_ptr, bytes, bad_flags, 0,
-                                 nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    // Invalid Flags
+    cl_mem_migration_flags bad_flags = ~cl_mem_migration_flags(0);
+    err = clEnqueueMigrateMemINTEL(queue, ptr, bytes, bad_flags, 0, nullptr,
+                                   nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
-  // Non-zero num_wait_events with null wait_events
-  err =
-      clEnqueueMigrateMemINTEL(queue, device_ptr, bytes,
-                               CL_MIGRATE_MEM_OBJECT_HOST, 1, nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Non-zero num_wait_events with null wait_events
+    err = clEnqueueMigrateMemINTEL(
+        queue, ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 1, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  // Zero num_wait_events with non-null wait_events
-  err = clEnqueueMigrateMemINTEL(
-      queue, device_ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 0, &event, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Zero num_wait_events with non-null wait_events
+    err = clEnqueueMigrateMemINTEL(
+        queue, ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 0, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  EXPECT_SUCCESS(clReleaseEvent(event));
+    EXPECT_SUCCESS(clReleaseEvent(event));
+  }
 }
 
 // Test for valid API usage of clEnqueueMigrateMemINTEL()
 TEST_F(USMCommandQueueTest, MigrateMem_ValidUsage) {
-  std::array<cl_event, 2> events;
-  cl_int err = clEnqueueMigrateMemINTEL(queue, device_ptr, bytes,
-                                        CL_MIGRATE_MEM_OBJECT_HOST, 0, nullptr,
-                                        &events[0]);
-  EXPECT_SUCCESS(err);
-
-  if (host_ptr) {
-    err = clEnqueueMigrateMemINTEL(queue, host_ptr, bytes,
-                                   CL_MIGRATE_MEM_OBJECT_HOST, 0, nullptr,
-                                   &events[1]);
+  for (auto ptr : allPointers()) {
+    std::array<cl_event, 1> events;
+    cl_int err = clEnqueueMigrateMemINTEL(
+        queue, ptr, bytes, CL_MIGRATE_MEM_OBJECT_HOST, 0, nullptr, &events[0]);
     EXPECT_SUCCESS(err);
 
-    err = clEnqueueMigrateMemINTEL(queue, host_ptr, bytes,
+    err = clEnqueueMigrateMemINTEL(queue, ptr, bytes,
                                    CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED, 1,
-                                   &events[1], nullptr);
+                                   &events[0], nullptr);
     EXPECT_SUCCESS(err);
 
     err = clEnqueueMigrateMemINTEL(
-        queue, host_ptr, bytes,
+        queue, ptr, bytes,
         CL_MIGRATE_MEM_OBJECT_HOST | CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED, 0,
         nullptr, nullptr);
     EXPECT_SUCCESS(err);
-  }
 
-  err = clEnqueueMigrateMemINTEL(queue, device_ptr, bytes,
-                                 CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED, 1,
-                                 &events[0], nullptr);
-  EXPECT_SUCCESS(err);
-
-  err = clEnqueueMigrateMemINTEL(
-      queue, device_ptr, bytes,
-      CL_MIGRATE_MEM_OBJECT_HOST | CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED, 0,
-      nullptr, nullptr);
-  EXPECT_SUCCESS(err);
-
-  EXPECT_SUCCESS(clReleaseEvent(events[0]));
-  if (host_ptr) {
-    EXPECT_SUCCESS(clReleaseEvent(events[1]));
+    EXPECT_SUCCESS(clReleaseEvent(events[0]));
   }
 }
 
 // Test for invalid API usage of clEnqueueMemAdviseINTEL()
 TEST_F(USMCommandQueueTest, MemAdvise_InvalidUsage) {
-  // NULL command queue
-  cl_mem_advice_intel advice = 0;
-  cl_int err = clEnqueueMemAdviseINTEL(nullptr, device_ptr, bytes, advice, 0,
-                                       nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
+  for (auto ptr : allPointers()) {
+    // NULL command queue
+    cl_mem_advice_intel advice = 0;
+    cl_int err = clEnqueueMemAdviseINTEL(nullptr, ptr, bytes, advice, 0,
+                                         nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_COMMAND_QUEUE);
 
-  // Context mismatch between event and queue
-  cl_context other_context =
-      clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
-  ASSERT_TRUE(other_context);
-  ASSERT_SUCCESS(err);
+    // Context mismatch between event and queue
+    cl_context other_context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    ASSERT_TRUE(other_context);
+    ASSERT_SUCCESS(err);
 
-  cl_event event = clCreateUserEvent(other_context, &err);
-  err = clEnqueueMemAdviseINTEL(queue, device_ptr, bytes, advice, 1, &event,
-                                nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
-  EXPECT_SUCCESS(clReleaseContext(other_context));
+    cl_event event = clCreateUserEvent(other_context, &err);
+    err =
+        clEnqueueMemAdviseINTEL(queue, ptr, bytes, advice, 1, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
+    EXPECT_SUCCESS(clReleaseContext(other_context));
 
-  // Non-zero num_wait_events with NULL wait_events
-  err = clEnqueueMemAdviseINTEL(queue, device_ptr, bytes, advice, 1, nullptr,
-                                nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Non-zero num_wait_events with NULL wait_events
+    err =
+        clEnqueueMemAdviseINTEL(queue, ptr, bytes, advice, 1, nullptr, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  // Zero num_wait_events with non-NULL wait_events
-  err = clEnqueueMemAdviseINTEL(queue, device_ptr, bytes, advice, 0, &event,
-                                nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
+    // Zero num_wait_events with non-NULL wait_events
+    err =
+        clEnqueueMemAdviseINTEL(queue, ptr, bytes, advice, 0, &event, nullptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_EVENT_WAIT_LIST);
 
-  // Advice flag not supported by device
-  cl_mem_advice_intel bad_advice = 0x4208;  // values reserved but not defined
-  if (host_ptr) {
-    err = clEnqueueMemAdviseINTEL(queue, host_ptr, bytes, bad_advice, 0,
-                                  nullptr, nullptr);
+    // Advice flag not supported by device
+    cl_mem_advice_intel bad_advice = 0x4208;  // values reserved but not defined
+    if (host_ptr) {
+      err = clEnqueueMemAdviseINTEL(queue, host_ptr, bytes, bad_advice, 0,
+                                    nullptr, nullptr);
+      EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+    }
+
+    err = clEnqueueMemAdviseINTEL(queue, ptr, bytes, bad_advice, 0, nullptr,
+                                  nullptr);
     EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
+
+    EXPECT_SUCCESS(clReleaseEvent(event));
   }
-
-  err = clEnqueueMemAdviseINTEL(queue, device_ptr, bytes, bad_advice, 0,
-                                nullptr, nullptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
-
-  EXPECT_SUCCESS(clReleaseEvent(event));
 }

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
@@ -46,17 +46,11 @@ struct USMKernelTest : public cl_intel_unified_shared_memory_Test {
         device, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL,
         sizeof(host_capabilities), &host_capabilities, nullptr));
 
-    cl_int err;
-    if (host_capabilities) {
-      host_ptr = clHostMemAllocINTEL(context, nullptr, bytes, align, &err);
-      ASSERT_SUCCESS(err);
-      ASSERT_NE(host_ptr, nullptr);
-    }
-    device_ptr =
-        clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
-    ASSERT_SUCCESS(err);
-    ASSERT_NE(device_ptr, nullptr);
+    ASSERT_SUCCESS(clGetDeviceInfo(
+        device, CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+        sizeof(shared_capabilities), &shared_capabilities, nullptr));
 
+    initPointers(bytes, align);
     user_ptr = malloc(bytes);
 
     cl_device_unified_shared_memory_capabilities_intel single_capabilities,
@@ -70,14 +64,6 @@ struct USMKernelTest : public cl_intel_unified_shared_memory_Test {
   }
 
   void TearDown() override {
-    if (device_ptr) {
-      EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, device_ptr));
-    }
-
-    if (host_ptr) {
-      EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, host_ptr));
-    }
-
     if (user_ptr) {
       free(user_ptr);
     }
@@ -92,15 +78,11 @@ struct USMKernelTest : public cl_intel_unified_shared_memory_Test {
     cl_intel_unified_shared_memory_Test::TearDown();
   }
 
-  cl_device_unified_shared_memory_capabilities_intel host_capabilities = 0;
-
   const size_t elements = 64;
   const size_t bytes = elements * sizeof(cl_int);
   const cl_uint align = sizeof(cl_int);
 
-  void *host_ptr = nullptr;
   void *user_ptr = nullptr;
-  void *device_ptr = nullptr;
 
   cl_kernel kernel = nullptr;
   cl_program program = nullptr;
@@ -139,16 +121,13 @@ TEST_P(USMSetKernelArgMemPointerTest, InvalidUsage) {
   cl_int err = clSetKernelArgMemPointerINTEL(nullptr, 0, device_ptr);
   EXPECT_EQ_ERRCODE(err, CL_INVALID_KERNEL);
 
-  err = clSetKernelArgMemPointerINTEL(kernel, CL_UINT_MAX, device_ptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_INDEX);
+  for (auto ptr : allPointers()) {
+    err = clSetKernelArgMemPointerINTEL(kernel, CL_UINT_MAX, ptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_INDEX);
 
-  if (host_ptr) {
-    err = clSetKernelArgMemPointerINTEL(kernel, 4, host_ptr);
+    err = clSetKernelArgMemPointerINTEL(kernel, 4, ptr);
     EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_INDEX);
   }
-
-  err = clSetKernelArgMemPointerINTEL(kernel, 4, device_ptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_INDEX);
 
   // The cl_intel_unified_shared_memory specification has an open question
   // whether invalid pointers should result in an error. We accept this as Intel
@@ -157,41 +136,26 @@ TEST_P(USMSetKernelArgMemPointerTest, InvalidUsage) {
   err = clSetKernelArgMemPointerINTEL(kernel, usm_arg_index, user_ptr);
   ASSERT_SUCCESS(err);
 
-  if (host_ptr) {
-    err = clSetKernelArgMemPointerINTEL(kernel, 2, host_ptr);
+  for (auto ptr : allPointers()) {
+    err = clSetKernelArgMemPointerINTEL(kernel, 2, ptr);
+    EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_VALUE);
+
+    err = clSetKernelArgMemPointerINTEL(kernel, 3, ptr);
     EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_VALUE);
   }
-
-  err = clSetKernelArgMemPointerINTEL(kernel, 2, device_ptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_VALUE);
-
-  if (host_ptr) {
-    err = clSetKernelArgMemPointerINTEL(kernel, 3, host_ptr);
-    EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_VALUE);
-  }
-
-  err = clSetKernelArgMemPointerINTEL(kernel, 3, device_ptr);
-  EXPECT_EQ_ERRCODE(err, CL_INVALID_ARG_VALUE);
 }
 
 // Test for valid API usage of clSetKernelArgMemPointerINTEL()
 TEST_P(USMSetKernelArgMemPointerTest, ValidUsage) {
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
-
   cl_uint arg_index = GetParam();
 
-  if (host_ptr) {
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
-    EXPECT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, arg_index, host_ptr));
+  for (auto ptr : allPointers()) {
+    void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int));
+    EXPECT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, arg_index, ptr));
 
     EXPECT_SUCCESS(
-        clSetKernelArgMemPointerINTEL(kernel, arg_index, offset_host_ptr));
+        clSetKernelArgMemPointerINTEL(kernel, arg_index, offset_ptr));
   }
-
-  EXPECT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, arg_index, device_ptr));
-
-  EXPECT_SUCCESS(
-      clSetKernelArgMemPointerINTEL(kernel, arg_index, offset_device_ptr));
 
   EXPECT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, arg_index, nullptr));
 }
@@ -210,12 +174,7 @@ TEST_P(USMSetKernelExecInfoTest, ValidUsage) {
   const cl_kernel_exec_info param_name = GetParam();
 
   if (CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL == param_name) {
-    cargo::small_vector<void *, 2> indirect_usm_pointers;
-    ASSERT_EQ(cargo::success, indirect_usm_pointers.assign({device_ptr}));
-
-    if (host_ptr) {
-      ASSERT_EQ(cargo::success, indirect_usm_pointers.push_back(host_ptr));
-    }
+    cargo::small_vector<void *, 3> indirect_usm_pointers = allPointers();
 
     EXPECT_SUCCESS(
         clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
@@ -243,12 +202,7 @@ TEST_P(USMSetKernelExecInfoTest, InvalidUsage) {
     cl_int err = clSetKernelExecInfo(nullptr, param_name, 0, nullptr);
     EXPECT_EQ_ERRCODE(err, CL_INVALID_KERNEL);
 
-    cargo::small_vector<void *, 2> indirect_usm_pointers;
-    ASSERT_EQ(cargo::success, indirect_usm_pointers.assign({device_ptr}));
-
-    if (host_ptr) {
-      ASSERT_EQ(cargo::success, indirect_usm_pointers.push_back(host_ptr));
-    }
+    cargo::small_vector<void *, 3> indirect_usm_pointers = allPointers();
 
     // Invalid param_value_size
     err = clSetKernelExecInfo(kernel, param_name, 0,
@@ -320,19 +274,17 @@ struct USMVectorAddKernelTest : public USMKernelTest {
 
     cl_int err;
     if (host_capabilities) {
-      host_ptrA = clHostMemAllocINTEL(context, nullptr, bytes, align, &err);
-      ASSERT_SUCCESS(err);
-      ASSERT_NE(host_ptrA, nullptr);
-
       host_ptrB = clHostMemAllocINTEL(context, nullptr, bytes, align, &err);
       ASSERT_SUCCESS(err);
       ASSERT_NE(host_ptrB, nullptr);
     }
 
-    device_ptrA =
-        clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
-    ASSERT_SUCCESS(err);
-    ASSERT_NE(device_ptrA, nullptr);
+    if (shared_capabilities) {
+      shared_ptrB =
+          clSharedMemAllocINTEL(context, device, nullptr, bytes, align, &err);
+      ASSERT_SUCCESS(err);
+      ASSERT_NE(shared_ptrB, nullptr);
+    }
 
     device_ptrB =
         clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
@@ -343,6 +295,7 @@ struct USMVectorAddKernelTest : public USMKernelTest {
     ASSERT_SUCCESS(err);
     ASSERT_NE(cl_mem_buffer, nullptr);
 
+    initPointers(bytes, align);
     BuildKernel(source);
 
     queue = clCreateCommandQueue(context, device, 0, &err);
@@ -350,7 +303,7 @@ struct USMVectorAddKernelTest : public USMKernelTest {
     ASSERT_SUCCESS(err);
 
     // Initialize default value of input USM allocations
-    err = clEnqueueMemFillINTEL(queue, device_ptrA, &patternA, sizeof(patternA),
+    err = clEnqueueMemFillINTEL(queue, device_ptr, &patternA, sizeof(patternA),
                                 bytes, 0, nullptr, nullptr);
     ASSERT_SUCCESS(err);
 
@@ -359,7 +312,7 @@ struct USMVectorAddKernelTest : public USMKernelTest {
     ASSERT_SUCCESS(err);
 
     if (host_capabilities) {
-      err = clEnqueueMemFillINTEL(queue, host_ptrA, &patternA, sizeof(patternA),
+      err = clEnqueueMemFillINTEL(queue, host_ptr, &patternA, sizeof(patternA),
                                   bytes, 0, nullptr, nullptr);
       ASSERT_SUCCESS(err);
 
@@ -367,19 +320,26 @@ struct USMVectorAddKernelTest : public USMKernelTest {
                                   bytes, 0, nullptr, nullptr);
       ASSERT_SUCCESS(err);
     }
+
+    if (shared_capabilities) {
+      err = clEnqueueMemFillINTEL(queue, shared_ptr, &patternA,
+                                  sizeof(patternA), bytes, 0, nullptr, nullptr);
+      ASSERT_SUCCESS(err);
+
+      err = clEnqueueMemFillINTEL(queue, shared_ptrB, &patternB,
+                                  sizeof(patternB), bytes, 0, nullptr, nullptr);
+      ASSERT_SUCCESS(err);
+    }
   }
 
   void TearDown() override {
-    if (host_ptrA) {
-      EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, host_ptrA));
-    }
-
+    clMemBlockingFreeINTEL(context, (void *)0x3e18df0);
     if (host_ptrB) {
       EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, host_ptrB));
     }
 
-    if (device_ptrA) {
-      EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, device_ptrA));
+    if (shared_ptrB) {
+      EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, shared_ptrB));
     }
 
     if (device_ptrB) {
@@ -397,10 +357,9 @@ struct USMVectorAddKernelTest : public USMKernelTest {
     USMKernelTest::TearDown();
   }
 
-  void *host_ptrA = nullptr;
   void *host_ptrB = nullptr;
-  void *device_ptrA = nullptr;
   void *device_ptrB = nullptr;
+  void *shared_ptrB = nullptr;
   cl_mem cl_mem_buffer = nullptr;
 
   cl_command_queue queue = nullptr;
@@ -425,7 +384,7 @@ const cl_int USMVectorAddKernelTest::patternB = 0xA;
 // Two device USM allocation input arguments, and a cl_mem buffer output arg
 TEST_F(USMVectorAddKernelTest, DeviceInputs) {
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptrB));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
@@ -443,7 +402,7 @@ TEST_F(USMVectorAddKernelTest, HostInputs) {
   }
 
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, host_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, host_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, host_ptrB));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
@@ -454,16 +413,15 @@ TEST_F(USMVectorAddKernelTest, HostInputs) {
   verifyOutputBuffer(elements);
 }
 
-// Two USM input arguments, a host and a device allocation, with a cl_mem buffer
-// output argument.
-TEST_F(USMVectorAddKernelTest, HostDeviceInputs) {
-  if (!host_capabilities) {
+// Two shared USM allocation input arguments, and a cl_mem buffer output arg
+TEST_F(USMVectorAddKernelTest, SharedInputs) {
+  if (!shared_capabilities) {
     GTEST_SKIP();
   }
 
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, host_ptrA));
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptrB));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, shared_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, shared_ptrB));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
   // Run 1-D kernel with a global size of 'elements'
@@ -471,6 +429,34 @@ TEST_F(USMVectorAddKernelTest, HostDeviceInputs) {
                                         nullptr, 0, nullptr, nullptr));
 
   verifyOutputBuffer(elements);
+}
+
+// Multiple different types for arguments, with a cl_mem buffer output argument.
+TEST_F(USMVectorAddKernelTest, MixedInputs) {
+  const std::array<std::pair<void *, void *>, 6> options{{
+      {host_ptr, device_ptrB},
+      {host_ptr, shared_ptrB},
+      {shared_ptr, device_ptrB},
+      {device_ptr, host_ptrB},
+      {shared_ptr, host_ptrB},
+      {device_ptr, shared_ptrB},
+  }};
+
+  for (auto ptr : options) {
+    if (!ptr.first || !ptr.second) {
+      continue;
+    }
+    // Set kernel arguments
+    ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, ptr.first));
+    ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, ptr.second));
+    ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
+
+    // Run 1-D kernel with a global size of 'elements'
+    ASSERT_SUCCESS(clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &elements,
+                                          nullptr, 0, nullptr, nullptr));
+
+    verifyOutputBuffer(elements);
+  }
 }
 
 // Two device USM allocation input arguments, and a host USM allocation output
@@ -481,12 +467,12 @@ TEST_F(USMVectorAddKernelTest, HostOutput) {
   }
 
   // Zero host allocation as it'll be used for output argument
-  std::memset(host_ptrA, 0, bytes);
+  std::memset(host_ptr, 0, bytes);
 
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptrB));
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 2, host_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 2, host_ptr));
 
   // Run 1-D kernel with a global size of 'elements'
   ASSERT_SUCCESS(clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &elements,
@@ -494,7 +480,7 @@ TEST_F(USMVectorAddKernelTest, HostOutput) {
   ASSERT_SUCCESS(clFinish(queue));
 
   // Verify output result
-  const cl_int *output = static_cast<cl_int *>(host_ptrA);
+  const cl_int *output = static_cast<cl_int *>(host_ptr);
   for (size_t i = 0; i < elements; i++) {
     const cl_int reference = patternA + patternB + i;
     ASSERT_EQ(output[i], reference) << " index " << i;
@@ -510,14 +496,42 @@ TEST_F(USMVectorAddKernelTest, OffsetHostInput) {
 
   // Find pointer addressing halfway into the memory allocation
   const size_t half_bytes = bytes / 2;
-  void *offset_host_ptr = getPointerOffset(host_ptrA, half_bytes);
+  void *offset_host_ptr = getPointerOffset(host_ptr, half_bytes);
   ASSERT_SUCCESS(clEnqueueMemFillINTEL(queue, offset_host_ptr, &patternB,
                                        sizeof(patternB), half_bytes, 0, nullptr,
                                        nullptr));
 
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, host_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, host_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_host_ptr));
+  ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
+
+  // Run 1-D kernel with a global size equal to half the number of cl_int
+  // elements in the buffer
+  const size_t half_elements = elements / 2;
+  ASSERT_SUCCESS(clEnqueueNDRangeKernel(
+      queue, kernel, 1, nullptr, &half_elements, nullptr, 0, nullptr, nullptr));
+
+  verifyOutputBuffer(half_elements);
+}
+
+// A single shared USM allocation used across two input arguments, with a cl_mem
+// buffer output argument
+TEST_F(USMVectorAddKernelTest, OffsetSharedInput) {
+  if (!shared_capabilities) {
+    GTEST_SKIP();
+  }
+
+  // Find pointer addressing halfway into the memory allocation
+  const size_t half_bytes = bytes / 2;
+  void *offset_shared_ptr = getPointerOffset(shared_ptr, half_bytes);
+  ASSERT_SUCCESS(clEnqueueMemFillINTEL(queue, offset_shared_ptr, &patternB,
+                                       sizeof(patternB), half_bytes, 0, nullptr,
+                                       nullptr));
+
+  // Set kernel arguments
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, shared_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_shared_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
   // Run 1-D kernel with a global size equal to half the number of cl_int
@@ -534,13 +548,13 @@ TEST_F(USMVectorAddKernelTest, OffsetHostInput) {
 TEST_F(USMVectorAddKernelTest, OffsetDeviceInput) {
   // Find pointer addressing halfway into the memory allocation
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptrA, half_bytes);
+  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
   ASSERT_SUCCESS(clEnqueueMemFillINTEL(queue, offset_device_ptr, &patternB,
                                        sizeof(patternB), half_bytes, 0, nullptr,
                                        nullptr));
 
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
@@ -561,13 +575,13 @@ TEST_F(USMVectorAddKernelTest, OverwriteUSMArg) {
 
   // Find pointer addressing halfway into the memory allocation
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptrA, half_bytes);
+  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
 
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
   // Overwrite Pointer arg
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
 
   // Run 1-D kernel with a global size equal to half the number of cl_int
   // elements in the buffer
@@ -583,7 +597,7 @@ TEST_F(USMVectorAddKernelTest, OverwriteUSMArg) {
 TEST_F(USMVectorAddKernelTest, OverwriteCLMemArg) {
   // Find pointer addressing halfway into the memory allocation
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptrA, half_bytes);
+  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
   ASSERT_SUCCESS(clEnqueueMemFillINTEL(queue, offset_device_ptr, &patternB,
                                        sizeof(patternB), half_bytes, 0, nullptr,
                                        nullptr));
@@ -595,7 +609,7 @@ TEST_F(USMVectorAddKernelTest, OverwriteCLMemArg) {
 
   // Overwrite args
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
 
   // Run 1-D kernel with a global size equal to half the number of cl_int
   // elements in the buffer
@@ -609,7 +623,7 @@ TEST_F(USMVectorAddKernelTest, OverwriteCLMemArg) {
 // Tests setting kernel arguments without enqueuing the kernel
 TEST_F(USMVectorAddKernelTest, SetArgsWithoutEnqueue) {
   // Set kernel arguments
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptrB));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
@@ -617,7 +631,7 @@ TEST_F(USMVectorAddKernelTest, SetArgsWithoutEnqueue) {
   ASSERT_SUCCESS(clReleaseKernel(kernel));
   kernel = nullptr;
 
-  ASSERT_SUCCESS(clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptrA, device_ptrB,
+  ASSERT_SUCCESS(clEnqueueMemcpyINTEL(queue, CL_TRUE, device_ptr, device_ptrB,
                                       bytes, 0, nullptr, nullptr));
 }
 
@@ -631,11 +645,11 @@ TEST_F(USMVectorAddKernelTest, MultipleKernels) {
 
   // Set original kernel arguments
   const size_t half_bytes = bytes / 2;
-  void *offset_deviceA_ptr = getPointerOffset(device_ptrA, half_bytes);
+  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
   void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
 
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_deviceA_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
   // Set arguments on new kernel
@@ -668,11 +682,11 @@ TEST_F(USMVectorAddKernelTest, MultipleKernels) {
 TEST_F(USMVectorAddKernelTest, RepeatedEnqueue) {
   // Set kernel arguments
   const size_t half_bytes = bytes / 2;
-  void *offset_deviceA_ptr = getPointerOffset(device_ptrA, half_bytes);
+  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
   void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
 
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_deviceA_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 
   // Run 1-D kernel with a global size equal to half the number of cl_int
@@ -700,7 +714,7 @@ TEST_F(USMVectorAddKernelTest, ClonedKernel) {
   }
 
   // Set arguments on original kernel
-  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptrA));
+  ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptrB));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cl_mem_buffer));
 

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
@@ -82,9 +82,6 @@ struct USMMemInfoTest : public cl_intel_unified_shared_memory_Test {
   const cl_uint align = 4;
 
   void *user_ptr = nullptr;
-  void *host_ptr = nullptr;
-  void *shared_ptr = nullptr;
-  void *device_ptr = nullptr;
 };
 
 // Test for invalid API usage of clGetMemAllocInfoINTEL()

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_set.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_set.cpp
@@ -23,39 +23,15 @@ struct USMMemSetTest : public cl_intel_unified_shared_memory_Test {
   void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(cl_intel_unified_shared_memory_Test::SetUp());
 
-    cl_device_unified_shared_memory_capabilities_intel host_capabilities;
-    ASSERT_SUCCESS(clGetDeviceInfo(
-        device, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL,
-        sizeof(host_capabilities), &host_capabilities, nullptr));
+    initPointers(bytes, align);
 
     cl_int err;
-    if (host_capabilities) {
-      host_ptr = clHostMemAllocINTEL(context, nullptr, bytes, align, &err);
-      ASSERT_SUCCESS(err);
-      ASSERT_TRUE(host_ptr != nullptr);
-    }
-
-    device_ptr =
-        clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
-    ASSERT_SUCCESS(err);
-    ASSERT_TRUE(device_ptr != nullptr);
-
     queue = clCreateCommandQueue(context, device, 0, &err);
     ASSERT_TRUE(queue != nullptr);
     ASSERT_SUCCESS(err);
   }
 
   void TearDown() override {
-    if (device_ptr) {
-      cl_int err = clMemBlockingFreeINTEL(context, device_ptr);
-      EXPECT_SUCCESS(err);
-    }
-
-    if (host_ptr) {
-      cl_int err = clMemBlockingFreeINTEL(context, host_ptr);
-      EXPECT_SUCCESS(err);
-    }
-
     if (queue) {
       EXPECT_SUCCESS(clReleaseCommandQueue(queue));
     }
@@ -66,9 +42,6 @@ struct USMMemSetTest : public cl_intel_unified_shared_memory_Test {
   static const cl_uint elements = 8;
   static const size_t bytes = sizeof(cl_int) * elements;
   static const size_t align = sizeof(cl_int);
-
-  void *host_ptr = nullptr;
-  void *device_ptr = nullptr;
 
   cl_command_queue queue = nullptr;
 };
@@ -118,6 +91,46 @@ TEST_F(USMMemSetTest, DeviceAllocation) {
   if (host_ptr) {
     // Copy whole device allocation to host for result validation
     err = clEnqueueMemcpyINTEL(queue, CL_FALSE, host_ptr, device_ptr, bytes, 0,
+                               nullptr, nullptr);
+    EXPECT_SUCCESS(err);
+  }
+
+  EXPECT_SUCCESS(clFinish(queue));
+
+  if (host_ptr) {
+    cl_int *host_validation_ptr = reinterpret_cast<cl_int *>(host_ptr);
+    const cl_int correct_result[8] = {CL_INT_MAX, 0xA,        0xA,
+                                      0xA,        CL_INT_MIN, CL_INT_MIN,
+                                      CL_INT_MIN, CL_INT_MIN};
+    EXPECT_TRUE(0 == std::memcmp(host_validation_ptr, correct_result, bytes));
+  }
+}
+
+TEST_F(USMMemSetTest, SharedAllocation) {
+  if (!shared_ptr) {
+    GTEST_SKIP();
+  }
+
+  // Zero initialize whole shared allocation then fill with data using
+  // clEnqueueMemsetINTEL and validate allocation contents.
+  cl_int value = 0xA;
+  cl_int err = clEnqueueMemsetINTEL(queue, shared_ptr, value, bytes, 0, nullptr,
+                                    nullptr);
+  EXPECT_SUCCESS(err);
+  value = CL_INT_MAX;
+  err = clEnqueueMemsetINTEL(queue, shared_ptr, value, sizeof(value), 0,
+                             nullptr, nullptr);
+  EXPECT_SUCCESS(err);
+
+  void *offset_shared_ptr = getPointerOffset(shared_ptr, bytes / 2);
+  value = CL_INT_MIN;
+  err = clEnqueueMemsetINTEL(queue, offset_shared_ptr, value, bytes / 2, 0,
+                             nullptr, nullptr);
+  EXPECT_SUCCESS(err);
+
+  if (host_ptr) {
+    // Copy whole device allocation to host for result validation
+    err = clEnqueueMemcpyINTEL(queue, CL_FALSE, host_ptr, shared_ptr, bytes, 0,
                                nullptr, nullptr);
     EXPECT_SUCCESS(err);
   }

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -44,10 +44,6 @@ class MutableDispatchUSMTest : public MutableDispatchTest,
         clCreateCommandBufferKHR(1, &command_queue, properties, &error);
     ASSERT_SUCCESS(error);
 
-    ASSERT_SUCCESS(clGetDeviceInfo(
-        device, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL,
-        sizeof(host_capabilities), &host_capabilities, nullptr));
-
     if (host_capabilities) {
       for (auto &host_ptr : host_ptrs) {
         host_ptr = clHostMemAllocINTEL(context, nullptr, data_size_in_bytes,
@@ -123,8 +119,6 @@ void kernel usm_copy(__global int* in,
   std::array<void *, 2> device_ptrs = {nullptr, nullptr};
   cl_program program = nullptr;
   cl_kernel kernel = nullptr;
-
-  cl_device_unified_shared_memory_capabilities_intel host_capabilities = 0;
 
   constexpr static size_t global_size = 256;
   constexpr static size_t data_size_in_bytes = global_size * sizeof(cl_int);


### PR DESCRIPTION
# Overview
This is a small rework of the USM testing framework to make it easier to add new USM memory types in the future, and also adds shared USM support to many tests.

# Reason for change

USM shared memory testing was lacking, this improves it by adding USM testing to most tests that currently do both device and host tests. It also removes duplication in the test suite itself.

# Description of change
This change brings a lot of duplicated code into
`cl_intel_unified_shared_memory_Test` (the base class of many tests). Specifically, it provides properties to check host and shared memory USM support, and helper functions to generate USM pointers.

One of the design changes was adding a way to iterate through all available USM pointer types without having to copy-paste code. This is used to add shared allocations to many places alongside device and host allocations.

This results in the tests doing more work, but this only causes a 10% reduction in the time taken for testing, which is about 300ms on my system.


# Anything else we should know?
N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
