### PR TITLE
DRAFT: Prefix compiler libs with ock-

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/CMakeLists.txt
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/CMakeLists.txt
@@ -50,8 +50,8 @@ if(CA_RUNTIME_COMPILER_ENABLED)
 
   target_link_libraries(compiler-refsi-g1-wi PUBLIC
     compiler-riscv-utils
-    compiler-pipeline
-    compiler-binary-metadata
+    ock-compiler-pipeline
+    ock-compiler-binary-metadata
     compiler-linker-utils
     refsidrv
     compiler-base

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/CMakeLists.txt
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/CMakeLists.txt
@@ -50,8 +50,8 @@ if(CA_RUNTIME_COMPILER_ENABLED)
 
   target_link_libraries(compiler-refsi-m1 PUBLIC
     compiler-riscv-utils
-    compiler-pipeline
-    compiler-binary-metadata
+    ock-compiler-pipeline
+    ock-compiler-binary-metadata
     compiler-linker-utils      
     refsidrv
     compiler-base

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
@@ -59,8 +59,8 @@ endif()
   target_link_libraries(compiler-{{cookiecutter.target_name}} PUBLIC
     compiler-base
     utils
-    compiler-pipeline
-    compiler-binary-metadata
+    ock-compiler-pipeline
+    ock-compiler-binary-metadata
     compiler-linker-utils
     LLVMCoverage LLVMDebugInfoCodeView LLVMExecutionEngine
     LLVMVectorize LLVMipo multi_llvm)

--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -91,7 +91,7 @@ list(TRANSFORM CLANG_LIBS
      APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 target_link_libraries(compiler-base PUBLIC
-  builtins cargo mux spirv-ll compiler-pipeline compiler-binary-metadata vecz
+  builtins cargo mux spirv-ll ock-compiler-pipeline ock-compiler-binary-metadata ock-vecz
   "${CLANG_LIBS}"
   # Link against version (for clang) on Windows.
   $<$<BOOL:${WIN32}>:version>

--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -69,7 +69,7 @@ target_include_directories(spirv-ll PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source>)
 target_include_directories(spirv-ll SYSTEM PUBLIC
   ${spirv-headers_SOURCE_DIR}/include)
-target_link_libraries(spirv-ll PUBLIC cargo multi_llvm compiler-pipeline LLVMCore LLVMBitWriter)
+target_link_libraries(spirv-ll PUBLIC cargo multi_llvm ock-compiler-pipeline LLVMCore LLVMBitWriter)
 
 add_subdirectory(tools)
 if(CA_ENABLE_TESTS)

--- a/modules/compiler/test/CMakeLists.txt
+++ b/modules/compiler/test/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(UnitCompiler PRIVATE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/include>)
 
 target_link_libraries(UnitCompiler PRIVATE cargo
-  compiler-static mux ca_gtest_main compiler-base compiler-pipeline compiler-binary-metadata)
+  compiler-static mux ca_gtest_main compiler-base ock-compiler-pipeline ock-compiler-binary-metadata)
 
 target_resources(UnitCompiler NAMESPACES ${BUILTINS_NAMESPACES})
 

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_ca_library(compiler-pipeline STATIC
+add_ca_library(ock-compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/StructTypeRemapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_kernel_wrapper_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_scheduling_parameters_pass.h
@@ -117,43 +117,43 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/work_item_loops_pass.cpp)
 
-target_include_directories(compiler-pipeline PUBLIC
+target_include_directories(ock-compiler-pipeline PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-target_compile_definitions(compiler-pipeline PRIVATE
+target_compile_definitions(ock-compiler-pipeline PRIVATE
   $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
   $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
   $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-target_link_libraries(compiler-pipeline PUBLIC
+target_link_libraries(ock-compiler-pipeline PUBLIC
  multi_llvm LLVMPasses LLVMTransformUtils)
 if(TARGET LLVMCore)
-  target_link_libraries(compiler-pipeline PUBLIC LLVMCore)
+  target_link_libraries(ock-compiler-pipeline PUBLIC LLVMCore)
 endif()
 
-add_ca_library(compiler-binary-metadata STATIC
+add_ca_library(ock-compiler-binary-metadata STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_metadata_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_analysis.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_hooks.h
   ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_analysis.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_hooks.cpp)
 
-target_include_directories(compiler-binary-metadata PUBLIC
+target_include_directories(ock-compiler-binary-metadata PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-target_compile_definitions(compiler-binary-metadata PRIVATE
+target_compile_definitions(ock-compiler-binary-metadata PRIVATE
   $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
   $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
   $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-target_link_libraries(compiler-binary-metadata PUBLIC
+target_link_libraries(ock-compiler-binary-metadata PUBLIC
   md_handler multi_llvm LLVMPasses LLVMTransformUtils)
 if(TARGET LLVMCore)
-  target_link_libraries(compiler-binary-metadata PUBLIC LLVMCore)
+  target_link_libraries(ock-compiler-binary-metadata PUBLIC LLVMCore)
 endif()
 
 

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -167,32 +167,32 @@ endif()
 
 if(CA_VECZ_ONLY)
   if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    add_llvm_loadable_module(vecz ${COMMON_SRCS})
+    add_llvm_loadable_module(ock-vecz ${COMMON_SRCS})
   else()
-    add_llvm_library(vecz ${COMMON_SRCS})
+    add_llvm_library(ock-vecz ${COMMON_SRCS})
   endif()
 else()
   # We want a static library for linking with libOpenCL
-  add_ca_library(vecz STATIC ${MODULES_LIBRARY_TYPE} ${COMMON_SRCS})
+  add_ca_library(ock-vecz STATIC ${MODULES_LIBRARY_TYPE} ${COMMON_SRCS})
 
   llvm_map_components_to_libnames(LLVM_LIBS
     support core analysis instcombine transformutils scalaropts ipo passes)
 endif()
 
-target_include_directories(vecz
+target_include_directories(ock-vecz
   PUBLIC $<BUILD_INTERFACE:${VECZ_PUBLIC_INCLUDE_DIR}>
   PRIVATE $<BUILD_INTERFACE:${VECZ_PRIVATE_INCLUDE_DIR}>)
-target_compile_options(vecz PRIVATE ${VECZ_COMPILE_OPTIONS})
-target_compile_definitions(vecz PRIVATE
+target_compile_options(ock-vecz PRIVATE ${VECZ_COMPILE_OPTIONS})
+target_compile_definitions(ock-vecz PRIVATE
   ${VECZ_COMPILE_DEFINITIONS})
 
-target_link_libraries(vecz PRIVATE compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
+target_link_libraries(ock-vecz PRIVATE ock-compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
 
 # intrinsics_gen uses tablegen to generate Attributes.inc, which is
 # (recursively) included by 'llvm/IR/Module.h', therefore this module depends
 # on that target.
 if(TARGET intrinsics_gen)
-  add_dependencies(vecz intrinsics_gen)
+  add_dependencies(ock-vecz intrinsics_gen)
 endif()
 
 if(NOT CA_VECZ_ONLY)
@@ -203,6 +203,6 @@ if(NOT CA_VECZ_ONLY)
 endif()
 
 # Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES vecz)
+list(APPEND MODULES_LIBRARIES ock-vecz)
 set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
   CACHE INTERNAL "List of module libraries.")

--- a/modules/compiler/vecz/tools/CMakeLists.txt
+++ b/modules/compiler/vecz/tools/CMakeLists.txt
@@ -23,5 +23,5 @@ llvm_map_components_to_libnames(llvm_libs all ${LLVM_TARGETS_TO_BUILD})
 # LLVM 8 adds these invalid libraries to the list, remove them to avoid
 # attempting to link against LTO-NOTFOUND and OptRemarks-NOTFOUND.
 list(REMOVE_ITEM llvm_libs LTO OptRemarks)
-target_link_libraries(veczc PUBLIC vecz multi_llvm compiler-pipeline ${llvm_libs})
+target_link_libraries(veczc PUBLIC ock-vecz multi_llvm ock-compiler-pipeline ${llvm_libs})
 install(TARGETS veczc RUNTIME DESTINATION bin COMPONENT VECZ)

--- a/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
+++ b/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
@@ -130,8 +130,8 @@ target_link_libraries({{cookiecutter.target_name}}
   PUBLIC
   cargo
   tracer
-  compiler-pipeline
-  compiler-binary-metadata
+  ock-compiler-pipeline
+  ock-compiler-binary-metadata
   utils
 )
 target_link_libraries({{cookiecutter.target_name}} PUBLIC loader)


### PR DESCRIPTION


# Overview

This prefixes some of the compiler libs (those under utils and vecz) with ock- to distinguish against llvm libraries if we are included from llvm.

# Reason for change

llvm libraries tend to have prefixes and this make it easier to see the ock libraries we build.
