### PR TITLE
[compiler] Remove extraneous semicolon

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_cast/convert_char.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_cast/convert_char.cpp
@@ -17,5 +17,5 @@
 #include <abacus/abacus_cast.h>
 #include <abacus/internal/convert_helper.h>
 
-DEF(char);
-DEF(uchar);
+DEF(char)
+DEF(uchar)

--- a/modules/compiler/builtins/abacus/source/abacus_cast/convert_int.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_cast/convert_int.cpp
@@ -17,5 +17,5 @@
 #include <abacus/abacus_cast.h>
 #include <abacus/internal/convert_helper.h>
 
-DEF(int);
-DEF(uint);
+DEF(int)
+DEF(uint)

--- a/modules/compiler/builtins/abacus/source/abacus_cast/convert_long.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_cast/convert_long.cpp
@@ -17,5 +17,5 @@
 #include <abacus/abacus_cast.h>
 #include <abacus/internal/convert_helper.h>
 
-DEF(long);
-DEF(ulong);
+DEF(long)
+DEF(ulong)

--- a/modules/compiler/builtins/abacus/source/abacus_cast/convert_other.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_cast/convert_other.cpp
@@ -18,9 +18,9 @@
 #include <abacus/internal/convert_helper.h>
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(half);
+DEF(half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
-DEF(float);
+DEF(float)
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(double);
+DEF(double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_cast/convert_short.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_cast/convert_short.cpp
@@ -17,5 +17,5 @@
 #include <abacus/abacus_cast.h>
 #include <abacus/internal/convert_helper.h>
 
-DEF(short);
-DEF(ushort);
+DEF(short)
+DEF(ushort)

--- a/modules/compiler/builtins/abacus/source/abacus_common/clamp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/clamp.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/degrees.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/degrees.cpp
@@ -23,26 +23,26 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/max.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/max.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/min.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/min.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/mix.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/mix.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/radians.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/radians.cpp
@@ -23,26 +23,26 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif  //  __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  //  __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/sign.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/sign.cpp
@@ -23,26 +23,26 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif  //  __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  //  __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/smoothstep.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/smoothstep.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_common/step.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_common/step.cpp
@@ -27,44 +27,44 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 
-DEF2(abacus_half2, abacus_half);
-DEF2(abacus_half3, abacus_half);
-DEF2(abacus_half4, abacus_half);
-DEF2(abacus_half8, abacus_half);
-DEF2(abacus_half16, abacus_half);
+DEF2(abacus_half2, abacus_half)
+DEF2(abacus_half3, abacus_half)
+DEF2(abacus_half4, abacus_half)
+DEF2(abacus_half8, abacus_half)
+DEF2(abacus_half16, abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
-DEF2(abacus_float2, abacus_float);
-DEF2(abacus_float3, abacus_float);
-DEF2(abacus_float4, abacus_float);
-DEF2(abacus_float8, abacus_float);
-DEF2(abacus_float16, abacus_float);
+DEF2(abacus_float2, abacus_float)
+DEF2(abacus_float3, abacus_float)
+DEF2(abacus_float4, abacus_float)
+DEF2(abacus_float8, abacus_float)
+DEF2(abacus_float16, abacus_float)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 
-DEF2(abacus_double2, abacus_double);
-DEF2(abacus_double3, abacus_double);
-DEF2(abacus_double4, abacus_double);
-DEF2(abacus_double8, abacus_double);
-DEF2(abacus_double16, abacus_double);
+DEF2(abacus_double2, abacus_double)
+DEF2(abacus_double3, abacus_double)
+DEF2(abacus_double4, abacus_double)
+DEF2(abacus_double8, abacus_double)
+DEF2(abacus_double16, abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_extra/bit_reverse.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_extra/bit_reverse.cpp
@@ -56,58 +56,58 @@ T bit_reverse(const T t) {
 #define DEF(TYPE) \
   TYPE ABACUS_API __abacus_bit_reverse(TYPE x) { return bit_reverse<>(x); }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_extra/find_lsb.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_extra/find_lsb.cpp
@@ -47,30 +47,30 @@ typename TypeTraits<T>::SignedType find_lsb(const T t) {
     return find_lsb<>(x);                                        \
   }
 
-DEF(char);
-DEF(char2);
-DEF(char3);
-DEF(char4);
-DEF(char8);
-DEF(char16);
+DEF(char)
+DEF(char2)
+DEF(char3)
+DEF(char4)
+DEF(char8)
+DEF(char16)
 
-DEF(short);
-DEF(short2);
-DEF(short3);
-DEF(short4);
-DEF(short8);
-DEF(short16);
+DEF(short)
+DEF(short2)
+DEF(short3)
+DEF(short4)
+DEF(short8)
+DEF(short16)
 
-DEF(int);
-DEF(int2);
-DEF(int3);
-DEF(int4);
-DEF(int8);
-DEF(int16);
+DEF(int)
+DEF(int2)
+DEF(int3)
+DEF(int4)
+DEF(int8)
+DEF(int16)
 
-DEF(long);
-DEF(long2);
-DEF(long3);
-DEF(long4);
-DEF(long8);
-DEF(long16);
+DEF(long)
+DEF(long2)
+DEF(long3)
+DEF(long4)
+DEF(long8)
+DEF(long16)

--- a/modules/compiler/builtins/abacus/source/abacus_extra/find_msb.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_extra/find_msb.cpp
@@ -66,30 +66,30 @@ typename TypeTraits<T>::SignedType find_msb(const T t) {
     return find_msb<>(x);                                        \
   }
 
-DEF(char);
-DEF(char2);
-DEF(char3);
-DEF(char4);
-DEF(char8);
-DEF(char16);
+DEF(char)
+DEF(char2)
+DEF(char3)
+DEF(char4)
+DEF(char8)
+DEF(char16)
 
-DEF(short);
-DEF(short2);
-DEF(short3);
-DEF(short4);
-DEF(short8);
-DEF(short16);
+DEF(short)
+DEF(short2)
+DEF(short3)
+DEF(short4)
+DEF(short8)
+DEF(short16)
 
-DEF(int);
-DEF(int2);
-DEF(int3);
-DEF(int4);
-DEF(int8);
-DEF(int16);
+DEF(int)
+DEF(int2)
+DEF(int3)
+DEF(int4)
+DEF(int8)
+DEF(int16)
 
-DEF(long);
-DEF(long2);
-DEF(long3);
-DEF(long4);
-DEF(long8);
-DEF(long16);
+DEF(long)
+DEF(long2)
+DEF(long3)
+DEF(long4)
+DEF(long8)
+DEF(long16)

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/cross.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/cross.cpp
@@ -23,14 +23,14 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/distance.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/distance.cpp
@@ -23,20 +23,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/dot.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/dot.cpp
@@ -23,20 +23,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_distance.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_distance.cpp
@@ -24,20 +24,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_length.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_length.cpp
@@ -23,20 +23,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/fast_normalize.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/fast_normalize.cpp
@@ -23,20 +23,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/length.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/length.cpp
@@ -23,20 +23,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_geometric/normalize.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_geometric/normalize.cpp
@@ -31,20 +31,20 @@
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-SCALAR_DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
+SCALAR_DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
 
-SCALAR_DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
+SCALAR_DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-SCALAR_DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
+SCALAR_DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_integer/abs.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/abs.cpp
@@ -22,58 +22,58 @@
     return abacus::detail::integer::abs(x);                        \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/abs_diff.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/abs_diff.cpp
@@ -23,58 +23,58 @@
     return abacus::detail::integer::abs_diff(x, y);                     \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/add_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/add_sat.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::add_sat(x, y);   \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/clamp.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/clamp.cpp
@@ -25,106 +25,106 @@
     return abacus::detail::integer::clamp(x, y, z);          \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF2(abacus_char2, abacus_char);
-DEF2(abacus_char3, abacus_char);
-DEF2(abacus_char4, abacus_char);
-DEF2(abacus_char8, abacus_char);
-DEF2(abacus_char16, abacus_char);
+DEF2(abacus_char2, abacus_char)
+DEF2(abacus_char3, abacus_char)
+DEF2(abacus_char4, abacus_char)
+DEF2(abacus_char8, abacus_char)
+DEF2(abacus_char16, abacus_char)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF2(abacus_uchar2, abacus_uchar);
-DEF2(abacus_uchar3, abacus_uchar);
-DEF2(abacus_uchar4, abacus_uchar);
-DEF2(abacus_uchar8, abacus_uchar);
-DEF2(abacus_uchar16, abacus_uchar);
+DEF2(abacus_uchar2, abacus_uchar)
+DEF2(abacus_uchar3, abacus_uchar)
+DEF2(abacus_uchar4, abacus_uchar)
+DEF2(abacus_uchar8, abacus_uchar)
+DEF2(abacus_uchar16, abacus_uchar)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF2(abacus_short2, abacus_short);
-DEF2(abacus_short3, abacus_short);
-DEF2(abacus_short4, abacus_short);
-DEF2(abacus_short8, abacus_short);
-DEF2(abacus_short16, abacus_short);
+DEF2(abacus_short2, abacus_short)
+DEF2(abacus_short3, abacus_short)
+DEF2(abacus_short4, abacus_short)
+DEF2(abacus_short8, abacus_short)
+DEF2(abacus_short16, abacus_short)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF2(abacus_ushort2, abacus_ushort);
-DEF2(abacus_ushort3, abacus_ushort);
-DEF2(abacus_ushort4, abacus_ushort);
-DEF2(abacus_ushort8, abacus_ushort);
-DEF2(abacus_ushort16, abacus_ushort);
+DEF2(abacus_ushort2, abacus_ushort)
+DEF2(abacus_ushort3, abacus_ushort)
+DEF2(abacus_ushort4, abacus_ushort)
+DEF2(abacus_ushort8, abacus_ushort)
+DEF2(abacus_ushort16, abacus_ushort)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF2(abacus_int2, abacus_int);
-DEF2(abacus_int3, abacus_int);
-DEF2(abacus_int4, abacus_int);
-DEF2(abacus_int8, abacus_int);
-DEF2(abacus_int16, abacus_int);
+DEF2(abacus_int2, abacus_int)
+DEF2(abacus_int3, abacus_int)
+DEF2(abacus_int4, abacus_int)
+DEF2(abacus_int8, abacus_int)
+DEF2(abacus_int16, abacus_int)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF2(abacus_uint2, abacus_uint);
-DEF2(abacus_uint3, abacus_uint);
-DEF2(abacus_uint4, abacus_uint);
-DEF2(abacus_uint8, abacus_uint);
-DEF2(abacus_uint16, abacus_uint);
+DEF2(abacus_uint2, abacus_uint)
+DEF2(abacus_uint3, abacus_uint)
+DEF2(abacus_uint4, abacus_uint)
+DEF2(abacus_uint8, abacus_uint)
+DEF2(abacus_uint16, abacus_uint)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF2(abacus_long2, abacus_long);
-DEF2(abacus_long3, abacus_long);
-DEF2(abacus_long4, abacus_long);
-DEF2(abacus_long8, abacus_long);
-DEF2(abacus_long16, abacus_long);
+DEF2(abacus_long2, abacus_long)
+DEF2(abacus_long3, abacus_long)
+DEF2(abacus_long4, abacus_long)
+DEF2(abacus_long8, abacus_long)
+DEF2(abacus_long16, abacus_long)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)
 
-DEF2(abacus_ulong2, abacus_ulong);
-DEF2(abacus_ulong3, abacus_ulong);
-DEF2(abacus_ulong4, abacus_ulong);
-DEF2(abacus_ulong8, abacus_ulong);
-DEF2(abacus_ulong16, abacus_ulong);
+DEF2(abacus_ulong2, abacus_ulong)
+DEF2(abacus_ulong3, abacus_ulong)
+DEF2(abacus_ulong4, abacus_ulong)
+DEF2(abacus_ulong8, abacus_ulong)
+DEF2(abacus_ulong16, abacus_ulong)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/clz.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/clz.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::clz(x); \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/ctz.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/ctz.cpp
@@ -21,58 +21,58 @@
     return (TYPE)abacus::detail::integer::ctz(x); \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/hadd.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/hadd.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::hadd(x, y);   \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad24.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad24.cpp
@@ -21,16 +21,16 @@
     return abacus::detail::integer::mad24(x, y, z);        \
   }
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad_hi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad_hi.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::mad_hi(x, y, z);        \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mad_sat.cpp
@@ -353,58 +353,58 @@ abacus_ulong16 mad_sat(const abacus_ulong16 x, const abacus_ulong16 y,
     return mad_sat<>(x, y, z);                               \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/max.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/max.cpp
@@ -25,106 +25,106 @@
     return abacus::detail::integer::max(x, y);    \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF2(abacus_char2, abacus_char);
-DEF2(abacus_char3, abacus_char);
-DEF2(abacus_char4, abacus_char);
-DEF2(abacus_char8, abacus_char);
-DEF2(abacus_char16, abacus_char);
+DEF2(abacus_char2, abacus_char)
+DEF2(abacus_char3, abacus_char)
+DEF2(abacus_char4, abacus_char)
+DEF2(abacus_char8, abacus_char)
+DEF2(abacus_char16, abacus_char)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF2(abacus_uchar2, abacus_uchar);
-DEF2(abacus_uchar3, abacus_uchar);
-DEF2(abacus_uchar4, abacus_uchar);
-DEF2(abacus_uchar8, abacus_uchar);
-DEF2(abacus_uchar16, abacus_uchar);
+DEF2(abacus_uchar2, abacus_uchar)
+DEF2(abacus_uchar3, abacus_uchar)
+DEF2(abacus_uchar4, abacus_uchar)
+DEF2(abacus_uchar8, abacus_uchar)
+DEF2(abacus_uchar16, abacus_uchar)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF2(abacus_short2, abacus_short);
-DEF2(abacus_short3, abacus_short);
-DEF2(abacus_short4, abacus_short);
-DEF2(abacus_short8, abacus_short);
-DEF2(abacus_short16, abacus_short);
+DEF2(abacus_short2, abacus_short)
+DEF2(abacus_short3, abacus_short)
+DEF2(abacus_short4, abacus_short)
+DEF2(abacus_short8, abacus_short)
+DEF2(abacus_short16, abacus_short)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF2(abacus_ushort2, abacus_ushort);
-DEF2(abacus_ushort3, abacus_ushort);
-DEF2(abacus_ushort4, abacus_ushort);
-DEF2(abacus_ushort8, abacus_ushort);
-DEF2(abacus_ushort16, abacus_ushort);
+DEF2(abacus_ushort2, abacus_ushort)
+DEF2(abacus_ushort3, abacus_ushort)
+DEF2(abacus_ushort4, abacus_ushort)
+DEF2(abacus_ushort8, abacus_ushort)
+DEF2(abacus_ushort16, abacus_ushort)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF2(abacus_int2, abacus_int);
-DEF2(abacus_int3, abacus_int);
-DEF2(abacus_int4, abacus_int);
-DEF2(abacus_int8, abacus_int);
-DEF2(abacus_int16, abacus_int);
+DEF2(abacus_int2, abacus_int)
+DEF2(abacus_int3, abacus_int)
+DEF2(abacus_int4, abacus_int)
+DEF2(abacus_int8, abacus_int)
+DEF2(abacus_int16, abacus_int)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF2(abacus_uint2, abacus_uint);
-DEF2(abacus_uint3, abacus_uint);
-DEF2(abacus_uint4, abacus_uint);
-DEF2(abacus_uint8, abacus_uint);
-DEF2(abacus_uint16, abacus_uint);
+DEF2(abacus_uint2, abacus_uint)
+DEF2(abacus_uint3, abacus_uint)
+DEF2(abacus_uint4, abacus_uint)
+DEF2(abacus_uint8, abacus_uint)
+DEF2(abacus_uint16, abacus_uint)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF2(abacus_long2, abacus_long);
-DEF2(abacus_long3, abacus_long);
-DEF2(abacus_long4, abacus_long);
-DEF2(abacus_long8, abacus_long);
-DEF2(abacus_long16, abacus_long);
+DEF2(abacus_long2, abacus_long)
+DEF2(abacus_long3, abacus_long)
+DEF2(abacus_long4, abacus_long)
+DEF2(abacus_long8, abacus_long)
+DEF2(abacus_long16, abacus_long)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)
 
-DEF2(abacus_ulong2, abacus_ulong);
-DEF2(abacus_ulong3, abacus_ulong);
-DEF2(abacus_ulong4, abacus_ulong);
-DEF2(abacus_ulong8, abacus_ulong);
-DEF2(abacus_ulong16, abacus_ulong);
+DEF2(abacus_ulong2, abacus_ulong)
+DEF2(abacus_ulong3, abacus_ulong)
+DEF2(abacus_ulong4, abacus_ulong)
+DEF2(abacus_ulong8, abacus_ulong)
+DEF2(abacus_ulong16, abacus_ulong)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/min.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/min.cpp
@@ -25,106 +25,106 @@
     return abacus::detail::integer::min(x, y);    \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF2(abacus_char2, abacus_char);
-DEF2(abacus_char3, abacus_char);
-DEF2(abacus_char4, abacus_char);
-DEF2(abacus_char8, abacus_char);
-DEF2(abacus_char16, abacus_char);
+DEF2(abacus_char2, abacus_char)
+DEF2(abacus_char3, abacus_char)
+DEF2(abacus_char4, abacus_char)
+DEF2(abacus_char8, abacus_char)
+DEF2(abacus_char16, abacus_char)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF2(abacus_uchar2, abacus_uchar);
-DEF2(abacus_uchar3, abacus_uchar);
-DEF2(abacus_uchar4, abacus_uchar);
-DEF2(abacus_uchar8, abacus_uchar);
-DEF2(abacus_uchar16, abacus_uchar);
+DEF2(abacus_uchar2, abacus_uchar)
+DEF2(abacus_uchar3, abacus_uchar)
+DEF2(abacus_uchar4, abacus_uchar)
+DEF2(abacus_uchar8, abacus_uchar)
+DEF2(abacus_uchar16, abacus_uchar)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF2(abacus_short2, abacus_short);
-DEF2(abacus_short3, abacus_short);
-DEF2(abacus_short4, abacus_short);
-DEF2(abacus_short8, abacus_short);
-DEF2(abacus_short16, abacus_short);
+DEF2(abacus_short2, abacus_short)
+DEF2(abacus_short3, abacus_short)
+DEF2(abacus_short4, abacus_short)
+DEF2(abacus_short8, abacus_short)
+DEF2(abacus_short16, abacus_short)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF2(abacus_ushort2, abacus_ushort);
-DEF2(abacus_ushort3, abacus_ushort);
-DEF2(abacus_ushort4, abacus_ushort);
-DEF2(abacus_ushort8, abacus_ushort);
-DEF2(abacus_ushort16, abacus_ushort);
+DEF2(abacus_ushort2, abacus_ushort)
+DEF2(abacus_ushort3, abacus_ushort)
+DEF2(abacus_ushort4, abacus_ushort)
+DEF2(abacus_ushort8, abacus_ushort)
+DEF2(abacus_ushort16, abacus_ushort)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF2(abacus_int2, abacus_int);
-DEF2(abacus_int3, abacus_int);
-DEF2(abacus_int4, abacus_int);
-DEF2(abacus_int8, abacus_int);
-DEF2(abacus_int16, abacus_int);
+DEF2(abacus_int2, abacus_int)
+DEF2(abacus_int3, abacus_int)
+DEF2(abacus_int4, abacus_int)
+DEF2(abacus_int8, abacus_int)
+DEF2(abacus_int16, abacus_int)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF2(abacus_uint2, abacus_uint);
-DEF2(abacus_uint3, abacus_uint);
-DEF2(abacus_uint4, abacus_uint);
-DEF2(abacus_uint8, abacus_uint);
-DEF2(abacus_uint16, abacus_uint);
+DEF2(abacus_uint2, abacus_uint)
+DEF2(abacus_uint3, abacus_uint)
+DEF2(abacus_uint4, abacus_uint)
+DEF2(abacus_uint8, abacus_uint)
+DEF2(abacus_uint16, abacus_uint)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF2(abacus_long2, abacus_long);
-DEF2(abacus_long3, abacus_long);
-DEF2(abacus_long4, abacus_long);
-DEF2(abacus_long8, abacus_long);
-DEF2(abacus_long16, abacus_long);
+DEF2(abacus_long2, abacus_long)
+DEF2(abacus_long3, abacus_long)
+DEF2(abacus_long4, abacus_long)
+DEF2(abacus_long8, abacus_long)
+DEF2(abacus_long16, abacus_long)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)
 
-DEF2(abacus_ulong2, abacus_ulong);
-DEF2(abacus_ulong3, abacus_ulong);
-DEF2(abacus_ulong4, abacus_ulong);
-DEF2(abacus_ulong8, abacus_ulong);
-DEF2(abacus_ulong16, abacus_ulong);
+DEF2(abacus_ulong2, abacus_ulong)
+DEF2(abacus_ulong3, abacus_ulong)
+DEF2(abacus_ulong4, abacus_ulong)
+DEF2(abacus_ulong8, abacus_ulong)
+DEF2(abacus_ulong16, abacus_ulong)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mul24.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mul24.cpp
@@ -21,16 +21,16 @@
     return abacus::detail::integer::mul24(x, y);   \
   }
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/mul_hi.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/mul_hi.cpp
@@ -49,58 +49,58 @@ T mul_hi(const T x, const T y) {
 #define DEF(TYPE) \
   TYPE ABACUS_API __abacus_mul_hi(TYPE x, TYPE y) { return mul_hi<TYPE>(x, y); }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/popcount.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/popcount.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::popcount(x); \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/rhadd.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/rhadd.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::rhadd(x, y);   \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/rotate.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/rotate.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::rotate(x, y);   \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/sub_sat.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/sub_sat.cpp
@@ -21,58 +21,58 @@
     return abacus::detail::integer::sub_sat(x, y);   \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)

--- a/modules/compiler/builtins/abacus/source/abacus_integer/upsample.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_integer/upsample.cpp
@@ -23,44 +23,44 @@
     return abacus::detail::integer::upsample<>(x, y);        \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)

