### PR TITLE
Split compiler-utils into compiler-pipeline and compiler-binary-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ Upgrade guidance:
   * Although hardware support for FMA is available on all platforms we currently
     test, if you are using OCK on a platform we do not test and encounter
     issues, please let us know by opening an issue!
-
+* `compiler-utils` library has been split into `compiler-pipeline` and
+  `compiler-binary-metadata` to  allow use of compiler pipeline utilities without
+   the binary metadata requirements. Both will be needed for `mux` targets.
 ## Version 3.0.0
 
 Upgrade guidance:
@@ -1461,7 +1463,6 @@ Bug fixes:
 ## Version 1.70.0 - 2022-06-07
 
 Upgrade guidance:
-
 * Headers in the `mux/utils` directory have been moved out of the `mux` target
   and into a separate `mux-utils` target, if using these headers update CMake to
   link against `mux-utils`.

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/CMakeLists.txt
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/CMakeLists.txt
@@ -50,7 +50,8 @@ if(CA_RUNTIME_COMPILER_ENABLED)
 
   target_link_libraries(compiler-refsi-g1-wi PUBLIC
     compiler-riscv-utils
-    compiler-utils
+    compiler-pipeline
+    compiler-binary-metadata
     compiler-linker-utils
     refsidrv
     compiler-base

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/CMakeLists.txt
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/CMakeLists.txt
@@ -50,7 +50,8 @@ if(CA_RUNTIME_COMPILER_ENABLED)
 
   target_link_libraries(compiler-refsi-m1 PUBLIC
     compiler-riscv-utils
-    compiler-utils  
+    compiler-pipeline
+    compiler-binary-metadata
     compiler-linker-utils      
     refsidrv
     compiler-base

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
   target_link_libraries(compiler-{{cookiecutter.target_name}} PUBLIC
     compiler-base
     utils
-    compiler-utils
+    compiler-pipeline
+    compiler-binary-metadata
     compiler-linker-utils
     LLVMCoverage LLVMDebugInfoCodeView LLVMExecutionEngine
     LLVMVectorize LLVMipo multi_llvm)

--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -91,7 +91,7 @@ list(TRANSFORM CLANG_LIBS
      APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 target_link_libraries(compiler-base PUBLIC
-  builtins cargo mux spirv-ll compiler-utils vecz
+  builtins cargo mux spirv-ll compiler-pipeline compiler-binary-metadata vecz
   "${CLANG_LIBS}"
   # Link against version (for clang) on Windows.
   $<$<BOOL:${WIN32}>:version>

--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -69,7 +69,7 @@ target_include_directories(spirv-ll PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source)
 target_include_directories(spirv-ll SYSTEM PUBLIC
   ${spirv-headers_SOURCE_DIR}/include ${LLVM_INCLUDE_DIR})
-target_link_libraries(spirv-ll PUBLIC cargo multi_llvm compiler-utils LLVMCore LLVMBitWriter)
+target_link_libraries(spirv-ll PUBLIC cargo multi_llvm compiler-pipeline LLVMCore LLVMBitWriter)
 
 add_subdirectory(tools)
 if(CA_ENABLE_TESTS)

--- a/modules/compiler/test/CMakeLists.txt
+++ b/modules/compiler/test/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(UnitCompiler PRIVATE
   ${PROJECT_SOURCE_DIR}/modules/compiler/include)
 
 target_link_libraries(UnitCompiler PRIVATE cargo
-  compiler-static mux ca_gtest_main compiler-base compiler-utils)
+  compiler-static mux ca_gtest_main compiler-base compiler-pipeline compiler-binary-metadata)
 
 target_resources(UnitCompiler NAMESPACES ${BUILTINS_NAMESPACES})
 

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -14,10 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_ca_library(compiler-utils STATIC
+add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/StructTypeRemapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_kernel_wrapper_pass.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_metadata_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_scheduling_parameters_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/address_spaces.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/align_module_structs_pass.h
@@ -43,8 +42,6 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/mangling.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/memory_buffer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_analysis.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_hooks.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/optimal_builtin_replacement_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/pass_functions.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/pass_machinery.h
@@ -94,8 +91,6 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/mangling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/manual_type_legalization_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_analysis.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_hooks.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/mux_builtin_info.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/optimal_builtin_replacement_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/pass_functions.cpp
@@ -120,21 +115,45 @@ add_ca_library(compiler-utils STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/work_item_loops_pass.cpp)
 
-target_include_directories(compiler-utils PUBLIC
+target_include_directories(compiler-pipeline PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_compile_definitions(compiler-utils PRIVATE
+target_compile_definitions(compiler-pipeline PRIVATE
   $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
   $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
   $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-target_link_libraries(compiler-utils PUBLIC
-  cargo md_handler multi_llvm LLVMPasses LLVMTransformUtils)
+target_link_libraries(compiler-pipeline PUBLIC
+ multi_llvm LLVMPasses LLVMTransformUtils)
 if(TARGET LLVMCore)
-  target_link_libraries(compiler-utils PUBLIC LLVMCore)
+  target_link_libraries(compiler-pipeline PUBLIC LLVMCore)
 endif()
+
+add_ca_library(compiler-binary-metadata STATIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_metadata_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_analysis.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_hooks.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_analysis.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_hooks.cpp)
+
+target_include_directories(compiler-binary-metadata PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_compile_definitions(compiler-binary-metadata PRIVATE
+  $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
+  $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
+  $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
+  $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
+  $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
+
+target_link_libraries(compiler-binary-metadata PUBLIC
+  md_handler multi_llvm LLVMPasses LLVMTransformUtils)
+if(TARGET LLVMCore)
+  target_link_libraries(compiler-binary-metadata PUBLIC LLVMCore)
+endif()
+
 
 # Determine whether LLVM was built with LLD, in which case add a support
 # library that exposes lld to ComputeMux compiler targets.

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -192,7 +192,7 @@ target_compile_options(vecz PRIVATE ${VECZ_COMPILE_OPTIONS})
 target_compile_definitions(vecz PRIVATE
   ${VECZ_COMPILE_DEFINITIONS})
 
-target_link_libraries(vecz PRIVATE compiler-utils multi_llvm PUBLIC ${LLVM_LIBS})
+target_link_libraries(vecz PRIVATE compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
 
 # intrinsics_gen uses tablegen to generate Attributes.inc, which is
 # (recursively) included by 'llvm/IR/Module.h', therefore this module depends

--- a/modules/compiler/vecz/tools/CMakeLists.txt
+++ b/modules/compiler/vecz/tools/CMakeLists.txt
@@ -23,5 +23,5 @@ llvm_map_components_to_libnames(llvm_libs all ${LLVM_TARGETS_TO_BUILD})
 # LLVM 8 adds these invalid libraries to the list, remove them to avoid
 # attempting to link against LTO-NOTFOUND and OptRemarks-NOTFOUND.
 list(REMOVE_ITEM llvm_libs LTO OptRemarks)
-target_link_libraries(veczc PUBLIC vecz multi_llvm compiler-utils ${llvm_libs})
+target_link_libraries(veczc PUBLIC vecz multi_llvm compiler-pipeline ${llvm_libs})
 install(TARGETS veczc RUNTIME DESTINATION bin COMPONENT VECZ)

--- a/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
+++ b/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
@@ -130,7 +130,8 @@ target_link_libraries({{cookiecutter.target_name}}
   PUBLIC
   cargo
   tracer
-  compiler-utils
+  compiler-pipeline
+  compiler-binary-metadata
   utils
 )
 target_link_libraries({{cookiecutter.target_name}} PUBLIC loader)


### PR DESCRIPTION

# Overview

`compiler-utils` library has been split into `compiler-pipeline` and `compiler-binary-metadata` .

# Reason for change

The split allows allow use of compiler pipeline utilities without the binary metadata requirements. Both will be needed for `mux` targets.
