### PR TITLE
Fix pendantic error unified runtime support

### DIFF
--- a/source/ur/source/context.cpp
+++ b/source/ur/source/context.cpp
@@ -182,7 +182,7 @@ ur::device_allocation_info::~device_allocation_info() {
     muxFreeMemory(device->mux_device, mux_memory,
                   device->platform->mux_allocator_info);
   }
-};
+}
 
 cargo::expected<ur_context_handle_t, ur_result_t> ur_context_handle_t_::create(
     ur_platform_handle_t platform,


### PR DESCRIPTION

# Overview

We now enable pedantic errors but our testing for pull requests does not cover unified runtime. This fixes a ';' after function body.

# Reason for change

Overnight testing showed failure to build when unified runtime was enabled.
