### PR TITLE
Fix the OCK demo package release name on github

### DIFF
--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -158,7 +158,7 @@ jobs:
             ock_demo_artifacts.tar.gz
             network_artifacts.tar.gz
           tag_name: nightly-${{ steps.tag.outputs.TAG }}
-          name: OCK daily ${{ steps.tag.outputs.TAG }}
+          name: OCK Demo Package ${{ steps.tag.outputs.TAG }}
           prerelease: true
-          body: "Daily build ${{ steps.tag.outputs.TAG }}"
+          body: "ock-demo build ${{ steps.tag.outputs.TAG }}"
           target_commitish: ${{ github.sha }}


### PR DESCRIPTION
# Overview

Replace OCK Daily with OCK Demo Package for the ock-demo release


