### PR TITLE
Fix combination of operator and FMA manual type legalization.

### DIFF
--- a/modules/compiler/test/lit/passes/manual_type_legalization.ll
+++ b/modules/compiler/test/lit/passes/manual_type_legalization.ll
@@ -20,7 +20,9 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-; CHECK-LABEL: define half @f
+declare half @llvm.fma.f16(half, half, half)
+
+; CHECK-LABEL: define half @fadd
 ; CHECK-DAG: [[AEXT:%.*]] = fpext half %a to float
 ; CHECK-DAG: [[BEXT:%.*]] = fpext half %b to float
 ; CHECK-DAG: [[CEXT:%.*]] = fpext half %c to float
@@ -30,9 +32,40 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-DAG: [[EADD:%.*]] = fadd float [[DEXT]], [[CEXT]]
 ; CHECK-DAG: [[ETRUNC:%.*]] = fptrunc float [[EADD]] to half
 ; CHECK: ret half [[ETRUNC]]
-define half @f(half %a, half %b, half %c) {
+define half @fadd(half %a, half %b, half %c) {
 entry:
   %d = fadd half %a, %b
+  %e = fadd half %d, %c
+  ret half %e
+}
+
+; CHECK-LABEL: define half @ffma
+; CHECK-DAG: [[AEXT:%.*]] = fpext half %a to double
+; CHECK-DAG: [[BEXT:%.*]] = fpext half %b to double
+; CHECK-DAG: [[CEXT:%.*]] = fpext half %c to double
+; CHECK-DAG: [[DFMA:%.*]] = call double @llvm.fmuladd.f64(double [[AEXT]], double [[BEXT]], double [[CEXT]])
+; CHECK-DAG: [[DTRUNC:%.*]] = fptrunc double [[DADD]] to half
+; CHECK: ret half [[DTRUNC]]
+define half @ffma(half %a, half %b, half %c) {
+entry:
+  %d = call half @llvm.fma.f16(half %a, half %b, half %c)
+  ret half %d
+}
+
+; CHECK-LABEL: define half @ffmaadd
+; CHECK-DAG: [[AEXTD:%.*]] = fpext half %a to double
+; CHECK-DAG: [[BEXTD:%.*]] = fpext half %b to double
+; CHECK-DAG: [[CEXTD:%.*]] = fpext half %c to double
+; CHECK-DAG: [[DFMAD:%.*]] = call double @llvm.fmuladd.f64(double [[AEXTD]], double [[BEXTD]], double [[CEXTD]])
+; CHECK-DAG: [[DTRUNC:%.*]] = fptrunc double [[DADD]] to half
+; CHECK-DAG: [[CEXTF:%.*]] = fpext half %c to float
+; CHECK-DAG: [[DEXTF:%.*]] = fpext half %d to float
+; CHECK-DAG: [[EADD:%.*]] = fadd float [[DEXTF]], [[CEXTF]]
+; CHECK-DAG: [[ETRUNC:%.*]] = fptrunc float [[EADD]] to half
+; CHECK: ret half [[ETRUNC]]
+define half @ffmaadd(half %a, half %b, half %c) {
+entry:
+  %d = call half @llvm.fma.f16(half %a, half %b, half %c)
   %e = fadd half %d, %c
   ret half %e
 }

--- a/modules/compiler/utils/source/manual_type_legalization_pass.cpp
+++ b/modules/compiler/utils/source/manual_type_legalization_pass.cpp
@@ -58,14 +58,14 @@ PreservedAnalyses compiler::utils::ManualTypeLegalizationPass::run(
     return PreservedAnalyses::all();
   }
 
-  DenseMap<Value *, Value *> FPExtVals;
+  DenseMap<std::pair<Value *, Type *>, Value *> FPExtVals;
   IRBuilder<> B(F.getContext());
 
   auto CreateFPExt = [&](Value *V, Type *Ty, Type *ExtTy) {
     (void)Ty;
     assert(V->getType() == Ty &&
            "Expected matching types for floating point operation");
-    auto *&FPExt = FPExtVals[V];
+    auto *&FPExt = FPExtVals[{V, ExtTy}];
     if (!FPExt) {
       if (auto *I = dyn_cast<Instruction>(V)) {
 #if LLVM_VERSION_GREATER_EQUAL(18, 0)


### PR DESCRIPTION
# Overview

Fix combination of operator and FMA manual type legalization.

# Reason for change

We were seeing errors on CI for ARM.

# Description of change

We now may promote values to either float or double, but we only cached a single promoted value regardless of type. We need to cache the promoted-to-float and promoted-to-double results separately.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
