### PR TITLE
[spirv-ll] Add noundef param attrs to kernel entry points

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_2d2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_2d2d.spvasm
@@ -49,7 +49,7 @@
             %numLines = OpConstant %int64T 8
           %lineLength = OpConstant %int64T 4
 
-; CHECK: define spir_kernel void @test(ptr addrspace(1) [[in:%.*]], ptr addrspace(3) [[scratch:%.*]], ptr addrspace(1) [[out:%.*]])
+; CHECK: define spir_kernel void @test(ptr addrspace(1) noundef [[in:%.*]], ptr addrspace(3) noundef [[scratch:%.*]], ptr addrspace(1) noundef [[out:%.*]])
               %testFn = OpFunction %voidT DontInline %testFnT
                   %in = OpFunctionParameter %intGlobalPtrT
              %scratch = OpFunctionParameter %intLocalPtrT

--- a/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_3d3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_3d3d.spvasm
@@ -51,7 +51,7 @@
            %numPlanes = OpConstant %int64T 2
            %planeArea = OpConstant %int64T 32   ; %lineLength * %numLines
 
-; CHECK: define spir_kernel void @test(ptr addrspace(1) [[in:%.*]], ptr addrspace(3) [[scratch:%.*]], ptr addrspace(1) [[out:%.*]])
+; CHECK: define spir_kernel void @test(ptr addrspace(1) noundef [[in:%.*]], ptr addrspace(3) noundef [[scratch:%.*]], ptr addrspace(1) noundef [[out:%.*]])
               %testFn = OpFunction %voidT DontInline %testFnT
                   %in = OpFunctionParameter %intGlobalPtrT
              %scratch = OpFunctionParameter %intLocalPtrT

--- a/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_usm_generic_address_space.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_usm_generic_address_space.spvasm
@@ -53,7 +53,7 @@
 ; of variable are covered: we have global and local OpFunctionParameters, a
 ; function scope OpVariable and a couple of OpVariables that represent work item
 ; builtins.
-; CHECK: define spir_kernel void @test(ptr{{( %.*)?}}, ptr{{( %.*)?}}, ptr{{( %.*)?}})
+; CHECK: define spir_kernel void @test(ptr noundef{{( %.*)?}}, ptr noundef{{( %.*)?}}, ptr noundef{{( %.*)?}})
          %11 = OpFunction %void DontInline %10
         %src = OpFunctionParameter %_ptr_Generic_uint
         %dst = OpFunctionParameter %_ptr_Generic_uint

--- a/modules/compiler/spirv-ll/test/spvasm/intel_arbitrary_precision_integers.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/intel_arbitrary_precision_integers.spvasm
@@ -35,7 +35,7 @@
 
        %3 = OpTypeFunction %void %u40 %ptr_u40
 