--- a/modules/compiler/builtins/abacus/source/abacus_memory/vload.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_memory/vload.cpp
@@ -55,18 +55,18 @@ T vload(const size_t offset, U p) {
   DEF_WITH_TYPE_AND_SIZE(TYPE, 8) \
   DEF_WITH_TYPE_AND_SIZE(TYPE, 16)
 
-DEF(abacus_char);
-DEF(abacus_uchar);
-DEF(abacus_short);
-DEF(abacus_ushort);
-DEF(abacus_int);
-DEF(abacus_uint);
-DEF(abacus_long);
-DEF(abacus_ulong);
+DEF(abacus_char)
+DEF(abacus_uchar)
+DEF(abacus_short)
+DEF(abacus_ushort)
+DEF(abacus_int)
+DEF(abacus_uint)
+DEF(abacus_long)
+DEF(abacus_ulong)
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
+DEF(abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_float);
+DEF(abacus_float)
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
+DEF(abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_memory/vstore.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_memory/vstore.cpp
@@ -52,18 +52,18 @@ void vstore(const T data, const size_t offset, U p) {
   DEF_WITH_TYPE_AND_SIZE(TYPE, 8) \
   DEF_WITH_TYPE_AND_SIZE(TYPE, 16)
 
-DEF(abacus_char);
-DEF(abacus_uchar);
-DEF(abacus_short);
-DEF(abacus_ushort);
-DEF(abacus_int);
-DEF(abacus_uint);
-DEF(abacus_long);
-DEF(abacus_ulong);
+DEF(abacus_char)
+DEF(abacus_uchar)
+DEF(abacus_short)
+DEF(abacus_ushort)
+DEF(abacus_int)
+DEF(abacus_uint)
+DEF(abacus_long)
+DEF(abacus_ulong)
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
+DEF(abacus_half)
 #endif  // __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_float);
+DEF(abacus_float)
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
+DEF(abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_misc/shuffle.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_misc/shuffle.cpp
@@ -68,15 +68,15 @@ R shuffle(const T x, const M m) {
   DEF_WITH_SIZE(TYPE, 8) \
   DEF_WITH_SIZE(TYPE, 16)
 
-DEF(abacus_char);
-DEF(abacus_uchar);
-DEF(abacus_short);
-DEF(abacus_ushort);
-DEF(abacus_int);
-DEF(abacus_uint);
-DEF(abacus_long);
-DEF(abacus_ulong);
-DEF(abacus_float);
+DEF(abacus_char)
+DEF(abacus_uchar)
+DEF(abacus_short)
+DEF(abacus_ushort)
+DEF(abacus_int)
+DEF(abacus_uint)
+DEF(abacus_long)
+DEF(abacus_ulong)
+DEF(abacus_float)
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
+DEF(abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_misc/shuffle2.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_misc/shuffle2.cpp
@@ -69,15 +69,15 @@ R shuffle2(const T x, const T y, const M m) {
   DEF_WITH_SIZE(TYPE, 8) \
   DEF_WITH_SIZE(TYPE, 16)
 
-DEF(abacus_char);
-DEF(abacus_uchar);
-DEF(abacus_short);
-DEF(abacus_ushort);
-DEF(abacus_int);
-DEF(abacus_uint);
-DEF(abacus_long);
-DEF(abacus_ulong);
-DEF(abacus_float);
+DEF(abacus_char)
+DEF(abacus_uchar)
+DEF(abacus_short)
+DEF(abacus_ushort)
+DEF(abacus_int)
+DEF(abacus_uint)
+DEF(abacus_long)
+DEF(abacus_ulong)
+DEF(abacus_float)
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
+DEF(abacus_double)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/all.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/all.cpp
@@ -22,30 +22,30 @@
     return abacus::detail::relational::all(x); \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)

--- a/modules/compiler/builtins/abacus/source/abacus_relational/any.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/any.cpp
@@ -22,30 +22,30 @@
     return abacus::detail::relational::any(x); \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)

--- a/modules/compiler/builtins/abacus/source/abacus_relational/bitselect.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/bitselect.cpp
@@ -22,83 +22,83 @@
     return abacus::detail::relational::bitselect(x, y, z);     \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isequal.cpp
@@ -47,26 +47,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isfinite.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isfinite.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isgreater.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isgreater.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isgreaterequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isgreaterequal.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isinf.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isinf.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isless.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isless.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/islessequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/islessequal.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/islessgreater.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/islessgreater.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnan.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnan.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnormal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnormal.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isnotequal.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isnotequal.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isordered.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isordered.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/isunordered.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/isunordered.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/select.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/select.cpp
@@ -27,83 +27,83 @@
     return abacus::detail::relational::select(x, y, z);               \
   }
 
-DEF(abacus_char);
-DEF(abacus_char2);
-DEF(abacus_char3);
-DEF(abacus_char4);
-DEF(abacus_char8);
-DEF(abacus_char16);
+DEF(abacus_char)
+DEF(abacus_char2)
+DEF(abacus_char3)
+DEF(abacus_char4)
+DEF(abacus_char8)
+DEF(abacus_char16)
 
-DEF(abacus_uchar);
-DEF(abacus_uchar2);
-DEF(abacus_uchar3);
-DEF(abacus_uchar4);
-DEF(abacus_uchar8);
-DEF(abacus_uchar16);
+DEF(abacus_uchar)
+DEF(abacus_uchar2)
+DEF(abacus_uchar3)
+DEF(abacus_uchar4)
+DEF(abacus_uchar8)
+DEF(abacus_uchar16)
 
-DEF(abacus_short);
-DEF(abacus_short2);
-DEF(abacus_short3);
-DEF(abacus_short4);
-DEF(abacus_short8);
-DEF(abacus_short16);
+DEF(abacus_short)
+DEF(abacus_short2)
+DEF(abacus_short3)
+DEF(abacus_short4)
+DEF(abacus_short8)
+DEF(abacus_short16)
 
-DEF(abacus_ushort);
-DEF(abacus_ushort2);
-DEF(abacus_ushort3);
-DEF(abacus_ushort4);
-DEF(abacus_ushort8);
-DEF(abacus_ushort16);
+DEF(abacus_ushort)
+DEF(abacus_ushort2)
+DEF(abacus_ushort3)
+DEF(abacus_ushort4)
+DEF(abacus_ushort8)
+DEF(abacus_ushort16)
 
-DEF(abacus_int);
-DEF(abacus_int2);
-DEF(abacus_int3);
-DEF(abacus_int4);
-DEF(abacus_int8);
-DEF(abacus_int16);
+DEF(abacus_int)
+DEF(abacus_int2)
+DEF(abacus_int3)
+DEF(abacus_int4)
+DEF(abacus_int8)
+DEF(abacus_int16)
 
-DEF(abacus_uint);
-DEF(abacus_uint2);
-DEF(abacus_uint3);
-DEF(abacus_uint4);
-DEF(abacus_uint8);
-DEF(abacus_uint16);
+DEF(abacus_uint)
+DEF(abacus_uint2)
+DEF(abacus_uint3)
+DEF(abacus_uint4)
+DEF(abacus_uint8)
+DEF(abacus_uint16)
 
-DEF(abacus_long);
-DEF(abacus_long2);
-DEF(abacus_long3);
-DEF(abacus_long4);
-DEF(abacus_long8);
-DEF(abacus_long16);
+DEF(abacus_long)
+DEF(abacus_long2)
+DEF(abacus_long3)
+DEF(abacus_long4)
+DEF(abacus_long8)
+DEF(abacus_long16)
 
-DEF(abacus_ulong);
-DEF(abacus_ulong2);
-DEF(abacus_ulong3);
-DEF(abacus_ulong4);
-DEF(abacus_ulong8);
-DEF(abacus_ulong16);
+DEF(abacus_ulong)
+DEF(abacus_ulong2)
+DEF(abacus_ulong3)
+DEF(abacus_ulong4)
+DEF(abacus_ulong8)
+DEF(abacus_ulong16)
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT

--- a/modules/compiler/builtins/abacus/source/abacus_relational/signbit.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_relational/signbit.cpp
@@ -46,26 +46,26 @@ struct helper<abacus_half> {
   }
 
 #ifdef __CA_BUILTINS_HALF_SUPPORT
-DEF(abacus_half);
-DEF(abacus_half2);
-DEF(abacus_half3);
-DEF(abacus_half4);
-DEF(abacus_half8);
-DEF(abacus_half16);
+DEF(abacus_half)
+DEF(abacus_half2)
+DEF(abacus_half3)
+DEF(abacus_half4)
+DEF(abacus_half8)
+DEF(abacus_half16)
 #endif
 
-DEF(abacus_float);
-DEF(abacus_float2);
-DEF(abacus_float3);
-DEF(abacus_float4);
-DEF(abacus_float8);
-DEF(abacus_float16);
+DEF(abacus_float)
+DEF(abacus_float2)
+DEF(abacus_float3)
+DEF(abacus_float4)
+DEF(abacus_float8)
+DEF(abacus_float16)
 
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
-DEF(abacus_double);
-DEF(abacus_double2);
-DEF(abacus_double3);
-DEF(abacus_double4);
-DEF(abacus_double8);
-DEF(abacus_double16);
+DEF(abacus_double)
+DEF(abacus_double2)
+DEF(abacus_double3)
+DEF(abacus_double4)
+DEF(abacus_double8)
+DEF(abacus_double16)
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT


### PR DESCRIPTION
These macros were being expanded to function definitions, to which an extraneous semicolon could produce a noisy compiler warning.