### PR TITLE
Based on intel/llvm recent change, replace using  `acc` with `fpga` in ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Now to compile the vector add from oneAPI samples, set the environment variables
 ```sh
 export OCL_ICD_FILENAMES=$ONEAPI_CON_KIT_INSTALL_DIR/lib/libCL.so
 export LD_LIBRARY_PATH=/path/to/intel/oneapi/compiler/2023.2.0/linux/lib:/path/to/intel/oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/path/to/intel/oneapi/compiler/2023.2.0/linux/compiler/lib/:$LD_LIBRARY_PATH
-export ONEAPI_DEVICE_SELECTOR="*:acc"
+export ONEAPI_DEVICE_SELECTOR="*:fpga"
 
 /path/to/intel/oneapi/compiler/2023.2.0/linux/bin-llvm/clang++ -fsycl /path/to/oneAPI-samples/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp -o vector-add-buffers
 CA_HAL_DEBUG=1 SYCL_CONFIG_FILE_NAME=  ./vector-add-buffers
@@ -158,7 +158,7 @@ Set the environment variables:
 ```sh
 export OCL_ICD_FILENAMES=$ONEAPI_CON_KIT_INSTALL_DIR/lib/libCL.so
 export LD_LIBRARY_PATH=/path/to/dpcpp_compiler/lib:$ONEAPI_CONKIT_INSTALL_DIR/lib:$LD_LIBRARY_PATH
-export ONEAPI_DEVICE_SELECTOR="*:acc"
+export ONEAPI_DEVICE_SELECTOR="*:fpga"
 ```
 
 Now to compile the vector add using the downloaded dpc++, follow the steps below:
@@ -303,7 +303,7 @@ Set the environment variables before compiling the code:
 ```sh
 export OCL_ICD_FILENAMES=$ONEAPI_CON_KIT_INSTALL_DIR/lib/libCL.so
 export LD_LIBRARY_PATH=$ONEAPI_TOOLKIT_BUILD_DIR/lib:$LD_LIBRARY_PATH
-export ONEAPI_DEVICE_SELECTOR="*:acc"
+export ONEAPI_DEVICE_SELECTOR="*:fpga"
 
 ```
 Compile the code using the `clang++` from the oneAPI toolkit.

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -1021,7 +1021,7 @@ export CMAKE_CXX_COMPILER=/path/to/intel_oneapi/bin/clang++
 export CMAKE_C_COMPILER=/path/to/intel_oneapi/bin/clang
 export CA_HAL_DEBUG=1
 export CA_PROFILE_LEVEL=3
-export ONEAPI_DEVICE_SELECTOR=opencl:acc
+export ONEAPI_DEVICE_SELECTOR=opencl:fpga
 export OCL_ICD_FILENAMES=/path/to/build/lib/libCL.so
 # As the oneAPI basetoolkit release has a whitelist of devices, it filters out RefSi.
 # To override it, as a temporary solution we can point SYCL_CONFIG_FILE_NAME to ``.

--- a/examples/technical_blogs/ock_demo_blog/build_and_run_networks.py
+++ b/examples/technical_blogs/ock_demo_blog/build_and_run_networks.py
@@ -210,7 +210,7 @@ def main():
     # Set the environment variables
     os.environ["CA_HAL_DEBUG"] =  os.environ.get("CA_HAL_DEBUG", "1")
     os.environ["CA_PROFILE_LEVEL"] = os.environ.get("CA_PROFILE_LEVEL", "3")
-    os.environ["ONEAPI_DEVICE_SELECTOR"] = os.environ.get("ONEAPI_DEVICE_SELECTOR", "opencl::acc")
+    os.environ["ONEAPI_DEVICE_SELECTOR"] = os.environ.get("ONEAPI_DEVICE_SELECTOR", "opencl::fpga")
     # To whitelist oneapi-construction-kit for the official Intel oneAPI basetoolkit,
     # SYCL_CONFIG_FILE_NAME needs to be overridden
     os.environ["SYCL_CONFIG_FILE_NAME"] = ""

--- a/examples/technical_blogs/ock_demo_blog/envvars
+++ b/examples/technical_blogs/ock_demo_blog/envvars
@@ -4,7 +4,7 @@ export LD_LIBRARY_PATH=$RELEASE_DIR/install/lib:$RELEASE_DIR/linux_nightly_relea
 export CMAKE_CXX_COMPILER=$RELEASE_DIR/linux_nightly_release/bin/clang++
 export CMAKE_C_COMPILER=$RELEASE_DIR/linux_nightly_release/bin/clang
 export OCL_ICD_VENDORS=/dev/null
-export ONEAPI_DEVICE_SELECTOR=opencl:acc
+export ONEAPI_DEVICE_SELECTOR=opencl:fpga
 export OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so
 # As the oneAPI basetoolkit release has a whitelist of devices, it filters out RefSi.
 # To override it, as a temporary solution we can point SYCL_CONFIG_FILE_NAME to ``.

--- a/examples/technical_blogs/ock_demo_blog/getting_started.md
+++ b/examples/technical_blogs/ock_demo_blog/getting_started.md
@@ -176,7 +176,7 @@ Here's how to dump the IR of the ```simple-vector-add``` kernel:
 
 
 ```sh
