### PR TITLE
[UnitCL] Test *Half* tests under the 'COMPILER' filter

### DIFF
--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -417,7 +417,7 @@ function(add_ca_unitcl_check name)
     # our testing by minimising duplication.
     # Allow users to tack on any extra tests to run. They may also disable any
     # tests that we run by default.
-    set(filter "--gtest_filter=*Compile*:*Link*:*Build*:*Execution*:*print*:*WorkGroupCollective*:*SubGroup*:${args_FILTER}")
+    set(filter "--gtest_filter=*Compile*:*Link*:*Build*:*Execution*:*Half*:*print*:*WorkGroupCollective*:*SubGroup*:${args_FILTER}")
   elseif(args_FILTER)
     set(filter "--gtest_filter=${args_FILTER}")
   endif()


### PR DESCRIPTION
These fp16 tests are important enough that we should be running them in more configurations more often - with vectorization, with different compilation flags, etc. Relegating them to only the `check-UnitCL-half` target means we miss out on this coverage.

These will all be skipped if half/fp16 isn't enabled so shouldn't negatively impact testing time in the majority of configs.