### PR TITLE
Extend CA_ENABLE_TESTS to include check targets

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -685,8 +685,11 @@ macro(get_target_link_libraries variable target)
   get_target_link_libraries_recursive(${target})
 endmacro()
 
-# Add the check target to run all registered checks, see add_ca_check() below.
-add_custom_target(check COMMENT "ComputeAorta checks.")
+# Add the check target to run all registered checks, see add_ca_check() below, if
+# cmake:variable:`CA_ENABLE_TESTS` is enabled.
+if (CA_ENABLE_TESTS)
+  add_custom_target(check COMMENT "ComputeAorta checks.")
+endif()
 
 if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
   message(WARNING "ComputeAorta check targets disabled as "
@@ -703,6 +706,11 @@ endif()
   build the ``check`` target. All checks are executed with a working directory
   of ``${PROJECT_SOURCE_DIR}`` and a comment of the form "Running ${name}
   checks" is displayed by the build system during execution.
+
+  .. note::
+
+    If  :cmake:variable:`CA_ENABLE_TESTS` is set to ``OFF`` this function does
+    nothing.
 
   Arguments:
     * ``name`` - Target name suffix for the check, this will create a target
@@ -730,6 +738,9 @@ endif()
       can be specified, each must be of the form: "VAR=<value>"
 #]=======================================================================]
 function(add_ca_check name)
+  if (NOT CA_ENABLE_TESTS)
+    return()
+  endif()
   cmake_parse_arguments(args
     "NOEMULATE;NOGLOBAL;GTEST;USES_TERMINAL" ""
     "CLEAN;COMMAND;DEPENDS;ENVIRONMENT" ${ARGN})
@@ -781,19 +792,22 @@ function(add_ca_check name)
     set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY
       ADDITIONAL_CLEAN_FILES ${args_CLEAN} APPEND)
   endif()
-  # Add a custom target, which runs the test, to the test target.
-  if(args_USES_TERMINAL)
-    add_custom_target(check-${name}
-      COMMAND ${command} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      USES_TERMINAL
-      DEPENDS ${args_DEPENDS} COMMENT "Running ${name} checks")
-  else()
-    add_custom_target(check-${name}
-      COMMAND ${command} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      DEPENDS ${args_DEPENDS} COMMENT "Running ${name} checks")
-  endif()
-  if(NOT args_NOGLOBAL)
-    add_dependencies(check check-${name})
+  # Add a custom target, which runs the test, to the test target,  if
+  # cmake:variable:`CA_ENABLE_TESTS` is enabled.
+  if (CA_ENABLE_TESTS)
+    if(args_USES_TERMINAL)
+      add_custom_target(check-${name}
+        COMMAND ${command} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        USES_TERMINAL
+        DEPENDS ${args_DEPENDS} COMMENT "Running ${name} checks")
+    else()
+      add_custom_target(check-${name}
+        COMMAND ${command} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        DEPENDS ${args_DEPENDS} COMMENT "Running ${name} checks")
+    endif()
+    if(NOT args_NOGLOBAL)
+      add_dependencies(check check-${name})
+    endif()
   endif()
   if(CA_ENABLE_COVERAGE AND (CA_RUNTIME_COMPILER_ENABLED OR
       (NOT CA_RUNTIME_COMPILER_ENABLED AND ${name} STREQUAL "UnitCL")))
@@ -811,6 +825,11 @@ endfunction()
   having a single named check for a set of disparate test suites. As with
   :cmake:command:`add_ca_check` the name is used to generate a target called
   ``check-${name}``.
+
+  .. note::
+
+    If  :cmake:variable:`CA_ENABLE_TESTS` is set to ``OFF`` this function does
+    nothing.
 
   Arguments:
     * ``name`` - Target name suffix for the check group, this will create a
@@ -831,6 +850,9 @@ endfunction()
     add_ca_check_group(foo DEPENDS bar check-foo)
 #]=======================================================================]
 function(add_ca_check_group name)
+  if (NOT CA_ENABLE_TESTS)
+    return()
+  endif()
   cmake_parse_arguments(args "" "" "DEPENDS" ${ARGN})
   if(args_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR

--- a/source/cl/cmake/AddCACL.cmake
+++ b/source/cl/cmake/AddCACL.cmake
@@ -164,11 +164,19 @@ endif()
   drivers from being found. If :cmake:variable:`CA_CL_ENABLE_INTERCEPT_LAYER`
   is ``ON`` the :envvar:`CLI_OpenCLFileName` environment variable is set.
 
+    .. note::
+    
+      If  :cmake:variable:`CA_ENABLE_TESTS` is set to ``OFF`` this function does
+      nothing.
+
   Arguments:
     * ``name`` A unique name for the check, should include the name of the
       target being checked.
 #]=======================================================================]
 function(add_ca_cl_check name)
+  if (NOT CA_ENABLE_TESTS)
+    return()
+  endif()
   cmake_parse_arguments(args "" "" "ENVIRONMENT" ${ARGN})
   set(environment ${args_ENVIRONMENT})
   if(CA_CL_ENABLE_ICD_LOADER)


### PR DESCRIPTION
# Overview

Disable check targets when CA_ENABLE_TEST=false

# Reason for change

Remove target name conflict when used with SYCL Native CPU, also seems more correct

# Description of change


This extends the cmake flag to include check targets.
