### PR TITLE
[NFC] Upgrade to clang-format-17.

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: setup-ubuntu-clang-format
         run:
-          pip install clang-format==16.0.6
+          pip install clang-format==17.0.6
 
       - name: run clang-format
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ find_package(PythonInterp 3.6 REQUIRED)
 # which perform static analysis and style checking on source files.
 # When updating the version here, also update that used in the merge request
 # config
-find_package(ClangTools 16 COMPONENTS clang-format)
+find_package(ClangTools 17 COMPONENTS clang-format)
 find_package(ClangTools 9 COMPONENTS clang-tidy)
 if(TARGET ClangTools::clang-tidy)
   ca_option(CA_CLANG_TIDY_FLAGS STRING

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install the dependencies on Ubuntu, open the terminal and run:
 To install the recommended packages, run:
 ```sh
    $ sudo apt install -y ninja-build doxygen python3-pip
-   $ sudo pip3 install lit virtualenv cmakelint clang-format==16.0.6
+   $ sudo pip3 install lit virtualenv cmakelint clang-format==17.0.6
 ```
 
 ### Compiling oneAPI Construction Kit 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -47,7 +47,7 @@ Recommended for Ubuntu 20.04
 
    $ sudo apt update
    $ sudo apt install -y ninja-build doxygen python3-pip
-   $ sudo pip3 install lit virtualenv cmakelint clang-format==16.0.6
+   $ sudo pip3 install lit virtualenv cmakelint clang-format==17.0.6
 
 .. tip::
    For ease of use ``python3`` and ``pip3`` can be symlinked to ``python`` and

--- a/modules/cargo/include/cargo/detail/expected.h
+++ b/modules/cargo/include/cargo/detail/expected.h
@@ -463,8 +463,8 @@ struct expected_operations_base<void, E> : expected_storage_base<void, E> {
 // This class manages conditionally having a trivial copy constructor
 // This specialization is for when T and E are trivially copy constructible
 template <class T, class E,
-          bool = is_void_or<T, is_trivially_copy_constructible<T>>::value
-              &&is_trivially_copy_constructible<E>::value>
+          bool = is_void_or<T, is_trivially_copy_constructible<T>>::value &&
+                 is_trivially_copy_constructible<E>::value>
 struct expected_copy_base : expected_operations_base<T, E> {
   using expected_operations_base<T, E>::expected_operations_base;
 };
@@ -491,8 +491,9 @@ struct expected_copy_base<T, E, false> : expected_operations_base<T, E> {
 
 // This class manages conditionally having a trivial move constructor
 template <class T, class E,
-          bool = is_void_or<T, std::is_trivially_move_constructible<T>>::value
-              &&std::is_trivially_move_constructible<E>::value>
+          bool =
+              is_void_or<T, std::is_trivially_move_constructible<T>>::value &&
+              std::is_trivially_move_constructible<E>::value>
 struct expected_move_base : expected_copy_base<T, E> {
   using expected_copy_base<T, E>::expected_copy_base;
 };
@@ -517,13 +518,15 @@ struct expected_move_base<T, E, false> : expected_copy_base<T, E> {
 };
 
 // This class manages conditionally having a trivial copy assignment operator
-template <class T, class E,
-          bool = is_void_or<T, conjunction<is_trivially_copy_assignable<T>,
-                                           is_trivially_copy_constructible<T>,
-                                           std::is_trivially_destructible<T>>>::
-              value &&is_trivially_copy_assignable<E>::value
-                  &&is_trivially_copy_constructible<E>::value
-                      &&std::is_trivially_destructible<E>::value>
+template <
+    class T, class E,
+    bool =
+        is_void_or<T, conjunction<is_trivially_copy_assignable<T>,
+                                  is_trivially_copy_constructible<T>,
+                                  std::is_trivially_destructible<T>>>::value &&
+        is_trivially_copy_assignable<E>::value &&
+        is_trivially_copy_constructible<E>::value &&
+        std::is_trivially_destructible<E>::value>
 struct expected_copy_assign_base : expected_move_base<T, E> {
   using expected_move_base<T, E>::expected_move_base;
 };
@@ -545,14 +548,15 @@ struct expected_copy_assign_base<T, E, false> : expected_move_base<T, E> {
 };
 
 // This class manages conditionally having a trivial move assignment operator
-template <class T, class E,
-          bool =
-              is_void_or<T, conjunction<std::is_trivially_destructible<T>,
-                                        std::is_trivially_move_constructible<T>,
-                                        std::is_trivially_move_assignable<T>>>::
-                  value &&std::is_trivially_destructible<E>::value
-                      &&std::is_trivially_move_constructible<E>::value
-                          &&std::is_trivially_move_assignable<E>::value>
+template <
+    class T, class E,
+    bool = is_void_or<
+               T, conjunction<std::is_trivially_destructible<T>,
+                              std::is_trivially_move_constructible<T>,
+                              std::is_trivially_move_assignable<T>>>::value &&
+           std::is_trivially_destructible<E>::value &&
+           std::is_trivially_move_constructible<E>::value &&
+           std::is_trivially_move_assignable<E>::value>
 struct expected_move_assign_base : expected_copy_assign_base<T, E> {
   using expected_copy_assign_base<T, E>::expected_copy_assign_base;
 };
@@ -570,10 +574,10 @@ struct expected_move_assign_base<T, E, false>
   expected_move_assign_base &operator=(const expected_move_assign_base &rhs) =
       default;
 
-  expected_move_assign_base &
-  operator=(expected_move_assign_base &&rhs) noexcept(
-      std::is_nothrow_move_constructible<T>::value
-          &&std::is_nothrow_move_assignable<T>::value) {
+  expected_move_assign_base &operator=(
+      expected_move_assign_base
+          &&rhs) noexcept(std::is_nothrow_move_constructible<T>::value &&
+                          std::is_nothrow_move_assignable<T>::value) {
     this->assign(std::move(rhs));
     return *this;
   }

--- a/modules/cargo/include/cargo/detail/optional.h
+++ b/modules/cargo/include/cargo/detail/optional.h
@@ -242,9 +242,9 @@ struct optional_move_base<T, false> : optional_copy_base<T> {
 };
 
 // This class manages conditionally having a trivial copy assignment operator
-template <class T, bool = is_trivially_copy_assignable<T>::value
-                       &&is_trivially_copy_constructible<T>::value
-                           &&std::is_trivially_destructible<T>::value>
+template <class T, bool = is_trivially_copy_assignable<T>::value &&
+                          is_trivially_copy_constructible<T>::value &&
+                          std::is_trivially_destructible<T>::value>
 struct optional_copy_assign_base : optional_move_base<T> {
   using optional_move_base<T>::optional_move_base;
 };
@@ -266,9 +266,9 @@ struct optional_copy_assign_base<T, false> : optional_move_base<T> {
 };
 
 // This class manages conditionally having a trivial move assignment operator
-template <class T, bool = std::is_trivially_destructible<T>::value
-                       &&std::is_trivially_move_constructible<T>::value
-                           &&std::is_trivially_move_assignable<T>::value>
+template <class T, bool = std::is_trivially_destructible<T>::value &&
+                          std::is_trivially_move_constructible<T>::value &&
+                          std::is_trivially_move_assignable<T>::value>
 struct optional_move_assign_base : optional_copy_assign_base<T> {
   using optional_copy_assign_base<T>::optional_copy_assign_base;
 };

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
@@ -179,7 +179,7 @@ template <>
 abacus_long mad_sat(const abacus_long x, const abacus_long y,
                     const abacus_long z) {
   const abacus_long mulSign = (x ^ y) & 0x8000000000000000;
-  const abacus_long zSign = (z)&0x8000000000000000;
+  const abacus_long zSign = (z) & 0x8000000000000000;
 
   const ulonger bX(__abacus_abs(x));
   const ulonger bY(__abacus_abs(y));

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -2042,7 +2042,7 @@ ValuePacket Packetizer::Impl::packetizeCall(CallInst *CI) {
       if (auto *const alloca = dyn_cast<AllocaInst>(ptr)) {
         if (!needsInstantiation(Ctx, *alloca)) {
           // If it's an alloca we can widen, we can just change the size
-          llvm::TypeSize const allocSize =
+          const llvm::TypeSize allocSize =
               Ctx.dataLayout()->getTypeAllocSize(alloca->getAllocatedType());
           const auto lifeSize =
               allocSize.isScalable() || SimdWidth.isScalable()

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -29,5 +29,4 @@ understanding and verifying your patch, please include it here.*
 * Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
 * Make sure the project builds successfully with your changes.
 * Run relevant testing locally to avoid regressions.
-* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
-  recent version available through `pip`) on all modified code.
+* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.

--- a/source/cl/test/UnitCL/source/Common.cpp
+++ b/source/cl/test/UnitCL/source/Common.cpp
@@ -70,13 +70,13 @@ void print_device_info_cl_device_type(cl_device_id device,
 
   bool matched = false;
 
-#define PRINT_MATCH(pname)    \
-  if ((pname)&param_value) {  \
-    if (matched) {            \
-      fprintf(stdout, " | "); \
-    }                         \
-    matched = true;           \
-    fprintf(stdout, #pname);  \
+#define PRINT_MATCH(pname)     \
+  if ((pname) & param_value) { \
+    if (matched) {             \
+      fprintf(stdout, " | ");  \
+    }                          \
+    matched = true;            \
+    fprintf(stdout, #pname);   \
   }
 
   PRINT_MATCH(CL_DEVICE_TYPE_CPU);
@@ -179,13 +179,13 @@ void print_device_info_cl_device_fp_config(cl_device_id device,
 
   bool matched = false;
 
-#define PRINT_MATCH(pname)    \
-  if ((pname)&param_value) {  \
-    if (matched) {            \
-      fprintf(stdout, " | "); \
-    }                         \
-    matched = true;           \
-    fprintf(stdout, #pname);  \
+#define PRINT_MATCH(pname)     \
+  if ((pname) & param_value) { \
+    if (matched) {             \
+      fprintf(stdout, " | ");  \
+    }                          \
+    matched = true;            \
+    fprintf(stdout, #pname);   \
   }
 
   PRINT_MATCH(CL_FP_DENORM);
@@ -281,13 +281,13 @@ void print_device_info_cl_device_exec_capabilities(
 
   bool matched = false;
 
-#define PRINT_MATCH(pname)    \
-  if ((pname)&param_value) {  \
-    if (matched) {            \
-      fprintf(stdout, " | "); \
-    }                         \
-    matched = true;           \
-    fprintf(stdout, #pname);  \
+#define PRINT_MATCH(pname)     \
+  if ((pname) & param_value) { \
+    if (matched) {             \
+      fprintf(stdout, " | ");  \
+    }                          \
+    matched = true;            \
+    fprintf(stdout, #pname);   \
   }
 
   PRINT_MATCH(CL_EXEC_KERNEL);
@@ -313,13 +313,13 @@ void print_device_info_cl_command_queue_properties(
 
   bool matched = false;
 
-#define PRINT_MATCH(pname)    \
-  if ((pname)&param_value) {  \
-    if (matched) {            \
-      fprintf(stdout, " | "); \
-    }                         \
-    matched = true;           \
-    fprintf(stdout, #pname);  \
+#define PRINT_MATCH(pname)     \
+  if ((pname) & param_value) { \
+    if (matched) {             \
+      fprintf(stdout, " | ");  \
+    }                          \
+    matched = true;            \
+    fprintf(stdout, #pname);   \
   }
 
   PRINT_MATCH(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE);
@@ -410,13 +410,13 @@ void print_device_info_cl_device_affinity_domain(
 
   bool matched = false;
 
-#define PRINT_MATCH(pname)    \
-  if ((pname)&param_value) {  \
-    if (matched) {            \
-      fprintf(stdout, " | "); \
-    }                         \
-    matched = true;           \
-    fprintf(stdout, #pname);  \
+#define PRINT_MATCH(pname)     \
+  if ((pname) & param_value) { \
+    if (matched) {             \
+      fprintf(stdout, " | ");  \
+    }                          \
+    matched = true;            \
+    fprintf(stdout, #pname);   \
   }
 
   PRINT_MATCH(CL_DEVICE_AFFINITY_DOMAIN_NUMA);
@@ -1142,13 +1142,13 @@ size_t UCL::getPixelSize(const cl_image_format &format) {
 #define SIZE(ELEMENTS, DATA_TYPE) \
   switch (DATA_TYPE) {            \
     case CL_SNORM_INT8:           \
-      return (ELEMENTS)*1;        \
+      return (ELEMENTS) * 1;      \
     case CL_SNORM_INT16:          \
-      return (ELEMENTS)*2;        \
+      return (ELEMENTS) * 2;      \
     case CL_UNORM_INT8:           \
-      return (ELEMENTS)*1;        \
+      return (ELEMENTS) * 1;      \
     case CL_UNORM_INT16:          \
-      return (ELEMENTS)*2;        \
+      return (ELEMENTS) * 2;      \
     case CL_UNORM_SHORT_565:      \
       return 2;                   \
     case CL_UNORM_SHORT_555:      \
@@ -1156,23 +1156,23 @@ size_t UCL::getPixelSize(const cl_image_format &format) {
     case CL_UNORM_INT_101010:     \
       return 4;                   \
     case CL_SIGNED_INT8:          \
-      return (ELEMENTS)*1;        \
+      return (ELEMENTS) * 1;      \
     case CL_SIGNED_INT16:         \
-      return (ELEMENTS)*2;        \
+      return (ELEMENTS) * 2;      \
     case CL_SIGNED_INT32:         \
-      return (ELEMENTS)*4;        \
+      return (ELEMENTS) * 4;      \
     case CL_UNSIGNED_INT8:        \
-      return (ELEMENTS)*1;        \
+      return (ELEMENTS) * 1;      \
     case CL_UNSIGNED_INT16:       \
-      return (ELEMENTS)*2;        \
+      return (ELEMENTS) * 2;      \
     case CL_UNSIGNED_INT32:       \
-      return (ELEMENTS)*4;        \
+      return (ELEMENTS) * 4;      \
     case CL_HALF_FLOAT:           \
-      return (ELEMENTS)*2;        \
+      return (ELEMENTS) * 2;      \
     case CL_FLOAT:                \
-      return (ELEMENTS)*4;        \
+      return (ELEMENTS) * 4;      \
     default:                      \
-      return (ELEMENTS)*0;        \
+      return (ELEMENTS) * 0;      \
   }
   switch (format.image_channel_order) {
     case CL_R:


### PR DESCRIPTION
# Overview

[NFC] Upgrade to clang-format-17.

# Reason for change

We can see in the diff that clang-format-17 is better able to figure out when (A)*b and (A)&b are a cast and when they are a binary operator.

# Description of change

* CMakeLists.txt is updated to look for clang-format-17.
* Documentation is updated to refer to clang-format-17.
* CI is updated to install clang-format-17.
* Code is reformatted with clang-format-17.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.