### PR TITLE
[NFC] Remove unused denorm_support.

### DIFF
--- a/source/cl/test/UnitCL/include/kts/precision.h
+++ b/source/cl/test/UnitCL/include/kts/precision.h
@@ -238,22 +238,18 @@ cl_half ConvertFloatToHalf(const T x,
 ///
 /// @param reference        Reference 32-bit float value
 /// @param test             Half precision value we've calculated
-/// @param denorm_support   Whether device supports denormal numbers
 ///
 /// @return ULP calculated as a float value.
-cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test,
-                              bool denorm_support);
+cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test);
 
 /// @brief Calculates the ULP between two floating points values, ignoring
 ///        the mantissa bits not available in half precision.
 ///
 /// @param reference        Reference 64-bit float value
 /// @param test             Half precision value we've calculated
-/// @param denorm_support   Whether device supports denormal numbers
 ///
 /// @return ULP calculated as a double precision value.
-cl_double calcHalfPrecisionULP(const cl_double reference, const cl_half test,
-                               bool denorm_support);
+cl_double calcHalfPrecisionULP(const cl_double reference, const cl_half test);
 
 /// @brief Discovers if input is a finite denormal number when converted from
 ///        single precision to half precision
@@ -411,19 +407,16 @@ struct ULPValidator final {
 /// @brief Verifies that two half values are within a template defined ULP
 template <cl_ulong ULP, bool test_denormals>
 struct ULPValidator<cl_half, ULP, test_denormals> final {
-  ULPValidator(cl_device_id device) : ulp_err(0.0f) {
-    denorm_support = test_denormals &&
-                     UCL::hasDenormSupport(device, CL_DEVICE_HALF_FP_CONFIG);
-  }
+  ULPValidator(cl_device_id) : ulp_err(0.0f) {}
 
   bool validate(const cl_float &expected, const cl_half &actual) {
-    ulp_err = calcHalfPrecisionULP(expected, actual, denorm_support);
+    ulp_err = calcHalfPrecisionULP(expected, actual);
     return (std::fabs(ulp_err) <= static_cast<cl_float>(ULP)) ||
            (std::isinf(ulp_err) && (ULP == MAX_ULP_ERROR));
   }
 
   bool validate(const cl_double &expected, const cl_half &actual) {
-    ulp_err = calcHalfPrecisionULP(expected, actual, denorm_support);
+    ulp_err = calcHalfPrecisionULP(expected, actual);
     return (std::fabs(ulp_err) <= static_cast<cl_double>(ULP)) ||
            (std::isinf(ulp_err) && (ULP == MAX_ULP_ERROR));
   }
@@ -467,7 +460,6 @@ struct ULPValidator<cl_half, ULP, test_denormals> final {
 
  private:
   cl_float ulp_err;
-  bool denorm_support;
 };
 
 template <typename T, cl_ulong ULP, bool test_denormals = true, typename F>

--- a/source/cl/test/UnitCL/source/kts/precision.cpp
+++ b/source/cl/test/UnitCL/source/kts/precision.cpp
@@ -370,8 +370,7 @@ cl_half ConvertFloatToHalf(const T x, RoundingMode rounding) {
 template cl_half ConvertFloatToHalf<cl_float>(const cl_float, RoundingMode);
 template cl_half ConvertFloatToHalf<cl_double>(const cl_double, RoundingMode);
 
-cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test,
-                              bool denorm_support) {
+cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test) {
   cl_float test_as_float = ConvertHalfToFloat(test);
   const cl_half ref_as_half = ConvertFloatToHalf(reference);
 
@@ -400,7 +399,6 @@ cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test,
     test_as_float = std::copysign(65536.0f, test_as_float);
   }
 
-  (void)denorm_support;
   int reference_exp = std::ilogb(reference);
   if (0 == (cargo::bit_cast<uint32_t>(reference) &
             TypeInfo<cl_float>::mantissa_mask)) {
@@ -416,8 +414,7 @@ cl_float calcHalfPrecisionULP(const cl_float reference, const cl_half test,
   return std::scalbn(test_as_float - reference, ulp_exp);
 }
 
-cl_double calcHalfPrecisionULP(const cl_double reference, const cl_half test,
-                               bool denorm_support) {
+cl_double calcHalfPrecisionULP(const cl_double reference, const cl_half test) {
   cl_double test_as_float = ConvertHalfToFloat(test);
   const cl_half ref_as_half = ConvertFloatToHalf(reference);
 
@@ -446,7 +443,6 @@ cl_double calcHalfPrecisionULP(const cl_double reference, const cl_half test,
     test_as_float = std::copysign(65536.0f, test_as_float);
   }
 
-  (void)denorm_support;
   int reference_exp = std::ilogb(reference);
   if (0 == (cargo::bit_cast<uint64_t>(reference) &
             TypeInfo<cl_double>::mantissa_mask)) {

--- a/source/cl/test/UnitCL/source/ktst_geometric.cpp
+++ b/source/cl/test/UnitCL/source/ktst_geometric.cpp
@@ -91,13 +91,11 @@ struct AbsoluteErrValidator final {
 };
 
 struct ULPErrValidator final {
-  ULPErrValidator(cl_device_id device) : previous(0.0), previous_set(false) {
-    denorm_support = UCL::hasDenormSupport(device, CL_DEVICE_HALF_FP_CONFIG);
-  }
+  ULPErrValidator(cl_device_id) : previous(0.0), previous_set(false) {}
 
   bool validate(const cl_float &expected, const cl_half &actual,
                 const cl_float ulp_threshold) {
-    const cl_float ulp = calcHalfPrecisionULP(expected, actual, denorm_support);
+    const cl_float ulp = calcHalfPrecisionULP(expected, actual);
     return std::fabs(ulp) <= std::fabs(ulp_threshold);
   }
 
@@ -107,8 +105,7 @@ struct ULPErrValidator final {
     s << ", as float 0x" << matchingType(as_float) << std::dec;
 
     if (previous_set) {
-      s << ", ulp: "
-        << calcHalfPrecisionULP(previous, as_float, denorm_support);
+      s << ", ulp: " << calcHalfPrecisionULP(previous, as_float);
     }
   }
 
@@ -125,7 +122,6 @@ struct ULPErrValidator final {
  private:
   cl_float previous;
   bool previous_set;
-  bool denorm_support;
 };
 
 template <class V>


### PR DESCRIPTION
# Overview

[NFC] Remove unused denorm_support.

# Reason for change

This was left over from a previous implementation, but is no longer used.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
