### PR TITLE
[compiler] Improve analysis of 'true uniform' values

### DIFF
--- a/modules/compiler/vecz/source/include/analysis/uniform_value_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/uniform_value_analysis.h
@@ -41,8 +41,11 @@ class VectorizationUnit;
 /// @brief Holds the result of Uniform Value Analysis for a given function.
 struct UniformValueResult {
   enum class VaryingKind {
-    /// @brief The value is uniform.
-    eValueUniform,
+    /// @brief The value is truly uniform on all active and inactive lanes.
+    eValueTrueUniform,
+    /// @brief The value is uniform on active lanes. May be poison or undefined
+    /// on inactive lanes.
+    eValueActiveUniform,
     /// @brief The value is varying and lanes may see different values.
     eValueVarying,
     /// @brief The value is uniform, but its mask is not.
@@ -71,23 +74,32 @@ struct UniformValueResult {
   ///
   /// @param[in] V Value to analyze.
   ///
-  /// @brief true if the value needs to be packetized, false otherwise.
+  /// @return true if the value needs to be packetized, false otherwise.
   bool isVarying(const llvm::Value *V) const;
 
   /// @brief Determine whether the given value has a varying mask or not.
   ///
   /// @param[in] V Value to analyze.
   ///
-  /// @brief true if the value has a varying mask, false otherwise.
+  /// @return true if the value has a varying mask, false otherwise.
   bool isMaskVarying(const llvm::Value *V) const;
 
   /// @brief Determine whether the given value has a varying mask or not.
   ///
   /// @param[in] V Value to analyze.
   ///
-  /// @brief true if the value is varying or has a varying mask, false
+  /// @return true if the value is varying or has a varying mask, false
   /// otherwise.
   bool isValueOrMaskVarying(const llvm::Value *V) const;
+
+  /// @brief Determine (on demand) whether the given value is a true uniform
+  /// value.
+  ///
+  /// @param[in] V Value to analyze.
+  ///
+  /// @return true if the value is true uniform, false otherwise. Caches the
+  /// result for future queries.
+  bool isTrueUniform(const llvm::Value *V);
 
   /// @brief Remove the value from the analysis.
   ///

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge3.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/boscc_merge3.ll
@@ -27,7 +27,7 @@ declare i64 @__mux_get_global_id(i32) #0
 ; Function Attrs: nounwind readnone
 declare spir_func <4 x float> @_Z6vload4mPU3AS1Kf(i64, float addrspace(1)*)
 
-define spir_kernel void @boscc_merge3(float addrspace(1)* %out, i64 %n, float %m) {
+define spir_kernel void @boscc_merge3(float addrspace(1)* %out, i64 noundef %n, float noundef %m) {
 entry:
   %gid0 = tail call i64 @__mux_get_global_id(i32 0) #0
   %gid1 = tail call i64 @__mux_get_global_id(i32 1) #0

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization12.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization12.ll
@@ -213,7 +213,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization17.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization17.ll
@@ -130,7 +130,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 %n, i32 %x) #0 {
+define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 noundef %n, i32 noundef %x) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization18.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization18.ll
@@ -109,7 +109,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization19.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization19.ll
@@ -118,7 +118,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization5.ll
@@ -88,7 +88,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
@@ -227,11 +227,7 @@ attributes #2 = { nobuiltin nounwind readonly }
 
 ; CHECK: [[IFELSE5]]:
 ; CHECK: %[[CMP7:.+]] = icmp
-; FIXME: We shouldn't need to mask this comparison, as it's truly uniform even
-; on inactive lanes.
-; CHECK: %[[CMP7_ACTIVE:.+]] = and i1 %[[CMP7]], {{%.*}}
-; CHECK: %[[CMP7_ACTIVE_ANY:.+]] = call i1 @__vecz_b_divergence_any(i1 %[[CMP7_ACTIVE]])
-; CHECK: br i1 %[[CMP7_ACTIVE_ANY]], label %[[IFTHEN]], label %[[FORCOND14PREHEADER:.+]]
+; CHECK: br i1 %[[CMP7]], label %[[IFTHEN]], label %[[FORCOND14PREHEADER:.+]]
 
 ; CHECK: [[FORCOND14PREHEADER]]:
 ; CHECK: br label %[[FORCOND14:.+]]

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization6.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization6.ll
@@ -85,7 +85,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization6(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization6(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
@@ -168,11 +168,7 @@ attributes #2 = { nobuiltin nounwind readonly }
 
 ; CHECK: [[WHILEBODY]]:
 ; CHECK: %[[CMP:.+]] = icmp
-; FIXME: We shouldn't need to mask this comparison, as it's truly uniform even
-; on inactive lanes.
-; CHECK: %[[CMP_ACTIVE:.+]] = and i1 %[[CMP]], {{%.*}}
-; CHECK: %[[CMP_ACTIVE_ANY:.+]] = call i1 @__vecz_b_divergence_any(i1 %[[CMP_ACTIVE]])
-; CHECK: br i1 %[[CMP_ACTIVE_ANY]], label %[[IFTHEN:.+]], label %[[IFELSE:.+]]
+; CHECK: br i1 %[[CMP]], label %[[IFTHEN:.+]], label %[[IFELSE:.+]]
 
 ; CHECK: [[IFTHEN]]:
 ; CHECK: %[[CMP2:.+]] = icmp

--- a/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization7.ll
+++ b/modules/compiler/vecz/test/lit/llvm/Boscc/partial_linearization7.ll
@@ -102,7 +102,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization12.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization12.ll
@@ -211,7 +211,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization12(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization17.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization17.ll
@@ -128,7 +128,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 %n, i32 %x) #0 {
+define spir_kernel void @partial_linearization17(i32 addrspace(1)* %out, i32 noundef %n, i32 noundef %x) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization18.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization18.ll
@@ -107,7 +107,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization18(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization19.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization19.ll
@@ -116,7 +116,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization19(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization5.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization5.ll
@@ -86,7 +86,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization5(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32
@@ -187,11 +187,7 @@ attributes #2 = { nobuiltin nounwind readonly }
 
 ; CHECK: [[IFELSE5]]:
 ; CHECK: %[[CMP7:.+]] = icmp
-; FIXME: We shouldn't need to mask this comparison, as it's truly uniform even
-; on inactive lanes.
-; CHECK: %[[CMP7_ACTIVE:.+]] = and i1 %[[CMP7]], {{%.*}}
-; CHECK: %[[CMP7_ACTIVE_ANY:.+]] = call i1 @__vecz_b_divergence_any(i1 %[[CMP7_ACTIVE]])
-; CHECK: br i1 %[[CMP7_ACTIVE_ANY]], label %[[IFTHEN]], label %[[FORCOND14PREHEADER:.+]]
+; CHECK: br i1 %[[CMP7]], label %[[IFTHEN]], label %[[FORCOND14PREHEADER:.+]]
 
 ; CHECK: [[FORCOND14PREHEADER]]:
 ; CHECK: br label %[[FORCOND14:.+]]

--- a/modules/compiler/vecz/test/lit/llvm/partial_linearization7.ll
+++ b/modules/compiler/vecz/test/lit/llvm/partial_linearization7.ll
@@ -93,7 +93,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 %n) #0 {
+define spir_kernel void @partial_linearization7(i32 addrspace(1)* %out, i32 noundef %n) #0 {
 entry:
   %call = call i64 @__mux_get_global_id(i32 0) #2
   %conv = trunc i64 %call to i32


### PR DESCRIPTION
This commit extends the Uniform Value Analysis with a fourth kind of uniformity: "true" uniformity. This represents a value that is uniform on both active and inactive lanes. The old class of "uniform" has been renamed to "active" uniformity to clarify this.

The analysis pass has been extended with a method to query whether a value is truly uniform. It processes this recursively on demand and caches the result. This is because the initial analysis run works from varying "roots" and marks all dependent values as varying - uniform values aren't handled at all. Rather than negatively affecting the performance of all Uniform Value Analysis runs, this on-demand method keeps costs the same except for users that need to query uniformity.

The query is still conservative, but less so. This can be seen in the test changes, where some cases which were previously conservatively handled as possibly varying/active uniform are now seen as truly uniform.