### PR TITLE
urKernelRetain: fix incorrect error result.

### DIFF
--- a/source/ur/source/kernel.cpp
+++ b/source/ur/source/kernel.cpp
@@ -97,7 +97,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
   if (!hKernel) {
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
   }
   return ur::retain(hKernel);
 }

--- a/source/ur/test/source/urKernelRetain.cpp
+++ b/source/ur/test/source/urKernelRetain.cpp
@@ -18,6 +18,8 @@
 
 using urKernelRetainTest = uur::KernelTest;
 
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelRetainTest);
+
 TEST_P(urKernelRetainTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));
   EXPECT_SUCCESS(urKernelRelease(kernel));


### PR DESCRIPTION
# Overview

urKernelRetain: fix incorrect error result.

# Reason for change

urKernelRetain is supposed to return UR_RESULT_ERROR_INVALID_NULL_HANDLE if a null kernel is passed in, but instead it previously returned UR_RESULT_ERROR_INVALID_NULL_POINTER. We had a test for this already, but it never ran so we never noticed.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
