### PR TITLE
[compiler] Provide a safe GDB JIT registration listener

### DIFF
--- a/modules/compiler/targets/host/include/host/target.h
+++ b/modules/compiler/targets/host/include/host/target.h
@@ -31,6 +31,7 @@
 
 namespace llvm {
 class Module;
+class JITEventListener;
 }  // namespace llvm
 
 namespace host {
@@ -57,6 +58,9 @@ class HostTarget : public compiler::BaseTarget {
 
   /// @see BaseTarget::getBuiltins
   llvm::Module *getBuiltins() const override;
+
+  /// @brief GDB Registration Event listener. Must outlive the LLJIT.
+  std::unique_ptr<llvm::JITEventListener> gdb_registration_listener;
 
   /// @brief LLVM context.
   llvm::orc::ThreadSafeContext llvm_ts_context;

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -56,6 +56,12 @@ HostKernel::HostKernel(HostTarget &target, compiler::Options &build_options,
 
 HostKernel::~HostKernel() {
   if (target.orc_engine) {
+    // Removing the JIT dynamic libraries notifies the GDB debugger
+    // registration listener, which accesses/modifies GDB global variables.
+    // These global variables are also modified/accessed when jitting kernels,
+    // where we also lock with the same LLVM global mutex (see below).
+    const std::lock_guard<std::mutex> globalLock(
+        compiler::utils::getLLVMGlobalMutex());
     auto &es = target.orc_engine->getExecutionSession();
     for (const auto &name : kernel_jit_dylibs) {
       if (auto *jit = es.getJITDylibByName(name)) {

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -39,10 +39,12 @@
 #include <llvm/Support/Host.h>
 #endif
 
+#include <compiler/utils/gdb_registration_listener.h>
+#include <compiler/utils/llvm_global_mutex.h>
+
 #include "host/device.h"
 #include "host/info.h"
 #include "host/module.h"
-
 #ifdef CA_ENABLE_HOST_BUILTINS
 #include "compiler/utils/memory_buffer.h"
 #include "host/resources.h"
@@ -58,6 +60,7 @@ HostTarget::HostTarget(const HostInfo *compiler_info,
 compiler::Result HostTarget::initWithBuiltins(
     std::unique_ptr<llvm::Module> builtins_module) {
   builtins = std::move(builtins_module);
+  gdb_registration_listener = compiler::utils::createGDBRegistrationListener();
 
 #ifdef CA_ENABLE_HOST_BUILTINS
   auto loadedModule = llvm::getOwningLazyBitcodeModule(
@@ -219,9 +222,8 @@ compiler::Result HostTarget::initWithBuiltins(
             std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(
                 ES, std::move(GetMemMgr));
 
-        // Register the event listener.
-        ObjLinkingLayer->registerJITEventListener(
-            *llvm::JITEventListener::createGDBRegistrationListener());
+        // Register the GDB JIT event listener.
+        ObjLinkingLayer->registerJITEventListener(*gdb_registration_listener);
 
         // Make sure the debug info sections aren't stripped.
         ObjLinkingLayer->setProcessAllSections(true);

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -33,6 +33,7 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/encode_builtin_range_metadata_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/encode_kernel_metadata_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/fixup_calling_convention_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/gdb_registration_listener.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/group_collective_helpers.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/link_builtins_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/llvm_global_mutex.h
@@ -83,6 +84,7 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/encode_builtin_range_metadata_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/encode_kernel_metadata_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/fixup_calling_convention_pass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/gdb_registration_listener.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/group_collective_helpers.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/link_builtins_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/llvm_global_mutex.cpp

--- a/modules/compiler/utils/include/compiler/utils/gdb_registration_listener.h
+++ b/modules/compiler/utils/include/compiler/utils/gdb_registration_listener.h
@@ -1,0 +1,27 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+
+namespace llvm {
+class JITEventListener;
+}
+
+namespace compiler {
+namespace utils {
+std::unique_ptr<llvm::JITEventListener> createGDBRegistrationListener();
+}
+}  // namespace compiler

--- a/modules/compiler/utils/source/gdb_registration_listener.cpp
+++ b/modules/compiler/utils/source/gdb_registration_listener.cpp
@@ -1,0 +1,239 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Note - this is essentially a copy of LLVM's
+// lib/ExecutionEngine/GDBRegistrationListener.cpp but with the static
+// singleton and internal locking removed, as this model isn't safe in a
+// library context (the static singleton may be destroyed before we are).
+//
+// In our version, the external users of GDBJITRegistrationListener must ensure
+// the accesses are correctly locked as there may be multiple
+// GDBJITRegistrationListeners alive at any one time.
+
+#include <compiler/utils/gdb_registration_listener.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ExecutionEngine/JITEventListener.h>
+#include <llvm/Object/ObjectFile.h>
+#include <llvm/Support/Compiler.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <llvm/Support/MemoryBuffer.h>
+
+using namespace llvm;
+using namespace llvm::object;
+
+// This must be kept in sync with gdb/gdb/jit.h .
+extern "C" {
+
+typedef enum {
+  JIT_NOACTION = 0,
+  JIT_REGISTER_FN,
+  JIT_UNREGISTER_FN
+} jit_actions_t;
+
+struct jit_code_entry {
+  struct jit_code_entry *next_entry;
+  struct jit_code_entry *prev_entry;
+  const char *symfile_addr;
+  uint64_t symfile_size;
+};
+
+struct jit_descriptor {
+  uint32_t version;
+  // This should be jit_actions_t, but we want to be specific about the
+  // bit-width.
+  uint32_t action_flag;
+  struct jit_code_entry *relevant_entry;
+  struct jit_code_entry *first_entry;
+};
+
+// We put information about the JITed function in this global, which the
+// debugger reads.  Make sure to specify the version statically, because the
+// debugger checks the version before we can set it during runtime.
+extern struct jit_descriptor __jit_debug_descriptor;
+
+// Debuggers puts a breakpoint in this function.
+extern "C" void __jit_debug_register_code();
+}
+
+namespace {
+
+// FIXME: lli aims to provide both, RuntimeDyld and JITLink, as the dynamic
+// loaders for it's JIT implementations. And they both offer debugging via the
+// GDB JIT interface, which builds on the two well-known symbol names below.
+// As these symbols must be unique across the linked executable, we can only
+// define them in one of the libraries and make the other depend on it.
+// OrcTargetProcess is a minimal stub for embedding a JIT client in remote
+// executors. For the moment it seems reasonable to have the definition there
+// and let ExecutionEngine depend on it, until we find a better solution.
+//
+LLVM_ATTRIBUTE_USED void requiredSymbolDefinitionsFromOrcTargetProcess() {
+  errs() << (void *)&__jit_debug_register_code
+         << (void *)&__jit_debug_descriptor;
+}
+
+struct RegisteredObjectInfo {
+  RegisteredObjectInfo() = default;
+
+  RegisteredObjectInfo(std::size_t Size, jit_code_entry *Entry,
+                       OwningBinary<ObjectFile> Obj)
+      : Size(Size), Entry(Entry), Obj(std::move(Obj)) {}
+
+  std::size_t Size;
+  jit_code_entry *Entry;
+  OwningBinary<ObjectFile> Obj;
+};
+
+// Buffer for an in-memory object file in executable memory
+typedef llvm::DenseMap<JITEventListener::ObjectKey, RegisteredObjectInfo>
+    RegisteredObjectBufferMap;
+
+/// Global access point for the JIT debugging interface. Must be locked when
+/// calling notifyObjectLoaded or notifyFreeingObject as both methods
+/// access/modify global variables.
+class GDBJITRegistrationListener : public JITEventListener {
+ public:
+  /// A map of in-memory object files that have been registered with the
+  /// JIT interface.
+  RegisteredObjectBufferMap ObjectBufferMap;
+
+  /// Instantiates the JIT service.
+  GDBJITRegistrationListener() = default;
+
+  /// Asserts that all resources have already been freed.
+  ~GDBJITRegistrationListener() override;
+
+  /// Creates an entry in the JIT registry for the buffer @p Object,
+  /// which must contain an object file in executable memory with any
+  /// debug information for the debugger.
+  void notifyObjectLoaded(ObjectKey K, const ObjectFile &Obj,
+                          const RuntimeDyld::LoadedObjectInfo &L) override;
+
+  /// Removes the internal registration of @p Object, and
+  /// frees associated resources.
+  void notifyFreeingObject(ObjectKey K) override;
+
+ private:
+  /// Deregister the debug info for the given object file from the debugger
+  /// and delete any temporary copies.  This private method does not remove
+  /// the function from Map so that it can be called while iterating over Map.
+  void deregisterObjectInternal(RegisteredObjectBufferMap::iterator I);
+};
+
+/// Do the registration.
+void NotifyDebugger(jit_code_entry *JITCodeEntry) {
+  __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
+
+  // Insert this entry at the head of the list.
+  JITCodeEntry->prev_entry = nullptr;
+  jit_code_entry *NextEntry = __jit_debug_descriptor.first_entry;
+  JITCodeEntry->next_entry = NextEntry;
+  if (NextEntry) {
+    NextEntry->prev_entry = JITCodeEntry;
+  }
+  __jit_debug_descriptor.first_entry = JITCodeEntry;
+  __jit_debug_descriptor.relevant_entry = JITCodeEntry;
+  __jit_debug_register_code();
+}
+
+GDBJITRegistrationListener::~GDBJITRegistrationListener() {
+  // It is the callers' responsibility to ensure all JIT resources have been
+  // manually freed up.
+  assert(ObjectBufferMap.empty() && "Not all JIT resources have been cleared!");
+}
+
+void GDBJITRegistrationListener::notifyObjectLoaded(
+    ObjectKey K, const ObjectFile &Obj,
+    const RuntimeDyld::LoadedObjectInfo &L) {
+  OwningBinary<ObjectFile> DebugObj = L.getObjectForDebug(Obj);
+
+  // Bail out if debug objects aren't supported.
+  if (!DebugObj.getBinary()) {
+    return;
+  }
+
+  const char *Buffer =
+      DebugObj.getBinary()->getMemoryBufferRef().getBufferStart();
+  const size_t Size =
+      DebugObj.getBinary()->getMemoryBufferRef().getBufferSize();
+
+  assert(ObjectBufferMap.find(K) == ObjectBufferMap.end() &&
+         "Second attempt to perform debug registration.");
+  jit_code_entry *JITCodeEntry = new jit_code_entry();
+
+  if (!JITCodeEntry) {
+    llvm::report_fatal_error(
+        "Allocation failed when registering a JIT entry!\n");
+  } else {
+    JITCodeEntry->symfile_addr = Buffer;
+    JITCodeEntry->symfile_size = Size;
+
+    ObjectBufferMap[K] =
+        RegisteredObjectInfo(Size, JITCodeEntry, std::move(DebugObj));
+    NotifyDebugger(JITCodeEntry);
+  }
+}
+
+void GDBJITRegistrationListener::notifyFreeingObject(ObjectKey K) {
+  const RegisteredObjectBufferMap::iterator I = ObjectBufferMap.find(K);
+
+  if (I != ObjectBufferMap.end()) {
+    deregisterObjectInternal(I);
+    ObjectBufferMap.erase(I);
+  }
+}
+
+void GDBJITRegistrationListener::deregisterObjectInternal(
+    RegisteredObjectBufferMap::iterator I) {
+  jit_code_entry *&JITCodeEntry = I->second.Entry;
+
+  // Do the unregistration.
+  {
+    __jit_debug_descriptor.action_flag = JIT_UNREGISTER_FN;
+
+    // Remove the jit_code_entry from the linked list.
+    jit_code_entry *PrevEntry = JITCodeEntry->prev_entry;
+    jit_code_entry *NextEntry = JITCodeEntry->next_entry;
+
+    if (NextEntry) {
+      NextEntry->prev_entry = PrevEntry;
+    }
+    if (PrevEntry) {
+      PrevEntry->next_entry = NextEntry;
+    } else {
+      assert(__jit_debug_descriptor.first_entry == JITCodeEntry);
+      __jit_debug_descriptor.first_entry = NextEntry;
+    }
+
+    // Tell the debugger which entry we removed, and unregister the code.
+    __jit_debug_descriptor.relevant_entry = JITCodeEntry;
+    __jit_debug_register_code();
+  }
+
+  delete JITCodeEntry;
+  JITCodeEntry = nullptr;
+}
+
+}  // end namespace
+
+namespace compiler {
+namespace utils {
+
+std::unique_ptr<llvm::JITEventListener> createGDBRegistrationListener() {
+  return std::make_unique<GDBJITRegistrationListener>();
+}
+
+}  // namespace utils
+}  // namespace compiler


### PR DESCRIPTION
This commit adds a version of LLVM's GDBRegistrationListener that is safe to use in our libraries.

This and the original listener is responsible for registering and deregistering dynamically compiled kernels with GDB's JIT compilation interface. It does this through access to global symbols understood by GDB. This requires that it must be made correctly thread-safe.

LLVM ensures this by having only one static singleton version of its GDB listener, which locks itself when notified of a new object, or notified or a freed one. This does not work for our use-case, as the static singleton may be destroyed before the OpenCL library is destroyed. Thus our modules and kernels may inadvertently use an already freed object.

To solve this, our version of this listener is no longer a singleton, and instead requires the callers to correctly lock access to it. In principle this requires the host target to lock when jitting a kernel and when freeing a kernel. Both of these are now locked under the same LLVM global mutex to ensure thread safety.

The original also accesses these globals in its destructor, but our version requires (asserts) that resources are already freed up at the time the listener is freed. This requires us to lock in one fewer instance and should simplify the mental model of how the listener works.