### PR TITLE
Upgrade to clang-tidy-17.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -247,6 +247,7 @@ Checks: "bugprone-*,\
          misc-*,\
          -misc-definitions-in-headers,\
          -misc-forwarding-reference-overload,\
+         -misc-include-cleaner,\
          -misc-macro-parentheses,\
          -misc-misplaced-const,\
          -misc-non-private-member-variables-in-classes,\
@@ -255,12 +256,14 @@ Checks: "bugprone-*,\
          -misc-string-compare,\
          -misc-unconventional-assign-operator,\
          -misc-unused-parameters,\
+         -misc-use-anonymous-namespace,\
          modernize-*,\
          -modernize-avoid-bind,\
          -modernize-avoid-c-arrays,\
          -modernize-concat-nested-namespaces,\
          -modernize-deprecated-headers,\
          -modernize-loop-convert,\
+         -modernize-macro-to-enum,\
          -modernize-make-unique,\
          -modernize-pass-by-value,\
          -modernize-redundant-void-arg,\
@@ -311,6 +314,7 @@ Checks: "bugprone-*,\
          -readability-string-compare,\
          -readability-uppercase-literal-suffix,\
          -readability-use-anyofallof"
+
 # -UNDEBUG so that clang-tidy always sees asserts, whatever the build type.
 # -fno-caret-diagnostics to silence warning counts from headers.
 # -Wno-unknown-warning-option so we can use compilation database on GCC configs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,7 @@ find_package(PythonInterp 3.6 REQUIRED)
 # which perform static analysis and style checking on source files.
 # When updating the version here, also update that used in the merge request
 # config
-find_package(ClangTools 17 COMPONENTS clang-format)
-find_package(ClangTools 9 COMPONENTS clang-tidy)
+find_package(ClangTools 17 COMPONENTS clang-format clang-tidy)
 if(TARGET ClangTools::clang-tidy)
   ca_option(CA_CLANG_TIDY_FLAGS STRING
     "Semi-color separated list of clang-tidy flags" "")

