### PR TITLE
[cmake] Switch uses of CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR

### DIFF
--- a/modules/compiler/targets/host/CMakeLists.txt
+++ b/modules/compiler/targets/host/CMakeLists.txt
@@ -69,13 +69,13 @@ add_ca_library(compiler-host STATIC ${HOST_SOURCES})
 target_include_directories(compiler-host PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/builtins/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/compiler/source/base/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/compiler/builtins/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/utils/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/debug/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/compiler/multi_llvm/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/mux/source/host/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/mux/include>)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/source/base/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/builtins/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/utils/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/debug/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/multi_llvm/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/mux/source/host/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/mux/include>)
 
 target_compile_definitions(compiler-host PUBLIC
   $<$<TARGET_EXISTS:resources-host>:CA_ENABLE_HOST_BUILTINS>)

--- a/modules/utils/targets/host/CMakeLists.txt
+++ b/modules/utils/targets/host/CMakeLists.txt
@@ -24,6 +24,6 @@ add_ca_library(host-utils STATIC ${HOST_UTILS_SOURCES})
 
 target_include_directories(host-utils PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/modules/utils/include>)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/utils/include>)
 
 target_link_libraries(host-utils PUBLIC cargo)


### PR DESCRIPTION
Using `CMAKE_SOURCE_DIR` doesn't work correctly when OCK is built as a sub-project.

There are some further uses of `CMAKE_SOURCE_DIR` where we *check* whether it equals some other directory, and I've left those for now. This commit deals with uses of `CMAKE_SOURCE_DIR` to find include specific OCK directories.