### PR TITLE
[compiler] Fix unchecked std::optional accesses

### DIFF
--- a/modules/compiler/utils/source/mux_builtin_info.cpp
+++ b/modules/compiler/utils/source/mux_builtin_info.cpp
@@ -1308,7 +1308,11 @@ std::optional<llvm::ConstantRange> BIMuxInfoConcept::getBuiltinRange(
         return std::nullopt;
       }
       uint64_t DimVal = cast<ConstantInt>(DimIdx)->getZExtValue();
-      if (DimVal >= SizesPtr->size() || !(*SizesPtr)[DimVal]) {
+      if (DimVal >= SizesPtr->size()) {
+        return std::nullopt;
+      }
+      std::optional<uint64_t> Size = (*SizesPtr)[DimVal];
+      if (!Size) {
         return std::nullopt;
       }
       // ID builtins range [0,size) (exclusive), and size builtins [1,size]
@@ -1317,9 +1321,8 @@ std::optional<llvm::ConstantRange> BIMuxInfoConcept::getBuiltinRange(
       const int SizeAdjust = ID == eMuxBuiltinGetLocalSize ||
                              ID == eMuxBuiltinGetEnqueuedLocalSize ||
                              ID == eMuxBuiltinGetGlobalSize;
-      return ConstantRange::getNonEmpty(
-          APInt(Bits, SizeAdjust),
-          APInt(Bits, *(*SizesPtr)[DimVal] + SizeAdjust));
+      return ConstantRange::getNonEmpty(APInt(Bits, SizeAdjust),
+                                        APInt(Bits, Size.value() + SizeAdjust));
     }
   }
 }

--- a/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
@@ -111,11 +111,17 @@ bool needsInstantiation(const VectorizationContext &Ctx, Instruction &I) {
   if (CallInst *CI = dyn_cast<CallInst>(&I)) {
     return analyzeCall(Ctx, CI);
   } else if (LoadInst *Load = dyn_cast<LoadInst>(&I)) {
-    MemOp Op = *MemOp::get(Load);
-    return analyzeMemOp(Op);
+    if (auto Op = MemOp::get(Load)) {
+      return analyzeMemOp(*Op);
+    }
+    // If it's not a MemOp, assume we don't need to instantiate.
+    return false;
   } else if (StoreInst *Store = dyn_cast<StoreInst>(&I)) {
-    MemOp Op = *MemOp::get(Store);
-    return analyzeMemOp(Op);
+    if (auto Op = MemOp::get(Store)) {
+      return analyzeMemOp(*Op);
+    }
+    // If it's not a MemOp, assume we don't need to instantiate.
+    return false;
   } else if (AllocaInst *Alloca = dyn_cast<AllocaInst>(&I)) {
     return analyzeAlloca(Ctx, Alloca);
   } else if (isa<AtomicRMWInst>(&I) || isa<AtomicCmpXchgInst>(&I)) {

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -2443,13 +2443,17 @@ Value *Packetizer::Impl::vectorizeInstruction(Instruction *Ins) {
 }
 
 ValuePacket Packetizer::Impl::packetizeLoad(LoadInst *Load) {
-  auto Op = *MemOp::get(Load);
-  return packetizeMemOp(Op);
+  if (auto Op = MemOp::get(Load)) {
+    return packetizeMemOp(*Op);
+  }
+  return ValuePacket{};
 }
 
 ValuePacket Packetizer::Impl::packetizeStore(StoreInst *Store) {
-  auto Op = *MemOp::get(Store);
-  return packetizeMemOp(Op);
+  if (auto Op = MemOp::get(Store)) {
+    return packetizeMemOp(*Op);
+  }
+  return ValuePacket{};
 }
 
 ValuePacket Packetizer::Impl::packetizeMemOp(MemOp &op) {


### PR DESCRIPTION
This cleans the project of the `bugprone-unchecked-optional-access` check which is present in newer versions of clang-tidy.

Some of these *are* checked as far as we're concerned, but clang-tidy can't know that that. Others are genuine oversights.