### PR TITLE
Use include_directories for llvm includes under compiler

### DIFF
--- a/modules/compiler/CMakeLists.txt
+++ b/modules/compiler/CMakeLists.txt
@@ -17,6 +17,12 @@
 add_subdirectory(builtins)
 
 if(CA_RUNTIME_COMPILER_ENABLED)
+  # Apply LLVM_INCLUDE_DIR to everything under compilers. This will include
+  # things like loader which technically does not need it, but we test this
+  # path anyway for no llvm. If we are in tree LLVM this is done already
+  if (NOT OCK_IN_LLVM_TREE)
+    include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
+  endif()
   if(CA_ENABLE_TESTS)
     # Open up an active set of 'compiler' lit suites
     ca_umbrella_lit_testsuite_open(compiler)

--- a/modules/compiler/multi_llvm/CMakeLists.txt
+++ b/modules/compiler/multi_llvm/CMakeLists.txt
@@ -19,14 +19,4 @@ add_ca_interface_library(multi_llvm)
 target_include_directories(multi_llvm INTERFACE
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-# If we are in-tree LLVM then we already have the include_directories available
-# for LLVM_INCLUDE_DIR. Otherwise they are not set regardless of which LLVM
-# targets we depend on, so we set it as part of the interface for multi_llvm
-# which all compiler libraries that need llvm depend on.
-# TODO: Review whether there is a better way to do this.
-if (NOT OCK_IN_LLVM_TREE)
-  target_include_directories(multi_llvm SYSTEM INTERFACE
-    ${LLVM_INCLUDE_DIR})
-endif()
-
 # No need to append interface libraries to MODULES_LIBRARIES variable

--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -68,7 +68,7 @@ target_include_directories(spirv-ll PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source>)
 target_include_directories(spirv-ll SYSTEM PUBLIC
-  ${spirv-headers_SOURCE_DIR}/include ${LLVM_INCLUDE_DIR})
+  ${spirv-headers_SOURCE_DIR}/include)
 target_link_libraries(spirv-ll PUBLIC cargo multi_llvm compiler-pipeline LLVMCore LLVMBitWriter)
 
 add_subdirectory(tools)

--- a/modules/compiler/tools/muxc/CMakeLists.txt
+++ b/modules/compiler/tools/muxc/CMakeLists.txt
@@ -26,7 +26,6 @@ target_compile_definitions(muxc PRIVATE
   muxc_VERSION="${PROJECT_VERSION}"
   muxc_LLVM_VERSION="${LLVM_PACKAGE_VERSION}"
   muxc_CL_STD_30=$<BOOL:${muxc_CL_STD_30}>)
-target_include_directories(muxc SYSTEM PUBLIC ${LLVM_INCLUDE_DIR})
 target_include_directories(muxc PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source/cl/source/compiler/include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/multi_llvm/include>)

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -170,8 +170,6 @@ if(CA_VECZ_ONLY)
     add_llvm_loadable_module(vecz ${COMMON_SRCS})
   else()
     add_llvm_library(vecz ${COMMON_SRCS})
-    target_include_directories(vecz PUBLIC
-      "${LLVM_INCLUDE_DIRS}")
   endif()
 else()
   # We want a static library for linking with libOpenCL

--- a/source/vk/CMakeLists.txt
+++ b/source/vk/CMakeLists.txt
@@ -90,6 +90,11 @@ target_include_directories(VK PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(VK SYSTEM PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/external/Khronos/include)
+
+# TODO: has some llvm dependencies via spirv-ll/module.h. This should be looked at
+target_include_directories(VK SYSTEM PRIVATE
+  ${LLVM_INCLUDE_DIR})
+
 # TODO(CA-1643): Add fully configurable extension options.
 target_compile_definitions(VK PRIVATE
   CA_VK_KHR_get_physical_device_properties2=1


### PR DESCRIPTION
# Overview

Use include_directories for llvm includes under compiler

# Reason for change

llvm suggests using include_directories for llvm projects and it is currently does not feel very clean.

# Description of change

At the moment we effectively add target include directories by having dependencies on multi_llvm which in itself adds the target include directories.

llvm suggests using include_directories for llvm projects and adding it at the compiler level feels a cleaner solution.