--- a/hal/include/hal.h
+++ b/hal/include/hal.h
@@ -107,7 +107,7 @@ struct hal_device_t {
   ///
   /// @return Returns `false` if the operation fails otherwise `true`.
   virtual bool mem_copy(hal_addr_t dst, hal_addr_t src, hal_size_t size) {
-    const constexpr hal_size_t max_malloc_size = 1024 * 1024;
+    const constexpr hal_size_t max_malloc_size = 1024L * 1024L;
     const std::unique_ptr<uint8_t[]> temp_ptr(new uint8_t[max_malloc_size]);
     void *temp = temp_ptr.get();
 

--- a/modules/cargo/include/cargo/optional.h
+++ b/modules/cargo/include/cargo/optional.h
@@ -1267,7 +1267,7 @@ auto optional_map_impl(Opt &&opt, F &&f) -> optional<monostate> {
 
 namespace std {
 template <class T>
-struct hash<cargo::optional<T>> {
+struct hash<cargo::optional<T>> {  // NOLINT(cert-dcl58-cpp)
   ::std::size_t operator()(const cargo::optional<T> &o) const {
     if (!o.has_value()) return 0;
     return std::hash<std::remove_const_t<T>>()(*o);

--- a/modules/cargo/include/cargo/utility.h
+++ b/modules/cargo/include/cargo/utility.h
@@ -87,7 +87,7 @@ inline Dest bit_cast(const Source &source) {
   // Initialization of dest looks like an uninitialized access to Klocwork
   Dest dest;
   std::memcpy(std::addressof(dest), std::addressof(source), sizeof(Source));
-  return dest;
+  return dest;  // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
 }
 
 /// @brief Construct a `std::string`-like object from a cargo container.

--- a/modules/compiler/builtins/abacus/generate/abacus_detail_geometric/abacus_detail_geometric.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_detail_geometric/abacus_detail_geometric.in
@@ -253,11 +253,11 @@ template <typename T>
 T normalize(T p) {
   constexpr size_t num_elements = TypeTraits<T>::num_elements;
   static_assert(num_elements >= 1 && num_elements <= 16);
-  if constexpr (num_elements == 1) {  // NOLINT
+  if constexpr (num_elements == 1) {
     if (p > 0) return 1;
     if (p < 0) return -1;
     return p;
-  } else {  // NOLINT
+  } else {
     using ElementType = typename TypeTraits<T>::ElementType;
     using UnsignedType = typename TypeTraits<T>::UnsignedType;
     using ScalarUnsignedType = typename FPShape<T>::ScalarUnsignedType;
@@ -268,7 +268,7 @@ T normalize(T p) {
     const UnsignedType abs_au = au & FPShape<T>::InverseSignMask();
     ScalarUnsignedType max_mag_au = abs_au[0];
     for (size_t i = 1; i < num_elements; ++i) {
-      ScalarUnsignedType absElem_au = abs_au[i];
+      const ScalarUnsignedType absElem_au = abs_au[i];
       if (max_mag_au < absElem_au) max_mag_au = absElem_au;
     }
     const ElementType max_mag = detail::cast::as<ElementType>(max_mag_au);

--- a/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/horner_polynomial.h
@@ -27,10 +27,10 @@ inline T horner_polynomial(const T x, const TCoef *p_coef, size_t N) {
   T coef_sum = T(p_coef[N - 1]);
 
   for (size_t n = N - 1; n > 0; n--) {
-    if constexpr (sizeof(typename TypeTraits<T>::ElementType) == 2) {  // NOLINT
+    if constexpr (sizeof(typename TypeTraits<T>::ElementType) == 2) {
       // For half, we need the precision of FMA
       coef_sum = __abacus_fma(coef_sum, x, T(p_coef[n - 1]));
-    } else {  // NOLINT
+    } else {
       coef_sum = T(p_coef[n - 1]) + x * coef_sum;
     }
   }

--- a/modules/compiler/builtins/abacus/include/abacus/internal/lgamma_positive.h
+++ b/modules/compiler/builtins/abacus/include/abacus/internal/lgamma_positive.h
@@ -130,7 +130,7 @@ inline abacus_half lgamma_positive(abacus_half x) {
   x -= _lgamma_translation_half[interval];
 
   ABACUS_CONSTANT abacus_half *coef_ptr =
-      __codeplay_lgamma_positive_coeff_half + interval * 8;
+      __codeplay_lgamma_positive_coeff_half + interval * (size_t)8;
   abacus_half semi = abacus::internal::horner_polynomial(x, coef_ptr, 8);
 
   return (interval) ? semi : semi - logx;
@@ -155,7 +155,7 @@ inline abacus_float lgamma_positive(abacus_float x) {
   x -= _lgamma_translation[interval];
 
   const abacus_float semi = abacus::internal::horner_polynomial(
-      x, __codeplay_lgamma_positive_coeff + interval * 8, 8);
+      x, __codeplay_lgamma_positive_coeff + interval * (size_t)8, 8);
 
   return (interval) ? semi : semi - logx;
 }
@@ -176,8 +176,8 @@ inline T lgamma_positive(const T &x) {
     interval = __abacus_select(interval, i, cond);
 
     const T poly = abacus::internal::horner_polynomial(
-        x - _lgamma_translation[i], __codeplay_lgamma_positive_coeff + i * 8,
-        8);
+        x - _lgamma_translation[i],
+        __codeplay_lgamma_positive_coeff + i * (size_t)8, 8);
 
     ans = __abacus_select(ans, poly, cond);
   }
@@ -215,7 +215,7 @@ inline T lgamma_positive_half(const T &x) {
 
     const T poly = abacus::internal::horner_polynomial(
         x - _lgamma_translation_half[i],
-        __codeplay_lgamma_positive_coeff_half + i * 8, 8);
+        __codeplay_lgamma_positive_coeff_half + i * (size_t)8, 8);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/acos.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/acos.cpp
@@ -125,10 +125,11 @@ abacus_float ABACUS_API __abacus_acos(abacus_float x) {
 
 // approximate acos*acos:
 #ifdef __CODEPLAY_USE_ESTRIN_POLYNOMIAL_REDUCTION__
-  abacus_float ans = __Codeplay__estrin_4coeff(xAbs, polynomial + interval * 4);
+  abacus_float ans =
+      __Codeplay__estrin_4coeff(xAbs, polynomial + interval * (size_t)4);
 #else
-  const abacus_float ans =
-      abacus::internal::horner_polynomial(xAbs, polynomial + interval * 4, 4);
+  const abacus_float ans = abacus::internal::horner_polynomial(
+      xAbs, polynomial + interval * (size_t)4, 4);
 #endif
 
   // get acos:
@@ -157,7 +158,7 @@ T acos(const T x) {
     interval = __abacus_select(interval, i, cond);
 
     const T poly = abacus::internal::horner_polynomial(
-        i < 12 ? oneMinusXAbs : xAbs, polynomial + i * 4, 4);
+        i < 12 ? oneMinusXAbs : xAbs, polynomial + i * (size_t)4, 4);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asin.cpp
@@ -130,10 +130,11 @@ abacus_float ABACUS_API __abacus_asin(abacus_float x) {
   float ans = (interval < 9) ? xAbs - 1.0f : xAbs;
 
 #ifdef __CODEPLAY_USE_ESTRIN_POLYNOMIAL_REDUCTION__
-  ans = __Codeplay__estrin_5coeff(ans, __codeplay_asin_coeff + interval * 5);
+  ans = __Codeplay__estrin_5coeff(ans,
+                                  __codeplay_asin_coeff + interval * (size_t)5);
 #else
   ans = abacus::internal::horner_polynomial(
-      ans, __codeplay_asin_coeff + interval * 5, 5);
+      ans, __codeplay_asin_coeff + interval * (size_t)5, 5);
 #endif
 
   if (interval < 9) {
@@ -229,7 +230,7 @@ T asin(const T x) {
     interval = __abacus_select(interval, i, cond);
 
     const T poly = abacus::internal::horner_polynomial(
-        i < 9 ? oneMinusXAbs : xAbs, __codeplay_asin_coeff + i * 5, 5);
+        i < 9 ? oneMinusXAbs : xAbs, __codeplay_asin_coeff + i * (size_t)5, 5);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/asinh.cpp
@@ -144,7 +144,7 @@ abacus_float ABACUS_API __abacus_asinh(abacus_float x) {
       high_two + ((xAbs < intervals[high_two + 1]) ? 1 : 0);
 
   abacus_float ans = abacus::internal::horner_polynomial(
-      xAbs, __codeplay_asinh_coeff + interval * 5, 5);
+      xAbs, __codeplay_asinh_coeff + interval * (size_t)5, 5);
 
   if (interval < 11) {
     ans = __abacus_log1p(ans);
@@ -175,7 +175,7 @@ T asinh(const T x) {
     interval = __abacus_select(interval, i, cond);
 
     const T poly = abacus::internal::horner_polynomial(
-        xAbs, __codeplay_asinh_coeff + i * 5, 5);
+        xAbs, __codeplay_asinh_coeff + i * (size_t)5, 5);
 
     ans = __abacus_select(ans, poly, cond);
   }

--- a/modules/compiler/builtins/abacus/source/abacus_math/log1p.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/log1p.cpp
@@ -262,7 +262,8 @@ struct helper<abacus_float, abacus_float> {
     }
 
     const abacus_float poly_approx = abacus::internal::horner_polynomial(
-        significand, __codeplay_log1p_coeff + polynomial_select * 10, 10);
+        significand, __codeplay_log1p_coeff + polynomial_select * (size_t)10,
+        10);
 
     if (polynomial_select != 0) {
       return poly_approx;

--- a/modules/compiler/builtins/libimg/source/host.cpp
+++ b/modules/compiler/builtins/libimg/source/host.cpp
@@ -706,6 +706,9 @@ void libimg::HostFillImage(HostImage *image, const void *fill_color,
     case CLK_FLOAT: {
       std::memcpy(final_color, &shuffled_color, desc.pixel_size);
     } break;
+    default: {
+      IMG_UNREACHABLE("unhandled channel type");
+    }
   }
 
   uint8_t *dst = image->image.raw_data + origin[0] * desc.pixel_size +

--- a/modules/compiler/include/compiler/limits.h
+++ b/modules/compiler/include/compiler/limits.h
@@ -29,7 +29,7 @@ namespace compiler {
 /// @{
 
 enum : size_t {
-  PRINTF_BUFFER_SIZE = 1024 * 1024,  ///< 1MiB is spec mandated minimum.
+  PRINTF_BUFFER_SIZE = 1024L * 1024L,  ///< 1MiB is spec mandated minimum.
 };
 
 /// @}

--- a/modules/compiler/multi_llvm/include/multi_llvm/vector_type_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/vector_type_helper.h
@@ -35,14 +35,14 @@ inline llvm::Type *getVectorElementType(const llvm::Type *ty) {
   return llvm::cast<llvm::VectorType>(ty)->getElementType();
 }
 
-inline unsigned getVectorNumElements(llvm::Type *ty) {
+inline uint64_t getVectorNumElements(llvm::Type *ty) {
   assert(ty->getTypeID() == llvm::Type::FixedVectorTyID &&
          "Not a fixed vector type");
   return llvm::cast<llvm::FixedVectorType>(ty)
       ->getElementCount()
       .getFixedValue();
 }
-inline unsigned getVectorNumElements(const llvm::Type *ty) {
+inline uint64_t getVectorNumElements(const llvm::Type *ty) {
   assert(ty->getTypeID() == llvm::Type::FixedVectorTyID &&
          "Not a fixed vector type");
   return llvm::cast<llvm::FixedVectorType>(ty)

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1125,8 +1125,8 @@ std::string BaseModule::debugDumpKernelSource(
         // Definitions are in the form of "macro" or "macro=value"
         auto pos = definition.find_first_of('=');
         if (pos != definition.npos) {
-          std::string macro = definition.substr(0, pos);
-          std::string value = definition.substr(pos + 1);
+          const std::string macro = definition.substr(0, pos);
+          const std::string value = definition.substr(pos + 1);
           dbg_fout << "#ifndef " << macro << "\n#define " << macro << " "
                    << value << "\n"
                    << "#endif // " << macro << "\n";
@@ -1154,8 +1154,8 @@ std::string BaseModule::printKernelSource(llvm::StringRef source,
 
   llvm::SmallString<128> absPath(path);
   if (!absPath.empty()) {
-    // Make file path absolute
-    llvm::sys::fs::make_absolute(absPath);
+    // Try to make file path absolute
+    (void)llvm::sys::fs::make_absolute(absPath);
 
     // Split path into directory and filename.
     const size_t delimiter = absPath.find_last_of(PATH_SEPARATOR);

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -346,6 +346,8 @@ std::optional<std::string> getPointerToStringAsString(Value *op) {
             var = dyn_cast<GlobalVariable>(const_string->getOperand(0));
           }
           break;
+        default:
+          break;
       }
     } else if (auto gep_string = dyn_cast<GetElementPtrInst>(op)) {
       var = dyn_cast<GlobalVariable>(gep_string->getPointerOperand());
@@ -359,13 +361,14 @@ std::optional<std::string> getPointerToStringAsString(Value *op) {
             // We only expect a direct store of a global variable or a GEP of
             // one.
             auto *const store_val = store_string->getValueOperand();
-            if ((var = dyn_cast<GlobalVariable>(store_val))) {
+            var = dyn_cast<GlobalVariable>(store_val);
+            if (var) {
               break;
             }
             if (auto const_string = dyn_cast<ConstantExpr>(store_val)) {
               if (const_string->getOpcode() == Instruction::GetElementPtr) {
-                if (nullptr != (var = dyn_cast<GlobalVariable>(
-                                    const_string->getOperand(0)))) {
+                var = dyn_cast<GlobalVariable>(const_string->getOperand(0));
+                if (var) {
                   break;
                 }
               }

--- a/modules/compiler/source/base/source/program_metadata.cpp
+++ b/modules/compiler/source/base/source/program_metadata.cpp
@@ -75,6 +75,8 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32};
         case 64:
           return {ArgumentKind::INT64};
+        default:
+          break;
       }
       break;
     case 2:
@@ -87,6 +89,8 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32_2};
         case 64:
           return {ArgumentKind::INT64_2};
+        default:
+          break;
       }
       break;
     case 3:
@@ -99,6 +103,8 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32_3};
         case 64:
           return {ArgumentKind::INT64_3};
+        default:
+          break;
       }
       break;
     case 4:
@@ -111,6 +117,8 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32_4};
         case 64:
           return {ArgumentKind::INT64_4};
+        default:
+          break;
       }
       break;
     case 8:
@@ -123,6 +131,8 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32_8};
         case 64:
           return {ArgumentKind::INT64_8};
+        default:
+          break;
       }
       break;
     case 16:
@@ -135,7 +145,11 @@ compiler::ArgumentType createIntegerOrSamplerType(
           return {ArgumentKind::INT32_16};
         case 64:
           return {ArgumentKind::INT64_16};
+        default:
+          break;
       }
+      break;
+    default:
       break;
   }
 
@@ -160,6 +174,8 @@ ArgumentType createFloatingPointType(uint32_t num_elements,
         return {ArgumentKind::HALF_8};
       case 16:
         return {ArgumentKind::HALF_16};
+      default:
+        break;
     }
   } else if (element_width == 32) {
     switch (num_elements) {
@@ -175,6 +191,8 @@ ArgumentType createFloatingPointType(uint32_t num_elements,
         return {ArgumentKind::FLOAT_8};
       case 16:
         return {ArgumentKind::FLOAT_16};
+      default:
+        break;
     }
   } else if (element_width == 64) {
     switch (num_elements) {
@@ -190,6 +208,8 @@ ArgumentType createFloatingPointType(uint32_t num_elements,
         return {ArgumentKind::DOUBLE_8};
       case 16:
         return {ArgumentKind::DOUBLE_16};
+      default:
+        break;
     }
   }
 

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1247,9 +1247,9 @@ std::string spirv_ll::Builder::getMangledTypeName(
       } else if (structName.contains("event_t")) {
         return "9ocl_event";
       } else {
-        std::fprintf(stderr,
-                     "mangler: unknown pointer to struct argument type: %.*s\n",
-                     static_cast<int>(structName.size()), structName.data());
+        (void)std::fprintf(
+            stderr, "mangler: unknown pointer to struct argument type: %.*s\n",
+            static_cast<int>(structName.size()), structName.data());
         std::abort();
       }
     }

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -602,9 +602,10 @@ llvm::Error Builder::create<OpTypeImage>(const OpTypeImage *op) {
       imageTypeName += "image1d_buffer_t";
       break;
     default:
-      fprintf(stderr,
-              "Unsupported type (Dim = %d) passed to 'create<OpTypeImage>'\n",
-              op->Dim());
+      (void)fprintf(
+          stderr,
+          "Unsupported type (Dim = %d) passed to 'create<OpTypeImage>'\n",
+          op->Dim());
       std::abort();
       break;
   }
@@ -1143,6 +1144,8 @@ llvm::Error Builder::create<OpSpecConstant>(const OpSpecConstant *op) {
               // Vulkan SPIR-V does not support 8 bit integers.
               size = -1;
             }
+            break;
+          default:
             break;
         }
         // SpecializationInfo::getValue does not require the type to match, it
@@ -1871,8 +1874,9 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
           arg_types.push_back(type);
         }
 
-        llvm::Type *push_constant_struct_type = nullptr;
-        if ((push_constant_struct_type = module.getPushConstantStructType())) {
+        llvm::Type *push_constant_struct_type =
+            module.getPushConstantStructType();
+        if (push_constant_struct_type) {
           arg_types.push_back(push_constant_struct_type);
         }
 
@@ -2009,7 +2013,7 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
               // than 1. This is an upsteam bug that may be resolved to encode
               // the legnth as 1, so here we handle both cases.
               numElements = std::max(numElements, static_cast<uint16_t>(1));
-              llvm::Type *vecTypeHint = nullptr;
+              llvm::Type *vecTypeHint;
               switch (dataType) {
                 case 0:  // 8-bit integer value
                   vecTypeHint = llvm::FixedVectorType::get(
@@ -2045,11 +2049,11 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
                       llvm::Type::getDoubleTy(*context.llvmContext),
                       numElements);
                   break;
+                default:
+                  llvm_unreachable(
+                      "OpExecutionMode VecTypeHint invalid vector type");
               }
 
-              SPIRV_LL_ASSERT(
-                  nullptr != vecTypeHint,
-                  "OpExecutionMode VecTypeHint invalid vector type");
               function->setMetadata(
                   "vec_type_hint",
                   llvm::MDNode::get(

--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -929,6 +929,8 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
                               flags, llvm::DINodeArray(),
                               /*RunTimeLang*/ 0, linkage_name);
       break;
+    default:
+      break;
   }
 
   // Make a note of this composite type, so that we'll come back to it later
@@ -2286,6 +2288,8 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translateDebugInstImpl(
       }
       return translate(cast<DebugTypeTemplateParameterPack>(op));
     }
+    default:
+      break;
   }
 
 #undef TRANSLATE_CASE
@@ -2367,6 +2371,8 @@ llvm::Error DebugInfoBuilder::create(const OpExtInst &opc) {
       // the very end. If any are referenced by other nodes in the mean time
       // we'll process them, but if those are forward referenced, we'll crash.
       template_types.push_back(opc.IdResult());
+      break;
+    default:
       break;
   }
 

--- a/modules/compiler/spirv-ll/tools/spirv-ll.cpp
+++ b/modules/compiler/spirv-ll/tools/spirv-ll.cpp
@@ -219,7 +219,7 @@ optional arguments:
 
   // Make sure everything is in order
   if (llvm::verifyModule(*spvModule->llvmModule, &llvm::errs())) {
-    std::cerr << "warning: module verification failed" << std::endl;
+    std::cerr << "warning: module verification failed\n";
   }
 
   return 0;

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -448,7 +448,8 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
           callback(llvm::toString(std::move(err)).c_str(), /*data*/ nullptr,
                    /*data_size*/ 0);
         } else {
-          llvm::consumeError(std::move(err));
+          llvm::consumeError(
+              std::move(err));  // NOLINT(clang-analyzer-cplusplus.Move)
         }
         return cargo::make_unexpected(
             compiler::Result::FINALIZE_PROGRAM_FAILURE);

--- a/modules/compiler/utils/source/align_module_structs_pass.cpp
+++ b/modules/compiler/utils/source/align_module_structs_pass.cpp
@@ -399,17 +399,20 @@ void replaceModuleTypes(const StructReplacementMap &typeMap, Module &module) {
         if (auto *alloca = dyn_cast<AllocaInst>(&inst)) {
           newType = getNewType(alloca->getAllocatedType(), typeMap);
         } else if (auto *GEP = dyn_cast<GetElementPtrInst>(&inst)) {
-          if (!(newType = getNewType(GEP->getSourceElementType(), typeMap))) {
+          newType = getNewType(GEP->getSourceElementType(), typeMap);
+          if (!newType) {
             newType = getNewType(GEP->getPointerOperand(), typeMap);
           }
         } else if (auto *cast = dyn_cast<CastInst>(&inst)) {
           newType = getNewType(cast->getOperand(0), typeMap);
         } else if (auto *load = dyn_cast<LoadInst>(&inst)) {
-          if (!(newType = getNewType(inst.getType(), typeMap))) {
+          newType = getNewType(inst.getType(), typeMap);
+          if (!newType) {
             newType = getNewType(load->getPointerOperand(), typeMap);
           }
         } else if (auto *store = dyn_cast<StoreInst>(&inst)) {
-          if (!(newType = getNewType(store->getValueOperand(), typeMap))) {
+          newType = getNewType(store->getValueOperand(), typeMap);
+          if (!newType) {
             newType = getNewType(store->getPointerOperand(), typeMap);
           }
         } else if (auto *cmpxchg = dyn_cast<AtomicCmpXchgInst>(&inst)) {
@@ -417,18 +420,21 @@ void replaceModuleTypes(const StructReplacementMap &typeMap, Module &module) {
         } else if (auto *atomicrmw = dyn_cast<AtomicRMWInst>(&inst)) {
           newType = getNewType(atomicrmw->getPointerOperand(), typeMap);
         } else if (auto *sel = dyn_cast<SelectInst>(&inst)) {
-          if (!(newType = getNewType(sel->getTrueValue(), typeMap))) {
+          newType = getNewType(sel->getTrueValue(), typeMap);
+          if (!newType) {
             newType = getNewType(sel->getFalseValue(), typeMap);
           }
         } else if (auto *phi = dyn_cast<PHINode>(&inst)) {
           for (auto &op : phi->incoming_values()) {
-            if ((newType = getNewType(op, typeMap))) {
+            newType = getNewType(op, typeMap);
+            if (newType) {
               break;
             }
           }
         } else if (auto *call = dyn_cast<CallInst>(&inst)) {
           for (auto &op : call->operands()) {
-            if ((newType = getNewType(op, typeMap))) {
+            newType = getNewType(op, typeMap);
+            if (newType) {
               break;
             }
           }

--- a/modules/compiler/utils/source/builtin_info.cpp
+++ b/modules/compiler/utils/source/builtin_info.cpp
@@ -1130,6 +1130,8 @@ std::optional<GroupCollective> BuiltinInfo::isMuxGroupCollective(BuiltinID ID) {
       case CASE_GROUP_OP_ALL_SCOPES(ScanLogicalXorExclusive):
         Collective.Recurrence = RecurKind::Xor;
         break;
+      default:
+        llvm_unreachable("Unhandled mux group operation");
     }
   } else if (!Collective.isBroadcast() && !Collective.isShuffleLike()) {
     llvm_unreachable("Unhandled mux group operation");

--- a/modules/compiler/utils/source/cl_builtin_info.cpp
+++ b/modules/compiler/utils/source/cl_builtin_info.cpp
@@ -2693,6 +2693,8 @@ static std::optional<unsigned> parseMemFenceFlagsParam(Value *const P) {
       case CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE:
         return (BIMuxInfoConcept::MemSemanticsWorkGroupMemory |
                 BIMuxInfoConcept::MemSemanticsCrossWorkGroupMemory);
+      default:
+        llvm_unreachable("unhandled memory fence flags");
     }
   }
   return std::nullopt;
@@ -2714,6 +2716,8 @@ static std::optional<unsigned> parseMemoryScopeParam(Value *const P) {
       case memory_scope_all_devices:
       case memory_scope_all_svm_devices:
         return BIMuxInfoConcept::MemScopeCrossDevice;
+      default:
+        llvm_unreachable("unhandled memory scope");
     }
   }
   return std::nullopt;
@@ -2732,6 +2736,8 @@ static std::optional<unsigned> parseMemoryOrderParam(Value *const P) {
         return BIMuxInfoConcept::MemSemanticsAcquireRelease;
       case memory_order_seq_cst:
         return BIMuxInfoConcept::MemSemanticsSequentiallyConsistent;
+      default:
+        llvm_unreachable("unhandled memory order");
     }
   }
   return std::nullopt;

--- a/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
+++ b/modules/compiler/utils/source/replace_c11_atomic_funcs_pass.cpp
@@ -271,10 +271,16 @@ void replaceFetchKey(CallInst *C11FetchKey) {
     auto OpTypeMangledIndex =
         BuiltinName.find("Atomic", KeyEndIndex) + std::strlen("Atomic");
     switch (BuiltinName[OpTypeMangledIndex]) {
+      case 'i':
+      case 'l':
+        break;
       case 'j':
       case 'm':
         KeyOpCode = (KeyOpCode == AtomicRMWInst::Min) ? AtomicRMWInst::UMin
                                                       : AtomicRMWInst::UMax;
+        break;
+      default:
+        llvm_unreachable("unhandled atomic type");
     }
   }
 

--- a/modules/compiler/utils/source/replace_mem_intrinsics_pass.cpp
+++ b/modules/compiler/utils/source/replace_mem_intrinsics_pass.cpp
@@ -46,6 +46,8 @@ PreservedAnalyses ReplaceMemIntrinsicsPass::run(Function &F,
               CallsToProcess.push_back(CI);
             }
             break;
+          default:
+            break;
         }
       }
     }
@@ -65,6 +67,8 @@ PreservedAnalyses ReplaceMemIntrinsicsPass::run(Function &F,
 #else
         expandMemMoveAsLoop(cast<MemMoveInst>(CI));
 #endif
+        break;
+      default:
         break;
     }
     CI->eraseFromParent();

--- a/modules/compiler/vecz/source/analysis/divergence_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/divergence_analysis.cpp
@@ -426,12 +426,12 @@ void DivergenceResult::markByAll(BasicBlock &src) {
           const auto *const DLoopTag = basicBlockTags[DIndex].loop;
           // If we are not in a loop, or the loop we live in does not diverge
           // nor does the one englobing us if it exists, then mark by_all.
-          Loop *parentLoop;
-          if (!DLoopTag || (!DLoopTag->isLoopDivergent() &&
-                            (!(parentLoop = DLoopTag->loop->getParentLoop()) ||
-                             isByAll(*parentLoop->getHeader())))) {
-            queue.push(DIndex);
+          if (DLoopTag) {
+            if (DLoopTag->isLoopDivergent()) continue;
+            Loop *parentLoop = DLoopTag->loop->getParentLoop();
+            if (parentLoop && !isByAll(*parentLoop->getHeader())) continue;
           }
+          queue.push(DIndex);
         }
       }
     }

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -3658,19 +3658,19 @@ ValuePacket Packetizer::Impl::packetizeInsertElement(
     if (Indices != Index) {
       Type *IdxTy = Index->getType();
       SmallVector<Constant *, 16> Offsets;
-      for (unsigned i = 0; i < Width; ++i) {
+      for (size_t i = 0; i < Width; ++i) {
         Offsets.push_back(ConstantInt::get(IdxTy, i * ScalarWidth));
       }
       Value *Add = B.CreateAdd(Indices, ConstantVector::get(Offsets));
 
-      for (unsigned i = 0; i < Width; ++i) {
+      for (size_t i = 0; i < Width; ++i) {
         Value *ExtractElt =
             (Elts != Elt) ? B.CreateExtractElement(Elts, B.getInt32(i)) : Elt;
         Value *ExtractIdx = B.CreateExtractElement(Add, B.getInt32(i));
         Result = B.CreateInsertElement(Result, ExtractElt, ExtractIdx, Name);
       }
     } else {
-      for (unsigned i = 0; i < Width; ++i) {
+      for (size_t i = 0; i < Width; ++i) {
         Value *ExtractElt =
             (Elts != Elt) ? B.CreateExtractElement(Elts, B.getInt32(i)) : Elt;
         Value *InsertIdx = B.CreateAdd(Index, B.getInt32(i * ScalarWidth));

--- a/modules/compiler/vecz/source/transform/scalarizer.cpp
+++ b/modules/compiler/vecz/source/transform/scalarizer.cpp
@@ -486,8 +486,8 @@ Value *Scalarizer::scalarizeOperandsBitCast(BitCastInst *BC) {
   Type *DstAsIntTy = DstTy;
   Type *SrcEleTy = VecSrcTy->getElementType();
   Type *SrcEleAsIntTy = SrcEleTy;
-  const unsigned SrcEleBits = SrcEleTy->getScalarSizeInBits();
-  const unsigned DstBits = DstTy->getPrimitiveSizeInBits();
+  const uint64_t SrcEleBits = SrcEleTy->getScalarSizeInBits();
+  const uint64_t DstBits = DstTy->getPrimitiveSizeInBits();
   if (!DstTy->isIntegerTy()) {
     DstAsIntTy = IntegerType::get(BC->getContext(), DstBits);
   }
@@ -1068,8 +1068,8 @@ SimdPacket *Scalarizer::scalarizeBitCast(BitCastInst *BC, PacketMask PM) {
     Value *SrcAsInt = Src;
     Type *DstEleTy = VecDstTy->getElementType();
     Type *DstEleAsIntTy = DstEleTy;
-    const unsigned SrcBits = SrcTy->getPrimitiveSizeInBits();
-    const unsigned LaneBits = DstEleTy->getPrimitiveSizeInBits();
+    const uint64_t SrcBits = SrcTy->getPrimitiveSizeInBits();
+    const uint64_t LaneBits = DstEleTy->getPrimitiveSizeInBits();
     if (!SrcTy->isIntegerTy()) {
       SrcAsIntTy = SrcTy->getIntNTy(BC->getContext(), SrcBits);
       SrcAsInt = B.CreateBitCast(SrcAsInt, SrcAsIntTy);

--- a/modules/kts/source/stdout_capture.cpp
+++ b/modules/kts/source/stdout_capture.cpp
@@ -117,7 +117,7 @@ void StdoutCapture::RestoreStdout() {
 }
 
 std::string StdoutCapture::ReadBuffer() {
-  std::fseek(stdout_tmp, 0, SEEK_SET);
+  (void)std::fseek(stdout_tmp, 0, SEEK_SET);
 
   // Read in the buffer.
   std::string str("");
@@ -128,7 +128,7 @@ std::string StdoutCapture::ReadBuffer() {
 
   // Now that we have read our output we can close the temporary file (it
   // will be deleted automatically).
-  std::fclose(stdout_tmp);
+  (void)std::fclose(stdout_tmp);
   stdout_tmp = NULL;
 
   return str;

--- a/modules/metadata/test/metadata/utils.cpp
+++ b/modules/metadata/test/metadata/utils.cpp
@@ -22,7 +22,7 @@
 
 TEST(UtilsTest, ReadValueBigEndianUint32) {
   // 4321 in BIG-ENDIAN -> uint32
-  uint8_t val[] = {0x00, 0x00, 0x10, 0xe1};
+  const uint8_t val[] = {0x00, 0x00, 0x10, 0xe1};
   const uint32_t read_val =
       md::utils::read_value<uint32_t>(&val[0], MD_ENDIAN::BIG);
   EXPECT_EQ(read_val, 4321);
@@ -30,14 +30,14 @@ TEST(UtilsTest, ReadValueBigEndianUint32) {
 
 TEST(UtilsTest, ReadValueLittleEndianUint32) {
   // 15432 in LITTLE-ENDIAN -> uint32
-  uint8_t val[] = {0x48, 0x3c, 0x00, 0x00};
+  const uint8_t val[] = {0x48, 0x3c, 0x00, 0x00};
   const uint32_t read_val =
       md::utils::read_value<uint32_t>(&val[0], MD_ENDIAN::LITTLE);
   EXPECT_EQ(read_val, 15432);
 }
 
 struct DecodeTest : ::testing::Test {
-  uint8_t *get_start() { return const_cast<uint8_t *>(&example_md_bin[0]); }
+  const uint8_t *get_start() { return &example_md_bin[0]; }
   size_t get_bin_size() {
     return sizeof(example_md_bin) / sizeof(example_md_bin[0]);
   }

--- a/modules/mux/source/device.cpp
+++ b/modules/mux/source/device.cpp
@@ -72,8 +72,9 @@ mux_result_t muxGetDeviceInfos(uint32_t device_types,
       auto targetGetDeviceInfos = targetGetDeviceInfosHooks[targetIndex];
 
       uint64_t devicesLength = 0;
-      if ((error = targetGetDeviceInfos(mux_device_type_all, 0, nullptr,
-                                        &devicesLength))) {
+      error =
+          targetGetDeviceInfos(mux_device_type_all, 0, nullptr, &devicesLength);
+      if (error) {
         return;
       }
 
@@ -84,8 +85,9 @@ mux_result_t muxGetDeviceInfos(uint32_t device_types,
       assert(devicesLength <= deviceInfos.size() &&
              "mux target has more than 16 devices, increase array size");
 
-      if ((error = (targetGetDeviceInfos(mux_device_type_all, devicesLength,
-                                         deviceInfos.data(), nullptr)))) {
+      error = targetGetDeviceInfos(mux_device_type_all, devicesLength,
+                                   deviceInfos.data(), nullptr);
+      if (error) {
         return;
       }
 

--- a/modules/mux/targets/host/extension/example/main.c
+++ b/modules/mux/targets/host/extension/example/main.c
@@ -20,13 +20,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define IS_CL_SUCCESS(X)                                                       \
-  {                                                                            \
-    cl_int ret_val = X;                                                        \
-    if (CL_SUCCESS != ret_val) {                                               \
-      fprintf(stderr, "OpenCL error occurred: %s returned %d\n", #X, ret_val); \
-      exit(1);                                                                 \
-    }                                                                          \
+#define IS_CL_SUCCESS(X)                                                   \
+  {                                                                        \
+    const cl_int ret_val = X;                                              \
+    if (CL_SUCCESS != ret_val) {                                           \
+      (void)fprintf(stderr, "OpenCL error occurred: %s returned %d\n", #X, \
+                    ret_val);                                              \
+      exit(1);                                                             \
+    }                                                                      \
   }
 
 void printUsage(const char *arg0) {
@@ -43,7 +44,7 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "expected platform name\n");
+        (void)fprintf(stderr, "expected platform name\n");
         exit(1);
       }
       *platform_name = argv[argi];
@@ -51,13 +52,13 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "error: expected device name\n");
+        (void)fprintf(stderr, "error: expected device name\n");
         exit(1);
       }
       *device_name = argv[argi];
     } else {
       printUsage(argv[0]);
-      fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
+      (void)fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
       exit(1);
     }
   }
@@ -68,13 +69,13 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   IS_CL_SUCCESS(clGetPlatformIDs(0, NULL, &num_platforms));
 
   if (0 == num_platforms) {
-    fprintf(stderr, "No OpenCL platforms found, exiting\n");
+    (void)fprintf(stderr, "No OpenCL platforms found, exiting\n");
     exit(1);
   }
 
   cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
   if (NULL == platforms) {
-    fprintf(stderr, "\nCould not allocate memory for platform ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for platform ids\n");
     exit(1);
   }
   IS_CL_SUCCESS(clGetPlatformIDs(num_platforms, platforms, NULL));
@@ -92,7 +93,8 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
     } else {
       char *platform_name = malloc(platform_name_size);
       if (NULL == platform_name) {
-        fprintf(stderr, "\nCould not allocate memory for platform name\n");
+        (void)fprintf(stderr,
+                      "\nCould not allocate memory for platform name\n");
         exit(1);
       }
       IS_CL_SUCCESS(clGetPlatformInfo(platforms[i], CL_PLATFORM_NAME,
@@ -106,8 +108,8 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   }
 
   if (platform_name_arg != NULL && selected_platform == 0) {
-    fprintf(stderr, "Platform name matching '--platform %s' not found\n",
-            platform_name_arg);
+    (void)fprintf(stderr, "Platform name matching '--platform %s' not found\n",
+                  platform_name_arg);
     exit(1);
   }
 
@@ -120,7 +122,7 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   } else {
     printf("\nPlease select a platform: ");
     if (1 != scanf("%u", &selected_platform)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -128,7 +130,7 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   selected_platform -= 1;
 
   if (num_platforms <= selected_platform) {
-    fprintf(stderr, "\nSelected unknown platform, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown platform, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on platform %u\n", selected_platform + 1);
@@ -147,13 +149,13 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
                                &num_devices));
 
   if (0 == num_devices) {
-    fprintf(stderr, "No OpenCL devices found, exiting\n");
+    (void)fprintf(stderr, "No OpenCL devices found, exiting\n");
     exit(1);
   }
 
   cl_device_id *devices = malloc(sizeof(cl_device_id) * num_devices);
   if (NULL == devices) {
-    fprintf(stderr, "\nCould not allocate memory for device ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for device ids\n");
     exit(1);
   }
   IS_CL_SUCCESS(clGetDeviceIDs(selected_platform, CL_DEVICE_TYPE_ALL,
@@ -172,7 +174,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
     } else {
       char *device_name = malloc(device_name_size);
       if (NULL == device_name) {
-        fprintf(stderr, "\nCould not allocate memory for device name\n");
+        (void)fprintf(stderr, "\nCould not allocate memory for device name\n");
         exit(1);
       }
       IS_CL_SUCCESS(clGetDeviceInfo(devices[i], CL_DEVICE_NAME,
@@ -186,8 +188,8 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   }
 
   if (device_name_arg != NULL && selected_device == 0) {
-    fprintf(stderr, "Device name matching '--device %s' not found\n",
-            device_name_arg);
+    (void)fprintf(stderr, "Device name matching '--device %s' not found\n",
+                  device_name_arg);
     exit(1);
   }
 
@@ -200,7 +202,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   } else {
     printf("\nPlease select a device: ");
     if (1 != scanf("%u", &selected_device)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -208,7 +210,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   selected_device -= 1;
 
   if (num_devices <= selected_device) {
-    fprintf(stderr, "\nSelected unknown device, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown device, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on device %u\n", selected_device + 1);

--- a/modules/mux/targets/host/source/builtin_kernel.cpp
+++ b/modules/mux/targets/host/source/builtin_kernel.cpp
@@ -115,8 +115,8 @@ host::builtin_kernel_map host::getBuiltinKernels(
   // Loop over all type combinations.
   for (auto &scalar_type : scalar_types) {
     for (auto &vector_size : vector_sizes) {
-      std::string type(scalar_type + vector_size);
-      std::string typeptr(type + get_spaces() + '*');
+      const std::string type(scalar_type + vector_size);
+      const std::string typeptr(type + get_spaces() + '*');
       std::string kernel_decl(get_spaces() + "args_" + type + get_spaces() +
                               '(');
 
@@ -128,7 +128,7 @@ host::builtin_kernel_map host::getBuiltinKernels(
 
       // Create pointer arguments with address space qualifiers.
       for (auto &address_space_qualifier : address_space_qualifiers) {
-        std::string addrspace(address_space_qualifier.data(), 2);
+        const std::string addrspace(address_space_qualifier.data(), 2);
         add_argument(kernel_decl,
                      {address_space_qualifier, typeptr, addrspace + "p"});
         add_argument(kernel_decl, {address_space_qualifier, "const", typeptr,
@@ -153,12 +153,12 @@ host::builtin_kernel_map host::getBuiltinKernels(
 
   {
     // `void*` types are special: there are no vector or value versions
-    std::string typeptr("void" + get_spaces() + '*');
+    const std::string typeptr("void" + get_spaces() + '*');
     std::string kernel_decl(get_spaces() + "args_void" + get_spaces() + '(');
 
     // Create pointer arguments with address space qualifiers.
     for (auto &address_space_qualifier : address_space_qualifiers) {
-      std::string addrspace(address_space_qualifier.data(), 2);
+      const std::string addrspace(address_space_qualifier.data(), 2);
       add_argument(kernel_decl,
                    {address_space_qualifier, typeptr, addrspace + "p"});
       add_argument(kernel_decl, {address_space_qualifier, "const", typeptr,

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -38,7 +38,7 @@ size_t calcPackedArgsAllocSize(
   size_t offset = 0;
   for (unsigned i = 0; i < descriptors.size(); i++) {
     const auto descriptor = descriptors[i];
-    size_t size = 0;
+    size_t size;
     switch (descriptor.type) {
       case mux_descriptor_info_type_sampler:
         size = sizeof(size_t);
@@ -53,6 +53,9 @@ size_t calcPackedArgsAllocSize(
       } break;
       case mux_descriptor_info_type_shared_local_buffer: {
         size = sizeof(size_t);
+      } break;
+      default: {
+        size = 0;
       } break;
     }
     offsets[i] = offset;
@@ -154,6 +157,8 @@ void populatePackedArgs(
         std::memcpy(packed_args_alloc + offset, &nullvar, sizeof(void *));
         offset += sizeof(void *);
       } break;
+      default:
+        break;
     }
   }
 }

--- a/modules/mux/targets/host/source/device.cpp
+++ b/modules/mux/targets/host/source/device.cpp
@@ -118,13 +118,13 @@ uint32_t os_cpu_frequency() {
         ;
       }
 
-      fclose(file);
+      (void)fclose(file);
       const float mhz = atof(buffer + i);
       return static_cast<uint32_t>(mhz);
     }
   }
 
-  fclose(file);
+  (void)fclose(file);
   return 0;  // could not find mhz value!
 #elif defined(__MCOS_POSIX__)
   return 0;
@@ -231,7 +231,7 @@ uint64_t os_cache_size() {
     assert(0 && "Reading from the cache file failed!");
   }
 
-  fclose(file);
+  (void)fclose(file);
 
   // caches are described in kilobytes, so multiply the cache size
   return static_cast<uint64_t>(atoi(data)) * 1024;
@@ -301,7 +301,7 @@ uint64_t os_cacheline_size() {
     assert(0 && "Reading from the cache file failed!");
   }
 
-  fclose(file);
+  (void)fclose(file);
 
   // caches are described in bytes
   return static_cast<uint64_t>(atoi(data));
@@ -440,7 +440,7 @@ device_info_s::device_info_s(host::arch arch, host::os os, bool native,
   this->cacheline_size = native ? os_cacheline_size() : 0;
 
   // See redmine #4947
-  this->shared_local_memory_size = 32 * 1024;
+  this->shared_local_memory_size = 32L * 1024L;
 
   // default to 128 bit (16 bytes)
   this->native_vector_width = 128 / (8 * sizeof(uint8_t));

--- a/modules/mux/targets/host/test/UnitCL/cl_codeplay_host_builtins.cpp
+++ b/modules/mux/targets/host/test/UnitCL/cl_codeplay_host_builtins.cpp
@@ -42,7 +42,7 @@ TEST_F(cl_codeplay_host_builtins_test, KernelWithBuiltin) {
   EXPECT_SUCCESS(errorcode);
 
   // Build should fail if the force header is missing
-  bool has_force_header =
+  const bool has_force_header =
       UCL::hasDeviceExtensionSupport(device, "cl_codeplay_host_builtins");
   if (has_force_header) {
     EXPECT_SUCCESS(

--- a/modules/mux/targets/host/test/UnitCL/hostBuiltInKernels.cpp
+++ b/modules/mux/targets/host/test/UnitCL/hostBuiltInKernels.cpp
@@ -32,7 +32,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, ValidNameWithEmptyName) {
     GTEST_SKIP() << "Not running on host device, skipping test.\n";
   }
   cl_int status;
-  std::string empty_kernel_name = "copy_buffer;";
+  const std::string empty_kernel_name = "copy_buffer;";
 
   ASSERT_FALSE(clCreateProgramWithBuiltInKernels(
       context, 1, &device, empty_kernel_name.c_str(), &status));
@@ -62,7 +62,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, BuildBuiltInProgram) {
   ASSERT_EQ(kernel_names_len + 1, size);
 
   auto split_device_names =
-      cargo::split_all(cargo::string_view(&kernel_names[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_names.data()), ";");
 
   ASSERT_FALSE(std::none_of(
       split_device_names.begin(), split_device_names.end(),
@@ -108,7 +108,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, CopyBuffer) {
   ASSERT_EQ(kernel_names_len + 1, size);
 
   auto split_device_names =
-      cargo::split_all(cargo::string_view(&kernel_names[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_names.data()), ";");
 
   ASSERT_FALSE(std::none_of(
       split_device_names.begin(), split_device_names.end(),
@@ -128,7 +128,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, CopyBuffer) {
   EXPECT_TRUE(kernel);
   EXPECT_SUCCESS(status);
   // START
-  cl_int NUM = 24;
+  const cl_int NUM = 24;
   cl_mem inMem =
       clCreateBuffer(context, 0, NUM * sizeof(cl_int), nullptr, &status);
   cl_mem outMem =
@@ -196,7 +196,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, Printf) {
   ASSERT_EQ(kernel_names_len + 1, size);
 
   auto split_device_names =
-      cargo::split_all(cargo::string_view(&kernel_names[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_names.data()), ";");
 
   ASSERT_FALSE(std::none_of(
       split_device_names.begin(), split_device_names.end(),
@@ -253,9 +253,9 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsFirstKernel) {
   ASSERT_EQ(kernel_names_len + 1, size);
 
   auto split_device_names =
-      cargo::split_all(cargo::string_view(&kernel_names[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_names.data()), ";");
   auto split_kernel_name =
-      cargo::split_all(cargo::string_view(&kernel_name[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_name.data()), ";");
   for (const auto &test_kernel_name : split_kernel_name) {
     ASSERT_FALSE(std::none_of(
         split_device_names.begin(), split_device_names.end(),
@@ -277,7 +277,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsFirstKernel) {
   EXPECT_TRUE(kernel);
   EXPECT_SUCCESS(status);
   // START
-  cl_int NUM = 24;
+  const cl_int NUM = 24;
   cl_mem inMem =
       clCreateBuffer(context, 0, NUM * sizeof(cl_int), nullptr, &status);
   cl_mem outMem =
@@ -346,9 +346,9 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsSecondKernel) {
   ASSERT_EQ(kernel_names_len + 1, size);
 
   auto split_device_names =
-      cargo::split_all(cargo::string_view(&kernel_names[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_names.data()), ";");
   auto split_kernel_name =
-      cargo::split_all(cargo::string_view(&kernel_name[0]), ";");
+      cargo::split_all(cargo::string_view(kernel_name.data()), ";");
   for (const auto &test_kernel_name : split_kernel_name) {
     ASSERT_FALSE(std::none_of(
         split_device_names.begin(), split_device_names.end(),
@@ -370,7 +370,7 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsSecondKernel) {
   EXPECT_TRUE(kernel);
   EXPECT_SUCCESS(status);
   // START
-  cl_int NUM = 24;
+  const cl_int NUM = 24;
   cl_mem inMem =
       clCreateBuffer(context, 0, NUM * sizeof(cl_int), nullptr, &status);
   cl_mem outMem =
@@ -426,7 +426,7 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
     if (size) {
       builtin_kernels.resize(size);
       ASSERT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_BUILT_IN_KERNELS, size,
-                                     &builtin_kernels[0], nullptr));
+                                     builtin_kernels.data(), nullptr));
     }
   }
 
@@ -533,7 +533,7 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
     if (!test_value_types) {
       (void)type_size;
     }
-    std::string kernel_name = "args_" + type;
+    const std::string kernel_name = "args_" + type;
     if (std::string::npos != type.find("half") &&
         !UCL::hasDeviceExtensionSupport(device, "cl_khr_fp16")) {
       GTEST_SKIP();
@@ -636,6 +636,8 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
         case CL_KERNEL_ARG_ADDRESS_CONSTANT:
           addrspace = "co";
           break;
+        default:
+          FAIL() << "Unexpected address qualifier.";
       }
 
       {  // <address_qualifier> <type>* <addrspace>p
@@ -814,7 +816,7 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
     if (!UCL::isDevice_host(device)) {
       GTEST_SKIP() << "Not running on host device, skipping test.\n";
     }
-    std::string kernel_name = "args_" + image_type;
+    const std::string kernel_name = "args_" + image_type;
     ASSERT_TRUE(hasBuiltinKernel(kernel_name))
         << "'" << kernel_name << "' kernel is not present";
     ASSERT_SUCCESS(createProgramAndKernel(kernel_name));
@@ -854,7 +856,7 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
     }
 
     {  // write_only <image_type> woi
-      bool image3d_writes =
+      const bool image3d_writes =
           UCL::hasDeviceExtensionSupport(device, "cl_khr_3d_image_writes");
       size_t size;
       ASSERT_EQ(CL_SUCCESS, clGetPlatformInfo(platform, CL_PLATFORM_PROFILE, 0,
@@ -862,7 +864,7 @@ struct hostBuiltInKernelsArgsTest : ucl::ContextTest {
       std::string platform_profile(size, '\0');
       ASSERT_EQ(CL_SUCCESS,
                 clGetPlatformInfo(platform, CL_PLATFORM_PROFILE, size,
-                                  &platform_profile[0], nullptr));
+                                  platform_profile.data(), nullptr));
       bool image2d_array_writes = true;
       if (platform_profile == "EMBEDDED") {
         image2d_array_writes = UCL::hasDeviceExtensionSupport(
@@ -940,7 +942,7 @@ TEST_F(hostBuiltInKernelsArgsTest, args_address_qualifiers) {
   if (!UCL::isDevice_host(device)) {
     GTEST_SKIP() << "Not running on host device, skipping test.\n";
   }
-  std::string kernel_name = "args_address_qualifiers";
+  const std::string kernel_name = "args_address_qualifiers";
   ASSERT_TRUE(hasBuiltinKernel(kernel_name))
       << "'" << kernel_name << "' kernel is not present.";
   ASSERT_SUCCESS(createProgramAndKernel(kernel_name));
@@ -1004,7 +1006,7 @@ TEST_F(hostBuiltInKernelsArgsTest, args_sampler_t) {
   if (!UCL::isDevice_host(device)) {
     GTEST_SKIP() << "Not running on host device, skipping test.\n";
   }
-  std::string kernel_name = "args_sampler_t";
+  const std::string kernel_name = "args_sampler_t";
 
   ASSERT_TRUE(hasBuiltinKernel(kernel_name))
       << "'" << kernel_name << "' kernel is not present.";

--- a/modules/mux/test/c.c
+++ b/modules/mux/test/c.c
@@ -4,4 +4,4 @@
 // unit to verify that it compiles correctly enabling a client to implement
 // Mux using the C language. This stub function is here to silence linker
 // warnings about empty translation units on some platforms.
-void stub() {}
+void stub(void) {}

--- a/modules/mux/test/muxBindBufferMemory.cpp
+++ b/modules/mux/test/muxBindBufferMemory.cpp
@@ -20,7 +20,7 @@
 
 #include "common.h"
 
-enum { MEMORY_SIZE = 128 };
+const size_t MEMORY_SIZE = 128;
 
 struct muxBindBufferMemoryTest : public DeviceTest {
   mux_memory_t memory = nullptr;

--- a/modules/mux/test/muxCommandReadBuffer.cpp
+++ b/modules/mux/test/muxCommandReadBuffer.cpp
@@ -18,7 +18,7 @@
 
 #include "common.h"
 
-enum { MEMORY_SIZE = 128 };
+const size_t MEMORY_SIZE = 128;
 
 struct muxCommandReadBufferTest : DeviceTest {
   mux_memory_t memory = nullptr;

--- a/modules/mux/test/muxCommandWriteBuffer.cpp
+++ b/modules/mux/test/muxCommandWriteBuffer.cpp
@@ -18,7 +18,7 @@
 
 #include "common.h"
 
-enum { MEMORY_SIZE = 128 };
+const size_t MEMORY_SIZE = 128;
 
 struct muxCommandWriteBufferTest : DeviceTest {
   mux_memory_t memory = nullptr;

--- a/source/cl/examples/CommandBufferKHR/source/main.cpp
+++ b/source/cl/examples/CommandBufferKHR/source/main.cpp
@@ -45,7 +45,7 @@ int main(const int argc, const char **argv) {
   std::string extension_names(extension_names_size, '\0');
 
   CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, extension_names.size(),
-                           &extension_names[0], nullptr));
+                           extension_names.data(), nullptr));
 
   if (std::string::npos == extension_names.find("cl_khr_command_buffer")) {
     std::cerr << "cl_khr_command_buffer not supported by device, skipping "

--- a/source/cl/examples/MutableDispatchKHR/source/main.cpp
+++ b/source/cl/examples/MutableDispatchKHR/source/main.cpp
@@ -45,7 +45,7 @@ int main(const int argc, const char **argv) {
   std::string extension_names(extension_names_size, '\0');
 
   CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, extension_names.size(),
-                           &extension_names[0], nullptr));
+                           extension_names.data(), nullptr));
 
   // Mutable-dispatch extension is only reported when cl_khr_command_buffer is
   // also enabled, so don't need to check for cl_khr_command_buffer as well.
@@ -209,11 +209,14 @@ int main(const int argc, const char **argv) {
     // If not executing the first frame
     if (i != 0) {
       // Configure the mutable configuration to update the kernel arguments
-      cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem), &input_A_buffer};
-      cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem), &input_B_buffer};
-      cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem), &output_buffer};
-      cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
-      cl_mutable_dispatch_config_khr dispatch_config{
+      const cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem),
+                                              &input_A_buffer};
+      const cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem),
+                                              &input_B_buffer};
+      const cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem),
+                                              &output_buffer};
+      const cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
+      const cl_mutable_dispatch_config_khr dispatch_config{
           CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
           nullptr,
           command_handle,
@@ -227,7 +230,7 @@ int main(const int argc, const char **argv) {
           nullptr /* global_work_offset */,
           nullptr /* global_work_size */,
           nullptr /* local_work_size */};
-      cl_mutable_base_config_khr mutable_config{
+      const cl_mutable_base_config_khr mutable_config{
           CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
           &dispatch_config};
 
@@ -258,7 +261,7 @@ int main(const int argc, const char **argv) {
       const cl_int result = input_a[i] + input_b[i];
       if (output[i] != result) {
         std::cerr << "Error: Incorrect result at index " << i << " - Expected "
-                  << output[i] << " was " << result << std::endl;
+                  << output[i] << " was " << result << '\n';
         std::exit(1);
       }
     }

--- a/source/cl/examples/SubGroups/source/main.cpp
+++ b/source/cl/examples/SubGroups/source/main.cpp
@@ -137,7 +137,7 @@ kernel void reduction(global int *in, local int *tmp, global int *out) {
       kernel, device, CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE, sizeof(size_t),
       &local_size, sizeof(size_t), &sub_group_count, nullptr));
   std::cout << "Sub-group count for local size (" << local_size
-            << ", 1, 1): " << sub_group_count << std::endl;
+            << ", 1, 1): " << sub_group_count << '\n';
   constexpr size_t input_buffer_size = global_size * sizeof(cl_int);
   constexpr size_t output_buffer_size = work_group_count * sizeof(cl_int);
   const size_t local_buffer_size = sub_group_count * sizeof(cl_int);

--- a/source/cl/examples/include/common.h
+++ b/source/cl/examples/include/common.h
@@ -26,13 +26,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define IS_CL_SUCCESS(X)                                                       \
-  {                                                                            \
-    const cl_int ret_val = X;                                                  \
-    if (CL_SUCCESS != ret_val) {                                               \
-      fprintf(stderr, "OpenCL error occurred: %s returned %d\n", #X, ret_val); \
-      exit(1);                                                                 \
-    }                                                                          \
+#define IS_CL_SUCCESS(X)                                                   \
+  {                                                                        \
+    const cl_int ret_val = X;                                              \
+    if (CL_SUCCESS != ret_val) {                                           \
+      (void)fprintf(stderr, "OpenCL error occurred: %s returned %d\n", #X, \
+                    ret_val);                                              \
+      exit(1);                                                             \
+    }                                                                      \
   }
 
 /// @brief Print help message on executable usage
@@ -62,7 +63,7 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "expected platform name\n");
+        (void)fprintf(stderr, "expected platform name\n");
         exit(1);
       }
       *platform_name = argv[argi];
@@ -70,13 +71,13 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "error: expected device name\n");
+        (void)fprintf(stderr, "error: expected device name\n");
         exit(1);
       }
       *device_name = argv[argi];
     } else {
       printUsage(argv[0]);
-      fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
+      (void)fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
       exit(1);
     }
   }
@@ -96,14 +97,14 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   IS_CL_SUCCESS(clGetPlatformIDs(0, NULL, &num_platforms));
 
   if (0 == num_platforms) {
-    fprintf(stderr, "No OpenCL platforms found, exiting\n");
+    (void)fprintf(stderr, "No OpenCL platforms found, exiting\n");
     exit(1);
   }
 
   cl_platform_id *platforms =
       (cl_platform_id *)malloc(sizeof(cl_platform_id) * num_platforms);
   if (NULL == platforms) {
-    fprintf(stderr, "\nCould not allocate memory for platform ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for platform ids\n");
     exit(1);
   }
   IS_CL_SUCCESS(clGetPlatformIDs(num_platforms, platforms, NULL));
@@ -121,7 +122,8 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
     } else {
       char *platform_name = (char *)malloc(platform_name_size);
       if (NULL == platform_name) {
-        fprintf(stderr, "\nCould not allocate memory for platform name\n");
+        (void)fprintf(stderr,
+                      "\nCould not allocate memory for platform name\n");
         exit(1);
       }
       IS_CL_SUCCESS(clGetPlatformInfo(platforms[i], CL_PLATFORM_NAME,
@@ -135,8 +137,8 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   }
 
   if (platform_name_arg != NULL && selected_platform == 0) {
-    fprintf(stderr, "Platform name matching '--platform %s' not found\n",
-            platform_name_arg);
+    (void)fprintf(stderr, "Platform name matching '--platform %s' not found\n",
+                  platform_name_arg);
     exit(1);
   }
 
@@ -149,7 +151,7 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   } else {
     printf("\nPlease select a platform: ");
     if (1 != scanf("%u", &selected_platform)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -157,7 +159,7 @@ cl_platform_id selectPlatform(const char *platform_name_arg) {
   selected_platform -= 1;
 
   if (num_platforms <= selected_platform) {
-    fprintf(stderr, "\nSelected unknown platform, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown platform, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on platform %u\n", selected_platform + 1);
@@ -187,14 +189,14 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
                                &num_devices));
 
   if (0 == num_devices) {
-    fprintf(stderr, "No OpenCL devices found, exiting\n");
+    (void)fprintf(stderr, "No OpenCL devices found, exiting\n");
     exit(1);
   }
 
   cl_device_id *devices =
       (cl_device_id *)malloc(sizeof(cl_device_id) * num_devices);
   if (NULL == devices) {
-    fprintf(stderr, "\nCould not allocate memory for device ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for device ids\n");
     exit(1);
   }
   IS_CL_SUCCESS(clGetDeviceIDs(selected_platform, CL_DEVICE_TYPE_ALL,
@@ -213,7 +215,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
     } else {
       char *device_name = (char *)malloc(device_name_size);
       if (NULL == device_name) {
-        fprintf(stderr, "\nCould not allocate memory for device name\n");
+        (void)fprintf(stderr, "\nCould not allocate memory for device name\n");
         exit(1);
       }
       IS_CL_SUCCESS(clGetDeviceInfo(devices[i], CL_DEVICE_NAME,
@@ -227,8 +229,8 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   }
 
   if (device_name_arg != NULL && selected_device == 0) {
-    fprintf(stderr, "Device name matching '--device %s' not found\n",
-            device_name_arg);
+    (void)fprintf(stderr, "Device name matching '--device %s' not found\n",
+                  device_name_arg);
     exit(1);
   }
 
@@ -241,7 +243,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   } else {
     printf("\nPlease select a device: ");
     if (1 != scanf("%u", &selected_device)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -249,7 +251,7 @@ cl_device_id selectDevice(cl_platform_id selected_platform,
   selected_device -= 1;
 
   if (num_devices <= selected_device) {
-    fprintf(stderr, "\nSelected unknown device, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown device, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on device %u\n", selected_device + 1);

--- a/source/cl/source/binary/source/spirv.cpp
+++ b/source/cl/source/binary/source/spirv.cpp
@@ -47,8 +47,6 @@ const std::array<const std::string, 11> supported_extensions = {
 cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
     mux_device_info_t device_info, cargo::string_view profile) {
   compiler::spirv::DeviceInfo spvDeviceInfo;
-  cargo::result result = cargo::result::success;
-
   auto &spvCapabilities = spvDeviceInfo.capabilities;
 
   // A set of capabilities shared between the OpenCL profiles we support.
@@ -77,11 +75,12 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
     if (!error_or) {
       return cargo::make_unexpected(error_or.error());
     }
-    if ((result = spvCapabilities.push_back(spv::CapabilityInt64))) {
+    if (auto result = spvCapabilities.push_back(spv::CapabilityInt64)) {
       return cargo::make_unexpected(result);
     }
     if (device_info->atomic_capabilities & mux_atomic_capabilities_64bit) {
-      if ((result = spvCapabilities.push_back(spv::CapabilityInt64Atomics))) {
+      if (auto result =
+              spvCapabilities.push_back(spv::CapabilityInt64Atomics)) {
         return cargo::make_unexpected(result);
       }
     }
@@ -93,11 +92,12 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
       return cargo::make_unexpected(error_or.error());
     }
     if (device_info->integer_capabilities & mux_integer_capabilities_64bit) {
-      if ((result = spvCapabilities.push_back(spv::CapabilityInt64))) {
+      if (auto result = spvCapabilities.push_back(spv::CapabilityInt64)) {
         return cargo::make_unexpected(result);
       }
       if (device_info->atomic_capabilities & mux_atomic_capabilities_64bit) {
-        if ((result = spvCapabilities.push_back(spv::CapabilityInt64Atomics))) {
+        if (auto result =
+                spvCapabilities.push_back(spv::CapabilityInt64Atomics)) {
           return cargo::make_unexpected(result);
         }
       }
@@ -118,7 +118,7 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
     }
   }
   if (device_info->half_capabilities) {
-    if ((result = spvCapabilities.push_back(spv::CapabilityFloat16))) {
+    if (auto result = spvCapabilities.push_back(spv::CapabilityFloat16)) {
       return cargo::make_unexpected(result);
     }
   }
@@ -144,7 +144,8 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
     }
   }
   if (device_info->supports_generic_address_space) {
-    if ((result = spvCapabilities.push_back(spv::CapabilityGenericPointer))) {
+    if (auto result =
+            spvCapabilities.push_back(spv::CapabilityGenericPointer)) {
       return cargo::make_unexpected(result);
     }
   }
@@ -152,12 +153,13 @@ cargo::expected<compiler::spirv::DeviceInfo, cargo::result> getSPIRVDeviceInfo(
     // Note: This is something of a lie, as we don't support DeviceEnqueue,
     // but we must support the 'SubgroupSize' ExecutionMode for SYCL 2020 and
     // that is lumped in with SubgroupDispatch.
-    if ((result = spvCapabilities.push_back(spv::CapabilitySubgroupDispatch))) {
+    if (auto result =
+            spvCapabilities.push_back(spv::CapabilitySubgroupDispatch)) {
       return cargo::make_unexpected(result);
     }
   }
   for (const std::string &extension : supported_extensions) {
-    if ((result = spvDeviceInfo.extensions.push_back(extension))) {
+    if (auto result = spvDeviceInfo.extensions.push_back(extension)) {
       return cargo::make_unexpected(result);
     }
   }

--- a/source/cl/source/command_queue.cpp
+++ b/source/cl/source/command_queue.cpp
@@ -1355,8 +1355,8 @@ cl::EnqueueMarker(cl_command_queue command_queue, cl_event *event) {
     cl_command_buffer_khr command_buffer, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *return_event) {
   // Lock both queue and command-buffer
-  std::lock_guard<std::mutex> lock_queue(context->getCommandQueueMutex());
-  std::lock_guard<std::mutex> lock_command_buffer(command_buffer->mutex);
+  const std::lock_guard<std::mutex> lock_queue(context->getCommandQueueMutex());
+  const std::lock_guard<std::mutex> lock_command_buffer(command_buffer->mutex);
 
   // Create the signal event if caller asks for it.
   cl_event event = nullptr;

--- a/source/cl/source/device.cpp
+++ b/source/cl/source/device.cpp
@@ -118,8 +118,8 @@ _cl_device_id::_cl_device_id(cl_platform_id platform,
                          : CL_GLOBAL),
       max_clock_frequency(mux_device->info->clock_frequency),
       max_compute_units(mux_device->info->compute_units),
-      max_constant_args(8),                 // 8 is spec mandated minimum
-      max_constant_buffer_size(64 * 1024),  // 64k is spec mandated minimum
+      max_constant_args(8),                   // 8 is spec mandated minimum
+      max_constant_buffer_size(64L * 1024L),  // 64k is spec mandated minimum
       max_mem_alloc_size(mux_device->info->allocation_size),
       max_parameter_size(1024),  // 1024 is spec mandated minimum
       max_read_image_args(mux_device->info->max_sampled_images),
@@ -297,6 +297,8 @@ _cl_device_id::_cl_device_id(cl_platform_id platform,
     case mux_device_type_custom:
       type = CL_DEVICE_TYPE_CUSTOM;
       break;
+    default:
+      OCL_ABORT("Unsupported device type");
   }
 
   auto builtins =

--- a/source/cl/source/extension/include/extension/khr_command_buffer.h
+++ b/source/cl/source/extension/include/extension/khr_command_buffer.h
@@ -24,13 +24,14 @@
 
 #include <CL/cl_ext.h>
 #include <cargo/dynamic_array.h>
+#include <cargo/expected.h>
 #include <cargo/small_vector.h>
 #include <cl/base.h>
-#include <cl/command_queue.h>
 #include <cl/limits.h>
 #include <cl/mux.h>
 #include <extension/extension.h>
 
+#include <array>
 #include <atomic>
 #include <mutex>
 

--- a/source/cl/source/extension/source/codeplay_wfv.cpp
+++ b/source/cl/source/extension/source/codeplay_wfv.cpp
@@ -165,6 +165,8 @@ cl_int CL_API_CALL clGetKernelWFVInfoCODEPLAY(
     }();
 
     switch (param_name) {
+      default:
+        return CL_INVALID_VALUE;
       case CL_KERNEL_WFV_STATUS_CODEPLAY: {
         cl_kernel_wfv_status_codeplay *result =
             static_cast<cl_kernel_wfv_status_codeplay *>(param_value);

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -17,6 +17,7 @@
 #include <cargo/array_view.h>
 #include <cargo/expected.h>
 #include <cl/buffer.h>
+#include <cl/command_queue.h>
 #include <cl/context.h>
 #include <cl/device.h>
 #include <cl/event.h>
@@ -219,7 +220,7 @@ _cl_command_buffer_khr::create(
 
     auto current = properties;
     do {
-      cl_command_buffer_properties_khr property = current[0];
+      const cl_command_buffer_properties_khr property = current[0];
       switch (property) {
         case CL_COMMAND_BUFFER_FLAGS_KHR:
           if (0 == (seen & CL_COMMAND_BUFFER_FLAGS_KHR)) {
@@ -274,7 +275,7 @@ cl_command_buffer_state_khr _cl_command_buffer_khr::getState() const {
 }
 
 cl_int _cl_command_buffer_khr::finalize() {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   if (is_finalized) {
     return CL_INVALID_OPERATION;
@@ -334,7 +335,7 @@ _cl_command_buffer_khr::convertWaitList(
 cl_int _cl_command_buffer_khr::commandBarrierWithWaitList(
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   auto command_wait_list = convertWaitList(cl_wait_list);
   if (!command_wait_list) {
@@ -374,7 +375,7 @@ cl_int _cl_command_buffer_khr::commandCopyBuffer(
     cl_mem src_buffer, cl_mem dst_buffer, size_t src_offset, size_t dst_offset,
     size_t size, cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add references to the buffers.
   if (auto error = retain(src_buffer)) {
@@ -426,7 +427,7 @@ cl_int _cl_command_buffer_khr::commandCopyImage(
     const size_t *dst_origin, const size_t *region,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add references to the images.
   if (auto error = retain(src_image)) {
@@ -487,7 +488,7 @@ cl_int _cl_command_buffer_khr::commandCopyBufferRect(
     size_t src_slice_pitch, size_t dst_row_pitch, size_t dst_slice_pitch,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add a references to the buffers.
   if (auto error = retain(src_buffer)) {
@@ -520,7 +521,7 @@ cl_int _cl_command_buffer_khr::commandCopyBufferRect(
 
   mux_sync_point_t mux_sync_point = nullptr;
   mux_sync_point_t *out_sync_point = cl_sync_point ? &mux_sync_point : nullptr;
-  mux_result_t mux_error = muxCommandCopyBufferRegions(
+  const mux_result_t mux_error = muxCommandCopyBufferRegions(
       mux_command_buffer, mux_src_buffer, mux_dst_buffer, &r_info, 1,
       wait_list_length, wait_list_length ? command_wait_list->data() : nullptr,
       out_sync_point);
@@ -553,7 +554,7 @@ cl_int _cl_command_buffer_khr::commandFillBuffer(
     cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset,
     size_t size, cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add a reference to the buffer.
   if (auto error = retain(buffer)) {
@@ -605,7 +606,7 @@ cl_int _cl_command_buffer_khr::commandFillImage(
     const size_t *region,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add a reference to the image.
   if (auto error = retain(image)) {
@@ -654,7 +655,7 @@ cl_int _cl_command_buffer_khr::commandCopyBufferToImage(
     const size_t *dst_origin, const size_t *region,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add references to the memory objects.
   if (auto error = retain(src_buffer)) {
@@ -711,7 +712,7 @@ cl_int _cl_command_buffer_khr::commandCopyImageToBuffer(
     const size_t *region, size_t dst_offset,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Add references to the memory objects.
   if (auto error = retain(src_image)) {
@@ -769,7 +770,7 @@ cl_int _cl_command_buffer_khr::commandNDRangeKernel(
     const size_t *global_work_size, const size_t *local_work_size,
     cargo::array_view<const cl_sync_point_khr> &cl_wait_list,
     cl_sync_point_khr *cl_sync_point, cl_mutable_command_khr *mutable_handle) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
 
   // Check the required work group size (if it exists).
   if (auto error = kernel->checkReqdWorkGroupSize(work_dim, local_work_size)) {
@@ -828,7 +829,7 @@ cl_int _cl_command_buffer_khr::commandNDRangeKernel(
 
   auto &device_program = kernel->program->programs[device];
   if (device_program.printf_calls.size() != 0) {
-    cl_int err = createPrintfBuffer(
+    const cl_int err = createPrintfBuffer(
         device, final_local_work_size, final_global_size, num_groups,
         buffer_group_size, printf_memory, printf_buffer);
     if (err) {
@@ -837,7 +838,7 @@ cl_int _cl_command_buffer_khr::commandNDRangeKernel(
   }
 
   const cl_uint device_index = kernel->program->context->getDeviceIndex(device);
-  mux_ndrange_options_t mux_execution_options =
+  const mux_ndrange_options_t mux_execution_options =
       kernel->createKernelExecutionOptions(
           device, device_index, work_dim, final_local_work_size,
           final_global_offset, final_global_size, printf_buffer,
@@ -1072,10 +1073,10 @@ cargo::expected<mux_descriptor_info_s, cl_int> createArgumentDescriptor(
 
 [[nodiscard]] cl_int _cl_command_buffer_khr::updateCommandBuffer(
     const cl_mutable_base_config_khr &mutable_config) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
   const cl_device_id device = command_queue->device;
 
-  cargo::array_view<const cl_mutable_dispatch_config_khr>
+  const cargo::array_view<const cl_mutable_dispatch_config_khr>
       mutable_dispatch_configs(mutable_config.mutable_dispatch_list,
                                mutable_config.num_mutable_dispatch);
 
@@ -1194,7 +1195,7 @@ bool _cl_command_buffer_khr::isQueueCompatible(
 CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clCreateCommandBufferKHR(
     cl_uint num_queues, const cl_command_queue *queues,
     const cl_command_buffer_properties_khr *properties, cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreateCommandBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCreateCommandBufferKHR");
 
   OCL_CHECK(!queues, OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_VALUE);
             return nullptr);
@@ -1221,7 +1222,7 @@ CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clCreateCommandBufferKHR(
 
 CL_API_ENTRY cl_int CL_API_CALL
 clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clReleaseCommandBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clReleaseCommandBufferKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
 
   return cl::releaseExternal(command_buffer);
@@ -1229,7 +1230,7 @@ clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer) {
 
 CL_API_ENTRY cl_int CL_API_CALL
 clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clRetainCommandBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clRetainCommandBufferKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
 
   return cl::retainExternal(command_buffer);
@@ -1237,7 +1238,7 @@ clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer) {
 
 CL_API_ENTRY cl_int CL_API_CALL
 clFinalizeCommandBufferKHR(cl_command_buffer_khr command_buffer) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clFinalizeCommandBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clFinalizeCommandBufferKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
 
   return command_buffer->finalize();
@@ -1247,7 +1248,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCommandBufferKHR(
     cl_uint num_queues, cl_command_queue *queues,
     cl_command_buffer_khr command_buffer, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *return_event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueCommandBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueCommandBufferKHR");
 
   // Verify queue arguments.
   OCL_CHECK(!queues ^ !num_queues, return CL_INVALID_COMMAND_QUEUE);
@@ -1278,7 +1279,8 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandBarrierWithWaitListKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandBarrierWithWaitListKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clCommandBarrierWithWaitListKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1304,7 +1306,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferKHR(
     size_t size, cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyBufferKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1315,7 +1317,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error = cl::validate::CopyBufferArguments(
+  const cl_int error = cl::validate::CopyBufferArguments(
       command_buffer->command_queue, src_buffer, dst_buffer, src_offset,
       dst_offset, size);
   OCL_CHECK(error, return error);
@@ -1339,7 +1341,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferRectKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyBufferRectKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyBufferRectKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1364,7 +1366,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferRectKHR(
     dst_slice_pitch = region[1] * dst_row_pitch;
   }
 
-  cl_int error = cl::validate::CopyBufferRectArguments(
+  const cl_int error = cl::validate::CopyBufferRectArguments(
       command_buffer->command_queue, src_buffer, dst_buffer, src_origin,
       dst_origin, region, src_row_pitch, src_slice_pitch, dst_row_pitch,
       dst_slice_pitch);
@@ -1388,7 +1390,8 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferToImageKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyBufferToImageKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clCommandCopyBufferToImageKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1399,7 +1402,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferToImageKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error = cl::validate::CopyBufferToImageArguments(
+  const cl_int error = cl::validate::CopyBufferToImageArguments(
       command_buffer->command_queue, src_buffer, dst_image, src_offset,
       dst_origin, region);
   OCL_CHECK(error, return error);
@@ -1422,7 +1425,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyImageKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyImageKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1433,7 +1436,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error = cl::validate::CopyImageArguments(
+  const cl_int error = cl::validate::CopyImageArguments(
       command_buffer->command_queue, src_image, dst_image, src_origin,
       dst_origin, region);
   OCL_CHECK(error, return error);
@@ -1456,7 +1459,8 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageToBufferKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandCopyImageToBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clCommandCopyImageToBufferKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1467,7 +1471,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageToBufferKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error = cl::validate::CopyImageToBufferArguments(
+  const cl_int error = cl::validate::CopyImageToBufferArguments(
       command_buffer->command_queue, src_image, dst_buffer, src_origin, region,
       dst_offset);
   OCL_CHECK(error, return error);
@@ -1489,7 +1493,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillBufferKHR(
     size_t size, cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandFillBufferKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandFillBufferKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1500,7 +1504,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillBufferKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error =
+  const cl_int error =
       cl::validate::FillBufferArguments(command_buffer->command_queue, buffer,
                                         pattern, pattern_size, offset, size);
   OCL_CHECK(error, return error);
@@ -1521,7 +1525,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillImageKHR(
     const size_t *region, cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandFillImageKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandFillImageKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1532,7 +1536,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillImageKHR(
   OCL_CHECK(!sync_point_wait_list && num_sync_points_in_wait_list,
             return CL_INVALID_SYNC_POINT_WAIT_LIST_KHR);
 
-  cl_int error = cl::validate::FillImageArguments(
+  const cl_int error = cl::validate::FillImageArguments(
       command_buffer->command_queue, image, fill_color, origin, region);
   OCL_CHECK(error, return error);
 
@@ -1554,7 +1558,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
     cl_uint num_sync_points_in_wait_list,
     const cl_sync_point_khr *sync_point_wait_list,
     cl_sync_point_khr *sync_point, cl_mutable_command_khr *mutable_handle) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCommandNDRangeKernelKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCommandNDRangeKernelKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(command_buffer->is_finalized, return CL_INVALID_OPERATION);
@@ -1585,7 +1589,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
     cl_ndrange_kernel_command_properties_khr seen = 0;
     auto current = properties;
     do {
-      cl_command_buffer_properties_khr property = current[0];
+      const cl_command_buffer_properties_khr property = current[0];
       switch (property) {
         case CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR:
           if (0 == (seen & CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR)) {
@@ -1661,7 +1665,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
 CL_API_ENTRY cl_int CL_API_CALL clGetCommandBufferInfoKHR(
     cl_command_buffer_khr command_buffer, cl_command_buffer_info_khr param_name,
     size_t param_value_size, void *param_value, size_t *param_value_size_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetCommandBufferInfoKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetCommandBufferInfoKHR");
 
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
 

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -85,7 +85,7 @@ cl_int extension::khr_command_buffer_mutable_dispatch::GetDeviceInfo(
 CL_API_ENTRY cl_int CL_API_CALL
 clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
                            const cl_mutable_base_config_khr *mutable_config) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(!command_buffer->is_finalized, return CL_INVALID_OPERATION);
 
@@ -121,7 +121,7 @@ clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
 CL_API_ENTRY cl_int CL_API_CALL clGetMutableCommandInfoKHR(
     cl_mutable_command_khr command, cl_mutable_command_info_khr param_name,
     size_t param_value_size, void *param_value, size_t *param_value_size_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetMutableCommandInfoKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetMutableCommandInfoKHR");
 
   OCL_CHECK(!command, return CL_INVALID_MUTABLE_COMMAND_KHR);
 

--- a/source/cl/source/image.cpp
+++ b/source/cl/source/image.cpp
@@ -68,6 +68,8 @@ _cl_mem_image::_cl_mem_image(_cl_context *context, cl_mem_flags validated_flags,
       case CL_MEM_OBJECT_IMAGE1D_ARRAY:
         image_desc.image_slice_pitch = image_desc.image_row_pitch;
         break;
+      default:
+        break;
     }
   }
 
@@ -88,6 +90,8 @@ _cl_mem_image::_cl_mem_image(_cl_context *context, cl_mem_flags validated_flags,
       break;
     case CL_MEM_OBJECT_IMAGE2D_ARRAY:
       size = image_desc.image_slice_pitch * image_desc.image_array_size;
+      break;
+    default:
       break;
   }
 }

--- a/source/cl/source/kernel.cpp
+++ b/source/cl/source/kernel.cpp
@@ -211,6 +211,8 @@ cl_int _cl_kernel::retainMems(cl_command_queue command_queue,
         case CL_MEM_OBJECT_IMAGE3D: {
           // TODO: Add synchronization of cl_mem_image objects once implemented.
         } break;
+        default:
+          return CL_INVALID_OPERATION;
       }
     }
   }

--- a/source/cl/source/platform.cpp
+++ b/source/cl/source/platform.cpp
@@ -133,7 +133,7 @@ cargo::expected<cl_platform_id, cl_int> _cl_platform_id::getInstance() {
     // Windows because DLL's which we rely on are not guarenteed to be loaded
     // when atexit handlers are invoked, the advice given by Microsoft is not
     // to perform any tear down at all.
-    atexit([]() {
+    (void)atexit([]() {
       for (auto device : platform.value()->devices) {
         cl::releaseInternal(device);
       }

--- a/source/cl/test/BenchCL/source/main.cpp
+++ b/source/cl/test/BenchCL/source/main.cpp
@@ -41,7 +41,8 @@ int main(int argc, char *argv[]) {
 
   if (help) {
     // If --help was passed print usage messages and exit.
-    fprintf(stdout, "benchcl   [--benchcl_device=<OpenCL device name>]\n");
+    (void)fprintf(stdout,
+                  "benchcl   [--benchcl_device=<OpenCL device name>]\n");
     benchmark::Initialize(&argc, argv);
     return 0;
   }

--- a/source/cl/test/BenchCL/source/utils.cpp
+++ b/source/cl/test/BenchCL/source/utils.cpp
@@ -67,16 +67,16 @@ cl_uint benchcl::get_device(cargo::string_view device_name,
   }
 
   if (device_name == nullptr) {
-    fprintf(stderr,
-            "error: multiple devices found but no device name specified, "
-            "please use '--benchcl_device='\n");
+    (void)fprintf(stderr,
+                  "error: multiple devices found but no device name specified, "
+                  "please use '--benchcl_device='\n");
   } else {
-    fprintf(stderr, "error: device '%s' not found\n", device_name.data());
+    (void)fprintf(stderr, "error: device '%s' not found\n", device_name.data());
   }
 
-  fprintf(stderr, "Available devices:\n");
+  (void)fprintf(stderr, "Available devices:\n");
   for (const std::string &name : names) {
-    fprintf(stderr, "  - '%s'\n", name.c_str());
+    (void)fprintf(stderr, "  - '%s'\n", name.c_str());
   }
 
   return CL_DEVICE_NOT_FOUND;

--- a/source/cl/test/FuzzCL/include/FuzzCL/context.h
+++ b/source/cl/test/FuzzCL/include/FuzzCL/context.h
@@ -32,14 +32,14 @@
 
 #include "FuzzCL/error.h"
 
-#define BUFFER_WIDTH 16
-#define BUFFER_HEIGHT 16
-#define BUFFER_DEPTH 16
-#define BUFFER_SIZE BUFFER_WIDTH *BUFFER_HEIGHT *BUFFER_DEPTH
+const size_t BUFFER_WIDTH = 16;
+const size_t BUFFER_HEIGHT = 16;
+const size_t BUFFER_DEPTH = 16;
+const size_t BUFFER_SIZE = BUFFER_WIDTH * BUFFER_HEIGHT * BUFFER_DEPTH;
 
-#define INT_PER_PIXEL 4
-#define IMAGE_WIDTH (BUFFER_WIDTH / INT_PER_PIXEL)
-#define IMAGE_HEIGHT BUFFER_HEIGHT
+const size_t INT_PER_PIXEL = 4;
+const size_t IMAGE_WIDTH = BUFFER_WIDTH / INT_PER_PIXEL;
+const size_t IMAGE_HEIGHT = BUFFER_HEIGHT;
 
 #define STR_EXPAND(...) #__VA_ARGS__
 #define STR(s) STR_EXPAND(s)
@@ -55,8 +55,6 @@
 
 #define MAX_CALLBACK_INPUT_SIZE 10
 
-#include "FuzzCL/generator.h"
-
 #define IS_CL_SUCCESS(X)                                                     \
   {                                                                          \
     const cl_int ret_val = X;                                                \
@@ -67,6 +65,8 @@
       exit(1);                                                               \
     }                                                                        \
   }
+
+#include "FuzzCL/generator.h"
 
 namespace fuzzcl {
 

--- a/source/cl/test/FuzzCL/include/FuzzCL/generator.h
+++ b/source/cl/test/FuzzCL/include/FuzzCL/generator.h
@@ -17,9 +17,8 @@
 #ifndef FUZZCL_GENERATOR_H_INCLUDED
 #define FUZZCL_GENERATOR_H_INCLUDED
 
+#include <cassert>
 #include <fstream>
-
-#include "FuzzCL/context.h"
 
 namespace fuzzcl {
 /// @brief Type containing test execution parameters
@@ -347,6 +346,8 @@ struct code_generator_t {
       case CL_MAP_WRITE:
         p->map_flags.push_back("CL_MAP_WRITE");
         break;
+      default:
+        assert(0 && "invalid map flag");
     }
 
     p->offsets.push_back(std::to_string(offset));
@@ -561,6 +562,8 @@ struct code_generator_t {
       case CL_MAP_WRITE:
         p->map_flags.push_back("CL_MAP_WRITE");
         break;
+      default:
+        assert(0 && "invalid map flag");
     }
 
     p->image_origins.push_back('{' + std::to_string(origin[0]) + ", " +

--- a/source/cl/test/FuzzCL/source/context.cpp
+++ b/source/cl/test/FuzzCL/source/context.cpp
@@ -242,9 +242,11 @@ void fuzzcl::enqueueReadBufferRect(fuzzcl::context_t &fc,
   const size_t host_row_pitch = region[0] * sizeof(cl_int);
   const size_t host_slice_pitch = region[1] * host_row_pitch;
 
-  assert(buffer_origin[2] * buffer_slice_pitch +
-             buffer_origin[1] * buffer_row_pitch + buffer_origin[0] +
-             region[0] * region[1] * region[2] * sizeof(cl_int) <=
+  assert(static_cast<size_t>(buffer_origin[2]) * buffer_slice_pitch +
+             static_cast<size_t>(buffer_origin[1]) * buffer_row_pitch +
+             static_cast<size_t>(buffer_origin[0]) +
+             static_cast<size_t>(region[0]) * static_cast<size_t>(region[1]) *
+                 static_cast<size_t>(region[2]) * sizeof(cl_int) <=
          BUFFER_SIZE * sizeof(cl_int));
 
   std::vector<cl_int> *host_buffer_ptr = new std::vector<cl_int>(BUFFER_SIZE);
@@ -311,23 +313,27 @@ void fuzzcl::enqueueWriteBufferRect(fuzzcl::context_t &fc,
 
   // in bytes
   std::array<size_t, 3> *buffer_origin_ptr = new std::array<size_t, 3>{
-      {buffer_origin[0] * sizeof(cl_int), static_cast<size_t>(buffer_origin[1]),
+      {static_cast<size_t>(buffer_origin[0]) * sizeof(cl_int),
+       static_cast<size_t>(buffer_origin[1]),
        static_cast<size_t>(buffer_origin[2])}};
   std::array<size_t, 3> *host_origin_ptr = new std::array<size_t, 3>{
-      {host_origin[0] * sizeof(cl_int), static_cast<size_t>(host_origin[1]),
+      {static_cast<size_t>(host_origin[0]) * sizeof(cl_int),
+       static_cast<size_t>(host_origin[1]),
        static_cast<size_t>(host_origin[2])}};
   std::array<size_t, 3> *region_ptr = new std::array<size_t, 3>{
-      {region[0] * sizeof(cl_int), static_cast<size_t>(region[1]),
-       static_cast<size_t>(region[2])}};
+      {static_cast<size_t>(region[0]) * sizeof(cl_int),
+       static_cast<size_t>(region[1]), static_cast<size_t>(region[2])}};
 
   const size_t buffer_row_pitch = BUFFER_WIDTH * sizeof(cl_int);
   const size_t buffer_slice_pitch = BUFFER_HEIGHT * buffer_row_pitch;
   const size_t host_row_pitch = region[0] * sizeof(cl_int);
   const size_t host_slice_pitch = region[1] * host_row_pitch;
 
-  assert(buffer_origin[2] * buffer_slice_pitch +
-             buffer_origin[1] * buffer_row_pitch + buffer_origin[0] +
-             region[0] * region[1] * region[2] * sizeof(cl_int) <=
+  assert(static_cast<size_t>(buffer_origin[2]) * buffer_slice_pitch +
+             static_cast<size_t>(buffer_origin[1]) * buffer_row_pitch +
+             static_cast<size_t>(buffer_origin[0]) +
+             static_cast<size_t>(region[0]) * static_cast<size_t>(region[1]) *
+                 static_cast<size_t>(region[2]) * sizeof(cl_int) <=
          BUFFER_SIZE * sizeof(cl_int));
 
   std::vector<cl_int> *host_buffer_ptr = new std::vector<cl_int>(BUFFER_SIZE);

--- a/source/cl/test/FuzzCL/source/fuzz.cpp
+++ b/source/cl/test/FuzzCL/source/fuzz.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[]) {
     for (const std::string &file : files) {
       // a flush is specifically needed so a python wrapper can get an
       // unbuffered output
-      std::cout << file << std::endl;
+      std::cout << file << '\n' << std::flush;
       std::vector<uint8_t> data =
           fuzzcl::read_file<uint8_t>(arguments.corpus + file);
 

--- a/source/cl/test/MultiDevice/source/main.cpp
+++ b/source/cl/test/MultiDevice/source/main.cpp
@@ -28,16 +28,16 @@ int main(int argc, char **argv) {
   // Get OpenCL platforms.
   cl_uint numPlatforms = 0;
   if (auto error = clGetPlatformIDs(0, nullptr, &numPlatforms)) {
-    std::fprintf(stderr, "error: call to clGetDeviceIDs failed\n");
+    (void)std::fprintf(stderr, "error: call to clGetDeviceIDs failed\n");
     return error;
   }
   if (numPlatforms == 0) {
-    std::fprintf(stderr, "error: could not find any OpenCL platforms\n");
+    (void)std::fprintf(stderr, "error: could not find any OpenCL platforms\n");
     return -1;
   }
   std::vector<cl_platform_id> platforms(numPlatforms);
   if (auto error = clGetPlatformIDs(numPlatforms, platforms.data(), nullptr)) {
-    std::fprintf(stderr, "error: call to clGetDeviceIDs failed\n");
+    (void)std::fprintf(stderr, "error: call to clGetDeviceIDs failed\n");
     return error;
   }
 
@@ -48,13 +48,13 @@ int main(int argc, char **argv) {
     size_t size;
     if (auto error =
             clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, nullptr, &size)) {
-      std::fprintf(stderr, "error: could not get platform name\n");
+      (void)std::fprintf(stderr, "error: could not get platform name\n");
       return error;
     }
     std::vector<char> platformName(size, '\0');
     if (auto error = clGetPlatformInfo(platform, CL_PLATFORM_NAME, size,
                                        platformName.data(), nullptr)) {
-      std::fprintf(stderr, "error: could not get platform name\n");
+      (void)std::fprintf(stderr, "error: could not get platform name\n");
       return error;
     }
     platformNames.emplace_back(
@@ -83,12 +83,12 @@ MultiDevice (version %s) - Options:
         }
       }
       if (selectedPlatform == nullptr) {
-        std::fprintf(stderr, "error: could not find platform name: %s\n",
-                     platformName.c_str());
+        (void)std::fprintf(stderr, "error: could not find platform name: %s\n",
+                           platformName.c_str());
         return -1;
       }
     } else {
-      std::fprintf(stderr, "error: invalid platform: %s\n", arg.c_str());
+      (void)std::fprintf(stderr, "error: invalid platform: %s\n", arg.c_str());
       return -1;
     }
   }
@@ -98,12 +98,12 @@ MultiDevice (version %s) - Options:
     if (platforms.size() == 1) {
       selectedPlatform = platforms[0];
     } else if (platforms.size() > 1) {
-      std::fprintf(
+      (void)std::fprintf(
           stderr,
           "error: multiple OpenCL platforms, use --opencl-platform=<name>\n");
-      std::fprintf(stderr, "choose for the following:\n");
+      (void)std::fprintf(stderr, "choose for the following:\n");
       for (const auto &platformName : platformNames) {
-        std::fprintf(stderr, "* %s\n", platformName.c_str());
+        (void)std::fprintf(stderr, "* %s\n", platformName.c_str());
       }
     }
   }

--- a/source/cl/test/UnitCL/source/ktst_offline.cpp
+++ b/source/cl/test/UnitCL/source/ktst_offline.cpp
@@ -93,7 +93,7 @@ TEST_P(Execution, Offline_04_MultiKernel) {
 }
 
 TEST_P(Execution, Offline_04_MultiKernel_WGS) {
-  const size_t N = 8 * 64;
+  const size_t N = 8 * 64L;
   AddInputBuffer(N, kts::Ref_A);
   AddInputBuffer(N, kts::Ref_B);
   AddOutputBuffer(N, kts::Ref_Add);
@@ -110,7 +110,7 @@ TEST_P(Execution, DISABLED_Offline_04_MultiKernel_WGS_VecZ) {
     GTEST_SKIP();
   }
   this->fail_if_not_vectorized_ = true;
-  const size_t N = 8 * 64;
+  const size_t N = 8 * 64L;
   AddInputBuffer(N, kts::Ref_A);
   AddInputBuffer(N, kts::Ref_B);
   AddOutputBuffer(N, kts::Ref_Add);

--- a/source/cl/tools/clc/clc.cpp
+++ b/source/cl/tools/clc/clc.cpp
@@ -139,8 +139,8 @@ bool matchSubstring(cargo::string_view big_string, cargo::string_view filter) {
 
 result printMuxCompilers(cargo::array_view<const compiler::Info *> compilers) {
   for (cl_uint i = 0; i < compilers.size(); i++) {
-    std::fprintf(stderr, "device %u: %s\n", i + 1,
-                 compilers[i]->device_info->device_name);
+    (void)std::fprintf(stderr, "device %u: %s\n", i + 1,
+                       compilers[i]->device_info->device_name);
   }
   return result::success;
 }
@@ -591,8 +591,8 @@ result driver::buildProgram() {
         source_type_name = "OpenCL C";
         break;
     }
-    std::fprintf(stderr, "info: Input file detected to be in %s format\n",
-                 source_type_name);
+    (void)std::fprintf(stderr, "info: Input file detected to be in %s format\n",
+                       source_type_name);
   }
 
   std::vector<char> cl_options;
@@ -605,8 +605,9 @@ result driver::buildProgram() {
   cl_options.push_back('\0');
 
   if (verbose) {
-    std::fprintf(stderr, "info: Compilation options: %.*s\n",
-                 static_cast<int>(cl_options.size() - 1), cl_options.data());
+    (void)std::fprintf(stderr, "info: Compilation options: %.*s\n",
+                       static_cast<int>(cl_options.size() - 1),
+                       cl_options.data());
   }
 
   const cargo::string_view device_profile =
@@ -656,16 +657,16 @@ result driver::buildProgram() {
   if (compiler::Result::SUCCESS !=
       module->finalize(&program_info, printf_calls)) {
     if (!module_log.empty() && module_log.front() != '\0') {
-      std::fprintf(stderr, "%.*s", static_cast<int>(module_log.size()),
-                   module_log.data());
+      (void)std::fprintf(stderr, "%.*s", static_cast<int>(module_log.size()),
+                         module_log.data());
       return result::failure;
     }
-    std::fprintf(stderr, "Unknown compilation error in 'finalize'.\n");
+    (void)std::fprintf(stderr, "Unknown compilation error in 'finalize'.\n");
     return result::failure;
   }
 
   if (verbose) {
-    std::fprintf(stderr, "info: Build successful\n");
+    (void)std::fprintf(stderr, "info: Build successful\n");
   }
 
   return result::success;
@@ -679,8 +680,8 @@ result driver::saveBinary() {
   cargo::array_view<uint8_t> module_executable;
   if (compiler::Result::SUCCESS != module->createBinary(module_executable)) {
     if (!module_log.empty() && module_log.front() != '\0') {
-      std::fprintf(stderr, "%.*s", static_cast<int>(module_log.size()),
-                   module_log.data());
+      (void)std::fprintf(stderr, "%.*s", static_cast<int>(module_log.size()),
+                         module_log.data());
     } else {
       (void)std::fprintf(stderr,
                          "Unknown compilation error in 'createBinary'.\n");
@@ -776,8 +777,8 @@ result driver::findDevice() {
   }
 
   if (verbose) {
-    std::fprintf(stderr, "info: Using device %s\n",
-                 compiler_info->device_info->device_name);
+    (void)std::fprintf(stderr, "info: Using device %s\n",
+                       compiler_info->device_info->device_name);
   }
 
   return result::success;

--- a/source/cl/tools/oclc/oclc.cpp
+++ b/source/cl/tools/oclc/oclc.cpp
@@ -124,263 +124,145 @@ oclc::Driver::~Driver() {
 void oclc::Driver::PrintUsage(int argc, char **argv) {
   (void)argc;
 
-  fprintf(stderr, "usage: %s [options] <CL kernel file>\n", argv[0]);
+  (void)fprintf(stderr, R"-(usage: %s [options] <CL kernel file>
 
-  fprintf(stderr, "\noptions:\n");
-  fprintf(stderr,
-          "-o <output_file>                                        Set the "
-          "output file to write the binary to.\n");
-  fprintf(stderr,
-          "-v                                                      Run oclc in "
-          "verbose mode.\n");
-  fprintf(stderr,
-          "-format <output_format>                                 Set the "
-          "output file format.\n");
-  fprintf(stderr,
-          "                                                        Matches the "
-          "first occurrence of stage as a substring\n");
-  fprintf(stderr,
-          "                                                        against "
-          "options from '-list'.\n");
-  fprintf(stderr,
-          "-cl-options 'options...'                                OpenCL "
-          "options to use when compiling the kernel.\n");
-  fprintf(stderr,
-          "-cl-device '<device name>'                              OpenCL "
-          "device to use when compiling the kernel.\n");
-  fprintf(stderr,
-          "-enqueue <kernel name>                                  Enqueues a "
-          "kernel to enqueue on work-group\n");
-  fprintf(stderr,
-          "                                                        size "
-          "specific transformations.\n");
-  fprintf(stderr,
-          "-execute                                                Executes "
-          "the enqueued kernel.\n");
-  fprintf(stderr,
-          "-seed <value>                                           Set the "
-          "seed of the random number engine used in rand() calls.\n");
-  fprintf(stderr,
-          "                                                        The seed is "
-          "set to a default value if this is not set.\n");
-  fprintf(stderr,
-          "-arg <name>[,<width>[,<height>]],<list>                 Assigns a "
-          "list value (as described below) to the\n");
-  fprintf(stderr,
-          "                                                        named "
-          "argument when the kernel is executed.\n");
-  fprintf(stderr,
-          "                                                        If the "
-          "argument is a 2D image, a width in pixels must be provided.\n");
-  fprintf(stderr,
-          "                                                        if the "
-          "argument is a 3D image, a height in pixels must also be "
-          "provided.\n");
-  fprintf(stderr,
-          "                                                        If the "
-          "argument is an image, 4 values must be provided per pixel,\n");
-  fprintf(stderr,
-          "                                                        as images "
-          "are treated as unsigned 8 bit RGBA arrays by default.\n");
-  fprintf(stderr,
-          "                                                        If the "
-          "argument is declared with the __local qualifier, the\n");
-  fprintf(stderr,
-          "                                                        first "
-          "integer specified will be used to denote the size of the\n");
-  fprintf(stderr,
-          "                                                        local "
-          "argument in bytes, and subsequent values will be ignored.\n");
-  fprintf(stderr,
-          "-arg <name>[,<width>[,<height>]],<list>:<filename>      Assigns a "
-          "list value (as described below), held in a\n");
-  fprintf(stderr,
-          "                                                        file, to "
-          "the named argument when the kernel is executed.\n");
-  fprintf(stderr,
-          "-print <name>[,<offset>],<size>                         Prints a "
-          "given number of elements from the given\n");
-  fprintf(stderr,
-          "                                                        named "
-          "argument after execution to stdout, possibly\n");
-  fprintf(stderr,
-          "                                                        starting "
-          "from some offset.\n");
-  fprintf(stderr,
-          "-print <name>[,<offset>],<size>:<filename>              Prints a "
-          "given number of elements from the given\n");
-  fprintf(stderr,
-          "                                                        named "
-          "argument after execution to a file, possibly\n");
-  fprintf(stderr,
-          "                                                        starting "
-          "from some offset.\n");
-  fprintf(stderr,
-          "-show <name>,<width>,[,<height>[,<depth>]][:<filename>] Prints the "
-          "named image argument of the specified size to stdout,\n");
-  fprintf(stderr,
-          "                                                        or a file, "
-          "if one is provided.\n");
-  fprintf(stderr,
-          "-compare <name>,<expected>                              Compares "
-          "the named buffer to an expected list.\n");
-  fprintf(stderr,
-          "-compare <name>:<filename>                              Compares "
-          "the named buffer to an expected list, held in a file.\n");
-  fprintf(stderr,
-          "-global <g1>,<g2>,...                                   Sets the "
-          "global work size to the given array of values.\n");
-  fprintf(stderr,
-          "-local <l1>,<l2>,...                                    Sets the "
-          "local work size to the given array of values.\n");
-  fprintf(stderr,
-          "-ulp-error <tolerance>                                  Sets the "
-          "maximum ULP error between the actual and target values accepted.\n");
-  fprintf(stderr,
-          "                                                        as a "
-          "'match' when -compare is applied to float or double values. "
-          "Defaults to 0.\n");
-  fprintf(stderr,
-          "-char-error <tolerance>                                 Sets the "
-          "maximum difference between the actual and target values accepted\n");
-  fprintf(stderr,
-          "                                                        as a "
-          "'match' when -compare is applied to char or uchar values. Defaults "
-          "to 0.\n");
-  fprintf(stderr,
-          "-repeat-execution <N>                                   Executes "
-          "the kernel N times. -global, -local, and -arg\n");
-  fprintf(stderr,
-          "                                                        arguments "
-          "may be set to {<list>},{<list>},... to take on\n");
-  fprintf(stderr,
-          "                                                        different "
-          "values on each execution.\n");
+options:
+-o <output_file>                                        Set the output file to write the binary to.
+-v                                                      Run oclc in verbose mode.
+-format <output_format>                                 Set the output file format.
+                                                        Matches the first occurrence of stage as a substring
+                                                        against options from '-list'.
+-cl-options 'options...'                                OpenCL options to use when compiling the kernel.
+-cl-device '<device name>'                              OpenCL device to use when compiling the kernel.
+-enqueue <kernel name>                                  Enqueues a kernel to enqueue on work-group
+                                                        size specific transformations.
+-execute                                                Executes the enqueued kernel.
+-seed <value>                                           Set the seed of the random number engine used in rand() calls.
+                                                        The seed is set to a default value if this is not set.
+-arg <name>[,<width>[,<height>]],<list>                 Assigns a list value (as described below) to the
+                                                        named argument when the kernel is executed.
+                                                        If the argument is a 2D image, a width in pixels must be provided.
+                                                        if the argument is a 3D image, a height in pixels must also be provided.
+                                                        If the argument is an image, 4 values must be provided per pixel,
+                                                        as images are treated as unsigned 8 bit RGBA arrays by default.
+                                                        If the argument is declared with the __local qualifier, the
+                                                        first integer specified will be used to denote the size of the
+                                                        local argument in bytes, and subsequent values will be ignored.
+-arg <name>[,<width>[,<height>]],<list>:<filename>      Assigns a list value (as described below), held in a
+                                                        file, to the named argument when the kernel is executed.
+-print <name>[,<offset>],<size>                         Prints a given number of elements from the given
+                                                        named argument after execution to stdout, possibly
+                                                        starting from some offset.
+-print <name>[,<offset>],<size>:<filename>              Prints a given number of elements from the given
+                                                        named argument after execution to a file, possibly
+                                                        starting from some offset.
+-show <name>,<width>,[,<height>[,<depth>]][:<filename>] Prints the named image argument of the specified size to stdout,
+                                                        or a file, if one is provided.
+-compare <name>,<expected>                              Compares the named buffer to an expected list.
+-compare <name>:<filename>                              Compares the named buffer to an expected list, held in a file.
+-global <g1>,<g2>,...                                   Sets the global work size to the given array of values.
+-local <l1>,<l2>,...                                    Sets the local work size to the given array of values.
+-ulp-error <tolerance>                                  Sets the maximum ULP error between the actual and target values accepted.
+                                                        as a 'match' when -compare is applied to float or double values. Defaults to 0.
+-char-error <tolerance>                                 Sets the maximum difference between the actual and target values accepted
+                                                        as a 'match' when -compare is applied to char or uchar values. Defaults to 0.
+-repeat-execution <N>                                   Executes the kernel N times. -global, -local, and -arg
+                                                        arguments may be set to {<list>},{<list>},... to take on
+                                                        different values on each execution.
 
-  fprintf(stderr, "\nAvailable output formats:\n");
-  fprintf(stderr,
-          "  text                                                  "
-          "  textual format such as LLVM IR or assembly\n");
-  fprintf(stderr,
-          "  binary                                                "
-          "  binary format such as LLVM BC or ELF\n");
+Available output formats:
+  text                                                    textual format such as LLVM IR or assembly
+  binary                                                  binary format such as LLVM BC or ELF
 
-  fprintf(stderr, "\nPossible kernel argument values:\n");
-  fprintf(stderr, "  <list>   ::= <el>\n");
-  fprintf(stderr, "            |  <el> \",\" <list>\n");
-  fprintf(stderr,
-          "            |  <cl_bool> \",\" <cl_addressing_mode> \",\" "
-          "<cl_filter_mode>\" (for specifying sampler_t only)\n\n");
-  fprintf(stderr, "  <el>     ::= <integer or decimal>\n");
-  fprintf(stderr,
-          "            |  \"repeat(\" <unsigned integer> \",\" <list> \")\"\n");
-  fprintf(stderr, "            |  \"rand(\" <decimal> \",\" <decimal> \")\"\n");
-  fprintf(stderr,
-          "            |  \"randint(\" <integer> \",\" <integer> \")\"\n");
-  fprintf(stderr,
-          "            |  \"range(\" <integer or decimal> \",\" <integer or "
-          "decimal> \")\"\n");
-  fprintf(stderr,
-          "            |  \"range(\" <integer or decimal> \",\" <integer or "
-          "decimal> \",\" <integer or decimal> \")\"\n\n");
+Possible kernel argument values:
+  <list>   ::= <el>
+            |  <el> "," <list>
+            |  <cl_bool> "," <cl_addressing_mode> "," <cl_filter_mode>" (for specifying sampler_t only)
 
-  fprintf(stderr, "  <cl_bool>            ::= \"CL_TRUE\" | \"CL_FALSE\"\n");
-  fprintf(stderr,
-          "  <cl_addressing_mode> ::= \"CL_ADDRESS_NONE\" | "
-          "\"CL_ADDRESS_CLAMP_TO_EDGE\" | \"CL_ADDRESS_CLAMP\"\n");
-  fprintf(stderr,
-          "                        |  \"CL_ADDRESS_REPEAT\" | "
-          "\"CL_ADDRESS_MIRRORED_REPEAT\"\n");
-  fprintf(stderr,
-          "  <cl_filter_mode>     ::= \"CL_FILTER_NEAREST\" | "
-          "\"CL_FILTER_LINEAR\"\n");
+  <el>     ::= <integer or decimal>
+            |  "repeat(" <unsigned integer> "," <list> ")"
+            |  "rand(" <decimal> "," <decimal> ")"
+            |  "randint(" <integer> "," <integer> ")"
+            |  "range(" <integer or decimal> "," <integer or decimal> ")"
+            |  "range(" <integer or decimal> "," <integer or decimal> "," <integer or decimal> ")"
 
-  fprintf(stderr, "\nSpecial kernel argument values:\n");
-  fprintf(stderr,
-          "  repeat(N,list)                              creates a list "
-          "containing `list` repeated `N` times\n");
-  fprintf(stderr,
-          "                                              repeat(3,2,4) => "
-          "2,4,2,4,2,4\n");
-  fprintf(stderr,
-          "  rand(min,max)                               creates a random "
-          "floating point number in [min,max]\n");
-  fprintf(stderr,
-          "                                              rand(1.2,4) => "
-          "3.195201 (potentially)\n");
-  fprintf(stderr,
-          "  randint(min,max)                            creates a random "
-          "integer number in [min,max]\n");
-  fprintf(stderr,
-          "                                              randint(1,4) => 3 "
-          "(potentially)\n");
-  fprintf(stderr,
-          "  range(a,b,stride)                           produces a list "
-          "beginning at `a`, moving in the direction of `b`\n"
-          "                                              by `stride` units. if "
-          "`stride` is not stated, it defaults to 1.\n");
-  fprintf(stderr,
-          "                                              range(-4,21,5) => "
-          "-4,1,6,11,16,21\n\n");
+  <cl_bool>            ::= "CL_TRUE" | "CL_FALSE"
+  <cl_addressing_mode> ::= "CL_ADDRESS_NONE" | "CL_ADDRESS_CLAMP_TO_EDGE" | "CL_ADDRESS_CLAMP"
+                        |  "CL_ADDRESS_REPEAT" | "CL_ADDRESS_MIRRORED_REPEAT"
+  <cl_filter_mode>     ::= "CL_FILTER_NEAREST" | "CL_FILTER_LINEAR"
+
+Special kernel argument values:
+  repeat(N,list)                              creates a list containing `list` repeated `N` times
+                                              repeat(3,2,4) => 2,4,2,4,2,4
+  rand(min,max)                               creates a random floating point number in [min,max]
+                                              rand(1.2,4) => 3.195201 (potentially)
+  randint(min,max)                            creates a random integer number in [min,max]
+                                              randint(1,4) => 3 (potentially)
+  range(a,b,stride)                           produces a list beginning at `a`, moving in the direction of `b`
+                                              by `stride` units. if `stride` is not stated, it defaults to 1.
+                                              range(-4,21,5) => -4,1,6,11,16,21
+
+)-",
+                argv[0]);
 }
 
 bool oclc::Driver::ParseArguments(int argc, char **argv) {
   Arguments args(argc, argv);
   std::vector<const char *> positional_args;
   while (args.HasMore()) {
-    const char *arg_str = nullptr;
     bool failed = false;
-    if ((arg_str = args.TakePositional(failed))) {
+    if (const char *arg_str = args.TakePositional(failed)) {
       positional_args.push_back(arg_str);
-    } else if ((arg_str = args.TakeKeyValue("-o", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-o", failed)) {
       output_file_ = arg_str;
     } else if (args.TakeKey("-v", failed)) {
       verbose_ = true;
-    } else if ((arg_str = args.TakeKeyValue("-cl-options", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-cl-options", failed)) {
       cl_options_ = arg_str;
-    } else if ((arg_str = args.TakeKeyValue("-cl-device", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-cl-device", failed)) {
       cl_device_name_ = arg_str;
-    } else if ((arg_str = args.TakeKeyValue("-enqueue", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-enqueue", failed)) {
       enqueue_kernel_ = arg_str;
     } else if (args.TakeKey("-execute", failed)) {
       execute_ = true;
-    } else if ((arg_str = args.TakeKeyValue("-arg", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-arg", failed)) {
       argument_queue_.push_back(std::string(arg_str));
-    } else if ((arg_str = args.TakeKeyValue("-print", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-print", failed)) {
       failed = (ParseArgumentPrintInfo(arg_str) == oclc::failure);
-    } else if ((arg_str = args.TakeKeyValue("-show", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-show", failed)) {
       failed = (ParseArgumentImageShowInfo(arg_str) == oclc::failure);
-    } else if ((arg_str = args.TakeKeyValue("-global", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-global", failed)) {
       std::vector<std::string> globalList;
       SplitAndExpandList(arg_str, '\0', globalList);
       failed = (ParseSizeInfo("global", globalList) == oclc::failure);
-    } else if ((arg_str = args.TakeKeyValue("-local", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-local", failed)) {
       std::vector<std::string> localList;
       SplitAndExpandList(arg_str, '\0', localList);
       failed = (ParseSizeInfo("local", localList) == oclc::failure);
-    } else if ((arg_str = args.TakeKeyValue("-seed", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-seed", failed)) {
       const unsigned long seed =
           static_cast<unsigned long>(strtoull(arg_str, nullptr, 10));
       OCLC_CHECK_FMT(seed == 0 && (strcmp(arg_str, "0") != 0),
                      "error: seed '%s' is an invalid value.\n", arg_str);
       engine_.seed(seed);
-    } else if ((arg_str = args.TakeKeyValue("-ulp-error", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-ulp-error", failed)) {
       const cl_ulong ulpVal =
           static_cast<cl_ulong>(strtol(arg_str, nullptr, 10));
       OCLC_CHECK_FMT(ulpVal == 0 && (strcmp(arg_str, "0") != 0),
                      "error: ulp tolerance '%s' is an invalid value.\n",
                      arg_str);
       ulp_tolerance_ = ulpVal;
-    } else if ((arg_str = args.TakeKeyValue("-char-error", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-char-error", failed)) {
       const cl_uchar charErrVal =
           static_cast<cl_uchar>(strtol(arg_str, nullptr, 10));
       OCLC_CHECK_FMT(charErrVal == 0 && (strcmp(arg_str, "0") != 0),
                      "error: char error tolerance '%s' is an invalid value.\n",
                      arg_str);
       char_tolerance_ = charErrVal;
-    } else if ((arg_str = args.TakeKeyValue("-compare", failed))) {
+    } else if (const char *arg_str = args.TakeKeyValue("-compare", failed)) {
       failed = ParseArgumentCompareInfo(arg_str) == oclc::failure;
-    } else if ((arg_str = args.TakeKeyValue("-repeat-execution", failed))) {
+    } else if (const char *arg_str =
+                   args.TakeKeyValue("-repeat-execution", failed)) {
       const size_t limit = static_cast<size_t>(strtoull(arg_str, nullptr, 10));
       OCLC_CHECK_FMT(limit == 0, "error: seed '%s' is an invalid value.\n",
                      arg_str);
@@ -464,7 +346,7 @@ bool oclc::Driver::VerifyDoubleVec(const std::vector<std::string> &vec) {
 char *oclc::Driver::VerifyDouble(const std::string &str) {
   char *end = nullptr;
   errno = 0;
-  strtod(str.c_str(), &end);
+  (void)strtod(str.c_str(), &end);
 
   return (end != str.c_str() && errno == 0) ? end : nullptr;
 }
@@ -722,7 +604,7 @@ char *oclc::Driver::VerifyRand(const char *arg) {
 
   errno = 0;
   char *cEnd = nullptr;
-  strtod(arg, &cEnd);
+  (void)strtod(arg, &cEnd);
 
   if (cEnd == arg || *cEnd != ',' || errno != 0) {
     return nullptr;
@@ -731,7 +613,7 @@ char *oclc::Driver::VerifyRand(const char *arg) {
   arg = cEnd + 1;  // move past comma
 
   cEnd = nullptr;
-  strtod(arg, &cEnd);
+  (void)strtod(arg, &cEnd);
 
   if (cEnd == arg || *cEnd != ')' || errno != 0) {
     return nullptr;
@@ -747,7 +629,7 @@ char *oclc::Driver::VerifyRandInt(const char *arg) {
 
   errno = 0;
   char *cEnd = nullptr;
-  strtoll(arg, &cEnd, 10);
+  (void)strtoll(arg, &cEnd, 10);
 
   if (cEnd == arg || *cEnd != ',' || errno != 0) {
     return nullptr;
@@ -756,7 +638,7 @@ char *oclc::Driver::VerifyRandInt(const char *arg) {
   arg = cEnd + 1;  // move past comma
 
   cEnd = nullptr;
-  strtoll(arg, &cEnd, 10);
+  (void)strtoll(arg, &cEnd, 10);
 
   if (cEnd == arg || *cEnd != ')' || errno != 0) {
     return nullptr;
@@ -1166,7 +1048,7 @@ bool oclc::Driver::InitCL() {
     err = clGetPlatformInfo(platform_, CL_PLATFORM_NAME, name_size,
                             platform_name.data(), nullptr);
     OCLC_CHECK_CL(err, "Getting the platform name failed");
-    fprintf(stderr, "Platform: %s\n", platform_name.c_str());
+    (void)fprintf(stderr, "Platform: %s\n", platform_name.c_str());
   }
 
   // Choose a device.
@@ -1204,9 +1086,9 @@ bool oclc::Driver::InitCL() {
 
     if (verbose_) {
       if (i == 0) {
-        fprintf(stderr, "Device list:\n");
+        (void)fprintf(stderr, "Device list:\n");
       }
-      fprintf(stderr, "\tDevice: %s\n", device_name.c_str());
+      (void)fprintf(stderr, "\tDevice: %s\n", device_name.c_str());
     }
 
     // if -cl-device was specified pick that device
@@ -1219,14 +1101,14 @@ bool oclc::Driver::InitCL() {
   OCLC_CHECK_FMT(!cl_device_name_.empty() && device_ == nullptr,
                  "Device \'%s\' not found.", cl_device_name_.c_str());
   if (verbose_ && !cl_device_name_.empty()) {
-    fprintf(stderr, "Using device: %s\n", picked_device_name.c_str());
+    (void)fprintf(stderr, "Using device: %s\n", picked_device_name.c_str());
   }
 
   // Create a context.
   context_ = clCreateContext(
       nullptr, 1, &device_,
       [](const char *errinfo, const void *, size_t, void *) {
-        std::fprintf(stderr, "%s\n", errinfo);
+        (void)std::fprintf(stderr, "%s\n", errinfo);
       },
       nullptr, &err);
   OCLC_CHECK_CL(err, "Could not create an OpenCL context (%d).\n");
@@ -1327,8 +1209,8 @@ bool oclc::Driver::BuildProgram() {
                                     nullptr);
     OCLC_CHECK_CL(err_log, "Requesting the build log failed");
 
-    fprintf(stderr, "Build log:\n\n");
-    fprintf(stderr, "%s", build_log.c_str());
+    (void)fprintf(stderr, "Build log:\n\n");
+    (void)fprintf(stderr, "%s", build_log.c_str());
 
     if (CL_SUCCESS != err) {
       (void)fprintf(stderr, "Build program failed with error: %s (%d)\n",

--- a/source/ur/examples/VectorAddition/source/main.c
+++ b/source/ur/examples/VectorAddition/source/main.c
@@ -23,14 +23,15 @@
 
 #include "ur_api.h"
 
-#define IS_UR_SUCCESS(X)                                                    \
-  {                                                                         \
-    ur_result_t ret_val = X;                                                \
-    if (UR_RESULT_SUCCESS != ret_val) {                                     \
-      fprintf(stderr, "Unified Runtime error occurred: %s returned 0x%x\n", \
-              #X, ret_val);                                                 \
-      exit(1);                                                              \
-    }                                                                       \
+#define IS_UR_SUCCESS(X)                                                      \
+  {                                                                           \
+    const ur_result_t ret_val = X;                                            \
+    if (UR_RESULT_SUCCESS != ret_val) {                                       \
+      (void)fprintf(stderr,                                                   \
+                    "Unified Runtime error occurred: %s returned 0x%x\n", #X, \
+                    ret_val);                                                 \
+      exit(1);                                                                \
+    }                                                                         \
   }
 
 /// @brief Print help message on executable usage
@@ -60,7 +61,7 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "expected platform name\n");
+        (void)fprintf(stderr, "expected platform name\n");
         exit(1);
       }
       *platform_name = argv[argi];
@@ -68,13 +69,13 @@ void parseArguments(const int argc, const char **argv,
       argi++;
       if (argi == argc) {
         printUsage(argv[0]);
-        fprintf(stderr, "error: expected device name\n");
+        (void)fprintf(stderr, "error: expected device name\n");
         exit(1);
       }
       *device_name = argv[argi];
     } else {
       printUsage(argv[0]);
-      fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
+      (void)fprintf(stderr, "error: invalid argument: %s\n", argv[argi]);
       exit(1);
     }
   }
@@ -94,14 +95,14 @@ ur_platform_handle_t selectPlatform(const char *platform_name_arg) {
   IS_UR_SUCCESS(urPlatformGet(0, NULL, &num_platforms));
 
   if (0 == num_platforms) {
-    fprintf(stderr, "No Unified Runtime platforms found, exiting\n");
+    (void)fprintf(stderr, "No Unified Runtime platforms found, exiting\n");
     exit(1);
   }
 
   ur_platform_handle_t *platforms = (ur_platform_handle_t *)malloc(
       sizeof(ur_platform_handle_t) * num_platforms);
   if (NULL == platforms) {
-    fprintf(stderr, "\nCould not allocate memory for platform ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for platform ids\n");
     exit(1);
   }
   IS_UR_SUCCESS(urPlatformGet(num_platforms, platforms, NULL));
@@ -119,7 +120,8 @@ ur_platform_handle_t selectPlatform(const char *platform_name_arg) {
     } else {
       char *platform_name = (char *)malloc(platform_name_size);
       if (NULL == platform_name) {
-        fprintf(stderr, "\nCould not allocate memory for platform name\n");
+        (void)fprintf(stderr,
+                      "\nCould not allocate memory for platform name\n");
         exit(1);
       }
       IS_UR_SUCCESS(urPlatformGetInfo(platforms[i], UR_PLATFORM_INFO_NAME,
@@ -133,8 +135,8 @@ ur_platform_handle_t selectPlatform(const char *platform_name_arg) {
   }
 
   if (platform_name_arg != NULL && selected_platform == 0) {
-    fprintf(stderr, "Platform name matching '--platform %s' not found\n",
-            platform_name_arg);
+    (void)fprintf(stderr, "Platform name matching '--platform %s' not found\n",
+                  platform_name_arg);
     exit(1);
   }
 
@@ -147,7 +149,7 @@ ur_platform_handle_t selectPlatform(const char *platform_name_arg) {
   } else {
     printf("\nPlease select a platform: ");
     if (1 != scanf("%u", &selected_platform)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -155,7 +157,7 @@ ur_platform_handle_t selectPlatform(const char *platform_name_arg) {
   selected_platform -= 1;
 
   if (num_platforms <= selected_platform) {
-    fprintf(stderr, "\nSelected unknown platform, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown platform, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on platform %u\n", selected_platform + 1);
@@ -185,14 +187,14 @@ ur_device_handle_t selectDevice(ur_platform_handle_t selected_platform,
                             &num_devices));
 
   if (0 == num_devices) {
-    fprintf(stderr, "No Unified Runtime devices found, exiting\n");
+    (void)fprintf(stderr, "No Unified Runtime devices found, exiting\n");
     exit(1);
   }
 
   ur_device_handle_t *devices =
       (ur_device_handle_t *)malloc(sizeof(ur_device_handle_t) * num_devices);
   if (NULL == devices) {
-    fprintf(stderr, "\nCould not allocate memory for device ids\n");
+    (void)fprintf(stderr, "\nCould not allocate memory for device ids\n");
     exit(1);
   }
   IS_UR_SUCCESS(urDeviceGet(selected_platform, UR_DEVICE_TYPE_ALL, num_devices,
@@ -211,7 +213,7 @@ ur_device_handle_t selectDevice(ur_platform_handle_t selected_platform,
     } else {
       char *device_name = (char *)malloc(device_name_size);
       if (NULL == device_name) {
-        fprintf(stderr, "\nCould not allocate memory for device name\n");
+        (void)fprintf(stderr, "\nCould not allocate memory for device name\n");
         exit(1);
       }
       IS_UR_SUCCESS(urDeviceGetInfo(devices[i], UR_DEVICE_INFO_NAME,
@@ -225,8 +227,8 @@ ur_device_handle_t selectDevice(ur_platform_handle_t selected_platform,
   }
 
   if (device_name_arg != NULL && selected_device == 0) {
-    fprintf(stderr, "Device name matching '--device %s' not found\n",
-            device_name_arg);
+    (void)fprintf(stderr, "Device name matching '--device %s' not found\n",
+                  device_name_arg);
     exit(1);
   }
 
@@ -239,7 +241,7 @@ ur_device_handle_t selectDevice(ur_platform_handle_t selected_platform,
   } else {
     printf("\nPlease select a device: ");
     if (1 != scanf("%u", &selected_device)) {
-      fprintf(stderr, "\nCould not parse provided input, exiting\n");
+      (void)fprintf(stderr, "\nCould not parse provided input, exiting\n");
       exit(1);
     }
   }
@@ -247,7 +249,7 @@ ur_device_handle_t selectDevice(ur_platform_handle_t selected_platform,
   selected_device -= 1;
 
   if (num_devices <= selected_device) {
-    fprintf(stderr, "\nSelected unknown device, exiting\n");
+    (void)fprintf(stderr, "\nSelected unknown device, exiting\n");
     exit(1);
   } else {
     printf("\nRunning example on device %u\n", selected_device + 1);

--- a/source/vk/examples/VectorAddition/source/main.c
+++ b/source/vk/examples/VectorAddition/source/main.c
@@ -21,20 +21,21 @@
 
 #include "vector_add.h"  // Contains shader SPIR-V
 
-#define IS_VK_SUCCESS(X)                                                       \
-  {                                                                            \
-    const VkResult ret_val = X;                                                \
-    if (VK_SUCCESS != ret_val) {                                               \
-      fprintf(stderr, "Vulkan error occurred: %s returned %d\n", #X, ret_val); \
-      exit(1);                                                                 \
-    }                                                                          \
+#define IS_VK_SUCCESS(X)                                                   \
+  {                                                                        \
+    const VkResult ret_val = X;                                            \
+    if (VK_SUCCESS != ret_val) {                                           \
+      (void)fprintf(stderr, "Vulkan error occurred: %s returned %d\n", #X, \
+                    ret_val);                                              \
+      exit(1);                                                             \
+    }                                                                      \
   }
 
 #define NUM_WORK_ITEMS 64
 
 // There is no global state in Vulkan. Create and return a VkInstance object
 // which initializes the Vulkan library and encapsulates per-application state.
-VkInstance createVkInstance() {
+VkInstance createVkInstance(void) {
   const VkApplicationInfo app_info = {
       VK_STRUCTURE_TYPE_APPLICATION_INFO,
       NULL,
@@ -92,9 +93,9 @@ uint32_t getMemoryTypeIndex(VkPhysicalDevice device, VkDeviceSize memory_size) {
   }
 
   if (mem_type_index == UINT32_MAX) {
-    fprintf(stderr,
-            "Couldn't find suitable memory of a least %" PRIu64 " bytes\n",
-            memory_size);
+    (void)fprintf(
+        stderr, "Couldn't find suitable memory of a least %" PRIu64 " bytes\n",
+        memory_size);
     exit(1);
   }
 
@@ -126,7 +127,7 @@ uint32_t getComputeQueueFamilyIndex(VkPhysicalDevice device) {
   }
 
   if (compute_queue_index == UINT32_MAX) {
-    fputs("Couldn't find a compute queue on device, exiting\n", stderr);
+    (void)fputs("Couldn't find a compute queue on device, exiting\n", stderr);
     exit(1);
   }
 
@@ -143,7 +144,7 @@ void createVkDevice(VkInstance instance, VkDevice* device,
   IS_VK_SUCCESS(vkEnumeratePhysicalDevices(instance, &num_devices, 0));
 
   if (0 == num_devices) {
-    fputs("No Vulkan devices found, exiting\n", stderr);
+    (void)fputs("No Vulkan devices found, exiting\n", stderr);
     exit(1);
   }
 
@@ -170,7 +171,7 @@ void createVkDevice(VkInstance instance, VkDevice* device,
   }
 
   if (NULL == codeplay_cpu_device) {
-    fputs("Couldn't find Codeplay Vulkan CPU device, exiting\n", stderr);
+    (void)fputs("Couldn't find Codeplay Vulkan CPU device, exiting\n", stderr);
     exit(1);
   }
 
@@ -446,7 +447,7 @@ void buildAndRunShader(VkDevice device, uint32_t compute_queue_family,
 }
 
 // Sample Vulkan compute application performing a vector add
-int main() {
+int main(void) {
   puts("Vector add Vulkan compute example:");
   // Initialize the Vulkan library
   VkInstance instance = createVkInstance();
@@ -457,7 +458,7 @@ int main() {
   createVkDevice(instance, &device, &physical_device);
 
   // We will have 3 buffers, each containing a single int32_t per work item
-  const uint32_t buffer_size = sizeof(int32_t) * NUM_WORK_ITEMS;
+  const VkDeviceSize buffer_size = sizeof(int32_t) * NUM_WORK_ITEMS;
   const VkDeviceSize memory_size = buffer_size * 3;
 
   // Type and amount of memory we want to allocate

--- a/source/vk/include/vk/error.h
+++ b/source/vk/include/vk/error.h
@@ -26,10 +26,10 @@
 /// @brief Display MESSAGE then abort due to catastrophic failure.
 ///
 /// @param MESSAGE Message to display.
-#define VK_ABORT(MESSAGE)                                        \
-  {                                                              \
-    fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, MESSAGE); \
-    abort();                                                     \
+#define VK_ABORT(MESSAGE)                                              \
+  {                                                                    \
+    (void)fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, MESSAGE); \
+    abort();                                                           \
   }
 
 /// @brief Check CONDITION and display MESSAGE then abort due to exceptional

--- a/source/vk/source/command_buffer.cpp
+++ b/source/vk/source/command_buffer.cpp
@@ -894,9 +894,9 @@ void CmdDispatch(vk::command_buffer commandBuffer, uint32_t x, uint32_t y,
     recorded_kernel.local_size = {commandBuffer->wgs[0], commandBuffer->wgs[1],
                                   commandBuffer->wgs[2]};
     recorded_kernel.global_offset = {0, 0, 0};
-    recorded_kernel.global_size = {x * (commandBuffer->wgs[0]),
-                                   y * (commandBuffer->wgs[1]),
-                                   z * (commandBuffer->wgs[2])};
+    recorded_kernel.global_size = {(size_t)x * (size_t)commandBuffer->wgs[0],
+                                   (size_t)y * (size_t)commandBuffer->wgs[1],
+                                   (size_t)z * (size_t)commandBuffer->wgs[2]};
     if (commandBuffer->mux_binary_kernel) {
       recorded_kernel.mux_binary_kernel = commandBuffer->mux_binary_kernel;
     } else {

--- a/source/vk/source/command_pool.cpp
+++ b/source/vk/source/command_pool.cpp
@@ -63,7 +63,6 @@ void DestroyCommandPool(vk::device device, vk::command_pool commandPool,
 VkResult ResetCommandPool(vk::device device, vk::command_pool commandPool,
                           VkCommandPoolResetFlags flags) {
   (void)flags;
-  mux_result_t error;
   for (vk::command_buffer command_buffer : commandPool->command_buffers) {
     command_buffer->descriptor_sets.clear();
 
@@ -76,11 +75,12 @@ VkResult ResetCommandPool(vk::device device, vk::command_pool commandPool,
 
     command_buffer->barrier_group_infos.clear();
 
-    if ((error = muxResetCommandBuffer(command_buffer->main_command_buffer))) {
+    if (auto error =
+            muxResetCommandBuffer(command_buffer->main_command_buffer)) {
       return vk::getVkResult(error);
     }
 
-    if ((error = muxResetSemaphore(command_buffer->main_semaphore))) {
+    if (auto error = muxResetSemaphore(command_buffer->main_semaphore)) {
       return vk::getVkResult(error);
     }
 

--- a/source/vk/test/UnitVK/include/kts_vk.h
+++ b/source/vk/test/UnitVK/include/kts_vk.h
@@ -558,13 +558,14 @@ class GenericKernelTest : public ::uvk::RecordCommandBufferTest,
       std::string name, prefix;
       const testing::UnitTest *test = testing::UnitTest::GetInstance();
       if (nullptr == test) {
-        std::fprintf(stderr, "Could not get a reference to the current test.");
+        (void)std::fprintf(stderr,
+                           "Could not get a reference to the current test.");
         std::abort();
       }
       const testing::TestInfo *test_info = test->current_test_info();
       if (nullptr == test_info) {
-        std::fprintf(stderr,
-                     "Could not get a reference to the current test info.");
+        (void)std::fprintf(
+            stderr, "Could not get a reference to the current test info.");
         std::abort();
       }
       GetKernelPrefixAndName(test_info->name(), prefix, name);

--- a/source/vk/test/UnitVK/source/UnitVK.cpp
+++ b/source/vk/test/UnitVK/source/UnitVK.cpp
@@ -72,7 +72,7 @@ void *VKAPI_CALL alloc(void *pUserData, size_t size, size_t alignment,
   pMemory = _aligned_malloc(size, alignment);
 #elif defined(__linux__) || defined(__APPLE__)
   if (posix_memalign(&pMemory, alignment, size)) {
-    fprintf(stderr, "posix_memalign failed!\n");
+    (void)fprintf(stderr, "posix_memalign failed!\n");
     abort();
   }
 #endif
@@ -151,7 +151,7 @@ void *VKAPI_CALL oneUseAlloc(void *pUserData, size_t size, size_t alignment,
     pMemory = _aligned_malloc(size, alignment);
 #elif defined(__linux__) || defined(__APPLE__)
     if (posix_memalign(&pMemory, alignment, size)) {
-      fprintf(stderr, "posix_memalign failed!\n");
+      (void)fprintf(stderr, "posix_memalign failed!\n");
       abort();
     }
 #endif

--- a/source/vk/test/UnitVK/source/ktst_dma.cpp
+++ b/source/vk/test/UnitVK/source/ktst_dma.cpp
@@ -43,14 +43,11 @@ TEST_F(Execution, Dma_01_Direct) {
   }
 }
 
-#define GLOBAL_ITEMS_1D 4
-#define GLOBAL_ITEMS_2D 4
-#define LOCAL_ITEMS_1D 2
-#define LOCAL_ITEMS_2D 2
-#define GROUP_RANGE_1D (GLOBAL_ITEMS_1D / LOCAL_ITEMS_1D)
-#define GLOBAL_ITEMS_TOTAL (GLOBAL_ITEMS_1D * GLOBAL_ITEMS_2D)
-#define LOCAL_ITEMS_TOTAL (LOCAL_ITEMS_1D * LOCAL_ITEMS_2D)
-#define GROUP_RANGE_TOTAL (GLOBAL_ITEMS_TOTAL / LOCAL_ITEMS_TOTAL)
+const size_t GLOBAL_ITEMS_1D = 4;
+const size_t GLOBAL_ITEMS_2D = 4;
+const size_t LOCAL_ITEMS_1D = 2;
+const size_t LOCAL_ITEMS_2D = 2;
+const size_t GLOBAL_ITEMS_TOTAL = GLOBAL_ITEMS_1D * GLOBAL_ITEMS_2D;
 
 class DmaAutoConvolutionExecute : public Execution {
  public:
@@ -59,8 +56,8 @@ class DmaAutoConvolutionExecute : public Execution {
     const size_t global_range[] = {GLOBAL_ITEMS_1D, GLOBAL_ITEMS_2D};
     const size_t local_range[] = {LOCAL_ITEMS_1D, LOCAL_ITEMS_2D};
 
-    const unsigned srcWidth = GLOBAL_ITEMS_1D + 16;
-    const unsigned srcHeight = GLOBAL_ITEMS_2D + 8;
+    const size_t srcWidth = GLOBAL_ITEMS_1D + 16;
+    const size_t srcHeight = GLOBAL_ITEMS_2D + 8;
     kts::Reference1D<cl_uint> inA = [](size_t x) {
       return kts::Ref_Identity(x);
     };

--- a/source/vk/test/UnitVK/source/ktst_regression.cpp
+++ b/source/vk/test/UnitVK/source/ktst_regression.cpp
@@ -422,7 +422,7 @@ TEST_F(ktst_regression_workgroup_spec, RegressionTest) {
 using ktst_regression_workgroup_spec_mixed =
     kts::uvk::GenericKernelTest<uvk::Shader::kts_workgroup_spec_mixed>;
 TEST_F(ktst_regression_workgroup_spec_mixed, RegressionTest) {
-  const int localY = 2;
+  const size_t localY = 2;
   glsl::uintTy specData[2] = {2, 2};
   uint32_t global[3] = {8, 1, 1};
 

--- a/source/vk/test/UnitVK/source/ktst_vecz_tasks_task_02.cpp
+++ b/source/vk/test/UnitVK/source/ktst_vecz_tasks_task_02.cpp
@@ -87,8 +87,8 @@ TEST_F(Execution, Task_02_07_Length_Builtin) {
 
 TEST_F(Execution, Task_02_08_Barrier_Add) {
   if (clspvSupported_) {
-    const cl_int array_size = 16;
-    const unsigned groupSize = array_size / 2;
+    const size_t array_size = 16;
+    const size_t groupSize = array_size / 2;
     kts::Reference1D<cl_int> refOut = [](size_t) { return 1; };
     AddInputBuffer(2 * groupSize, kts::Ref_A);
     AddInputBuffer(2 * groupSize, kts::Ref_B);


### PR DESCRIPTION
# Overview

Upgrade to clang-tidy-17.

# Reason for change

Our current version, clang-tidy-9, does not understand C++17 constructs and regardless, it will be nice to not be stuck on old versions for no real reason.

# Description of change

* misc-include-cleaner is disabled globally because at the moment, it requires annotations in external headers we have no control over.
* misc-use-anonymous-namespace is disabled globally because it goes against LLVM style, and the warning is triggered by use of LLVM macros that we have no control over.
* modernize-macro-to-enum is disabled globally because it also warns on macros that should be usable in preprocessor conditions.

Everything else either has the code adjusted according to the intent of the warning, or has the warning suppressed as appropriate. Warnings are suppressed for false positives (intentionally unused function return values, and two instances of clang-tidy warning about undefined code that is actually well-defined), and for code that we cannot improve without a bigger refactor (unused function return values in places where we have no way to indicate an error).

# Anything else we should know?

Two warnings that we had suppressed to work around a clang-tidy-9 limitation are no longer suppressed.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
