### PR TITLE
[NFC] Move .cl sources to abacus_math_sources_device.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_math/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/source/abacus_math/CMakeLists.txt
@@ -45,9 +45,7 @@ set(abacus_math_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/fmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fmin.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fmod.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/fract.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/fract.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/frexp.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/frexp.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/half_cos.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/half_divide.cpp
@@ -67,7 +65,6 @@ set(abacus_math_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/ilogb.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ldexp.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/lgamma.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/lgamma_r.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/lgamma_r.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/log10.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/log1p.cpp
@@ -77,7 +74,6 @@ set(abacus_math_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/mad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/maxmag.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/minmag.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/modf.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/modf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/nan.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/native_cos.cpp
@@ -99,13 +95,11 @@ set(abacus_math_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/pown.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/powr.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/remainder.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/remquo.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/remquo.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rint.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rootn.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/round.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rsqrt.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/sincos.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/sincos.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sin.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sinh.cpp
@@ -121,6 +115,12 @@ set(abacus_math_sources_host ${abacus_math_sources}
   ${CMAKE_CURRENT_SOURCE_DIR}/inplace_sqrt.cpp
   PARENT_SCOPE)
 set(abacus_math_sources_device ${abacus_math_sources}
+  ${CMAKE_CURRENT_SOURCE_DIR}/fract.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/frexp.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/inplace_fma.ll.in
   ${CMAKE_CURRENT_SOURCE_DIR}/inplace_sqrt.ll.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/lgamma_r.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/modf.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/remquo.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/sincos.cl
   PARENT_SCOPE)


### PR DESCRIPTION
# Overview

[NFC] Move .cl sources to abacus_math_sources_device.

# Reason for change

We were relying on these being implicitly excluded for host, but this is fragile, and breaks if we are included from within LLVM which tries to set up support for compilation of .cl sources in its libclc.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
