### PR TITLE
Update the getting started guide for ock_demo package

### DIFF
--- a/.github/actions/build_vgg_resnet_action/action.yml
+++ b/.github/actions/build_vgg_resnet_action/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
 

--- a/.github/actions/build_vgg_resnet_action/action.yml
+++ b/.github/actions/build_vgg_resnet_action/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Download Daily Release
       shell: bash
       run: |
-        wget "https://github.com/intel/llvm/releases/download/nightly-2023-12-18/sycl_linux.tar.gz"
+        wget "https://github.com/intel/llvm/releases/download/nightly-2024-02-08/sycl_linux.tar.gz"
         mkdir linux_nightly_release
         tar -xzf sycl_linux.tar.gz -C linux_nightly_release
 

--- a/.github/workflows/build_pr_cache.yml
+++ b/.github/workflows/build_pr_cache.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       # installs tools, ninja and installs llvm (default 17, RelAssert) and sets up cache
       - name: setup-ubuntu

--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout repo
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
           ref: release/${{matrix.version}}.x

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
        # installs tools, ninja, installs llvm and sets up sccache
       - name: Setup ubuntu
@@ -30,7 +30,7 @@ jobs:
           llvm_build_type: Release
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -99,7 +99,7 @@ jobs:
           fi
 
       - name: Create OCK pre-release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -1,8 +1,12 @@
 # Build, Run and Test OCK Demo EcoSystem
 name: Build and Run OCK Demo
 on:
-  schedule:
-    - cron: '59 23 * * 5'  # Run every Friday at 11:59 PM
+  pull_request:
+    paths:
+      - '.github/workflows/run_ock_demo.yml'
+  push:
+    branches:
+      - stable
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -18,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
        # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup ubuntu
@@ -80,6 +84,7 @@ jobs:
           cd ock_example_tests
           ctest bin/ --verbose
           cd ..
+          mv ock_example_tests/bin install/tests
 
       - name: Build portBLAS
         uses: ./.github/actions/build_portBLAS_action
@@ -91,16 +96,23 @@ jobs:
         with:
           workspace: ${{ github.workspace }}
 
-      - name: Package Build Artifacts
+      - name: Package build artifacts
         run: |
           mv install ock_install_dir
-          tar -cvzf ock_demo_artifacts.tar.gz ock_install_dir portDNN_build_dir portBLAS_build_dir ock_example_tests examples/technical_blogs/ock_demo_blog/getting_started.md examples/technical_blogs/ock_demo_blog/envvars
+          tar -cvzf ock_demo_artifacts.tar.gz ock_install_dir
+          tar -cvzf ock_demo_components.tar.gz portDNN_build_dir portBLAS_build_dir examples/technical_blogs/ock_demo_blog/getting_started.md examples/technical_blogs/ock_demo_blog/envvars
 
-      - name: Upload Artifacts
+      - name: Upload OCK artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ock_demo_build
           path: ock_demo_artifacts.tar.gz
+
+      - name: Upload OCK demo components artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ock_demo_components
+          path: ock_demo_components.tar.gz
 
   build_and_run_networks:
     runs-on: ubuntu-22.04
@@ -109,14 +121,20 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Download artifacts
+      - name: Download OCK artifacts
         uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
 
+      - name: Download OCK components artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ock_demo_components
+
       - name: Untar artifacts
         run: |
           tar -xvzf ock_demo_artifacts.tar.gz
+          tar -xvzf ock_demo_components.tar.gz
 
       - name: Build vgg and resnet
         uses: ./.github/actions/build_vgg_resnet_action
@@ -129,10 +147,15 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
-      - name: Download artifacts
+      - name: Download OCK artifacts
         uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
+
+      - name: Download OCK components artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ock_demo_components
 
       - name: Download network artifacts
         uses: actions/download-artifact@v4
@@ -156,8 +179,9 @@ jobs:
         with:
           files: |
             ock_demo_artifacts.tar.gz
+            ock_demo_components.tar.gz
             network_artifacts.tar.gz
-          tag_name: nightly-${{ steps.tag.outputs.TAG }}
+          tag_name: ock-demo-${{ steps.tag.outputs.TAG }}
           name: OCK Demo Package ${{ steps.tag.outputs.TAG }}
           prerelease: true
           body: "ock-demo build ${{ steps.tag.outputs.TAG }}"

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -1,9 +1,6 @@
 # Build, Run and Test OCK Demo EcoSystem
 name: Build and Run OCK Demo
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/run_ock_demo.yml'
   push:
     branches:
       - stable
@@ -32,7 +29,7 @@ jobs:
           llvm_build_type: RelAssert
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -57,7 +54,7 @@ jobs:
         run: |
           # Update the nightly release from intel/llvm from 2024-01-30 to daily once
           # everything has stablised
-          wget "https://github.com/intel/llvm/releases/download/nightly-2024-01-30/sycl_linux.tar.gz"
+          wget "https://github.com/intel/llvm/releases/download/nightly-2024-02-12/sycl_linux.tar.gz"
           mkdir linux_nightly_release
           tar -xzf sycl_linux.tar.gz -C linux_nightly_release
 
@@ -100,7 +97,7 @@ jobs:
         run: |
           mv install ock_install_dir
           tar -cvzf ock_demo_artifacts.tar.gz ock_install_dir
-          tar -cvzf ock_demo_components.tar.gz portDNN_build_dir portBLAS_build_dir examples/technical_blogs/ock_demo_blog/getting_started.md examples/technical_blogs/ock_demo_blog/envvars
+          tar -cvzf ock_demo_components.tar.gz portDNN_build_dir portBLAS_build_dir -C examples/technical_blogs/ock_demo_blog getting_started.md envvars
 
       - name: Upload OCK artifacts
         uses: actions/upload-artifact@v4
