### PR TITLE
[NFC] Use *_t and *_v type traits.

### DIFF
--- a/modules/cargo/include/cargo/array_view.h
+++ b/modules/cargo/include/cargo/array_view.h
@@ -102,7 +102,7 @@ class array_view {
   /// @tparam Container Type of the array like container.
   /// @param container Reference to the container to view.
   template <class Container,
-            enable_if_t<
+            std::enable_if_t<
 #if !defined(_MSC_VER) || \
     (defined(_MSC_VER) && !(_MSC_VER >= 1910 && _MSC_VER < 1921))
                 // Disabled for Visual Studio 2017 due to a regression

--- a/modules/cargo/include/cargo/detail/optional.h
+++ b/modules/cargo/include/cargo/detail/optional.h
@@ -39,11 +39,11 @@ struct is_optional_impl : std::false_type {};
 template <class T>
 struct is_optional_impl<optional<T>> : std::true_type {};
 template <class T>
-using is_optional = is_optional_impl<decay_t<T>>;
+using is_optional = is_optional_impl<std::decay_t<T>>;
 
 // Change void to cargo::monostate
 template <class U>
-using fixup_void = conditional_t<std::is_void<U>::value, monostate, U>;
+using fixup_void = std::conditional_t<std::is_void_v<U>, monostate, U>;
 
 template <class F, class U, class = invoke_result_t<F, U>>
 using get_map_return = optional<fixup_void<invoke_result_t<F, U>>>;
@@ -52,62 +52,62 @@ using get_map_return = optional<fixup_void<invoke_result_t<F, U>>>;
 template <class F, class = void, class... U>
 struct returns_void_impl;
 template <class F, class... U>
-struct returns_void_impl<F, void_t<invoke_result_t<F, U...>>, U...>
+struct returns_void_impl<F, std::void_t<invoke_result_t<F, U...>>, U...>
     : std::is_void<invoke_result_t<F, U...>> {};
 template <class F, class... U>
 using returns_void = returns_void_impl<F, void, U...>;
 
 template <class T, class... U>
-using enable_if_ret_void = enable_if_t<returns_void<T &&, U...>::value>;
+using enable_if_ret_void = std::enable_if_t<returns_void<T &&, U...>::value>;
 
 template <class T, class... U>
-using disable_if_ret_void = enable_if_t<!returns_void<T &&, U...>::value>;
+using disable_if_ret_void = std::enable_if_t<!returns_void<T &&, U...>::value>;
 
 template <class T, class U>
 using enable_forward_value =
-    enable_if_t<std::is_constructible<T, U &&>::value &&
-                !std::is_same<decay_t<U>, in_place_t>::value &&
-                !std::is_same<optional<T>, decay_t<U>>::value>;
+    std::enable_if_t<std::is_constructible_v<T, U &&> &&
+                     !std::is_same_v<std::decay_t<U>, in_place_t> &&
+                     !std::is_same_v<optional<T>, std::decay_t<U>>>;
 
 template <class T, class U, class Other>
 using enable_from_other =
-    enable_if_t<std::is_constructible<T, Other>::value &&
-                !std::is_constructible<T, optional<U> &>::value &&
-                !std::is_constructible<T, optional<U> &&>::value &&
-                !std::is_constructible<T, const optional<U> &>::value &&
-                !std::is_constructible<T, const optional<U> &&>::value &&
-                !std::is_convertible<optional<U> &, T>::value &&
-                !std::is_convertible<optional<U> &&, T>::value &&
-                !std::is_convertible<const optional<U> &, T>::value &&
-                !std::is_convertible<const optional<U> &&, T>::value>;
+    std::enable_if_t<std::is_constructible_v<T, Other> &&
+                     !std::is_constructible_v<T, optional<U> &> &&
+                     !std::is_constructible_v<T, optional<U> &&> &&
+                     !std::is_constructible_v<T, const optional<U> &> &&
+                     !std::is_constructible_v<T, const optional<U> &&> &&
+                     !std::is_convertible_v<optional<U> &, T> &&
+                     !std::is_convertible_v<optional<U> &&, T> &&
+                     !std::is_convertible_v<const optional<U> &, T> &&
+                     !std::is_convertible_v<const optional<U> &&, T>>;
 
 template <class T, class U>
-using enable_assign_forward = enable_if_t<
-    !std::is_same<optional<T>, decay_t<U>>::value &&
-    !conjunction<std::is_scalar<T>, std::is_same<T, decay_t<U>>>::value &&
-    std::is_constructible<T, U>::value && std::is_assignable<T &, U>::value>;
+using enable_assign_forward = std::enable_if_t<
+    !std::is_same_v<optional<T>, std::decay_t<U>> &&
+    !conjunction<std::is_scalar<T>, std::is_same<T, std::decay_t<U>>>::value &&
+    std::is_constructible_v<T, U> && std::is_assignable_v<T &, U>>;
 
 template <class T, class U, class Other>
 using enable_assign_from_other =
-    enable_if_t<std::is_constructible<T, Other>::value &&
-                std::is_assignable<T &, Other>::value &&
-                !std::is_constructible<T, optional<U> &>::value &&
-                !std::is_constructible<T, optional<U> &&>::value &&
-                !std::is_constructible<T, const optional<U> &>::value &&
-                !std::is_constructible<T, const optional<U> &&>::value &&
-                !std::is_convertible<optional<U> &, T>::value &&
-                !std::is_convertible<optional<U> &&, T>::value &&
-                !std::is_convertible<const optional<U> &, T>::value &&
-                !std::is_convertible<const optional<U> &&, T>::value &&
-                !std::is_assignable<T &, optional<U> &>::value &&
-                !std::is_assignable<T &, optional<U> &&>::value &&
-                !std::is_assignable<T &, const optional<U> &>::value &&
-                !std::is_assignable<T &, const optional<U> &&>::value>;
+    std::enable_if_t<std::is_constructible_v<T, Other> &&
+                     std::is_assignable_v<T &, Other> &&
+                     !std::is_constructible_v<T, optional<U> &> &&
+                     !std::is_constructible_v<T, optional<U> &&> &&
+                     !std::is_constructible_v<T, const optional<U> &> &&
+                     !std::is_constructible_v<T, const optional<U> &&> &&
+                     !std::is_convertible_v<optional<U> &, T> &&
+                     !std::is_convertible_v<optional<U> &&, T> &&
+                     !std::is_convertible_v<const optional<U> &, T> &&
+                     !std::is_convertible_v<const optional<U> &&, T> &&
+                     !std::is_assignable_v<T &, optional<U> &> &&
+                     !std::is_assignable_v<T &, optional<U> &&> &&
+                     !std::is_assignable_v<T &, const optional<U> &> &&
+                     !std::is_assignable_v<T &, const optional<U> &&>>;
 
 // The storage base manages the actual storage, and correctly propagates
 // trivial destruction from T This case is for when T is trivially
 // destructible
-template <class T, bool = std::is_trivially_destructible<T>::value>
+template <class T, bool = std::is_trivially_destructible_v<T>>
 struct optional_storage_base {
   constexpr optional_storage_base() : m_dummy(0), m_has_value(false) {}
 
@@ -192,7 +192,7 @@ struct optional_operations_base : optional_storage_base<T> {
 
 // This class manages conditionally having a trivial copy constructor
 // This specialization is for when T is trivially copy constructible
-template <class T, bool = is_trivially_copy_constructible<T>::value>
+template <class T, bool = std::is_trivially_copy_constructible_v<T>>
 struct optional_copy_base : optional_operations_base<T> {
   using optional_operations_base<T>::optional_operations_base;
 };
@@ -218,7 +218,7 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
 };
 
 // This class manages conditionally having a trivial move constructor
-template <class T, bool = std::is_trivially_move_constructible<T>::value>
+template <class T, bool = std::is_trivially_move_constructible_v<T>>
 struct optional_move_base : optional_copy_base<T> {
   using optional_copy_base<T>::optional_copy_base;
 };
@@ -242,9 +242,9 @@ struct optional_move_base<T, false> : optional_copy_base<T> {
 };
 
 // This class manages conditionally having a trivial copy assignment operator
-template <class T, bool = is_trivially_copy_assignable<T>::value &&
-                          is_trivially_copy_constructible<T>::value &&
-                          std::is_trivially_destructible<T>::value>
+template <class T, bool = std::is_trivially_copy_assignable_v<T> &&
+                          std::is_trivially_copy_constructible_v<T> &&
+                          std::is_trivially_destructible_v<T>>
 struct optional_copy_assign_base : optional_move_base<T> {
   using optional_move_base<T>::optional_move_base;
 };
@@ -266,9 +266,9 @@ struct optional_copy_assign_base<T, false> : optional_move_base<T> {
 };
 
 // This class manages conditionally having a trivial move assignment operator
-template <class T, bool = std::is_trivially_destructible<T>::value &&
-                          std::is_trivially_move_constructible<T>::value &&
-                          std::is_trivially_move_assignable<T>::value>
+template <class T, bool = std::is_trivially_destructible_v<T> &&
+                          std::is_trivially_move_constructible_v<T> &&
+                          std::is_trivially_move_assignable_v<T>>
 struct optional_move_assign_base : optional_copy_assign_base<T> {
   using optional_copy_assign_base<T>::optional_copy_assign_base;
 };

--- a/modules/cargo/include/cargo/endian.h
+++ b/modules/cargo/include/cargo/endian.h
@@ -64,10 +64,10 @@ constexpr bool is_little_endian() { return detail::endianness_helper::little; }
 /// @brief Reads an integer into the native endian format from a little-endian
 /// byte iterator.
 template <typename InputIterator>
-typename cargo::enable_if_t<
-    std::is_same<cargo::remove_const_t<
-                     typename std::iterator_traits<InputIterator>::reference>,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<std::remove_const_t<
+                       typename std::iterator_traits<InputIterator>::reference>,
+                   uint8_t &>,
     InputIterator>
 read_little_endian(uint8_t *v, InputIterator it) {
   *v = *it++;
@@ -77,10 +77,10 @@ read_little_endian(uint8_t *v, InputIterator it) {
 /// @brief Reads an integer into the native endian format from a little-endian
 /// byte iterator.
 template <typename InputIterator>
-typename cargo::enable_if_t<
-    std::is_same<cargo::remove_const_t<
-                     typename std::iterator_traits<InputIterator>::reference>,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<std::remove_const_t<
+                       typename std::iterator_traits<InputIterator>::reference>,
+                   uint8_t &>,
     InputIterator>
 read_little_endian(uint16_t *v, InputIterator it) {
   *v = *it++;
@@ -91,10 +91,10 @@ read_little_endian(uint16_t *v, InputIterator it) {
 /// @brief Reads an integer into the native endian format from a little-endian
 /// byte iterator.
 template <typename InputIterator>
-typename cargo::enable_if_t<
-    std::is_same<cargo::remove_const_t<
-                     typename std::iterator_traits<InputIterator>::reference>,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<std::remove_const_t<
+                       typename std::iterator_traits<InputIterator>::reference>,
+                   uint8_t &>,
     InputIterator>
 read_little_endian(uint32_t *v, InputIterator it) {
   *v = *it++;
@@ -107,10 +107,10 @@ read_little_endian(uint32_t *v, InputIterator it) {
 /// @brief Reads an integer into the native endian format from a little-endian
 /// byte iterator.
 template <typename InputIterator>
-typename cargo::enable_if_t<
-    std::is_same<cargo::remove_const_t<
-                     typename std::iterator_traits<InputIterator>::reference>,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<std::remove_const_t<
+                       typename std::iterator_traits<InputIterator>::reference>,
+                   uint8_t &>,
     InputIterator>
 read_little_endian(uint64_t *v, InputIterator it) {
   *v = *it++;
@@ -127,15 +127,15 @@ read_little_endian(uint64_t *v, InputIterator it) {
 /// @brief Reads an integer into the native endian format from a big-endian
 /// byte iterator.
 template <typename Integer, typename InputIterator>
-typename cargo::enable_if_t<
-    std::is_same<cargo::remove_const_t<
-                     typename std::iterator_traits<InputIterator>::reference>,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<std::remove_const_t<
+                       typename std::iterator_traits<InputIterator>::reference>,
+                   uint8_t &>,
     InputIterator>
 read_big_endian(Integer *v, InputIterator it) {
   // read from little-endian to native and swap to achieve the same effect as a
   // big-endian read with less code duplication
-  typename std::remove_cv<Integer>::type le;
+  std::remove_cv_t<Integer> le;
   it = read_little_endian(&le, it);
   *v = byte_swap(le);
   return it;
@@ -144,9 +144,9 @@ read_big_endian(Integer *v, InputIterator it) {
 /// @brief Writes a native-endian integer to a little-endian stream byte
 /// iterator.
 template <typename OutputIterator>
-typename cargo::enable_if_t<
-    std::is_same<typename std::iterator_traits<OutputIterator>::reference,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<typename std::iterator_traits<OutputIterator>::reference,
+                   uint8_t &>,
     OutputIterator>
 write_little_endian(uint8_t v, OutputIterator it) {
   *it++ = v;
@@ -156,9 +156,9 @@ write_little_endian(uint8_t v, OutputIterator it) {
 /// @brief Writes a native-endian integer to a little-endian stream byte
 /// iterator.
 template <typename OutputIterator>
-typename cargo::enable_if_t<
-    std::is_same<typename std::iterator_traits<OutputIterator>::reference,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<typename std::iterator_traits<OutputIterator>::reference,
+                   uint8_t &>,
     OutputIterator>
 write_little_endian(uint16_t v, OutputIterator it) {
   *it++ = v & 0xFF;
@@ -169,9 +169,9 @@ write_little_endian(uint16_t v, OutputIterator it) {
 /// @brief Writes a native-endian integer to a little-endian stream byte
 /// iterator.
 template <typename OutputIterator>
-typename cargo::enable_if_t<
-    std::is_same<typename std::iterator_traits<OutputIterator>::reference,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<typename std::iterator_traits<OutputIterator>::reference,
+                   uint8_t &>,
     OutputIterator>
 write_little_endian(uint32_t v, OutputIterator it) {
   *it++ = v & 0xFF;
@@ -184,9 +184,9 @@ write_little_endian(uint32_t v, OutputIterator it) {
 /// @brief Writes a native-endian integer to a little-endian stream byte
 /// iterator.
 template <typename OutputIterator>
-typename cargo::enable_if_t<
-    std::is_same<typename std::iterator_traits<OutputIterator>::reference,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<typename std::iterator_traits<OutputIterator>::reference,
+                   uint8_t &>,
     OutputIterator>
 write_little_endian(uint64_t v, OutputIterator it) {
   *it++ = v & 0xFF;
@@ -202,9 +202,9 @@ write_little_endian(uint64_t v, OutputIterator it) {
 
 /// @brief Writes a native-endian integer to a big-endian stream byte iterator.
 template <typename Integer, typename OutputIterator>
-typename cargo::enable_if_t<
-    std::is_same<typename std::iterator_traits<OutputIterator>::reference,
-                 uint8_t &>::value,
+typename std::enable_if_t<
+    std::is_same_v<typename std::iterator_traits<OutputIterator>::reference,
+                   uint8_t &>,
     OutputIterator>
 write_big_endian(Integer v, OutputIterator it) {
   // write swapped native to little-endian to achieve the same effect as a

--- a/modules/cargo/include/cargo/error.h
+++ b/modules/cargo/include/cargo/error.h
@@ -97,7 +97,7 @@ enum result : int32_t {
 template <class T>
 class error_or {
  public:
-  using value_type = typename std::remove_reference<T>::type;
+  using value_type = std::remove_reference_t<T>;
   using pointer = value_type *;
   using const_pointer = const value_type *;
   using reference = value_type &;
@@ -129,9 +129,9 @@ class error_or {
   /// @param first First argument.
   /// @param args Variadic arguments.
   template <class First, class... Args,
-            class = enable_if_t<
+            class = std::enable_if_t<
                 !(sizeof...(Args) == 0 &&
-                  std::is_same<error_or, remove_reference_t<First>>::value)>>
+                  std::is_same_v<error_or, std::remove_reference_t<First>>)>>
   error_or(First &&first, Args &&...args) : HasError(false) {
     new (&ValueStorage) value_storage_type(std::forward<First>(first),
                                            std::forward<Args>(args)...);

--- a/modules/cargo/include/cargo/function_ref.h
+++ b/modules/cargo/include/cargo/function_ref.h
@@ -58,16 +58,16 @@ class function_ref<R(Args...)> {
   /// Constructs a `function_ref` referring to `f`.
   ///
   /// \synopsis template <typename F> constexpr function_ref(F &&f) noexcept
-  template <typename F,
-            enable_if_t<!std::is_same<decay_t<F>, function_ref>::value &&
-                        is_invocable_r<R, F &&, Args...>::value> * = nullptr>
+  template <
+      typename F,
+      std::enable_if_t<!std::is_same_v<std::decay_t<F>, function_ref> &&
+                       is_invocable_r<R, F &&, Args...>::value> * = nullptr>
   constexpr function_ref(F &&f) noexcept
       : obj_(const_cast<void *>(
             reinterpret_cast<const void *>(std::addressof(f)))) {
     callback_ = [](void *obj, Args... args) -> R {
-      return cargo::invoke(
-          *reinterpret_cast<typename std::add_pointer<F>::type>(obj),
-          std::forward<Args>(args)...);
+      return cargo::invoke(*reinterpret_cast<std::add_pointer_t<F>>(obj),
+                           std::forward<Args>(args)...);
     };
   }
 
@@ -79,14 +79,14 @@ class function_ref<R(Args...)> {
   ///
   /// \synopsis template <typename F> constexpr function_ref &operator=(F &&f)
   /// noexcept;
-  template <typename F,
-            enable_if_t<is_invocable_r<R, F &&, Args...>::value> * = nullptr>
+  template <
+      typename F,
+      std::enable_if_t<is_invocable_r<R, F &&, Args...>::value> * = nullptr>
   constexpr function_ref<R(Args...)> &operator=(F &&f) noexcept {
     obj_ = reinterpret_cast<void *>(std::addressof(f));
     callback_ = [](void *obj, Args... args) {
-      return cargo::invoke(
-          *reinterpret_cast<typename std::add_pointer<F>::type>(obj),
-          std::forward<Args>(args)...);
+      return cargo::invoke(*reinterpret_cast<std::add_pointer_t<F>>(obj),
+                           std::forward<Args>(args)...);
     };
 
     return *this;

--- a/modules/cargo/include/cargo/functional.h
+++ b/modules/cargo/include/cargo/functional.h
@@ -40,8 +40,9 @@ namespace cargo {
 /// @param args Arguments to call the function with
 ///
 /// @return The result of calling `f` with the given arguments.
-template <typename Fn, typename... Args,
-          enable_if_t<std::is_member_pointer<decay_t<Fn>>::value> * = nullptr>
+template <
+    typename Fn, typename... Args,
+    std::enable_if_t<std::is_member_pointer_v<std::decay_t<Fn>>> * = nullptr>
 constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
     noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
     -> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
@@ -57,8 +58,9 @@ constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
 /// @param args Arguments to call the function with
 ///
 /// @return The result of calling `f` with the given arguments.
-template <typename Fn, typename... Args,
-          enable_if_t<!std::is_member_pointer<decay_t<Fn>>::value> * = nullptr>
+template <
+    typename Fn, typename... Args,
+    std::enable_if_t<!std::is_member_pointer_v<std::decay_t<Fn>>> * = nullptr>
 constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
     noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
     -> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
@@ -119,8 +121,8 @@ using is_invocable_r =
 /// @tparam T Type to wrap if it is a reference.
 template <class T>
 using wrap_reference_t =
-    conditional_t<std::is_reference<T>::value,
-                  std::reference_wrapper<remove_reference_t<T>>, T>;
+    std::conditional_t<std::is_reference_v<T>,
+                       std::reference_wrapper<std::remove_reference_t<T>>, T>;
 
 /// @}
 }  // namespace cargo

--- a/modules/cargo/include/cargo/small_vector.h
+++ b/modules/cargo/include/cargo/small_vector.h
@@ -74,7 +74,7 @@ namespace cargo {
 /// @tparam N Capacity of the embedded storage.
 template <class T, size_t N, class A = mallocator<T>>
 class small_vector {
-  using storage_type = aligned_storage_t<sizeof(T), alignof(T)>;
+  using storage_type = std::aligned_storage_t<sizeof(T), alignof(T)>;
 
  public:
   using value_type = T;
@@ -220,8 +220,8 @@ class small_vector {
   /// @return Returns `cargo::bad_alloc` on allocation failure, `cargo::success`
   /// otherwise.
   template <class InputIterator>
-  [[nodiscard]] enable_if_t<is_input_iterator<InputIterator>::value,
-                            cargo::result>
+  [[nodiscard]] std::enable_if_t<is_input_iterator<InputIterator>::value,
+                                 cargo::result>
   assign(InputIterator first, InputIterator last) {
     erase(Begin, End);
     if (auto error = insert(Begin, first, last).error()) {
@@ -484,9 +484,9 @@ class small_vector {
   /// @return Returns iterator at the inserted element, or `cargo::bad_alloc` on
   /// allocation failure.
   template <typename VT = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_copy_assignable<VT>::value &&
-                                       std::is_copy_constructible<VT>::value,
-                                   error_or<iterator>>
+  [[nodiscard]] std::enable_if_t<std::is_copy_assignable_v<VT> &&
+                                     std::is_copy_constructible_v<VT>,
+                                 error_or<iterator>>
   insert(const_iterator pos, const_reference value) {
     CARGO_ASSERT(Begin <= pos && End >= pos, "invalid position");
     size_type index = pos - Begin;
@@ -510,9 +510,9 @@ class small_vector {
   /// @return Returns iterator at the inserted element, or `cargo::bad_alloc` on
   /// allocation failure.
   template <typename VT = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_move_assignable<VT>::value &&
-                                       std::is_move_constructible<VT>::value,
-                                   error_or<iterator>>
+  [[nodiscard]] std::enable_if_t<std::is_move_assignable_v<VT> &&
+                                     std::is_move_constructible_v<VT>,
+                                 error_or<iterator>>
   insert(const_iterator pos, value_type &&value) {
     CARGO_ASSERT(Begin <= pos && End >= pos, "invalid position");
     size_type index = pos - Begin;
@@ -537,9 +537,9 @@ class small_vector {
   /// @return Returns iterator pointing to the first element inserted, or
   /// `cargo::bad_alloc` on allocation failure.
   template <typename VT = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_copy_assignable<VT>::value &&
-                                       std::is_copy_constructible<VT>::value,
-                                   error_or<iterator>>
+  [[nodiscard]] std::enable_if_t<std::is_copy_assignable_v<VT> &&
+                                     std::is_copy_constructible_v<VT>,
+                                 error_or<iterator>>
   insert(const_iterator pos, size_type count, const_reference value) {
     CARGO_ASSERT(Begin <= pos && End >= pos, "invalid position");
     size_type index = pos - Begin;
@@ -566,10 +566,10 @@ class small_vector {
   /// @return Returns iterator pointing to the first element inserted, or
   /// `cargo::bad_alloc` on allocation failure.
   template <typename InputIterator, typename VT = value_type>
-  [[nodiscard]] enable_if_t<is_input_iterator<InputIterator>::value &&
-                                std::is_move_constructible<VT>::value &&
-                                std::is_move_assignable<VT>::value,
-                            error_or<iterator>>
+  [[nodiscard]] std::enable_if_t<is_input_iterator<InputIterator>::value &&
+                                     std::is_move_constructible_v<VT> &&
+                                     std::is_move_assignable_v<VT>,
+                                 error_or<iterator>>
   insert(const_iterator pos, InputIterator first, InputIterator last) {
     CARGO_ASSERT(Begin <= pos && End >= pos, "invalid position");
     size_type index = pos - Begin;
@@ -595,9 +595,9 @@ class small_vector {
   /// @return Returns iterator pointing to the first element inserted, or
   /// `cargo::bad_alloc` on allocation failure.
   template <typename VT = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_move_assignable<VT>::value &&
-                                       std::is_move_constructible<VT>::value,
-                                   error_or<iterator>>
+  [[nodiscard]] std::enable_if_t<std::is_move_assignable_v<VT> &&
+                                     std::is_move_constructible_v<VT>,
+                                 error_or<iterator>>
   insert(const_iterator pos, std::initializer_list<VT> list) {
     CARGO_ASSERT(Begin <= pos && End >= pos, "invalid position");
     size_type index = pos - Begin;
@@ -679,8 +679,8 @@ class small_vector {
   /// @return Returns `cargo::bad_alloc` on allocation failure, `cargo::success`
   /// otherwise.
   template <class ValueType = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_copy_constructible<ValueType>::value,
-                                   cargo::result>
+  [[nodiscard]] std::enable_if_t<std::is_copy_constructible_v<ValueType>,
+                                 cargo::result>
   push_back(const_reference value) {
     if (auto error = extend(1)) {
       return error;
@@ -699,8 +699,8 @@ class small_vector {
   /// @return Returns `cargo::bad_alloc` on allocation failure, `cargo::success`
   /// otherwise.
   template <class ValueType = value_type>
-  [[nodiscard]] cargo::enable_if_t<std::is_move_constructible<ValueType>::value,
-                                   cargo::result>
+  [[nodiscard]] std::enable_if_t<std::is_move_constructible_v<ValueType>,
+                                 cargo::result>
   push_back(value_type &&value) {
     if (auto error = extend(1)) {
       return error;
@@ -851,15 +851,15 @@ class small_vector {
 
   // use move if possible, copy otherwise
   template <class Iterator = iterator>
-  enable_if_t<std::is_move_constructible<
-      typename std::iterator_traits<Iterator>::value_type>::value>
+  std::enable_if_t<std::is_move_constructible_v<
+      typename std::iterator_traits<Iterator>::value_type>>
   move_or_copy(Iterator first, Iterator last, Iterator dest) {
     cargo::uninitialized_move(first, last, dest);
   }
 
   template <class Iterator = iterator>
-  enable_if_t<!std::is_move_constructible<
-      typename std::iterator_traits<Iterator>::value_type>::value>
+  std::enable_if_t<!std::is_move_constructible_v<
+      typename std::iterator_traits<Iterator>::value_type>>
   move_or_copy(Iterator first, Iterator last, Iterator dest) {
     std::uninitialized_copy(first, last, dest);
   }

--- a/modules/cargo/include/cargo/string_view.h
+++ b/modules/cargo/include/cargo/string_view.h
@@ -85,10 +85,10 @@ class string_view {
   /// @param string Reference to the `std::string` like object.
   template <
       class String,
-      enable_if_t<is_detected<detail::data_member_fn, String>::value &&
-                  is_detected<detail::size_member_fn, String>::value &&
-                  has_value_type_convertible_to<value_type, String>::value> * =
-          nullptr>
+      std::enable_if_t<is_detected<detail::data_member_fn, String>::value &&
+                       is_detected<detail::size_member_fn, String>::value &&
+                       has_value_type_convertible_to<value_type, String>::value>
+          * = nullptr>
   string_view(const String &string)
       : Begin(string.data()), Size(string.size()) {
     while (Begin + Size - 1 >= Begin && Begin[Size - 1] == '\0') {

--- a/modules/cargo/include/cargo/type_traits.h
+++ b/modules/cargo/include/cargo/type_traits.h
@@ -25,104 +25,6 @@
 #include <type_traits>
 
 namespace cargo {
-namespace detail {
-/// @brief Helper struct to turn void_t into void.
-///
-/// Work around for a C++14 standard defect to enable `void_t`.
-///
-/// @see http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1558
-///
-/// @tparam Ts Template parameter pack.
-template <class... Ts>
-struct make_void {
-  using type = void;
-};
-}  // namespace detail
-
-/// @addtogroup cargo
-/// @{
-
-/// @brief Maps a sequence of any types to void.
-///
-/// Used to detect ill-formed types in SFINAE context.
-///
-/// @tparam Ts Template parameter pack.
-template <class... Ts>
-using void_t = typename detail::make_void<Ts...>::type;
-
-/// @brief Alias for `std::enable_if` to reduce noise.
-///
-/// @tparam C Boolean condition.
-/// @tparam T Specified type.
-template <bool C, class T = void>
-using enable_if_t = typename std::enable_if<C, T>::type;
-
-/// @brief Alias for `std::aligned_storage` to reduce noise.
-///
-/// @tparam S Size for aligned storage.
-/// @tparam A Alignment for aligned storage.
-template <size_t S, size_t A>
-using aligned_storage_t = typename std::aligned_storage<S, A>::type;
-
-/// @brief Alias for `std::has_trivial_copy_constructor` using correct name.
-///
-/// @note GCC versions below 5 do not support
-/// `std::is_trivially_copy_constructible`.
-///
-/// @tparam T Sepcific type.
-template <class T>
-using is_trivially_copy_constructible = std::is_trivially_copy_constructible<T>;
-
-/// @brief Alias for `std::has_trivial_copy_assign` using correct name.
-///
-/// @note GCC versions below 5 do not support
-/// `std::is_trivially_copy_assignable`.
-///
-/// @tparam T Sepcific type.
-template <class T>
-using is_trivially_copy_assignable = std::is_trivially_copy_assignable<T>;
-
-/// @brief Alias for `std::is_trivially_copyable`.
-///
-/// @note GCC versions below 5 do not support `std::is_trivially_copyable`.
-///
-/// @tparam T Specified type.
-template <class T>
-using is_trivially_copyable = std::is_trivially_copyable<T>;
-
-/// @brief Alias for `std::remove_reference` to reduce noise.
-///
-/// @tparam Ts Type to remove reference from.
-template <class... Ts>
-using remove_reference_t = typename std::remove_reference<Ts...>::type;
-
-/// @brief Alias for `std::remove_pointer` to reduce noise.
-///
-/// @tparam T Type to remove pointer from.
-template <class T>
-using remove_pointer_t = typename std::remove_pointer<T>::type;
-
-/// @brief Alias for `std::remove_const` to reduce noise.
-///
-/// @tparam Ts Type to remove const from.
-template <class... Ts>
-using remove_const_t = typename std::remove_const<Ts...>::type;
-
-/// @brief Alias for `std::decay` to reduce noise.
-///
-/// @tparam Ts Type to decay.
-template <class... Ts>
-using decay_t = typename std::decay<Ts...>::type;
-
-/// @brief Alias for `std::conditional` to reduce noise.
-///
-/// @tparam B Boolean condition.
-/// @tparam T Result if the condition is true.
-/// @tparam F Result if the condition is false.
-template <bool B, class T, class F>
-using conditional_t = typename std::conditional<B, T, F>::type;
-
-/// @}
 
 namespace detail {
 /// @brief Failure case, member type `iterator_category` not found.
@@ -133,8 +35,8 @@ struct has_iterator_category : public std::false_type {};
 ///
 /// @tparam IteratorTraits Type of iterator traits.
 template <class IteratorTraits>
-struct has_iterator_category<IteratorTraits,
-                             void_t<typename IteratorTraits::iterator_category>>
+struct has_iterator_category<
+    IteratorTraits, std::void_t<typename IteratorTraits::iterator_category>>
     : std::true_type {};
 
 /// @brief Success case, determine if iterator category matches.
@@ -183,7 +85,7 @@ template <class B>
 struct conjunction<B> : B {};
 template <class B, class... Bs>
 struct conjunction<B, Bs...>
-    : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
+    : std::conditional_t<bool(B::value), conjunction<Bs...>, B> {};
 
 /// @}
 
@@ -200,7 +102,7 @@ struct detector : std::false_type {};
 /// @tparam Op Template or alias template of the operation to be detected.
 /// @tparam Args Type parameter pack describing arguments to the expression.
 template <template <class...> class Op, class... Args>
-struct detector<void_t<Op<Args...>>, Op, Args...> : std::true_type {};
+struct detector<std::void_t<Op<Args...>>, Op, Args...> : std::true_type {};
 }  // namespace detail
 
 /// @addtogroup cargo
@@ -245,7 +147,8 @@ struct has_value_type : public std::false_type {};
 ///
 /// @tparam T Type to detect `value_type` member type on.
 template <class T>
-struct has_value_type<T, void_t<typename T::value_type>> : std::true_type {};
+struct has_value_type<T, std::void_t<typename T::value_type>> : std::true_type {
+};
 
 /// @brief Failure case, member type `iterator` not found.
 template <class, class = void>
@@ -255,7 +158,7 @@ struct has_iterator : public std::false_type {};
 ///
 /// @tparam T Type to detect `iterator` member type on.
 template <class T>
-struct has_iterator<T, void_t<typename T::iterator>> : std::true_type {};
+struct has_iterator<T, std::void_t<typename T::iterator>> : std::true_type {};
 }  // namespace detail
 
 /// @addtogroup cargo

--- a/modules/cargo/test/array_view.cpp
+++ b/modules/cargo/test/array_view.cpp
@@ -308,7 +308,7 @@ TEST(array_view, as_std_vector_convertible_type) {
   std::vector<int> v{12, 0, 15, 16, 14, 13};
   cargo::array_view<int> av(v);
   auto v2(cargo::as<std::vector<size_t>>(av));
-  static_assert(std::is_same<decltype(v2)::value_type, size_t>::value,
+  static_assert(std::is_same_v<decltype(v2)::value_type, size_t>,
                 "Deduction failed");
   ASSERT_TRUE(v2[0] == 12 && v2[2] == 15 && v2[5] == 13);
 }

--- a/modules/cargo/test/expected.cpp
+++ b/modules/cargo/test/expected.cpp
@@ -68,7 +68,7 @@ TEST(expected, assignment_simple) {
   ASSERT_TRUE(*e4 == 21);
 
   const bool expectedRefIsDefaultConstructible =
-      std::is_default_constructible<cargo::expected<int &, int>>::value;
+      std::is_default_constructible_v<cargo::expected<int &, int>>;
   ASSERT_FALSE(expectedRefIsDefaultConstructible);
 }
 
@@ -209,54 +209,54 @@ TEST(expected, constructors) {
 
   {
     cargo::expected<int, int> e;
-    ASSERT_TRUE(std::is_default_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_assignable<decltype(e)>::value);
-    ASSERT_TRUE(cargo::is_trivially_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(cargo::is_trivially_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(std::is_trivially_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_trivially_move_assignable<decltype(e)>::value);
+    ASSERT_TRUE(std::is_default_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_trivially_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_trivially_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_trivially_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_trivially_move_assignable_v<decltype(e)>);
   }
 
   {
     cargo::expected<int, std::string> e;
-    ASSERT_TRUE(std::is_default_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_assignable<decltype(e)>::value);
+    ASSERT_TRUE(std::is_default_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_assignable_v<decltype(e)>);
   }
 
   {
     cargo::expected<std::string, int> e;
-    ASSERT_TRUE(std::is_default_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_assignable<decltype(e)>::value);
+    ASSERT_TRUE(std::is_default_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_assignable_v<decltype(e)>);
   }
 
   {
     cargo::expected<std::string, std::string> e;
-    ASSERT_TRUE(std::is_default_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(std::is_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(std::is_move_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!cargo::is_trivially_copy_assignable<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_constructible<decltype(e)>::value);
-    ASSERT_TRUE(!std::is_trivially_move_assignable<decltype(e)>::value);
+    ASSERT_TRUE(std::is_default_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(std::is_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(std::is_move_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_copy_assignable_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_constructible_v<decltype(e)>);
+    ASSERT_TRUE(!std::is_trivially_move_assignable_v<decltype(e)>);
   }
 
   {
@@ -403,64 +403,56 @@ TEST(expected, extensions_map) {
     cargo::expected<int, int> e = 21;
     auto ret = e.map(ret_void);
     ASSERT_TRUE(bool(ret));
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     const cargo::expected<int, int> e = 21;
     auto ret = e.map(ret_void);
     ASSERT_TRUE(bool(ret));
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     cargo::expected<int, int> e = 21;
     auto ret = std::move(e).map(ret_void);
     ASSERT_TRUE(bool(ret));
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     const cargo::expected<int, int> e = 21;
     auto ret = std::move(e).map(ret_void);
     ASSERT_TRUE(bool(ret));
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     cargo::expected<int, int> e(cargo::unexpect, 21);
     auto ret = e.map(ret_void);
     ASSERT_TRUE(!ret);
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     const cargo::expected<int, int> e(cargo::unexpect, 21);
     auto ret = e.map(ret_void);
     ASSERT_TRUE(!ret);
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     cargo::expected<int, int> e(cargo::unexpect, 21);
     auto ret = std::move(e).map(ret_void);
     ASSERT_TRUE(!ret);
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   {
     const cargo::expected<int, int> e(cargo::unexpect, 21);
     auto ret = std::move(e).map(ret_void);
     ASSERT_TRUE(!ret);
-    ASSERT_TRUE(
-        (std::is_same<decltype(ret), cargo::expected<void, int>>::value));
+    ASSERT_TRUE((std::is_same_v<decltype(ret), cargo::expected<void, int>>));
   }
 
   // mapping functions which return references
@@ -948,14 +940,14 @@ TEST(expected, observers) {
   ASSERT_TRUE(o2.value_or(42) == 42);
   ASSERT_TRUE(o2.error() == 0);
   ASSERT_TRUE(o3.value() == 42);
-  auto success = std::is_same<decltype(o1.value()), int &>::value;
+  auto success = std::is_same_v<decltype(o1.value()), int &>;
   ASSERT_TRUE(success);
-  success = std::is_same<decltype(o3.value()), const int &>::value;
+  success = std::is_same_v<decltype(o3.value()), const int &>;
   ASSERT_TRUE(success);
-  success = std::is_same<decltype(std::move(o1).value()), int &&>::value;
+  success = std::is_same_v<decltype(std::move(o1).value()), int &&>;
   ASSERT_TRUE(success);
 
-  success = std::is_same<decltype(std::move(o3).value()), const int &&>::value;
+  success = std::is_same_v<decltype(std::move(o3).value()), const int &&>;
   ASSERT_TRUE(success);
 
   cargo::expected<move_detector, int> o4{cargo::in_place};

--- a/modules/cargo/test/optional.cpp
+++ b/modules/cargo/test/optional.cpp
@@ -68,13 +68,11 @@ TEST(optional, assignment) {
 }
 
 TEST(optional, bases_triviality) {
-  ASSERT_TRUE(
-      std::is_trivially_copy_constructible<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_trivially_copy_assignable<cargo::optional<int>>::value);
-  ASSERT_TRUE(
-      std::is_trivially_move_constructible<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_trivially_move_assignable<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_trivially_destructible<cargo::optional<int>>::value);
+  ASSERT_TRUE(std::is_trivially_copy_constructible_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_trivially_copy_assignable_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_trivially_move_constructible_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_trivially_move_assignable_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_trivially_destructible_v<cargo::optional<int>>);
 
   {
     struct T {
@@ -84,13 +82,11 @@ TEST(optional, bases_triviality) {
       T &operator=(T &&) = default;
       ~T() = default;
     };
-    ASSERT_TRUE(
-        std::is_trivially_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_trivially_copy_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(
-        std::is_trivially_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_trivially_move_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_trivially_destructible<cargo::optional<T>>::value);
+    ASSERT_TRUE(std::is_trivially_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_trivially_copy_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_trivially_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_trivially_move_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_trivially_destructible_v<cargo::optional<T>>);
   }
 
   {
@@ -101,22 +97,20 @@ TEST(optional, bases_triviality) {
       T &operator=(T &&) { return *this; };
       ~T() {}
     };
-    ASSERT_TRUE(
-        !std::is_trivially_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_trivially_copy_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(
-        !std::is_trivially_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_trivially_move_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_trivially_destructible<cargo::optional<T>>::value);
+    ASSERT_TRUE(!std::is_trivially_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_trivially_copy_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_trivially_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_trivially_move_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_trivially_destructible_v<cargo::optional<T>>);
   }
 }
 
 TEST(optional, bases_deletion) {
-  ASSERT_TRUE(std::is_copy_constructible<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_copy_assignable<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_move_constructible<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_move_assignable<cargo::optional<int>>::value);
-  ASSERT_TRUE(std::is_destructible<cargo::optional<int>>::value);
+  ASSERT_TRUE(std::is_copy_constructible_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_copy_assignable_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_move_constructible_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_move_assignable_v<cargo::optional<int>>);
+  ASSERT_TRUE(std::is_destructible_v<cargo::optional<int>>);
 
   {
     struct T {
@@ -126,11 +120,11 @@ TEST(optional, bases_deletion) {
       T &operator=(T &&) = default;
       ~T() = default;
     };
-    ASSERT_TRUE(std::is_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_copy_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_move_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_destructible<cargo::optional<T>>::value);
+    ASSERT_TRUE(std::is_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_copy_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_move_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_destructible_v<cargo::optional<T>>);
   }
 
   {
@@ -140,10 +134,10 @@ TEST(optional, bases_deletion) {
       T &operator=(const T &) = delete;
       T &operator=(T &&) = delete;
     };
-    ASSERT_TRUE(!std::is_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_copy_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_move_assignable<cargo::optional<T>>::value);
+    ASSERT_TRUE(!std::is_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_copy_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_move_assignable_v<cargo::optional<T>>);
   }
 
   {
@@ -153,10 +147,10 @@ TEST(optional, bases_deletion) {
       T &operator=(const T &) = delete;
       T &operator=(T &&) = default;
     };
-    ASSERT_TRUE(!std::is_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(!std::is_copy_assignable<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_move_assignable<cargo::optional<T>>::value);
+    ASSERT_TRUE(!std::is_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(!std::is_copy_assignable_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_move_assignable_v<cargo::optional<T>>);
   }
 
   {
@@ -166,12 +160,12 @@ TEST(optional, bases_deletion) {
       T &operator=(const T &) = default;
       T &operator=(T &&) = delete;
     };
-    ASSERT_TRUE(std::is_copy_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_copy_assignable<cargo::optional<T>>::value);
+    ASSERT_TRUE(std::is_copy_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_copy_assignable_v<cargo::optional<T>>);
 
     // These should both be true, as it should just copy instead of move
-    ASSERT_TRUE(std::is_move_constructible<cargo::optional<T>>::value);
-    ASSERT_TRUE(std::is_move_assignable<cargo::optional<T>>::value);
+    ASSERT_TRUE(std::is_move_constructible_v<cargo::optional<T>>);
+    ASSERT_TRUE(std::is_move_assignable_v<cargo::optional<T>>);
   }
 }
 
@@ -251,13 +245,13 @@ TEST(optional, map) {
   // lhs is empty
   cargo::optional<int> o1;
   auto o1r = o1.map([](int i) { return i + 2; });
-  ASSERT_TRUE((std::is_same<decltype(o1r), cargo::optional<int>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o1r), cargo::optional<int>>));
   ASSERT_TRUE(!o1r);
 
   // lhs has value
   cargo::optional<int> o2 = 40;
   auto o2r = o2.map([](int i) { return i + 2; });
-  ASSERT_TRUE((std::is_same<decltype(o2r), cargo::optional<int>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o2r), cargo::optional<int>>));
   ASSERT_EQ(o2r.value(), 42);
 
   struct rval_call_map {
@@ -267,19 +261,19 @@ TEST(optional, map) {
   // ensure that function object is forwarded
   cargo::optional<int> o3 = 42;
   auto o3r = o3.map(rval_call_map{});
-  ASSERT_TRUE((std::is_same<decltype(o3r), cargo::optional<double>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o3r), cargo::optional<double>>));
   ASSERT_EQ(o3r.value(), 42);
 
   // ensure that lhs is forwarded
   cargo::optional<int> o4 = 40;
   auto o4r = std::move(o4).map([](int &&i) { return i + 2; });
-  ASSERT_TRUE((std::is_same<decltype(o4r), cargo::optional<int>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o4r), cargo::optional<int>>));
   ASSERT_EQ(o4r.value(), 42);
 
   // ensure that lhs is const-propagated
   const cargo::optional<int> o5 = 40;
   auto o5r = o5.map([](const int &i) { return i + 2; });
-  ASSERT_TRUE((std::is_same<decltype(o5r), cargo::optional<int>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o5r), cargo::optional<int>>));
   ASSERT_EQ(o5r.value(), 42);
 
   // test void return
@@ -287,7 +281,7 @@ TEST(optional, map) {
   auto f7 = [](const int &) { return; };
   auto o7r = o7.map(f7);
   ASSERT_TRUE(
-      (std::is_same<decltype(o7r), cargo::optional<cargo::monostate>>::value));
+      (std::is_same_v<decltype(o7r), cargo::optional<cargo::monostate>>));
   ASSERT_TRUE(o7r.has_value());
 
   // test each overload in turn
@@ -387,25 +381,25 @@ TEST(optional, and_then) {
   // lhs is empty
   cargo::optional<int> o1;
   auto o1r = o1.and_then([](int) { return cargo::optional<float>{42}; });
-  ASSERT_TRUE((std::is_same<decltype(o1r), cargo::optional<float>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o1r), cargo::optional<float>>));
   ASSERT_TRUE(!o1r);
 
   // lhs has value
   cargo::optional<int> o2 = 12;
   auto o2r = o2.and_then([](int) { return cargo::optional<float>{42}; });
-  ASSERT_TRUE((std::is_same<decltype(o2r), cargo::optional<float>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o2r), cargo::optional<float>>));
   ASSERT_EQ(o2r.value(), 42.f);
 
   // lhs is empty, rhs returns empty
   cargo::optional<int> o3;
   auto o3r = o3.and_then([](int) { return cargo::optional<float>{}; });
-  ASSERT_TRUE((std::is_same<decltype(o3r), cargo::optional<float>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o3r), cargo::optional<float>>));
   ASSERT_TRUE(!o3r);
 
   // rhs returns empty
   cargo::optional<int> o4 = 12;
   auto o4r = o4.and_then([](int) { return cargo::optional<float>{}; });
-  ASSERT_TRUE((std::is_same<decltype(o4r), cargo::optional<float>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o4r), cargo::optional<float>>));
   ASSERT_TRUE(!o4r);
 
   struct rval_call_and_then {
@@ -417,21 +411,21 @@ TEST(optional, and_then) {
   // ensure that function object is forwarded
   cargo::optional<int> o5 = 42;
   auto o5r = o5.and_then(rval_call_and_then{});
-  ASSERT_TRUE((std::is_same<decltype(o5r), cargo::optional<double>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o5r), cargo::optional<double>>));
   ASSERT_EQ(o5r.value(), 42);
 
   // ensure that lhs is forwarded
   cargo::optional<int> o6 = 42;
   auto o6r = std::move(o6).and_then(
       [](int &&i) { return cargo::optional<double>(i); });
-  ASSERT_TRUE((std::is_same<decltype(o6r), cargo::optional<double>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o6r), cargo::optional<double>>));
   ASSERT_EQ(o6r.value(), 42);
 
   // ensure that function object is const-propagated
   const cargo::optional<int> o7 = 42;
   auto o7r =
       o7.and_then([](const int &i) { return cargo::optional<double>(i); });
-  ASSERT_TRUE((std::is_same<decltype(o7r), cargo::optional<double>>::value));
+  ASSERT_TRUE((std::is_same_v<decltype(o7r), cargo::optional<double>>));
   ASSERT_EQ(o7r.value(), 42);
 
   // test each overload in turn
@@ -608,8 +602,7 @@ TEST(optional, make_optional) {
   auto o1 = cargo::make_optional(42);
   auto o2 = cargo::optional<int>(42);
 
-  constexpr bool is_same =
-      std::is_same<decltype(o1), cargo::optional<int>>::value;
+  constexpr bool is_same = std::is_same_v<decltype(o1), cargo::optional<int>>;
   ASSERT_TRUE(is_same);
   ASSERT_EQ(o1, o2);
 
@@ -643,7 +636,7 @@ TEST(optional, nullopt) {
   ASSERT_TRUE(!o3);
   ASSERT_TRUE(!o4);
 
-  ASSERT_TRUE(!std::is_default_constructible<cargo::nullopt_t>::value);
+  ASSERT_TRUE(!std::is_default_constructible_v<cargo::nullopt_t>);
 }
 
 TEST(optional, emplace) {
@@ -683,14 +676,14 @@ TEST(optional, observers) {
   ASSERT_EQ(*o1, o1.value());
   ASSERT_EQ(o2.value_or(42), 42);
   ASSERT_EQ(o3.value(), 42);
-  auto success = std::is_same<decltype(o1.value()), int &>::value;
+  auto success = std::is_same_v<decltype(o1.value()), int &>;
   ASSERT_TRUE(success);
-  success = std::is_same<decltype(o3.value()), const int &>::value;
+  success = std::is_same_v<decltype(o3.value()), const int &>;
   ASSERT_TRUE(success);
-  success = std::is_same<decltype(std::move(o1).value()), int &&>::value;
+  success = std::is_same_v<decltype(std::move(o1).value()), int &&>;
   ASSERT_TRUE(success);
 
-  success = std::is_same<decltype(std::move(o3).value()), const int &&>::value;
+  success = std::is_same_v<decltype(std::move(o3).value()), const int &&>;
   ASSERT_TRUE(success);
 
   cargo::optional<move_detector> o4{cargo::in_place};

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
@@ -311,36 +311,36 @@ void {{cookiecutter.target_name.capitalize()}}PassMachinery::registerPassCallbac
   PB.registerPipelineParsingCallback(
       [](llvm::StringRef Name, llvm::ModulePassManager &PM,
          llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
-        (void) Name;
-        (void) PM;
-#define MODULE_PASS(NAME, CREATE_PASS) \
-  if (Name == NAME) {                  \
-    PM.addPass(CREATE_PASS);           \
-    return true;                       \
+        (void)Name;
+        (void)PM;
+#define MODULE_PASS(NAME, CREATE_PASS)   \
+  if (Name == NAME) {                    \
+    PM.addPass(CREATE_PASS);             \
+    return true;                         \
   }
 
-#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS) \
-  if (utils::checkParametrizedPassName(Name, NAME)) {                     \
-    auto Params = utils::parsePassParameters(PARSER, Name, NAME);         \
-    if (!Params) {                                                        \
-      errs() << toString(Params.takeError()) << "\n";                     \
-      return false;                                                       \
-    }                                                                     \
-    PM.addPass(CREATE_PASS(Params.get()));                                \
-    return true;                                                          \
+#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)   \
+  if (utils::checkParametrizedPassName(Name, NAME)) {                       \
+    auto Params = utils::parsePassParameters(PARSER, Name, NAME);           \
+    if (!Params) {                                                          \
+      errs() << toString(Params.takeError()) << "\n";                       \
+      return false;                                                         \
+    }                                                                       \
+    PM.addPass(CREATE_PASS(Params.get()));                                  \
+    return true;                                                            \
   }
 
-#define MODULE_ANALYSIS(NAME, CREATE_PASS)                             \
-  if (Name == "require<" NAME ">") {                                   \
-    PM.addPass(RequireAnalysisPass<                                    \
-               std::remove_reference<decltype(CREATE_PASS)>::type,     \
-               llvm::Module>());                                       \
-    return true;                                                       \
-  }                                                                    \
-  if (Name == "invalidate<" NAME ">") {                                \
-    PM.addPass(InvalidateAnalysisPass<                                 \
-               std::remove_reference<decltype(CREATE_PASS)>::type>()); \
-    return true;                                                       \
+#define MODULE_ANALYSIS(NAME, CREATE_PASS)                                  \
+  if (Name == "require<" NAME ">") {                                        \
+    PM.addPass(                                                             \
+        RequireAnalysisPass<std::remove_reference_t<decltype(CREATE_PASS)>, \
+                            llvm::Module>());                               \
+    return true;                                                            \
+  }                                                                         \
+  if (Name == "invalidate<" NAME ">") {                                     \
+    PM.addPass(InvalidateAnalysisPass<                                      \
+               std::remove_reference_t<decltype(CREATE_PASS)>>());          \
+    return true;                                                            \
   }
 
 #define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                \

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -493,17 +493,17 @@ void BaseModulePassMachinery::registerPassCallbacks() {
     return true;                                                            \
   }
 
-#define MODULE_ANALYSIS(NAME, CREATE_PASS)                             \
-  if (Name == "require<" NAME ">") {                                   \
-    PM.addPass(RequireAnalysisPass<                                    \
-               std::remove_reference<decltype(CREATE_PASS)>::type,     \
-               llvm::Module>());                                       \
-    return true;                                                       \
-  }                                                                    \
-  if (Name == "invalidate<" NAME ">") {                                \
-    PM.addPass(InvalidateAnalysisPass<                                 \
-               std::remove_reference<decltype(CREATE_PASS)>::type>()); \
-    return true;                                                       \
+#define MODULE_ANALYSIS(NAME, CREATE_PASS)                                  \
+  if (Name == "require<" NAME ">") {                                        \
+    PM.addPass(                                                             \
+        RequireAnalysisPass<std::remove_reference_t<decltype(CREATE_PASS)>, \
+                            llvm::Module>());                               \
+    return true;                                                            \
+  }                                                                         \
+  if (Name == "invalidate<" NAME ">") {                                     \
+    PM.addPass(InvalidateAnalysisPass<                                      \
+               std::remove_reference_t<decltype(CREATE_PASS)>>());          \
+    return true;                                                            \
   }
 
 #define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                \

--- a/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/opcodes.h
@@ -85,7 +85,7 @@ class OpCode {
 
 template <class Op>
 inline bool isa(const OpCode *op) {
-  static_assert(std::is_base_of<OpCode, Op>::value, "invalid OpCode cast");
+  static_assert(std::is_base_of_v<OpCode, Op>, "invalid OpCode cast");
   return Op::ClassCode == op->code;
 }
 

--- a/modules/kts/include/kts/arguments_shared.h
+++ b/modules/kts/include/kts/arguments_shared.h
@@ -164,11 +164,8 @@ class Reference1D {
   /// will construct a reference from it. The second argument is used purely to
   /// trigger SFINAE.
   template <typename F>
-  Reference1D(
-      F &&f,
-      typename std::enable_if<HasOperatorSizeT<F>::value,
-                              typename std::remove_reference<F>::type>::type * =
-          0) {
+  Reference1D(F &&f, std::enable_if_t<HasOperatorSizeT<F>::value,
+                                      std::remove_reference_t<F>> * = 0) {
     Ref = std::make_shared<ReferenceFun<T(size_t)>>(f);
     Type = Value;
   }
@@ -181,11 +178,8 @@ class Reference1D {
   /// will construct a reference from it. The second argument is used purely to
   /// trigger SFINAE.
   template <typename F>
-  Reference1D(
-      F &&f,
-      typename std::enable_if<HasOperatorSizeTT<F>::value,
-                              typename std::remove_reference<F>::type>::type * =
-          0) {
+  Reference1D(F &&f, std::enable_if_t<HasOperatorSizeTT<F>::value,
+                                      std::remove_reference_t<F>> * = 0) {
     Ref = std::make_shared<ReferenceFun<bool(size_t, T &)>>(f);
     Type = Boolean;
   }

--- a/modules/loader/include/loader/elf.h
+++ b/modules/loader/include/loader/elf.h
@@ -493,7 +493,7 @@ class ElfFile {
   /// @brief Use this wrapper if reading directly from ELF structures, it
   /// converts the values in memory to the right endianness for the CPU.
   template <typename Integer>
-  inline cargo::enable_if_t<std::is_unsigned<Integer>::value, Integer> field(
+  inline std::enable_if_t<std::is_unsigned_v<Integer>, Integer> field(
       Integer v) const {
     CARGO_ASSERT(!bytes.empty(), "Using a null ElfFile instance");
     return (headerIdent()->endianness == (cargo::is_little_endian()
@@ -505,12 +505,11 @@ class ElfFile {
 
   /// @brief Use this wrapper if reading directly from ELF structures, it
   /// converts the values in memory to the right endianness for the CPU.
-  template <typename Enum,
-            typename = cargo::enable_if_t<std::is_enum<Enum>::value>>
-  inline cargo::enable_if_t<
-      std::is_unsigned<typename std::underlying_type<Enum>::type>::value, Enum>
+  template <typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
+  inline std::enable_if_t<std::is_unsigned_v<std::underlying_type_t<Enum>>,
+                          Enum>
   field(Enum v) const {
-    using Integer = typename std::underlying_type<Enum>::type;
+    using Integer = std::underlying_type_t<Enum>;
     CARGO_ASSERT(!bytes.empty(), "Using a null ElfFile instance");
     return (headerIdent()->endianness == (cargo::is_little_endian()
                                               ? ElfFields::Endianness::LITTLE

--- a/modules/metadata/include/metadata/detail/stack_serializer.h
+++ b/modules/metadata/include/metadata/detail/stack_serializer.h
@@ -38,8 +38,8 @@ namespace {
 /// @param output The output binary.
 /// @param endianness The desired endianness.
 template <class NumberTy,
-          std::enable_if_t<std::is_integral<NumberTy>::value ||
-                               std::is_floating_point<NumberTy>::value,
+          std::enable_if_t<std::is_integral_v<NumberTy> ||
+                               std::is_floating_point_v<NumberTy>,
                            bool> = true>
 void serialize_number(NumberTy num, std::vector<uint8_t> &output,
                       MD_ENDIAN endianness) {

--- a/modules/metadata/include/metadata/detail/utils.h
+++ b/modules/metadata/include/metadata/detail/utils.h
@@ -42,7 +42,7 @@ namespace utils {
 /// @param in The value to be written to.
 /// @param it An encoded integer byte-array value.
 /// @param endianness The source endianness.
-template <class T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+template <class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
 T read_value(uint8_t *it, uint8_t endianness) {
   T out;
   if (endianness == MD_ENDIAN::BIG) {

--- a/modules/metadata/source/metadata/utils.cpp
+++ b/modules/metadata/source/metadata/utils.cpp
@@ -152,7 +152,7 @@ namespace {
 /// @tparam T The specific integral type.
 /// @param val The value to be serialized.
 /// @param output The output byte-array to which the bytes are written.
-template <class T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+template <class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
 void serialize_int(T val, std::vector<uint8_t> &output, uint8_t endianness) {
   T out_val = read_value<T>(reinterpret_cast<uint8_t *>(&val), endianness);
   auto width = sizeof(T);

--- a/modules/mux/include/mux/mux.hpp
+++ b/modules/mux/include/mux/mux.hpp
@@ -225,7 +225,7 @@ struct deleter<mux_kernel_t> {
 ///
 /// @tparam T Type of the Mux API object.
 template <class T>
-using unique_ptr = std::unique_ptr<cargo::remove_pointer_t<T>, mux::deleter<T>>;
+using unique_ptr = std::unique_ptr<std::remove_pointer_t<T>, mux::deleter<T>>;
 }  // namespace mux
 
 #endif  // MUX_MUX_HPP_INCLUDED

--- a/source/cl/source/device.cpp
+++ b/source/cl/source/device.cpp
@@ -502,16 +502,15 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetDeviceInfo(
     OCL_SET_IF_NOT_NULL(param_value_size_ret, typeSize);         \
   } break
 
-#define DEVICE_INFO_CASE(ENUM, TYPE)                                         \
-  case ENUM: {                                                               \
-    const size_t typeSize = sizeof(TYPE);                                    \
-    OCL_CHECK(param_value && (param_value_size < typeSize),                  \
-              return CL_INVALID_VALUE);                                      \
-    if (param_value) {                                                       \
-      *static_cast<std::remove_const<decltype(TYPE)>::type *>(param_value) = \
-          TYPE;                                                              \
-    }                                                                        \
-    OCL_SET_IF_NOT_NULL(param_value_size_ret, typeSize);                     \
+#define DEVICE_INFO_CASE(ENUM, TYPE)                                           \
+  case ENUM: {                                                                 \
+    const size_t typeSize = sizeof(TYPE);                                      \
+    OCL_CHECK(param_value && (param_value_size < typeSize),                    \
+              return CL_INVALID_VALUE);                                        \
+    if (param_value) {                                                         \
+      *static_cast<std::remove_const_t<decltype(TYPE)> *>(param_value) = TYPE; \
+    }                                                                          \
+    OCL_SET_IF_NOT_NULL(param_value_size_ret, typeSize);                       \
   } break
 
   switch (param_name) {

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -1354,16 +1354,16 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetProgramInfo(
   OCL_CHECK(!program, return CL_INVALID_PROGRAM);
   OCL_CHECK(!param_value && !param_value_size_ret, return CL_INVALID_VALUE);
 
-#define PROGRAM_INFO_CASE(ENUM, VALUE)                                        \
-  case ENUM: {                                                                \
-    const size_t typeSize = sizeof(VALUE);                                    \
-    OCL_CHECK(param_value && (param_value_size < typeSize),                   \
-              return CL_INVALID_VALUE);                                       \
-    if (param_value) {                                                        \
-      *static_cast<std::remove_const<decltype(VALUE)>::type *>(param_value) = \
-          VALUE;                                                              \
-    }                                                                         \
-    OCL_SET_IF_NOT_NULL(param_value_size_ret, typeSize);                      \
+#define PROGRAM_INFO_CASE(ENUM, VALUE)                                    \
+  case ENUM: {                                                            \
+    const size_t typeSize = sizeof(VALUE);                                \
+    OCL_CHECK(param_value && (param_value_size < typeSize),               \
+              return CL_INVALID_VALUE);                                   \
+    if (param_value) {                                                    \
+      *static_cast<std::remove_const_t<decltype(VALUE)> *>(param_value) = \
+          VALUE;                                                          \
+    }                                                                     \
+    OCL_SET_IF_NOT_NULL(param_value_size_ret, typeSize);                  \
   } break
 
 #define PROGRAM_INFO_CASE_WITH_TYPE(ENUM, VALUE, TYPE)      \

--- a/source/cl/test/UnitCL/include/kts/generator.h
+++ b/source/cl/test/UnitCL/include/kts/generator.h
@@ -69,7 +69,7 @@ class InputGenerator final {
   /// @param buffer Vector that will be populated. Size should already be
   ///        at the capacity of number of elements to fill.
   template <typename T,
-            cargo::enable_if_t<std::is_floating_point<T>::value> * = nullptr>
+            std::enable_if_t<std::is_floating_point_v<T>> * = nullptr>
   void GenerateFloatData(std::vector<T> &buffer);
 
   /// @brief Populates buffer with random float of type T while avoiding inf
@@ -90,7 +90,7 @@ class InputGenerator final {
   /// imply smallest in magnitude (i.e. closest to zero), which is not
   /// necessarily the case.
   template <typename T,
-            cargo::enable_if_t<std::is_floating_point<T>::value> * = nullptr>
+            std::enable_if_t<std::is_floating_point_v<T>> * = nullptr>
   void GenerateFiniteFloatData(std::vector<T> &buffer,
                                T low = std::numeric_limits<T>::lowest(),
                                T high = std::numeric_limits<T>::max());
@@ -140,8 +140,7 @@ class InputGenerator final {
   /// @param buffer Vector that will be populated. Size should already be
   ///        at the capacity of number of elements to fill.
   template <typename T>
-  cargo::enable_if_t<std::is_integral<T>::value> GenerateData(
-      std::vector<T> &buffer) {
+  std::enable_if_t<std::is_integral_v<T>> GenerateData(std::vector<T> &buffer) {
     GenerateIntData(buffer);
   }
 
@@ -153,13 +152,13 @@ class InputGenerator final {
   /// @param buffer Vector that will be populated. Size should already be
   ///        at the capacity of number of elements to fill.
   template <typename T>
-  cargo::enable_if_t<std::is_integral<T>::value> GenerateData(
-      std::vector<T> &buffer, T min, T max) {
+  std::enable_if_t<std::is_integral_v<T>> GenerateData(std::vector<T> &buffer,
+                                                       T min, T max) {
     GenerateIntData(buffer, min, max);
   }
 
   template <typename T>
-  cargo::enable_if_t<std::is_floating_point<T>::value> GenerateData(
+  std::enable_if_t<std::is_floating_point_v<T>> GenerateData(
       std::vector<T> &buffer) {
     GenerateFloatData(buffer);
   }
@@ -175,7 +174,7 @@ class InputGenerator final {
   unsigned seed_;
 };
 
-template <class T, cargo::enable_if_t<std::is_floating_point<T>::value> *>
+template <class T, std::enable_if_t<std::is_floating_point_v<T>> *>
 void InputGenerator::GenerateFiniteFloatData(std::vector<T> &buffer, T low,
                                              T high) {
   // Generate a distribution where each floating point value in the given range
@@ -207,7 +206,7 @@ void InputGenerator::GenerateFiniteFloatData(std::vector<T> &buffer, T low,
   });
 }
 
-template <class T, cargo::enable_if_t<std::is_floating_point<T>::value> *>
+template <class T, std::enable_if_t<std::is_floating_point_v<T>> *>
 void InputGenerator::GenerateFloatData(std::vector<T> &buffer) {
   GenerateFiniteFloatData(buffer);
 
@@ -249,11 +248,9 @@ void InputGenerator::GenerateIntData(std::vector<T> &buffer, T min, T max) {
   // This is a work around for the fact that std::uniform_int_distribution isn't
   // defined for 8 bit types. If we get an 8 bit type we use a wider integer
   // then cast back the result.
-  using LargerType = typename std::conditional<
-      std::is_same<typename std::make_unsigned<T>::type, uint8_t>::value,
-      typename std::conditional<std::is_unsigned<T>::value, uint32_t,
-                                int32_t>::type,
-      T>::type;
+  using LargerType = std::conditional_t<
+      std::is_same_v<std::make_unsigned_t<T>, uint8_t>,
+      std::conditional_t<std::is_unsigned<T>::value, uint32_t, int32_t>, T>;
 
   std::uniform_int_distribution<LargerType> dist(min, max);
   std::generate(buffer.begin(), buffer.end(),
@@ -318,11 +315,9 @@ T InputGenerator::GenerateInt(T min, T max) {
   // This is a work around for the fact that std::uniform_int_distribution isn't
   // defined for 8 bit types. If we get an 8 bit type we use a wider integer
   // then cast back the result.
-  using LargerType = typename std::conditional<
-      std::is_same<typename std::make_unsigned<T>::type, uint8_t>::value,
-      typename std::conditional<std::is_unsigned<T>::value, uint32_t,
-                                int32_t>::type,
-      T>::type;
+  using LargerType = std::conditional_t<
+      std::is_same_v<std::make_unsigned_t<T>, uint8_t>,
+      std::conditional_t<std::is_unsigned<T>::value, uint32_t, int32_t>, T>;
   std::uniform_int_distribution<LargerType> dist(min, max);
   return static_cast<T>(dist(gen_));
 }

--- a/source/cl/test/UnitCL/include/kts/precision.h
+++ b/source/cl/test/UnitCL/include/kts/precision.h
@@ -279,9 +279,8 @@ bool IsDenormalAsHalf(cl_float x);
 template <class T>
 cl_float calculateULP(const typename TypeInfo<T>::LargerType reference,
                       const T actual) {
-  static_assert(
-      std::is_same<T, cl_float>::value || std::is_same<T, cl_double>::value,
-      "T must be cl_float or cl_double");
+  static_assert(std::is_same_v<T, cl_float> || std::is_same_v<T, cl_double>,
+                "T must be cl_float or cl_double");
 
   if (static_cast<T>(reference) == actual) {
     // catches reference overflow and underflow
@@ -305,7 +304,7 @@ cl_float calculateULP(const typename TypeInfo<T>::LargerType reference,
     return static_cast<cl_float>(promoted - reference);
   }
 
-  if (std::isinf(promoted) && std::is_same<T, cl_float>::value) {
+  if (std::isinf(promoted) && std::is_same_v<T, cl_float>) {
     // 2**128 is next representable value on the single-precision number line
     promoted = std::copysign(3.4028237e+38, promoted);
   }
@@ -362,7 +361,7 @@ struct ULPValidator final {
   bool validate(const LargerType &expected, const T &actual) {
     bool denormSupport =
         test_denormals &&
-        UCL::hasDenormSupport(device, std::is_same<T, cl_float>::value
+        UCL::hasDenormSupport(device, std::is_same_v<T, cl_float>
                                           ? CL_DEVICE_SINGLE_FP_CONFIG
                                           : CL_DEVICE_DOUBLE_FP_CONFIG);
     // Note that we cannot use `std::isnormal` or `std::fpclassify` to detect
@@ -383,7 +382,7 @@ struct ULPValidator final {
   void print(std::stringstream &s, Y value) {
     s << value << "[0x" << std::hex << matchingType(value) << std::dec << "]";
 
-    if (std::is_same<Y, T>::value) {
+    if (std::is_same_v<Y, T>) {
       printULPError(s);
     }
   }

--- a/source/cl/test/UnitCL/include/ucl/types.h
+++ b/source/cl/test/UnitCL/include/ucl/types.h
@@ -210,8 +210,8 @@ inline bool operator>=(const ScalarType<T, Tag> &left,
 template <class T, size_t N, class Tag>
 struct VectorType {
   using cl_type = T;
-  using value_type = typename std::remove_reference<
-      decltype(std::declval<cl_type>().s[0])>::type;
+  using value_type =
+      std::remove_reference_t<decltype(std::declval<cl_type>().s[0])>;
   using reference = value_type &;
   using const_reference = const value_type &;
   using pointer = value_type *;

--- a/source/cl/test/UnitCL/source/ctz.cpp
+++ b/source/cl/test/UnitCL/source/ctz.cpp
@@ -25,7 +25,7 @@
 #include "Common.h"
 
 template <typename T>
-static cargo::enable_if_t<std::is_integral<T>::value, T> reference_ctz(T val) {
+static std::enable_if_t<std::is_integral<T>::value, T> reference_ctz(T val) {
   if (!val) {
     return sizeof(val) << 3;
   }
@@ -38,7 +38,7 @@ static cargo::enable_if_t<std::is_integral<T>::value, T> reference_ctz(T val) {
 }
 
 template <typename T>
-static cargo::enable_if_t<UCL::is_cl_vector<T>::value, T> reference_ctz(T val) {
+static std::enable_if_t<UCL::is_cl_vector<T>::value, T> reference_ctz(T val) {
   T output{};
   unsigned i{0};
   for (const auto &element : val.s) {

--- a/source/vk/include/vk/type_traits.h
+++ b/source/vk/include/vk/type_traits.h
@@ -222,7 +222,7 @@ struct is_convertible_to<vk::command_pool, VkCommandPool> : std::true_type {};
 ///
 /// @return Returns `u` cast to type `T`.
 template <class T, class U>
-cargo::enable_if_t<is_convertible_to<T, U>::value, T> cast(U u) {
+std::enable_if_t<is_convertible_to<T, U>::value, T> cast(U u) {
   return reinterpret_cast<T>(u);
 }
 
@@ -234,8 +234,8 @@ cargo::enable_if_t<is_convertible_to<T, U>::value, T> cast(U u) {
 ///
 /// @return Returns `u` cast to type `T`.
 template <class T, class U>
-cargo::enable_if_t<is_convertible_to<cargo::remove_pointer_t<T>, U>::value, T>
-cast(U *u) {
+std::enable_if_t<is_convertible_to<std::remove_pointer_t<T>, U>::value, T> cast(
+    U *u) {
   return reinterpret_cast<T>(u);
 }
 
@@ -247,10 +247,10 @@ cast(U *u) {
 ///
 /// @return Returns `u` cast to type `T`.
 template <class T, class U>
-cargo::enable_if_t<
-    std::is_pointer<T>::value &&
-        is_convertible_to<cargo::remove_const_t<cargo::remove_pointer_t<T>>,
-                          cargo::remove_const_t<U>>::value,
+std::enable_if_t<
+    std::is_pointer_v<T> &&
+        is_convertible_to<std::remove_const_t<std::remove_pointer_t<T>>,
+                          std::remove_const_t<U>>::value,
     T>
 cast(const U *u) {
   return reinterpret_cast<T>(u);

--- a/source/vk/include/vk/unique_ptr.h
+++ b/source/vk/include/vk/unique_ptr.h
@@ -46,7 +46,7 @@ struct deleter {
 ///
 /// @tparam T Type of any object created with a `vk::allocator`
 template <class T>
-using unique_ptr = std::unique_ptr<cargo::remove_pointer_t<T>, deleter<T>>;
+using unique_ptr = std::unique_ptr<std::remove_pointer_t<T>, deleter<T>>;
 }  // namespace vk
 
 #endif  // VK_UNIQUE_PTR_H_INCLUDED

--- a/source/vk/test/UnitVK/include/GLSLTestDefs.h
+++ b/source/vk/test/UnitVK/include/GLSLTestDefs.h
@@ -26,8 +26,7 @@
 // Namespace used to store types and helper functions
 namespace glsl {
 
-template <typename T,
-          typename En = std::enable_if<std::is_arithmetic<T>::value>>
+template <typename T, typename En = std::enable_if<std::is_arithmetic_v<T>>>
 T abs(T x) {
   return (x >= 0) ? x : -x;
 }
@@ -384,18 +383,17 @@ struct is_double_struct<glsl_ModfStruct<glsl_vec<doubleTy, N>>>
 
 template <class T>
 struct is_double_type
-    : std::conditional<std::is_same<T, double>::value ||
-                           is_double_vec<T>::value ||
-                           is_double_struct<T>::value,
-                       std::true_type, std::false_type>::type {};
+    : std::conditional_t<std::is_same_v<T, double> || is_double_vec<T>::value ||
+                             is_double_struct<T>::value,
+                         std::true_type, std::false_type> {};
 
 template <class... Ts>
 struct has_double_type : std::false_type {};
 
 template <class T, class... Ts>
 struct has_double_type<T, Ts...>
-    : std::conditional<is_double_type<T>::value, std::true_type,
-                       has_double_type<Ts...>>::type {};
+    : std::conditional_t<is_double_type<T>::value, std::true_type,
+                         has_double_type<Ts...>> {};
 }  // namespace glsl
 
 /// @brief Generic class used as base test fixture for all GLSL builtins


### PR DESCRIPTION
# Overview

[NFC] Use *_t and *_v type traits.

# Reason for change

They are suggested by newer versions of clang-tidy, and slightly less error-prone.

# Description of change

This updates the code base to use *_t and *_v type traits.

This also removes several traits from <cargo/type_traits.h> that duplicate the C++14 versions. We had these to be able to build in C++11 mode, but we build in C++17 mode now so no longer need them.

# Anything else we should know?

This also removes several traits from <cargo/type_traits.h> that duplicate the C++14 versions. We had these to be able to build in C++11 mode, but we build in C++17 mode now so no longer need them.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
