### PR TITLE
Fix missing "frees" on USM pointers

### DIFF
--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
@@ -139,6 +139,12 @@ struct USMBlockingFreeTest : public cl_intel_unified_shared_memory_Test {
   }
 
   void TearDown() override {
+    for (auto device_ptr : fixture_device_ptrs) {
+      if (device_ptr) {
+        EXPECT_SUCCESS(clMemBlockingFreeINTEL(context, device_ptr));
+      }
+    }
+
     for (auto queue : fixture_queues) {
       if (queue) {
         EXPECT_SUCCESS(clReleaseCommandQueue(queue));


### PR DESCRIPTION
# Overview

Free some pointers which were incorrectly not freed.

# Reason for change

This was failing a sanitizer due to memory leaks.

# Description of change

Free'd memory at the end of a test case.

# Anything else we should know?


# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
