### PR TITLE
Remove debug code that snuck in

### DIFF
--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
@@ -333,7 +333,6 @@ struct USMVectorAddKernelTest : public USMKernelTest {
   }
 
   void TearDown() override {
-    clMemBlockingFreeINTEL(context, (void *)0x3e18df0);
     if (host_ptrB) {
       EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, host_ptrB));
     }


### PR DESCRIPTION
# Overview

Remove some debugging code that snuck in.

# Reason for change

This causes a segfault when building when USM is disabled (and probably elsewhere).

# Description of change
Removed bad line.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
