### PR TITLE
Add "deviceless" shared USM pointer

### DIFF
--- a/source/cl/test/UnitCL/include/cl_intel_unified_shared_memory.h
+++ b/source/cl/test/UnitCL/include/cl_intel_unified_shared_memory.h
@@ -65,7 +65,7 @@ struct cl_intel_unified_shared_memory_Test : public virtual ucl::ContextTest {
       cl_int err = clMemBlockingFreeINTEL(context, ptr);
       EXPECT_SUCCESS(err);
     }
-    device_ptr = shared_ptr = host_ptr = nullptr;
+    device_ptr = shared_ptr = host_shared_ptr = host_ptr = nullptr;
 
     ucl::ContextTest::TearDown();
   }
@@ -95,6 +95,11 @@ struct cl_intel_unified_shared_memory_Test : public virtual ucl::ContextTest {
           clSharedMemAllocINTEL(context, device, {}, bytes, align, &err);
       ASSERT_SUCCESS(err);
       ASSERT_TRUE(shared_ptr != nullptr);
+
+      host_shared_ptr =
+          clSharedMemAllocINTEL(context, nullptr, {}, bytes, align, &err);
+      ASSERT_SUCCESS(err);
+      ASSERT_TRUE(host_shared_ptr != nullptr);
     }
 
     device_ptr =
@@ -107,14 +112,17 @@ struct cl_intel_unified_shared_memory_Test : public virtual ucl::ContextTest {
   ///
   /// This will return an array containing up to 3 pointers, one of each device,
   /// host and shared, depending on the capabilities of the device.
-  cargo::small_vector<void *, 3> allPointers() {
-    cargo::small_vector<void *, 3> to_return{};
+  cargo::small_vector<void *, 4> allPointers() {
+    cargo::small_vector<void *, 4> to_return{};
 
     if (device_ptr) {
       (void)to_return.push_back(device_ptr);
     }
     if (shared_ptr) {
       (void)to_return.push_back(shared_ptr);
+    }
+    if (host_shared_ptr) {
+      (void)to_return.push_back(host_shared_ptr);
     }
     if (host_ptr) {
       (void)to_return.push_back(host_ptr);
@@ -126,6 +134,7 @@ struct cl_intel_unified_shared_memory_Test : public virtual ucl::ContextTest {
   constexpr static size_t MAX_NUM_POINTERS = 3;
   void *host_ptr = nullptr;
   void *shared_ptr = nullptr;
+  void *host_shared_ptr = nullptr;
   void *device_ptr = nullptr;
 
   cl_device_unified_shared_memory_capabilities_intel host_capabilities = 0;

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_event_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_event_info.cpp
@@ -78,6 +78,11 @@ TEST_F(USMEventInfoTest, clEnqueueMemFillINTEL_EventInfo) {
   cl_int err;
 
   for (auto ptr : allPointers()) {
+    if (ptr == host_shared_ptr) {
+      // The host shared_ptr isn't valid for this queue's device
+      continue;
+    }
+
     cl_event wait_event{};
     err = clEnqueueMemFillINTEL(queue, ptr, pattern, sizeof(pattern),
                                 sizeof(pattern) * 2, 0, nullptr, &wait_event);

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
@@ -174,7 +174,7 @@ TEST_P(USMSetKernelExecInfoTest, ValidUsage) {
   const cl_kernel_exec_info param_name = GetParam();
 
   if (CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL == param_name) {
-    cargo::small_vector<void *, 3> indirect_usm_pointers = allPointers();
+    auto indirect_usm_pointers = allPointers();
 
     EXPECT_SUCCESS(
         clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
@@ -202,7 +202,7 @@ TEST_P(USMSetKernelExecInfoTest, InvalidUsage) {
     cl_int err = clSetKernelExecInfo(nullptr, param_name, 0, nullptr);
     EXPECT_EQ_ERRCODE(err, CL_INVALID_KERNEL);
 
-    cargo::small_vector<void *, 3> indirect_usm_pointers = allPointers();
+    auto indirect_usm_pointers = allPointers();
 
     // Invalid param_value_size
     err = clSetKernelExecInfo(kernel, param_name, 0,


### PR DESCRIPTION
# Overview
Add a new pointer to the available pointers (used by allPointers()) for a "deviceless" shared USM pointer. This is a shared USM pointer without an associated device.

# Reason for change

Improves USM testing

# Description of change
Added a new pointer type to the pointers list.

# Anything else we should know?
The tests should all still pass.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
