### PR TITLE
Disable manual type legalization for operators for ARM in LLVM 19.

### DIFF
--- a/modules/compiler/utils/source/manual_type_legalization_pass.cpp
+++ b/modules/compiler/utils/source/manual_type_legalization_pass.cpp
@@ -51,8 +51,11 @@ PreservedAnalyses compiler::utils::ManualTypeLegalizationPass::run(
   const llvm::Triple TT(F.getParent()->getTargetTriple());
 
   auto &TTI = FAM.getResult<TargetIRAnalysis>(F);
-  const bool HaveCorrectHalfOps =
-      TTI.isTypeLegal(HalfT) || TT.isX86() || TT.isRISCV();
+  const bool HaveCorrectHalfOps = TTI.isTypeLegal(HalfT) ||
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+                                  TT.isARM() ||
+#endif
+                                  TT.isX86() || TT.isRISCV();
   const bool HaveCorrectHalfFMA = TT.isRISCV();
   if (HaveCorrectHalfOps && HaveCorrectHalfFMA) {
     return PreservedAnalyses::all();


### PR DESCRIPTION
# Overview

Disable manual type legalization for operators for ARM in LLVM 19.

# Reason for change

The upstream change to fix this has been accepted.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
