### PR TITLE
[muxc] Link against compiler-base

### DIFF
--- a/modules/compiler/tools/muxc/CMakeLists.txt
+++ b/modules/compiler/tools/muxc/CMakeLists.txt
@@ -28,11 +28,10 @@ target_compile_definitions(muxc PRIVATE
   muxc_CL_STD_30=$<BOOL:${muxc_CL_STD_30}>)
 target_include_directories(muxc SYSTEM PUBLIC ${LLVM_INCLUDE_DIR})
 target_include_directories(muxc PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/source/base/include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source/cl/source/compiler/include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/multi_llvm/include>)
 target_link_libraries(muxc PRIVATE
-  compiler-static mux builtins cargo LLVMBitWriter LLVMIRReader)
+  compiler-static compiler-base LLVMBitWriter LLVMIRReader)
 target_resources(muxc NAMESPACES ${BUILTINS_NAMESPACES})
 
 install(TARGETS muxc RUNTIME DESTINATION bin COMPONENT muxc)


### PR DESCRIPTION
This tool includes code from 'base' and clang headers and so should link against the compiler-base library.

This will transitively add the appropriate clang headers to the include path. In a pre-installed/external LLVM build they'll be included anyway because they live at the same location as the LLVM headers. However, in a (eventually correct) in-tree LLVM build, the clang headers will be in a different location and will only be included by the compiler-base library, and not the compiler-static library.