-; CHECK: define spir_kernel void @kernel(i40 %x, {{(ptr|i40\*)}} %p)
+; CHECK: define spir_kernel void @kernel(i40 noundef %x, {{(ptr|i40\*)}} noundef %p)
   %kernel = OpFunction %void None %3
        %x = OpFunctionParameter %u40
        %p = OpFunctionParameter %ptr_u40

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_generic.spvasm
@@ -40,7 +40,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(4) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(4) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_andPU3AS4Vjj(ptr addrspace(4) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_andPU3AS4Vjj(ptr addrspace(4), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_andPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_andPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_and_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_andPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_andPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_generic.spvasm
@@ -40,7 +40,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(4) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(4) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z14atomic_cmpxchgPU3AS4Vjjj(ptr addrspace(4) [[IN]], i32 1, i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z14atomic_cmpxchgPU3AS4Vjjj(ptr addrspace(4), i32, i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z14atomic_cmpxchgPU3AS1Vjjj(ptr addrspace(1) [[IN]], i32 1, i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z14atomic_cmpxchgPU3AS1Vjjj(ptr addrspace(1), i32, i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_compare_exchange_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z14atomic_cmpxchgPU3AS3Vjjj(ptr addrspace(3) [[IN]], i32 1, i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z14atomic_cmpxchgPU3AS3Vjjj(ptr addrspace(3), i32, i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_generic.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_generic.spvasm
@@ -40,7 +40,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(4) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(4) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z11atomic_xchgPU3AS4Vjj(ptr addrspace(4) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z11atomic_xchgPU3AS4Vjj(ptr addrspace(4), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z11atomic_xchgPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z11atomic_xchgPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_global_float.spvasm
@@ -39,7 +39,7 @@
 %original = OpAtomicExchange %float %a %uint_1 %uint_0 %9
             OpReturn
             OpFunctionEnd
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func float @_Z11atomic_xchgPU3AS1Vff(ptr addrspace(1) [[IN]], float 4.240000e+02)
 ; CHECK: ret void
 ; CHECK: declare spir_func float @_Z11atomic_xchgPU3AS1Vff(ptr addrspace(1), float)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_exchange_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z11atomic_xchgPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z11atomic_xchgPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_addPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_addPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_add_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_addPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_addPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_subPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_subPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_i_sub_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_subPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_subPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z9atomic_orPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z9atomic_orPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_or_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z9atomic_orPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z9atomic_orPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_maxPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_maxPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_max_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_maxPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_maxPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_minPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_minPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_u_min_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_minPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_minPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_global.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(1) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_xorPU3AS1Vjj(ptr addrspace(1) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_xorPU3AS1Vjj(ptr addrspace(1), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_local.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_atomic_xor_local.spvasm
@@ -39,7 +39,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @atomic(ptr addrspace(3) [[IN:%.*]])
+; CHECK: define spir_kernel void @atomic(ptr addrspace(3) noundef [[IN:%.*]])
 ; CHECK: = call spir_func i32 @_Z10atomic_xorPU3AS3Vjj(ptr addrspace(3) [[IN]], i32 424)
 ; CHECK: ret void
 ; CHECK: declare spir_func i32 @_Z10atomic_xorPU3AS3Vjj(ptr addrspace(3), i32)

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -40,8 +40,8 @@
        %const_sampler = OpConstantSampler %sampler_t None 0 Nearest
     %constant_sampler = OpFunction %void_t None %sampler_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
        %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -46,8 +46,8 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image1d_array_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -46,8 +46,8 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -44,8 +44,8 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_array_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -44,8 +44,8 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image3d_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
 ; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)

--- a/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_generic_pointer.spvasm
@@ -39,7 +39,7 @@
          %20 = OpFunction %void None %19
    %_arg_ptr = OpFunctionParameter %_ptr_Generic_ulong
 ; Check we use the right address space for generic pointers
-; CHECK: define spir_kernel void @entry_pt(ptr addrspace(4) [[PTR:%.*]])
+; CHECK: define spir_kernel void @entry_pt(ptr addrspace(4) noundef [[PTR:%.*]])
       %entry = OpLabel
 
           %x = OpIAdd %ulong %ulong_0 %ulong_1

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_all.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_all.spvasm
@@ -44,7 +44,7 @@
            %sub_group_scope = OpConstant %uint_ty 3
 
 
-; CHECK: define spir_kernel void @sub_group_all(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_all(ptr addrspace(1) noundef [[IN:%.*]])
          %sub_group_all_fcn = OpFunction %void_ty None %fcn_ty
           %sub_group_all_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
           %sub_group_all_bb = OpLabel
@@ -60,7 +60,7 @@
                               OpReturn
                               OpFunctionEnd
 
-; CHECK: define spir_kernel void @work_group_all(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @work_group_all(ptr addrspace(1) noundef [[IN:%.*]])
         %work_group_all_fcn = OpFunction %void_ty None %fcn_ty
          %work_group_all_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
          %work_group_all_bb = OpLabel
@@ -76,7 +76,7 @@
                              OpReturn
                              OpFunctionEnd
 
-; CHECK: define spir_kernel void @variable_scope_all(ptr addrspace(1) %a, i32 %0)
+; CHECK: define spir_kernel void @variable_scope_all(ptr addrspace(1) noundef %a, i32 noundef %0)
     %variable_scope_all_fcn = OpFunction %void_ty None %variable_scope_fcn_ty
      %variable_scope_all_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
                      %scope = OpFunctionParameter %uint_ty

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_any.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_any.spvasm
@@ -43,7 +43,7 @@
           %work_group_scope = OpConstant %uint_ty 2
            %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_any(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_any(ptr addrspace(1) noundef [[IN:%.*]])
          %sub_group_any_fcn = OpFunction %void_ty None %fcn_ty
           %sub_group_any_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
           %sub_group_any_bb = OpLabel
@@ -59,7 +59,7 @@
                               OpReturn
                               OpFunctionEnd
 
-; CHECK: define spir_kernel void @work_group_any(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @work_group_any(ptr addrspace(1) noundef [[IN:%.*]])
         %work_group_any_fcn = OpFunction %void_ty None %fcn_ty
          %work_group_any_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
          %work_group_any_bb = OpLabel
@@ -75,7 +75,7 @@
                              OpReturn
                              OpFunctionEnd
 
-; CHECK: define spir_kernel void @variable_scope_any(ptr addrspace(1) %a, i32 %0)
+; CHECK: define spir_kernel void @variable_scope_any(ptr addrspace(1) noundef %a, i32 noundef %0)
     %variable_scope_any_fcn = OpFunction %void_ty None %variable_scope_fcn_ty
      %variable_scope_any_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
                      %scope = OpFunctionParameter %uint_ty

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
@@ -55,7 +55,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
@@ -54,7 +54,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
@@ -53,7 +53,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
@@ -53,7 +53,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
@@ -55,7 +55,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
@@ -54,7 +54,7 @@
                OpReturn
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size)
+; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
 ; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
 ; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
 ; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast.spvasm
@@ -51,7 +51,7 @@
                        %zero = OpConstant %uint_ty 0
 
 ; CHCK-LABEL: sub_group_uint_broadcast
-; CHECK: define spir_kernel void @sub_group_uint_broadcast(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_uint_broadcast(ptr addrspace(1) noundef [[IN:%.*]])
 %sub_group_uint_broadcast_fcn = OpFunction %void_ty None %uint_fcn_ty
            %uint_broadcast_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
            %uint_broadcast_bb = OpLabel
@@ -66,7 +66,7 @@
                                 OpFunctionEnd
 
 ; CHCK-LABEL: work_group_uint_broadcast
-; CHECK: define spir_kernel void @work_group_uint_broadcast(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @work_group_uint_broadcast(ptr addrspace(1) noundef [[IN:%.*]])
 %work_group_uint_broadcast_fcn = OpFunction %void_ty None %uint_fcn_ty
  %uint_work_group_broadcast_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
  %uint_work_group_broadcast_bb = OpLabel
@@ -81,7 +81,7 @@
                                  OpFunctionEnd
 
 ; CHCK-LABEL: variable_scope_uint_broadcast
-; CHECK: define spir_kernel void @variable_scope_uint_broadcast(ptr addrspace(1) [[IN:%.*]], i32 %{{.*}})
+; CHECK: define spir_kernel void @variable_scope_uint_broadcast(ptr addrspace(1) noundef [[IN:%.*]], i32 noundef %{{.*}})
 %variable_scope_uint_broadcast_fcn = OpFunction %void_ty None %uint_uint_fcn_ty
  %uint_variable_scope_broadcast_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
                             %scope = OpFunctionParameter %uint_ty
@@ -97,7 +97,7 @@
                                      OpFunctionEnd
 
 ; CHCK-LABEL: float_broadcast
-; CHECK: define spir_kernel void @float_broadcast(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @float_broadcast(ptr addrspace(1) noundef [[IN:%.*]])
         %float_broadcast_fcn = OpFunction %void_ty None %float_fcn_ty
          %float_broadcast_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
          %float_broadcast_bb = OpLabel
@@ -114,7 +114,7 @@
 ; CHECK: declare spir_func float @_Z19sub_group_broadcastfj(float, i32)
 
 ; CHCK-LABEL: bool_broadcast
-; CHECK: define spir_kernel void @bool_broadcast(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @bool_broadcast(ptr addrspace(1) noundef [[IN:%.*]])
          %bool_broadcast_fcn = OpFunction %void_ty None %bool_fcn_ty
           %bool_broadcast_in = OpFunctionParameter %ptr_CrossWorkgroup_bool_ty
           %bool_broadcast_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_2D.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_2D.spvasm
@@ -37,7 +37,7 @@
           %fcn_ty = OpTypeFunction %void_ty %uint_ty %uint2_ty
 %work_group_scope = OpConstant %uint_ty 2
 
-; CHECK: define spir_kernel void @broadcast(i32 [[VAL:%.*]], <2 x i32> [[XY:%.*]])
+; CHECK: define spir_kernel void @broadcast(i32 noundef [[VAL:%.*]], <2 x i32> noundef [[XY:%.*]])
 ; CHECK:  [[X:%.*]] = extractelement <2 x i32> [[XY]], i64 0
 ; CHECK:  [[Y:%.*]] = extractelement <2 x i32> [[XY]], i64 1
 ; CHECK:  [[Xi64:%.*]] = zext i32 [[X]] to i64

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_3D.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_broadcast_3D.spvasm
@@ -37,7 +37,7 @@
           %fcn_ty = OpTypeFunction %void_ty %uint_ty %uint3_ty
 %work_group_scope = OpConstant %uint_ty 2
 
-; CHECK: define spir_kernel void @broadcast(i32 [[VAL:%.*]], <3 x i32> [[XYZ:%.*]])
+; CHECK: define spir_kernel void @broadcast(i32 noundef [[VAL:%.*]], <3 x i32> noundef [[XYZ:%.*]])
 ; CHECK:  [[X:%.*]] = extractelement <3 x i32> [[XYZ]], i64 0
 ; CHECK:  [[Y:%.*]] = extractelement <3 x i32> [[XYZ]], i64 1
 ; CHECK:  [[Z:%.*]] = extractelement <3 x i32> [[XYZ]], i64 2

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_add.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_add.spvasm
@@ -41,7 +41,7 @@
 
             %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
      %sub_group_reduction_bb = OpLabel
@@ -57,7 +57,7 @@
 
 ; CHECK: declare spir_func float @_Z20sub_group_reduce_addf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_inc_bb = OpLabel
@@ -73,7 +73,7 @@
 
 ; CHECK: declare spir_func float @_Z28sub_group_scan_inclusive_addf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_max.spvasm
@@ -41,7 +41,7 @@
 
             %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
      %sub_group_reduction_bb = OpLabel
@@ -57,7 +57,7 @@
 
 ; CHECK: declare spir_func float @_Z20sub_group_reduce_maxf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_inc_bb = OpLabel
@@ -73,7 +73,7 @@
 
 ; CHECK: declare spir_func float @_Z28sub_group_scan_inclusive_maxf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_min.spvasm
@@ -41,7 +41,7 @@
 
             %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
      %sub_group_reduction_bb = OpLabel
@@ -57,7 +57,7 @@
 
 ; CHECK: declare spir_func float @_Z20sub_group_reduce_minf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_inc_bb = OpLabel
@@ -73,7 +73,7 @@
 
 ; CHECK: declare spir_func float @_Z28sub_group_scan_inclusive_minf(float)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
      %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
       %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_float_ty
       %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_i_add.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_i_add.spvasm
@@ -45,7 +45,7 @@
             %work_group_scope = OpConstant %uint_ty 2
 
 ; CHCK-LABEL: uint_sub_group_reduction
-; CHECK: define spir_kernel void @uint_sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @uint_sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
 %uint_sub_group_reduction_fcn = OpFunction %void_ty None %uint_fcn_ty
  %uint_sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
  %uint_sub_group_reduction_bb = OpLabel
@@ -61,7 +61,7 @@
 ; CHECK: declare spir_func i32 @_Z20sub_group_reduce_addj(i32)
 
 ; CHCK-LABEL: uint_work_group_reduction
-; CHECK: define spir_kernel void @uint_work_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @uint_work_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
 %uint_work_group_reduction_fcn = OpFunction %void_ty None %uint_fcn_ty
  %uint_work_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
  %uint_work_group_reduction_bb = OpLabel
@@ -76,7 +76,7 @@
                                 OpFunctionEnd
 
 ; CHCK-LABEL: uint_variable_scope_reduction
-; CHECK: define spir_kernel void @uint_variable_scope_reduction(ptr addrspace(1) [[IN:%.*]], i32 %{{.*}})
+; CHECK: define spir_kernel void @uint_variable_scope_reduction(ptr addrspace(1) noundef [[IN:%.*]], i32 noundef %{{.*}})
 %uint_variable_scope_reduction_fcn = OpFunction %void_ty None %uint_uint_fcn_ty
  %uint_variable_scope_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
                             %scope = OpFunctionParameter %uint_ty
@@ -92,7 +92,7 @@
                                 OpFunctionEnd
 
 ; CHCK-LABEL: uint_sub_group_inclusive_scan
-; CHECK: define spir_kernel void @uint_sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @uint_sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
  %uint_sub_group_scan_inc_fcn = OpFunction %void_ty None %uint_fcn_ty
   %uint_sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
   %uint_sub_group_scan_inc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_s_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_s_max.spvasm
@@ -40,7 +40,7 @@
 
            %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
    %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
     %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
     %sub_group_reduction_bb = OpLabel
@@ -56,7 +56,7 @@
 
 ; CHECK: declare spir_func i32 @_Z20sub_group_reduce_maxi(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
      %sub_group_scan_inc_bb = OpLabel
@@ -72,7 +72,7 @@
 
 ; CHECK: declare spir_func i32 @_Z28sub_group_scan_inclusive_maxi(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
      %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_s_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_s_min.spvasm
@@ -40,7 +40,7 @@
 
            %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
    %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
     %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
     %sub_group_reduction_bb = OpLabel
@@ -56,7 +56,7 @@
 
 ; CHECK: declare spir_func i32 @_Z20sub_group_reduce_mini(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
      %sub_group_scan_inc_bb = OpLabel
@@ -72,7 +72,7 @@
 
 ; CHECK: declare spir_func i32 @_Z28sub_group_scan_inclusive_mini(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_int_ty
      %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_u_max.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_u_max.spvasm
@@ -40,7 +40,7 @@
 
            %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
    %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
     %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
     %sub_group_reduction_bb = OpLabel
@@ -56,7 +56,7 @@
 
 ; CHECK: declare spir_func i32 @_Z20sub_group_reduce_maxj(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_inc(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inc(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
      %sub_group_scan_inc_bb = OpLabel
@@ -72,7 +72,7 @@
 
 ; CHECK: declare spir_func i32 @_Z28sub_group_scan_inclusive_maxj(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_exc(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exc(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
      %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_u_min.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_u_min.spvasm
@@ -40,7 +40,7 @@
 
            %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_reduction(ptr addrspace(1) noundef [[IN:%.*]])
    %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
     %sub_group_reduction_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
     %sub_group_reduction_bb = OpLabel
@@ -56,7 +56,7 @@
 
 ; CHECK: declare spir_func i32 @_Z20sub_group_reduce_minj(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_inclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_inc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_inc_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
      %sub_group_scan_inc_bb = OpLabel
@@ -72,7 +72,7 @@
 
 ; CHECK: declare spir_func i32 @_Z28sub_group_scan_inclusive_minj(i32)
 
-; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) [[IN:%.*]])
+; CHECK: define spir_kernel void @sub_group_scan_exclusive(ptr addrspace(1) noundef [[IN:%.*]])
     %sub_group_scan_exc_fcn = OpFunction %void_ty None %fcn_ty
      %sub_group_scan_exc_in = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
      %sub_group_scan_exc_bb = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_wait_events.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_wait_events.spvasm
@@ -40,7 +40,7 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK: define spir_kernel void @await_events(ptr addrspace(4) %event)
+; CHECK: define spir_kernel void @await_events(ptr addrspace(4) noundef %event)
 ; CHECK-SAME: !kernel_arg_addr_space [[ARG_AS:\![0-9]+]] !kernel_arg_access_qual {{\!.*}} !kernel_arg_type [[ARG_TYS:\![0-9]+]] !kernel_arg_base_type [[ARG_TYS]] !kernel_arg_type_qual {{\!.*}} !kernel_arg_name [[ARG_NAMES:\![0-9]*]]
 
 ; CHECK: call spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event(i32 1, ptr addrspace(4) %event)

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_wrapper_clash.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_wrapper_clash.spvasm
@@ -40,7 +40,7 @@
 
              %sub_group_scope = OpConstant %uint_ty 3
 
-; CHECK: define spir_kernel void @sub_group_reduction_fn(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %c)
+; CHECK: define spir_kernel void @sub_group_reduction_fn(ptr addrspace(1) noundef %a, ptr addrspace(1) noundef %b, ptr addrspace(1) noundef %c)
      %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty
                            %a = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty
                            %b = OpFunctionParameter %ptr_CrossWorkgroup_uint_ty

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -46,8 +46,8 @@
            %4 = OpImageRead %float4_t %get_image %int_0
                 OpReturn
                 OpFunctionEnd
-; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image, target("spirv.Sampler"){{( %0)?}})
-; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] %image, ptr{{( %0)?}})
+; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image, target("spirv.Sampler") noundef{{( %0)?}})
+; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] noundef %image, ptr noundef{{( %0)?}})
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[IMG_TY]] %image, i32 0)
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di([[IMG_TY]] %image, i32 0)
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image1d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
@@ -35,8 +35,8 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image1darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
@@ -35,8 +35,8 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type17ocl_image1dbuffer([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
@@ -35,8 +35,8 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image2darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image3d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image1d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
@@ -35,8 +35,8 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order16ocl_image1darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
@@ -35,8 +35,8 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order17ocl_image1dbuffer([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image2d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
@@ -35,8 +35,8 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order16ocl_image2darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
@@ -35,8 +35,8 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image3d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
@@ -36,8 +36,8 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %int_t %image %int_1
 ; CHECK: = call spir_func i32 @_Z15get_image_width11ocl_image1d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
@@ -37,8 +37,8 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
@@ -37,8 +37,8 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
@@ -37,8 +37,8 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image2d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
@@ -37,8 +37,8 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
@@ -37,8 +37,8 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
@@ -37,8 +37,8 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image3d([[IMG_TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image3d([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image3d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image3d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
@@ -36,8 +36,8 @@
       %uint_0 = OpConstant %uint_t 0
      %image1d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %uint_0
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[TY]] %image, i32 0)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
@@ -38,8 +38,8 @@
             %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
    %image1d_array = OpFunction %void_t None %foo_t
            %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %image)
                %1 = OpLabel
                %3 = OpImageRead %uint4_t %image %int2_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darrayDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
@@ -36,8 +36,8 @@
                %int_0 = OpConstant %uint_t 0
       %image1d_buffer = OpFunction %void_t None %foo_t
                %image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %image)
                    %1 = OpLabel
                    %3 = OpImageRead %uint4_t %image %int_0
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui17ocl_image1dbufferi([[TY]] %image, i32 0)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
@@ -38,8 +38,8 @@
       %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
      %image2d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int2_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2dDv2_i([[TY]] %image, <2 x i32> <i32 1, i32 1>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
@@ -37,8 +37,8 @@
             %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image2d_array = OpFunction %void_t None %foo_t
              %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %image)
                  %1 = OpLabel
                  %3 = OpImageRead %uint4_t %image %int4_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darrayDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
@@ -37,8 +37,8 @@
       %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image3d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int4_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3dDv4_i([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -44,10 +44,10 @@
            %image1d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] noundef %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                 %10 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                 %11 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -48,10 +48,10 @@
      %image1d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] noundef %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -48,10 +48,10 @@
            %image2d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] noundef %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -45,10 +45,10 @@
      %image2d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] noundef %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
         %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -46,10 +46,10 @@
            %image3d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] %in_image)
+; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
+; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] noundef %in_sampler,
+; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
@@ -45,8 +45,8 @@
 ; All functions              
                     %test = OpFunction %void_t None %testfnty
                    %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @test([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @test([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @test([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @test([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %int_0 %float4_color
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image1diDv4_f([[TY]] %image, i32 0, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
@@ -45,8 +45,8 @@
 ; All functions
            %image1d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef16ocl_image1darrayDv2_iDv4_f([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
@@ -43,8 +43,8 @@
 ; All functions
           %image1d_buffer = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %uint_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef17ocl_image1dbufferiDv4_f([[TY]] %image, i32 1, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
@@ -44,8 +44,8 @@
 ; All functions
                  %image2d = OpFunction %void_t None %image_write_fn_t                            
                    %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f([[TY]] %image, <2 x i32> <i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
@@ -41,8 +41,8 @@
 ; All functions
            %image2d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef16ocl_image2darrayDv4_iDv4_f([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
@@ -42,8 +42,8 @@
 ; All functions
                  %image3d = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] %image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] %image)
+; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
+; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4uint_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image3dDv4_iDv4_f([[TY]] %image, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
@@ -42,7 +42,7 @@
             OpReturn
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
-; CHECK: define spir_kernel void @lifetime(ptr addrspace(3) [[PTR:%.*]])
+; CHECK: define spir_kernel void @lifetime(ptr addrspace(3) noundef [[PTR:%.*]])
 ; We can't generate these intrinsics with address space 3 on llvm 4.0
 ; CHECK: {{(call void @llvm.lifetime.start.p3(i64 4, ptr addrspace(3) [[PTR]]))?}}
 ; CHECK: {{(call void @llvm.lifetime.end.p3(i64 4, ptr addrspace(3) [[PTR]]))?}}

--- a/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_semantics.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_memory_barrier_variable_semantics.spvasm
@@ -32,5 +32,5 @@
                OpMemoryBarrier %uint_2 %input_semantics
                OpReturn
                OpFunctionEnd
-; CHECK: define spir_kernel void @testfn(i32 [[SEMANTICS:%.*]])
+; CHECK: define spir_kernel void @testfn(i32 noundef [[SEMANTICS:%.*]])
 ; CHECK: call spir_func void @__mux_mem_barrier(i32 2, i32 [[SEMANTICS]])

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
@@ -58,11 +58,11 @@
                 OpFunctionEnd
 
 
-; CHECK: define spir_kernel void @my_kernel(ptr addrspace(1) %a,
-; CHECK-SAME:                              [3 x ptr addrspace(1)] %b, ptr addrspace(3) %c,
-; CHECK-GE17-SAME:                         target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %d
-; CHECK-LT17-SAME:                         ptr addrspace(1) %d
-; CHECK-SAME:                              ptr addrspace(1) %e)
+; CHECK: define spir_kernel void @my_kernel(ptr addrspace(1) noundef %a,
+; CHECK-SAME:                              [3 x ptr addrspace(1)] noundef %b, ptr addrspace(3) noundef %c,
+; CHECK-GE17-SAME:                         target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) noundef %d
+; CHECK-LT17-SAME:                         ptr addrspace(1) noundef %d
+; CHECK-SAME:                              ptr addrspace(1) noundef %e)
 
 ; CHECK-SAME: !kernel_arg_addr_space !0 !kernel_arg_access_qual !1 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !3 !kernel_arg_name !4 {
 

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
          %fract_float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @fract_float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 fract %float_1 %in_ptr
 ; CHECK: = call spir_func float @_Z5fractfPU3AS1f(float 0x3FF6666660000000, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
       %fract_v16float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @fract_v16float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_v16float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 fract %v16float_1 %in_ptr
 ; CHECK: = call spir_func <16 x float> @_Z5fractDv16_fPU3AS1S_(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v2float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @fract_v2float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_v2float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 fract %v2float_1 %in_ptr
 ; CHECK: = call spir_func <2 x float> @_Z5fractDv2_fPU3AS1S_(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v3float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @fract_v3float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_v3float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 fract %v3float_1 %in_ptr
 ; CHECK: = call spir_func <3 x float> @_Z5fractDv3_fPU3AS1S_(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v4float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @fract_v4float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_v4float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 fract %v4float_1 %in_ptr
 ; CHECK: = call spir_func <4 x float> @_Z5fractDv4_fPU3AS1S_(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_global_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
        %fract_v8float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @fract_v8float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @fract_v8float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 fract %v8float_1 %in_ptr
 ; CHECK: = call spir_func <8 x float> @_Z5fractDv8_fPU3AS1S_(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
          %fract_float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @fract_float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 fract %float_1 %in_ptr
 ; CHECK: = call spir_func float @_Z5fractfPU3AS3f(float 0x3FF6666660000000, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
       %fract_v16float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @fract_v16float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_v16float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 fract %v16float_1 %in_ptr
 ; CHECK: = call spir_func <16 x float> @_Z5fractDv16_fPU3AS3S_(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v2float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @fract_v2float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_v2float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 fract %v2float_1 %in_ptr
 ; CHECK: = call spir_func <2 x float> @_Z5fractDv2_fPU3AS3S_(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v3float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @fract_v3float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_v3float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 fract %v3float_1 %in_ptr
 ; CHECK: = call spir_func <3 x float> @_Z5fractDv3_fPU3AS3S_(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %fract_v4float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @fract_v4float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_v4float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 fract %v4float_1 %in_ptr
 ; CHECK: = call spir_func <4 x float> @_Z5fractDv4_fPU3AS3S_(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_fract_local_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
        %fract_v8float = OpFunction %void_t None %fract_fn_t
               %in_ptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @fract_v8float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @fract_v8float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 fract %v8float_1 %in_ptr
 ; CHECK: = call spir_func <8 x float> @_Z5fractDv8_fPU3AS3S_(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_float.spvasm
@@ -36,7 +36,7 @@
 ; All functions
          %frexp_float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %int_ptr_t
-; CHECK: define spir_kernel void @frexp_float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 frexp %float_1 %in_ptr
 ; CHECK: = call spir_func float @_Z5frexpfPU3AS1i(float 0x3FF6666660000000, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v16float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
       %frexp_v16float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @frexp_v16float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v16float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 frexp %v16float_1 %in_ptr
 ; CHECK: = call spir_func <16 x float> @_Z5frexpDv16_fPU3AS1Dv16_i(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v2float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v2float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @frexp_v2float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v2float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 frexp %v2float_1 %in_ptr
 ; CHECK: = call spir_func <2 x float> @_Z5frexpDv2_fPU3AS1Dv2_i(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v3float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v3float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @frexp_v3float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v3float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 frexp %v3float_1 %in_ptr
 ; CHECK: = call spir_func <3 x float> @_Z5frexpDv3_fPU3AS1Dv3_i(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v4float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v4float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @frexp_v4float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v4float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 frexp %v4float_1 %in_ptr
 ; CHECK: = call spir_func <4 x float> @_Z5frexpDv4_fPU3AS1Dv4_i(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_global_v8float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
        %frexp_v8float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @frexp_v8float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v8float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 frexp %v8float_1 %in_ptr
 ; CHECK: = call spir_func <8 x float> @_Z5frexpDv8_fPU3AS1Dv8_i(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_float.spvasm
@@ -36,7 +36,7 @@
 ; All functions
          %frexp_float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %int_ptr_t
-; CHECK: define spir_kernel void @frexp_float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 frexp %float_1 %in_ptr
 ; CHECK: = call spir_func float @_Z5frexpfPU3AS3i(float 0x3FF6666660000000, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v16float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
       %frexp_v16float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @frexp_v16float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v16float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 frexp %v16float_1 %in_ptr
 ; CHECK: = call spir_func <16 x float> @_Z5frexpDv16_fPU3AS3Dv16_i(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v2float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v2float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @frexp_v2float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v2float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 frexp %v2float_1 %in_ptr
 ; CHECK: = call spir_func <2 x float> @_Z5frexpDv2_fPU3AS3Dv2_i(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v3float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v3float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @frexp_v3float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v3float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 frexp %v3float_1 %in_ptr
 ; CHECK: = call spir_func <3 x float> @_Z5frexpDv3_fPU3AS3Dv3_i(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v4float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
        %frexp_v4float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @frexp_v4float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v4float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 frexp %v4float_1 %in_ptr
 ; CHECK: = call spir_func <4 x float> @_Z5frexpDv4_fPU3AS3Dv4_i(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_frexp_local_v8float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
        %frexp_v8float = OpFunction %void_t None %frexp_fn_t
               %in_ptr = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @frexp_v8float(ptr addrspace(3) %in_ptr)
+; CHECK: define spir_kernel void @frexp_v8float(ptr addrspace(3) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 frexp %v8float_1 %in_ptr
 ; CHECK: = call spir_func <8 x float> @_Z5frexpDv8_fPU3AS3Dv8_i(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_ptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_float.spvasm
@@ -36,7 +36,7 @@
 ; All functions
       %lgamma_r_float_uint = OpFunction %void_t None %lgamma_r_uint_fn_t
             %in_signp_uint = OpFunctionParameter %uint_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_float_uint(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_float_uint(ptr addrspace(1) noundef %in_signp)
                    %4 = OpLabel
                    %5 = OpExtInst %float_t %1 lgamma_r %float_2 %in_signp_uint
 ; CHECK: = call spir_func float @_Z8lgamma_rfPU3AS1i(float 0x40011EB860000000, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v16float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
    %lgamma_r_v16float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v16float(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v16float(ptr addrspace(1) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 lgamma_r %v16float_2 %in_signp
 ; CHECK: = call spir_func <16 x float> @_Z8lgamma_rDv16_fPU3AS1Dv16_i(<16 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v2float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v2float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v2float(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v2float(ptr addrspace(1) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 lgamma_r %v2float_2 %in_signp
 ; CHECK: = call spir_func <2 x float> @_Z8lgamma_rDv2_fPU3AS1Dv2_i(<2 x float> <float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v3float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v3float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v3float(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v3float(ptr addrspace(1) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 lgamma_r %v3float_2 %in_signp
 ; CHECK: = call spir_func <3 x float> @_Z8lgamma_rDv3_fPU3AS1Dv3_i(<3 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v4float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v4float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v4float(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v4float(ptr addrspace(1) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 lgamma_r %v4float_2 %in_signp
 ; CHECK: = call spir_func <4 x float> @_Z8lgamma_rDv4_fPU3AS1Dv4_i(<4 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_global_v8float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
     %lgamma_r_v8float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v8float(ptr addrspace(1) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v8float(ptr addrspace(1) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 lgamma_r %v8float_2 %in_signp
 ; CHECK: = call spir_func <8 x float> @_Z8lgamma_rDv8_fPU3AS1Dv8_i(<8 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(1) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_float.spvasm
@@ -36,7 +36,7 @@
 ; All functions
       %lgamma_r_float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 lgamma_r %float_2 %in_signp
 ; CHECK: = call spir_func float @_Z8lgamma_rfPU3AS3i(float 0x40011EB860000000, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v16float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
    %lgamma_r_v16float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v16float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v16float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 lgamma_r %v16float_2 %in_signp
 ; CHECK: = call spir_func <16 x float> @_Z8lgamma_rDv16_fPU3AS3Dv16_i(<16 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v2float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v2float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v2float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v2float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 lgamma_r %v2float_2 %in_signp
 ; CHECK: = call spir_func <2 x float> @_Z8lgamma_rDv2_fPU3AS3Dv2_i(<2 x float> <float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v3float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v3float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v3float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v3float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 lgamma_r %v3float_2 %in_signp
 ; CHECK: = call spir_func <3 x float> @_Z8lgamma_rDv3_fPU3AS3Dv3_i(<3 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v4float.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %lgamma_r_v4float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v4float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v4float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 lgamma_r %v4float_2 %in_signp
 ; CHECK: = call spir_func <4 x float> @_Z8lgamma_rDv4_fPU3AS3Dv4_i(<4 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_lgamma_r_local_v8float.spvasm
@@ -40,7 +40,7 @@
 ; All functions
     %lgamma_r_v8float = OpFunction %void_t None %lgamma_r_fn_t
             %in_signp = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @lgamma_r_v8float(ptr addrspace(3) %in_signp)
+; CHECK: define spir_kernel void @lgamma_r_v8float(ptr addrspace(3) noundef %in_signp)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 lgamma_r %v8float_2 %in_signp
 ; CHECK: = call spir_func <8 x float> @_Z8lgamma_rDv8_fPU3AS3Dv8_i(<8 x float> <float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000, float 0x40011EB860000000>, ptr addrspace(3) %in_signp)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset.spvasm
@@ -43,7 +43,7 @@
          %22 = OpConstantComposite %_arr_uchar_ulong_4 %uchar_42 %uchar_42 %uchar_42 %uchar_42
          %24 = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_16 UniformConstant %22
           %6 = OpFunction %void None %5
-; CHECK: define spir_kernel void @memset(ptr addrspace(1) %out)
+; CHECK: define spir_kernel void @memset(ptr addrspace(1) noundef %out)
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
          %16 = OpConvertPtrToU %ulong %out

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_gotcha.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_gotcha.spvasm
@@ -48,7 +48,7 @@
          %22 = OpConstantComposite %_arr_uchar_ulong_4 %uchar_42 %uchar_42 %uchar_42 %uchar_41
          %24 = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_16 UniformConstant %22
           %6 = OpFunction %void None %5
-; CHECK: define spir_kernel void @memset_gotcha(ptr addrspace(1) %out)
+; CHECK: define spir_kernel void @memset_gotcha(ptr addrspace(1) noundef %out)
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel
          %16 = OpConvertPtrToU %ulong %out

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_zero.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_memset_zero.spvasm
@@ -42,7 +42,7 @@
 %_ptr_UniformConstant_uchar = OpTypePointer UniformConstant %uchar
          %22 = OpConstantNull %_arr_uchar_ulong_64
          %24 = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_64 UniformConstant %22
-; CHECK: define spir_kernel void @memset_zero(ptr addrspace(1) %out)
+; CHECK: define spir_kernel void @memset_zero(ptr addrspace(1) noundef %out)
           %6 = OpFunction %void None %5
         %out = OpFunctionParameter %_ptr_CrossWorkgroup_uint
       %entry = OpLabel

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
           %modf_float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @modf_float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 modf %float_1 %in_iptr
 ; CHECK: = call spir_func float @_Z4modffPU3AS1f(float 0x3FF6666660000000, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
        %modf_v16float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @modf_v16float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_v16float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 modf %v16float_1 %in_iptr
 ; CHECK: = call spir_func <16 x float> @_Z4modfDv16_fPU3AS1S_(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v2float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @modf_v2float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_v2float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 modf %v2float_1 %in_iptr
 ; CHECK: = call spir_func <2 x float> @_Z4modfDv2_fPU3AS1S_(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v3float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @modf_v3float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_v3float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 modf %v3float_1 %in_iptr
 ; CHECK: = call spir_func <3 x float> @_Z4modfDv3_fPU3AS1S_(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v4float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @modf_v4float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_v4float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 modf %v4float_1 %in_iptr
 ; CHECK: = call spir_func <4 x float> @_Z4modfDv4_fPU3AS1S_(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_global_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
         %modf_v8float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @modf_v8float(ptr addrspace(1) %in_iptr)
+; CHECK: define spir_kernel void @modf_v8float(ptr addrspace(1) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 modf %v8float_1 %in_iptr
 ; CHECK: = call spir_func <8 x float> @_Z4modfDv8_fPU3AS1S_(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(1) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
           %modf_float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @modf_float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 modf %float_1 %in_iptr
 ; CHECK: = call spir_func float @_Z4modffPU3AS3f(float 0x3FF6666660000000, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
        %modf_v16float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @modf_v16float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_v16float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 modf %v16float_1 %in_iptr
 ; CHECK: = call spir_func <16 x float> @_Z4modfDv16_fPU3AS3S_(<16 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v2float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @modf_v2float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_v2float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 modf %v2float_1 %in_iptr
 ; CHECK: = call spir_func <2 x float> @_Z4modfDv2_fPU3AS3S_(<2 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v3float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @modf_v3float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_v3float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 modf %v3float_1 %in_iptr
 ; CHECK: = call spir_func <3 x float> @_Z4modfDv3_fPU3AS3S_(<3 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %modf_v4float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @modf_v4float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_v4float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 modf %v4float_1 %in_iptr
 ; CHECK: = call spir_func <4 x float> @_Z4modfDv4_fPU3AS3S_(<4 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_modf_local_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
         %modf_v8float = OpFunction %void_t None %modf_fn_t
              %in_iptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @modf_v8float(ptr addrspace(3) %in_iptr)
+; CHECK: define spir_kernel void @modf_v8float(ptr addrspace(3) noundef %in_iptr)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 modf %v8float_1 %in_iptr
 ; CHECK: = call spir_func <8 x float> @_Z4modfDv8_fPU3AS3S_(<8 x float> <float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000, float 0x3FF6666660000000>, ptr addrspace(3) %in_iptr)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
      %prefetch_double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %double_ptr_t
-; CHECK: define spir_kernel void @prefetch_double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kdj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_double_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %prefetch_double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %double_ptr_t
-; CHECK: define spir_kernel void @prefetch_double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kdm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_32bit.spvasm
@@ -36,7 +36,7 @@
 ; All functions
       %prefetch_float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @prefetch_float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kfj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_float_64bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %prefetch_float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @prefetch_float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kfm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
   %prefetch_v16double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v16double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v16double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_dj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16double_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
   %prefetch_v16double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v16double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v16double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_dm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
    %prefetch_v16float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v16float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v16float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_fj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v16float_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %prefetch_v16float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v16float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v16float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_fm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
    %prefetch_v2double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v2double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v2double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_dj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2double_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %prefetch_v2double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v2double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v2double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_dm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %prefetch_v2float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v2float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v2float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_fj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v2float_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %prefetch_v2float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v2float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v2float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_fm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
    %prefetch_v3double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v3double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v3double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_dj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3double_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %prefetch_v3double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v3double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v3double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_dm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %prefetch_v3float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v3float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v3float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_fj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v3float_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %prefetch_v3float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v3float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v3float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_fm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
    %prefetch_v4double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v4double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v4double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_dj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4double_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %prefetch_v4double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v4double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v4double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_dm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %prefetch_v4float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v4float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v4float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_fj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v4float_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %prefetch_v4float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v4float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v4float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_fm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %prefetch_v8double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v8double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v8double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_dj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8double_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
    %prefetch_v8double = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8double_ptr_t
-; CHECK: define spir_kernel void @prefetch_v8double(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v8double(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_dm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %prefetch_v8float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v8float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v8float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_fj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_prefetch_v8float_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %prefetch_v8float = OpFunction %void_t None %prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @prefetch_v8float(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @prefetch_v8float(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_fm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_float.spvasm
@@ -36,7 +36,7 @@
 
    %remquo_float_uint = OpFunction %void_t None %remquo_uint_fn_t
          %in_quo_uint = OpFunctionParameter %uint_ptr_t
-; CHECK: define spir_kernel void @remquo_float_uint(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_float_uint(ptr addrspace(1) noundef %in_quo)
                    %4 = OpLabel
                    %5 = OpExtInst %float_t %1 remquo %float_2 %float_1 %in_quo_uint
 ; CHECK: = call spir_func float @_Z6remquoffPU3AS1i(float 2.000000e+00, float 1.500000e+00, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v16float.spvasm
@@ -42,7 +42,7 @@
 ; All functions
      %remquo_v16float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @remquo_v16float(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_v16float(ptr addrspace(1) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 remquo %v16float_2 %v16float_1 %in_quo
 ; CHECK: = call spir_func <16 x float> @_Z6remquoDv16_fS_PU3AS1Dv16_i(<16 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <16 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v2float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v2float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @remquo_v2float(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_v2float(ptr addrspace(1) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 remquo %v2float_2 %v2float_1 %in_quo
 ; CHECK: = call spir_func <2 x float> @_Z6remquoDv2_fS_PU3AS1Dv2_i(<2 x float> <float 2.000000e+00, float 2.000000e+00>, <2 x float> <float 1.500000e+00, float 1.500000e+00>, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v3float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v3float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @remquo_v3float(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_v3float(ptr addrspace(1) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 remquo %v3float_2 %v3float_1 %in_quo
 ; CHECK: = call spir_func <3 x float> @_Z6remquoDv3_fS_PU3AS1Dv3_i(<3 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <3 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v4float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v4float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @remquo_v4float(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_v4float(ptr addrspace(1) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 remquo %v4float_2 %v4float_1 %in_quo
 ; CHECK: = call spir_func <4 x float> @_Z6remquoDv4_fS_PU3AS1Dv4_i(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <4 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_global_v8float.spvasm
@@ -42,7 +42,7 @@
 ; All functions
       %remquo_v8float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @remquo_v8float(ptr addrspace(1) %in_quo)
+; CHECK: define spir_kernel void @remquo_v8float(ptr addrspace(1) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 remquo %v8float_2 %v8float_1 %in_quo
 ; CHECK: = call spir_func <8 x float> @_Z6remquoDv8_fS_PU3AS1Dv8_i(<8 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <8 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(1) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
         %remquo_float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %int_ptr_t
-; CHECK: define spir_kernel void @remquo_float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 remquo %float_2 %float_1 %in_quo
 ; CHECK: = call spir_func float @_Z6remquoffPU3AS3i(float 2.000000e+00, float 1.500000e+00, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v16float.spvasm
@@ -42,7 +42,7 @@
 ; All functions
      %remquo_v16float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v16int_ptr_t
-; CHECK: define spir_kernel void @remquo_v16float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_v16float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 remquo %v16float_2 %v16float_1 %in_quo
 ; CHECK: = call spir_func <16 x float> @_Z6remquoDv16_fS_PU3AS3Dv16_i(<16 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <16 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v2float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v2float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v2int_ptr_t
-; CHECK: define spir_kernel void @remquo_v2float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_v2float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 remquo %v2float_2 %v2float_1 %in_quo
 ; CHECK: = call spir_func <2 x float> @_Z6remquoDv2_fS_PU3AS3Dv2_i(<2 x float> <float 2.000000e+00, float 2.000000e+00>, <2 x float> <float 1.500000e+00, float 1.500000e+00>, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v3float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v3float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v3int_ptr_t
-; CHECK: define spir_kernel void @remquo_v3float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_v3float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 remquo %v3float_2 %v3float_1 %in_quo
 ; CHECK: = call spir_func <3 x float> @_Z6remquoDv3_fS_PU3AS3Dv3_i(<3 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <3 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v4float.spvasm
@@ -41,7 +41,7 @@
 ; All functions
       %remquo_v4float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v4int_ptr_t
-; CHECK: define spir_kernel void @remquo_v4float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_v4float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 remquo %v4float_2 %v4float_1 %in_quo
 ; CHECK: = call spir_func <4 x float> @_Z6remquoDv4_fS_PU3AS3Dv4_i(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <4 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_remquo_local_v8float.spvasm
@@ -42,7 +42,7 @@
 ; All functions
       %remquo_v8float = OpFunction %void_t None %remquo_fn_t
               %in_quo = OpFunctionParameter %v8int_ptr_t
-; CHECK: define spir_kernel void @remquo_v8float(ptr addrspace(3) %in_quo)
+; CHECK: define spir_kernel void @remquo_v8float(ptr addrspace(3) noundef %in_quo)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 remquo %v8float_2 %v8float_1 %in_quo
 ; CHECK: = call spir_func <8 x float> @_Z6remquoDv8_fS_PU3AS3Dv8_i(<8 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, <8 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, ptr addrspace(3) %in_quo)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
         %sincos_float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @sincos_float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 sincos %float_1 %in_cosval
 ; CHECK: = call spir_func float @_Z6sincosfPU3AS1f(float 0x3FF0CCCCC0000000, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %sincos_v16float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @sincos_v16float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v16float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 sincos %v16float_1 %in_cosval
 ; CHECK: = call spir_func <16 x float> @_Z6sincosDv16_fPU3AS1S_(<16 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v2float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @sincos_v2float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v2float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 sincos %v2float_1 %in_cosval
 ; CHECK: = call spir_func <2 x float> @_Z6sincosDv2_fPU3AS1S_(<2 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v3float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @sincos_v3float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v3float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 sincos %v3float_1 %in_cosval
 ; CHECK: = call spir_func <3 x float> @_Z6sincosDv3_fPU3AS1S_(<3 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v4float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @sincos_v4float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v4float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 sincos %v4float_1 %in_cosval
 ; CHECK: = call spir_func <4 x float> @_Z6sincosDv4_fPU3AS1S_(<4 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_global_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
       %sincos_v8float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @sincos_v8float(ptr addrspace(1) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v8float(ptr addrspace(1) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 sincos %v8float_1 %in_cosval
 ; CHECK: = call spir_func <8 x float> @_Z6sincosDv8_fPU3AS1S_(<8 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(1) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_float.spvasm
@@ -35,7 +35,7 @@
 ; All functions
         %sincos_float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %float_ptr_t
-; CHECK: define spir_kernel void @sincos_float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %float_t %1 sincos %float_1 %in_cosval
 ; CHECK: = call spir_func float @_Z6sincosfPU3AS3f(float 0x3FF0CCCCC0000000, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v16float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v16float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %sincos_v16float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v16float_ptr_t
-; CHECK: define spir_kernel void @sincos_v16float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v16float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v16float_t %1 sincos %v16float_1 %in_cosval
 ; CHECK: = call spir_func <16 x float> @_Z6sincosDv16_fPU3AS3S_(<16 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v2float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v2float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v2float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v2float_ptr_t
-; CHECK: define spir_kernel void @sincos_v2float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v2float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v2float_t %1 sincos %v2float_1 %in_cosval
 ; CHECK: = call spir_func <2 x float> @_Z6sincosDv2_fPU3AS3S_(<2 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v3float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v3float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v3float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v3float_ptr_t
-; CHECK: define spir_kernel void @sincos_v3float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v3float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v3float_t %1 sincos %v3float_1 %in_cosval
 ; CHECK: = call spir_func <3 x float> @_Z6sincosDv3_fPU3AS3S_(<3 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v4float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v4float.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %sincos_v4float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v4float_ptr_t
-; CHECK: define spir_kernel void @sincos_v4float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v4float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v4float_t %1 sincos %v4float_1 %in_cosval
 ; CHECK: = call spir_func <4 x float> @_Z6sincosDv4_fPU3AS3S_(<4 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v8float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_sincos_local_v8float.spvasm
@@ -38,7 +38,7 @@
 ; All functions
       %sincos_v8float = OpFunction %void_t None %sincos_fn_t
            %in_cosval = OpFunctionParameter %v8float_ptr_t
-; CHECK: define spir_kernel void @sincos_v8float(ptr addrspace(3) %in_cosval)
+; CHECK: define spir_kernel void @sincos_v8float(ptr addrspace(3) noundef %in_cosval)
                    %2 = OpLabel
                    %3 = OpExtInst %v8float_t %1 sincos %v8float_1 %in_cosval
 ; CHECK: = call spir_func <8 x float> @_Z6sincosDv8_fPU3AS3S_(<8 x float> <float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000>, ptr addrspace(3) %in_cosval)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %u_prefetch_i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Ktj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i16_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
       %u_prefetch_i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Ktm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_32bit.spvasm
@@ -35,7 +35,7 @@
 ; All functions
       %u_prefetch_i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kjj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i32_64bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %u_prefetch_i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kjm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
       %u_prefetch_i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kmj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i64_64bit.spvasm
@@ -36,7 +36,7 @@
 ; All functions
       %u_prefetch_i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Kmm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
        %u_prefetch_i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Khj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_i8_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
        %u_prefetch_i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1Khm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %u_prefetch_v16i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_tj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i16_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
    %u_prefetch_v16i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_tm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
    %u_prefetch_v16i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_jj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i32_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %u_prefetch_v16i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_jm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
    %u_prefetch_v16i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_mj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i64_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
    %u_prefetch_v16i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_mm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v16i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_hj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v16i8_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
     %u_prefetch_v16i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v16i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v16i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v16i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv16_hm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v2i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_tj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i16_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v2i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_tm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_32bit.spvasm
@@ -36,7 +36,7 @@
 ; All functions
     %u_prefetch_v2i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_jj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i32_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v2i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_jm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v2i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_mj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i64_64bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %u_prefetch_v2i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_mm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %u_prefetch_v2i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_hj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v2i8_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
      %u_prefetch_v2i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v2i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v2i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v2i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv2_hm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v3i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_tj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i16_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v3i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_tm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_32bit.spvasm
@@ -36,7 +36,7 @@
 ; All functions
     %u_prefetch_v3i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_jj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i32_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v3i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_jm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v3i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_mj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i64_64bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %u_prefetch_v3i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_mm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %u_prefetch_v3i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_hj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v3i8_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
      %u_prefetch_v3i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v3i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v3i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v3i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv3_hm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v4i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_tj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i16_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v4i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_tm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_32bit.spvasm
@@ -36,7 +36,7 @@
 ; All functions
     %u_prefetch_v4i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_jj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i32_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v4i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_jm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v4i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_mj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i64_64bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %u_prefetch_v4i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_mm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_32bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
      %u_prefetch_v4i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_hj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v4i8_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
      %u_prefetch_v4i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v4i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v4i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v4i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv4_hm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v8i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_tj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i16_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
     %u_prefetch_v8i16 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i16_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i16(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i16(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_tm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_32bit.spvasm
@@ -37,7 +37,7 @@
 ; All functions
     %u_prefetch_v8i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_jj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i32_64bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v8i32 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i32_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i32(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i32(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_jm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
     %u_prefetch_v8i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_mj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i64_64bit.spvasm
@@ -38,7 +38,7 @@
 ; All functions
     %u_prefetch_v8i64 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i64_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i64(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i64(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_mm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_32bit.spvasm
@@ -39,7 +39,7 @@
 ; All functions
      %u_prefetch_v8i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i32_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_hj(ptr addrspace(1) %in_ptr, i32 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_64bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_u_prefetch_v8i8_64bit.spvasm
@@ -40,7 +40,7 @@
 ; All functions
      %u_prefetch_v8i8 = OpFunction %void_t None %u_prefetch_fn_t
               %in_ptr = OpFunctionParameter %v8i8_ptr_t
-; CHECK: define spir_kernel void @u_prefetch_v8i8(ptr addrspace(1) %in_ptr)
+; CHECK: define spir_kernel void @u_prefetch_v8i8(ptr addrspace(1) noundef %in_ptr)
                    %2 = OpLabel
                    %3 = OpExtInst %void_t %1 prefetch %in_ptr %i64_1
 ; CHECK: call spir_func void @_Z8prefetchPU3AS1KDv8_hm(ptr addrspace(1) %in_ptr, i64 2)

--- a/modules/compiler/spirv-ll/test/spvasm/op_phi_forward_ref.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_phi_forward_ref.spvasm
@@ -56,7 +56,7 @@
       %fn_ty = OpTypeFunction %void %ptr_uchar %ptr_uint
        %true = OpConstantTrue %bool
 
-; CHECK: define spir_kernel void @testfn(ptr addrspace(1) %output, ptr addrspace(1) %input)
+; CHECK: define spir_kernel void @testfn(ptr addrspace(1) noundef %output, ptr addrspace(1) noundef %input)
      %testfn = OpFunction %void None %fn_ty
      %output = OpFunctionParameter %ptr_uchar
       %input = OpFunctionParameter %ptr_uint

--- a/modules/compiler/spirv-ll/test/spvasm/op_ptr_access_chain.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_ptr_access_chain.spvasm
@@ -47,7 +47,7 @@
     %_uint_input = OpFunctionParameter %uint
     %_uint_input2 = OpFunctionParameter %uint
    
-; CHECK: define spir_kernel void @entry_pt(ptr addrspace(1) [[PTR:%.*]], i32 {{%.*}}, i32 {{%.*}}
+; CHECK: define spir_kernel void @entry_pt(ptr addrspace(1) noundef [[PTR:%.*]], i32 noundef {{%.*}}, i32 noundef {{%.*}}
     %entry = OpLabel
 
     ; some maths for the gep input (multiple and an add)

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
@@ -28,8 +28,8 @@
           %sampler_t = OpTypeSampler
         %sampler_fn_t = OpTypeFunction %void %sampler_t %sampler_t
         %sampler_type = OpFunction %void None %sampler_fn_t
-; CHECK-GE17: define spir_kernel void @sampler_type(target("spirv.Sampler") %0, target("spirv.Sampler") %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
-; CHECK-LT17: define spir_kernel void @sampler_type(ptr %0, ptr %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
+; CHECK-GE17: define spir_kernel void @sampler_type(target("spirv.Sampler") noundef %0, target("spirv.Sampler") noundef %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
+; CHECK-LT17: define spir_kernel void @sampler_type(ptr noundef %0, ptr noundef %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
   %sampler_type_enter = OpLabel
                         OpReturn
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_debug_info_100_arrays.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_debug_info_100_arrays.spvasm
@@ -63,7 +63,7 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK: define spir_kernel void @foo(ptr addrspace(1) {{%.*}}){{.*}} !dbg [[DBG:![0-9]+]]
+; CHECK: define spir_kernel void @foo(ptr addrspace(1) noundef {{%.*}}){{.*}} !dbg [[DBG:![0-9]+]]
 
 ; CHECK-DAG: [[DBG]] = distinct !DISubprogram({{.*}}, type: [[TY:![0-9]+]],
 ; CHECK-DAG: [[TY]] = !DISubroutineType(types: [[TYLIST:![0-9]+]])

--- a/modules/compiler/spirv-ll/test/spvasm/opencl_max_byte_offset.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/opencl_max_byte_offset.spvasm
@@ -35,7 +35,7 @@
           %6 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_Workgroup_uint
 %_ptr_Function__ptr_CrossWorkgroup_uint = OpTypePointer Function %_ptr_CrossWorkgroup_uint
 %_ptr_Function__ptr_Workgroup_uint = OpTypePointer Function %_ptr_Workgroup_uint
-; CHECK: define spir_kernel void @foo(ptr addrspace(1) dereferenceable(128) {{%.*}}, ptr addrspace(3) dereferenceable(256) {{%.*}})
+; CHECK: define spir_kernel void @foo(ptr addrspace(1) noundef dereferenceable(128) {{%.*}}, ptr addrspace(3) noundef dereferenceable(256) {{%.*}})
           %7 = OpFunction %void DontInline %6
           %8 = OpFunctionParameter %_ptr_CrossWorkgroup_uint
           %9 = OpFunctionParameter %_ptr_Workgroup_uint


### PR DESCRIPTION
In SPIR-V, entry points can only be called from outside the module, and not from other functions inside the module.

Given this, we can safely add 'noundef' parameter attributes to entry points with the "kernel" execution mode. Passing undefined or poison values to a kernel is undefined behaviour. We could perhaps extend this to other execution modes but we don't test those quite as well and they aren't as important to us right now.

We'd ideally like to do this with *all* function parameters, which would better match the semantics of C, C++, OpenCL C, but as noted in the FIXME in the code, SPIR-V doesn't specify that passing an undefined value to a function call results in undefined behaviour, so we need to tread carefully. We might need to use `freeze` in more places to stop the propagation of undef/poison values around the module.