### PR TITLE
Fix building documentation.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,10 @@
 # Documentation generator.
 sphinx==4.5.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 # Markdown -> Sphinx extension.
 myst-parser==0.15.2
 linkify-it-py==1.0.2


### PR DESCRIPTION
# Overview

Fix building documentation.

# Reason for change

Sphinx 4.5.0 does not specify which versions of sphinxcontrib-* it needs and later versions have been released which no longer support Sphinx 4.

# Description of change

To unblock CI, as a first step, use specific older versions.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-16](https://clang.llvm.org/docs/ClangFormat.html) (the most
  recent version available through `pip`) on all modified code.
