### PR TITLE
[NFC] Add more const.

### DIFF
--- a/modules/compiler/source/base/source/image_argument_substitution_pass.cpp
+++ b/modules/compiler/source/base/source/image_argument_substitution_pass.cpp
@@ -135,13 +135,13 @@ PreservedAnalyses compiler::ImageArgumentSubstitutionPass::run(
       // Our wrapper hasn't been created with any parameter attributes, as the
       // parameter types have changed. We must copy across all attributes from
       // the non-sampler arguments to maintain program semantics.
-      AttributeList KernelAttrs = KernelF->getAttributes();
+      const AttributeList KernelAttrs = KernelF->getAttributes();
       SmallVector<AttributeSet, 4> WrapperParamAttrs(KernelF->arg_size());
 
       for (auto [OldArg, NewArg] :
            zip(KernelF->args(), WrapperKernel->args())) {
         // Copy parameter names across
-        unsigned ArgIdx = Args.size();
+        const unsigned ArgIdx = Args.size();
         NewArg.setName(OldArg.getName());
         if (OldArg.getType() == NewArg.getType()) {
           Args.push_back(&NewArg);

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -237,10 +237,11 @@ static bool loadKernelAPIHeader(clang::CompilerInstance &compiler,
   // stored inside the PCH file.
   llvm::BitstreamCursor &Cursor = moduleFile->InputFilesCursor;
   const clang::SavedStreamPosition SavedPosition(Cursor);
-  uint64_t Base = 0;
 #if LLVM_VERSION_GREATER_EQUAL(18, 0)
   // LLVM 18 introduces a new offset that should be included
-  Base = moduleFile->InputFilesOffsetBase;
+  const uint64_t Base = moduleFile->InputFilesOffsetBase;
+#else
+  const uint64_t Base = 0;
 #endif
   if (Cursor.JumpToBit(Base + moduleFile->InputFileOffsets[0])) {
     return false;

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -3772,11 +3772,11 @@ llvm::Error Builder::create<OpImageQuerySizeLod>(
       module.getInternalStructType(opFunctionParameter->IdResultType());
   SPIRV_LL_ASSERT(imgTy, "Unknown/untracked image type");
 
-  llvm::StringRef imageTypeName = imgTy->getStructName();
+  const llvm::StringRef imageTypeName = imgTy->getStructName();
 
-  bool isArray = imageTypeName.contains("array");
-  bool is2D = imageTypeName.contains("2d");
-  bool is3D = imageTypeName.contains("3d");
+  const bool isArray = imageTypeName.contains("array");
+  const bool is2D = imageTypeName.contains("2d");
+  const bool is3D = imageTypeName.contains("3d");
 #endif
 
   llvm::Value *result = llvm::UndefValue::get(returnType);

--- a/modules/compiler/utils/source/lld_linker.cpp
+++ b/modules/compiler/utils/source/lld_linker.cpp
@@ -141,7 +141,7 @@ Expected<std::unique_ptr<MemoryBuffer>> lldLinkToBinary(
   const bool linkResult = !s.retCode && s.canRunAgain;
   ::lld::CommonLinkerContext::destroy();
 #else
-  bool linkResult =
+  const bool linkResult =
       lld::elf::link(lld_args, outs(), stderrOS,
                      /*exitEarly*/ false, /*disableOutput*/ false);
   lld::CommonLinkerContext::destroy();


### PR DESCRIPTION
# Overview

[NFC] Add more const.

# Reason for change

This is a continuation of https://github.com/codeplaysoftware/oneapi-construction-kit/pull/304.

# Description of change

The main work on adding const was done on LLVM 18, but there are some variables that should be defined as const on LLVM 16 and LLVM 17 too.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