-    CA_RISCV_DUMP_IR=1 CA_HAL_DEBUG=1 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc SYCL_CONFIG_FILE_NAME="" ./simple-vector-add
+    CA_RISCV_DUMP_IR=1 CA_HAL_DEBUG=1 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:fpga SYCL_CONFIG_FILE_NAME="" ./simple-vector-add
 ```
 
 This is the expected output you should have:
@@ -646,10 +646,10 @@ in `$RELEASE_DIR/vgg_data` and `$RELEASE_DIR\resnet_data` respectively.
 #### Running VGG16 & ResNet50
 ```
     # Testing on image for VGG16
-    CA_HAL_DEBUG=1 CA_PROFILE_LEVEL=3 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc SYCL_CONFIG_FILE_NAME=  $RELEASE_DIR/portDNN_build_dir/samples/networks/vgg/vgg vgg_data/ $RELEASE_DIR/Labrador_Retriever_Molly.jpg.bin
+    CA_HAL_DEBUG=1 CA_PROFILE_LEVEL=3 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:fpga SYCL_CONFIG_FILE_NAME=  $RELEASE_DIR/portDNN_build_dir/samples/networks/vgg/vgg vgg_data/ $RELEASE_DIR/Labrador_Retriever_Molly.jpg.bin
 
     # Testing on image for Resnet50
-    CA_HAL_DEBUG=1 CA_PROFILE_LEVEL=3 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:acc SYCL_CONFIG_FILE_NAME=  $RELEASE_DIR/portDNN_build_dir/samples/networks/resnet50/resnet50 resnet_data/ $(pwd)/Labrador_Retriever_Molly.jpg.bin
+    CA_HAL_DEBUG=1 CA_PROFILE_LEVEL=3 OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so ONEAPI_DEVICE_SELECTOR=opencl:fpga SYCL_CONFIG_FILE_NAME=  $RELEASE_DIR/portDNN_build_dir/samples/networks/resnet50/resnet50 resnet_data/ $(pwd)/Labrador_Retriever_Molly.jpg.bin
 ```
 
 This may take a few minutes and the expected output should end like this:


### PR DESCRIPTION

# Overview

Based on https://github.com/intel/llvm/pull/12551, replace using  with  in tests and documentation using ONEAPI_DEVICE_SELECTOR

# Reason for change
```quote
As per the ONEAPI_DEVICE_SELECTOR [documentation](https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md#oneapi_device_selector), the device type can only be cpu, gpu, or fpga (or any combination of those). Currently, 'acc' is also accepted by ONEAPI_DEVICE_SELECTOR as a valid device type, which is incorrect.
Therefore, I'm changing test cases and documentation, that uses ONEAPI_DEVICE_SELECTOR with 'acc' device type to instead use 'fpga'. Functionality wise, 'acc' and 'fpga' device types are equivalent so this change should not change the functionality of the test cases.
```
