### PR TITLE
Fix bug in new ldexp implementation.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_math/ldexp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/ldexp.cpp
@@ -37,11 +37,12 @@ inline T ldexp(const T x, const S n) {
   // n_1) to be exact so that we do not introduce errors due to double rounding,
   // which requires avoiding turning normals into subnormals early.
   const SignedType n_1_min =
-      SignedType(1) - (SignedType(((abacus::detail::cast::as<UnsignedType>(x) &
+      (SignedType(1) - SignedType(((abacus::detail::cast::as<UnsignedType>(x) &
                                     Shape::ExponentMask()) >>
-                                   Shape::Mantissa())) /
-                       2);
-  const SignedType n_1 = __abacus_max(SignedType(n_c / 3), n_1_min);
+                                   Shape::Mantissa()))) /
+      2;
+  const SignedType n_1 =
+      __abacus_max(SignedType(n_c - ((n_c / 3) << 1)), n_1_min);
   const SignedType n_2 = n_c - (n_1 << 1);
 
   // Construct pow(2, n_1) and pow(2, n_2) by building the floating point

--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -2235,7 +2235,7 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
     GTEST_SKIP();
   }
 
-  const size_t N = 17;
+  const size_t N = 18;
   const std::pair<cl_half, cl_int> inputs[N] = {
       {0x21f8 /* 0.01165772 */, -17},
       {0x11f8 /* 0.0007286075 */, -13},
@@ -2254,6 +2254,7 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
       {0x78ae /* 38336 */, -40},
       {0xfb93 /* -62048 */, -40},
       {0x7bed /* 64928 */, -40},
+      {0xf934 /* -42624 */, -41},
   };
 
   const cl_half outputs[N] = {
@@ -2304,6 +2305,8 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
       // Although this result is too low to be representable in half we expect
       // the lowest representable half rather than zero due to rounding.
       0x1, /* 5.960464477539063e-08 */
+      // ldexp(-42624, -41) is too small to represent.
+      0x8000,
   };
 
   AddInputBuffer(N, kts::Reference1D<cl_half>([&inputs](size_t i) {


### PR DESCRIPTION
# Overview

Fix bug in new ldexp implementation.

# Reason for change

* The calculation of n_1_min was not quite right. This seems to have not caused any issues, but there is no reason not to get it right.
* The calculation of n_1 rounded to zero, which causes issues. For a scale of -41, we would split it into factors with scales of -13, -13, -15 which breaks because the last would be subnormal. We should instead split it into factors with scales of -14, -14, -13.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
