### PR TITLE
Update findDbgDeclares for LLVM 18

### DIFF
--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -971,8 +971,7 @@ void compiler::utils::Barrier::MakeLiveVariableMemType() {
     // Check if the alloca has a debug info source variable attached. If
     // so record this and the matching byte offset into the struct.
 #if LLVM_VERSION_GREATER_EQUAL(18, 0)
-    SmallVector<DbgDeclareInst *, 1> DbgIntrinsics;
-    findDbgDeclares(DbgIntrinsics, member.value);
+    auto DbgIntrinsics = findDbgDeclares(member.value);
 #elif LLVM_VERSION_GREATER_EQUAL(17, 0)
     auto DbgIntrinsics = FindDbgDeclareUses(member.value);
 #else

--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -184,8 +184,7 @@ bool BasicMem2RegPass::promoteAlloca(AllocaInst *Alloca) const {
       ToDelete.push_back(Store);
       DIBuilder DIB(*Alloca->getModule(), /*AllowUnresolved*/ false);
 #if LLVM_VERSION_GREATER_EQUAL(18, 0)
-      SmallVector<DbgDeclareInst *, 1> DbgIntrinsics;
-      findDbgDeclares(DbgIntrinsics, Alloca);
+      auto DbgIntrinsics = findDbgDeclares(Alloca);
 #elif LLVM_VERSION_GREATER_EQUAL(17, 0)
       auto DbgIntrinsics = FindDbgDeclareUses(Alloca);
 #else


### PR DESCRIPTION
# Overview

Updates uses of `findDbgDeclares` to account for upstream LLVM changes (https://github.com/llvm/llvm-project/commit/304119860ac0ded0a126ab1c8cc30367e29ebd01)