@@ -119,7 +116,7 @@ jobs:
     needs: run_riscv_m1_ock_demo
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download OCK artifacts
         uses: actions/download-artifact@v4
@@ -173,7 +170,7 @@ jobs:
           fi
 
       - name: Create OCK demo release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-ubuntu-clang-format
         run:

--- a/examples/technical_blogs/ock_demo_blog/envvars
+++ b/examples/technical_blogs/ock_demo_blog/envvars
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-export LD_LIBRARY_PATH=$RELEASE_DIR/install/lib:$RELEASE_DIR/linux_nightly_release/lib/libsycl.so:$RELEASE_DIR/linux_nightly_release/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$RELEASE_DIR/ock_install_dir/lib:$RELEASE_DIR/linux_nightly_release/lib/libsycl.so:$RELEASE_DIR/linux_nightly_release/lib:$LD_LIBRARY_PATH
 export CMAKE_CXX_COMPILER=$RELEASE_DIR/linux_nightly_release/bin/clang++
 export CMAKE_C_COMPILER=$RELEASE_DIR/linux_nightly_release/bin/clang
 export OCL_ICD_VENDORS=/dev/null
 export ONEAPI_DEVICE_SELECTOR=opencl:fpga
-export OCL_ICD_FILENAMES=$RELEASE_DIR/install/lib/libCL.so
+export OCL_ICD_FILENAMES=$RELEASE_DIR/ock_install_dir/lib/libCL.so
 # As the oneAPI basetoolkit release has a whitelist of devices, it filters out RefSi.
 # To override it, as a temporary solution we can point SYCL_CONFIG_FILE_NAME to ``.
 # This way it doesn't set the default sycl.conf.

--- a/examples/technical_blogs/ock_demo_blog/getting_started.md
+++ b/examples/technical_blogs/ock_demo_blog/getting_started.md
@@ -41,11 +41,13 @@ You'll need to extract the files from the archive file and and oneAPI nighlty re
 downloaded from `intel/llvm`:
 
 ```sh
+    # TODO: Add wget commands for ock_build_artifacts, ock_demo_components and network_artifacts.
     mkdir Release
     cd Release
     tar -xf ../ock_demo_artifacts.tar.gz
+    tar -xf ../ock_demo_components.tar.gz
     tar -xf ../network_artifacts.tar.gz
-    As of the current documentation, the latest nightly release available is dated 2024-01-30.
+    # As of the current documentation, the latest nightly release available is dated 2024-01-30.
     wget "https://github.com/intel/llvm/releases/download/nightly-2024-01-30/sycl_linux.tar.gz"
     mkdir linux_nightly_release
     tar -xzf sycl_linux.tar.gz -C linux_nightly_release
@@ -58,8 +60,7 @@ hierarchy that looks like this:
 
 ```
 - WORKDIR: $RELEASE_DIR
-    - DIR: ock_example_tests/
-    - DIR: install/
+    - DIR: ock_install_dir/
     - DIR: portBLAS_build_dir/
     - DIR: portDNN_build_dir/
     - DIR: resnet_data
@@ -68,7 +69,7 @@ hierarchy that looks like this:
     - FILE: Labrador_Retriever_Molly.jpg
     - FILE: Labrador_Retriever_Molly.jpg.bin
     - FILE: get-started.md
-    - FILE: vect
+    - FILE: envvars
 ```
 
 Then, you'll need to set the environment variables that will be used during this
@@ -113,7 +114,7 @@ OCK demo contains more than one executable, but for the sake of our example, we 
 using SYCL.
 
 ```sh
-    cd $RELEASE_DIR/ock_example_tests/bin/
+    cd $RELEASE_DIR/ock_install_dir/tests/
     ./simple-vector-add
 ```
 
@@ -169,7 +170,7 @@ Setting the ```CA_RISCV_DUMP_IR``` will display the IR on stderr.
 First, check you are in the right directory to run the sample:
 
 ```sh
-    cd $RELEASE_DIR/ock_example_tests/bin
+    cd $RELEASE_DIR/ock_install_dir/tests
 ```
 
 Here's how to dump the IR of the ```simple-vector-add``` kernel:
@@ -415,7 +416,7 @@ setting the previously shown environment variables:
 First, check you are in the right directory to run the sample:
 
 ```sh
-    cd $RELEASE_DIR/ock_example_tests/bin
+    cd $RELEASE_DIR/ock_install_dir/tests
 ```
 
 Then run the command:
@@ -476,7 +477,7 @@ We will focus on ```clVectorAddition``` in this subsection.
 Here's how to run ```clVectorAddition```:
 
 ```sh
-    cd $RELEASE_DIR/ock_example_tests/bin
+    cd $RELEASE_DIR/ock_install_dir/tests
     ./clVectorAddition
 ```
 
@@ -516,14 +517,14 @@ level instructions emitted during program execution using the samples and
 benchmarks we previously built.
 
 The following examples will be using the ```simple-vector-add``` kernel from
-the ock_example_tests directory.
+the `ock_install_dir/tests` directory.
 
 ### Profiler
 
 First, check you are in the right directory to run the sample:
 
 ```sh
-    cd $RELEASE_DIR/ock_example_tests/bin
+    cd $RELEASE_DIR/ock_install_dir/tests
 ```
 
 The profiler is a built-in feature that enables you to profile or track


### PR DESCRIPTION
# Overview

Update the getting started guide for ock_demo package. 
Some minor changes were made in the last  commits, so updating the getting_started_guide.md accordingly.