### PR TITLE
Fix memory leak in USM testing.

### DIFF
--- a/source/cl/test/UnitCL/include/cl_intel_unified_shared_memory.h
+++ b/source/cl/test/UnitCL/include/cl_intel_unified_shared_memory.h
@@ -85,23 +85,27 @@ struct cl_intel_unified_shared_memory_Test : public virtual ucl::ContextTest {
     cl_int err;
 
     if (host_capabilities) {
+      ASSERT_TRUE(host_ptr == nullptr);
       host_ptr = clHostMemAllocINTEL(context, {}, bytes, align, &err);
       ASSERT_SUCCESS(err);
       ASSERT_TRUE(host_ptr != nullptr);
     }
 
     if (shared_capabilities != 0) {
+      ASSERT_TRUE(shared_ptr == nullptr);
       shared_ptr =
           clSharedMemAllocINTEL(context, device, {}, bytes, align, &err);
       ASSERT_SUCCESS(err);
       ASSERT_TRUE(shared_ptr != nullptr);
 
+      ASSERT_TRUE(host_shared_ptr == nullptr);
       host_shared_ptr =
           clSharedMemAllocINTEL(context, nullptr, {}, bytes, align, &err);
       ASSERT_SUCCESS(err);
       ASSERT_TRUE(host_shared_ptr != nullptr);
     }
 
+    ASSERT_TRUE(device_ptr == nullptr);
     device_ptr =
         clDeviceMemAllocINTEL(context, device, nullptr, bytes, align, &err);
     ASSERT_SUCCESS(err);

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
@@ -295,7 +295,6 @@ struct USMVectorAddKernelTest : public USMKernelTest {
     ASSERT_SUCCESS(err);
     ASSERT_NE(cl_mem_buffer, nullptr);
 
-    initPointers(bytes, align);
     BuildKernel(source);
 
     queue = clCreateCommandQueue(context, device, 0, &err);


### PR DESCRIPTION
# Overview

Fix memory leak in USM testing.

# Reason for change

USMVectorAddKernelTest::SetUp() called initPointers() after it had called USMKernelTest::SetUp() which had already called initPointers().

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
