### PR TITLE
Conditionally rename check targets in an LLVM tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,17 +318,24 @@ add_to_group(ComputeAorta
   UnitCL UnitCargo UnitCore UnitMux UnitCompiler UnitVK UnitMD FuzzCL
   clVectorAddition vkVectorAddition veczc UnitUR urVectorAddition)
 
-# Create a check-ComputeAorta target to build+test.
-add_ca_check_group(ComputeAorta DEPENDS ComputeAorta check)
+# Create a ComputeAorta check target to alias the global build+test check
+# target.
+add_ca_check_group(ComputeAorta NOGLOBAL
+  DEPENDS ${OCK_CHECK_TARGET} ComputeAorta)
 
-# Create a check-tidy-ComputeAorta target to build+test+tidy.
-add_ca_check_group(tidy-ComputeAorta DEPENDS check-ComputeAorta tidy)
+# Create a tidy-ComputeAorta check target to build+test+tidy.
+get_ock_check_name(check_ComputeAorta_name ComputeAorta)
+add_ca_check_group(tidy-ComputeAorta NOGLOBAL
+  DEPENDS ${check_ComputeAorta_name} tidy)
 
 if(CMAKE_CROSSCOMPILING)
-  # Create a check-cross-ComputeAorta target to build+test fast subset of checks.
-  add_ca_check_group(cross-ComputeAorta DEPENDS ComputeAorta
-    check-host-lit check-spirv-ll-lit check-vecz-lit check-UnitCargo
-    check-UnitMux check-UnitCL-offline)
+  # Create a cross-ComputeAorta check target to build+test fast subset of checks.
+  set(check_deps ComputeAorta)
+  foreach(target host-lit;spirv-ll-lit;vecz-lit;UnitCargo;UnitMux;UnitCL-offline)
+    get_ock_check_name(check_name ${target})
+    list(APPEND check_deps ${check_name})
+  endforeach()
+  add_ca_check_group(cross-ComputeAorta DEPENDS ${check_deps})
 endif()
 
 if(CA_ENABLE_TESTS)

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -352,6 +352,8 @@ The builtin CMake options used when invoking CMake on the command line.
   selection of testing is used by continuous integration to verify a baseline of
   correctness, individual test suites can also be tested in isolation by
   specifying the target to test.
+  * Note that when building inside an LLVM tree, all `check-*` targets are
+    instead names `check-ock-*`.
 * `internal_builtins`: Builds the compiler builtins functions, this target can
   be used even if automatically building the builtins was disabled with
   `CA_EXTERNAL_BUILTINS`, although this target will fail in cross compile

--- a/doc/source/cl/test/unitcl.rst
+++ b/doc/source/cl/test/unitcl.rst
@@ -222,6 +222,12 @@ convention. It is possible that additional tests are added by a customer team
 for a specific ComputeMux target that *do* test the compiler but *do not* match
 any of the filter words.
 
+.. note::
+
+  When building the oneAPI Construction Kit inside an LLVM tree, the
+  ``check-*`` targets are instead prefixed ``check-ock-``: `check-ock-UnitCL`,
+  etc.
+
 .. warning::
 
   If the intent of a UnitCL test is to test the compiler and the various

--- a/source/cl/cmake/AddCACL.cmake
+++ b/source/cl/cmake/AddCACL.cmake
@@ -148,8 +148,9 @@ function(add_ca_cl_icd_file target)
   install(FILES DESTINATION share/OpenCL/vendors COMPONENT CLIcd)
 endfunction()
 
-if(NOT TARGET check-cl)
-  add_ca_check_group(cl)
+get_ock_check_name(check_cl_name cl)
+if(NOT TARGET ${check_cl_name})
+  add_ca_check_group(cl NOGLOBAL)
 endif()
 
 #[=======================================================================[.rst:
@@ -177,6 +178,7 @@ function(add_ca_cl_check name)
   if (NOT CA_ENABLE_TESTS)
     return()
   endif()
+  get_ock_check_name(check_name ${name})
   cmake_parse_arguments(args "" "" "ENVIRONMENT" ${ARGN})
   set(environment ${args_ENVIRONMENT})
   if(CA_CL_ENABLE_ICD_LOADER)
@@ -218,22 +220,22 @@ function(add_ca_cl_check name)
       # to the Inject subdirectory of DumpDir and renamed.
       set(injectPrepareBins
         ${PROJECT_SOURCE_DIR}/scripts/testing/inject-prepare-bins.py)
-      add_custom_target(check-${name}-prepare
+      add_custom_target(${check_name}-prepare
         COMMAND ${PYTHON_EXECUTABLE}
           ${injectPrepareBins} --clean ${dumpDirectory}
-        DEPENDS check-${name}-dump
+        DEPENDS ${check_name}-dump
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Running ${name}-prepare checks")
 
-      # Enable injecting program binaries for check-${name}, this is stage 3
+      # Enable injecting program binaries for the check target. This is stage 3
       # which uses the same target as the non OpenCL-Intercept-Layer path.
       list(INSERT environment 0 "CLI_InjectProgramBinaries=1")
     endif()
   endif()
   add_ca_check(${name}
     ${args_UNPARSED_ARGUMENTS} ENVIRONMENT ${environment})
-  add_dependencies(check-cl check-${name})
+  add_dependencies(${check_cl_name} ${check_name})
   if(CA_CL_ENABLE_INTERCEPT_LAYER)
-    add_dependencies(check-${name} check-${name}-prepare)
+    add_dependencies(${check_name} ${check_name}-prepare)
   endif()
 endfunction()

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -428,8 +428,9 @@ function(add_ca_unitcl_check name)
     COMMAND UnitCL "--unitcl_platform=Codeplay Software Ltd."
     --gtest_output=xml:${PROJECT_BINARY_DIR}/${name}.xml ${args_ARGS} ${filter}
     ${environment} CLEAN ${PROJECT_BINARY_DIR}/${name}.xml NOGLOBAL DEPENDS UnitCL)
+  get_ock_check_name(check_name ${name})
   if (args_GROUP)
-    add_dependencies(${args_GROUP} check-${name})
+    add_dependencies(${args_GROUP} ${check_name})
   endif()
 endfunction()
 
@@ -440,12 +441,14 @@ add_ca_check_group(UnitCL-group-vecz)
 
 # Convenience function to add a UnitCL check in the default group
 function(add_ca_default_unitcl_check name)
-  add_ca_unitcl_check(${name} ${ARGV} GROUP check-UnitCL-group)
+  get_ock_check_name(group_check_name UnitCL-group)
+  add_ca_unitcl_check(${name} ${ARGV} GROUP ${group_check_name})
 endfunction()
 
 # Convenience function to add a UnitCL check in the vecz group
 function(add_ca_vecz_unitcl_check name)
-  add_ca_unitcl_check(${name} ${ARGV} GROUP check-UnitCL-group-vecz)
+  get_ock_check_name(group_check_name UnitCL-group-vecz)
+  add_ca_unitcl_check(${name} ${ARGV} GROUP ${group_check_name})
 endfunction()
 
 
@@ -492,9 +495,6 @@ add_ca_default_unitcl_check(UnitCL-prevec-vecz-full-scalarization COMPILER
 # At least one kernel is known not to vectorize in this config.
 add_ca_default_unitcl_check(UnitCL-prevec-opt-disable COMPILER
   ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-opt-disable")
-
-# Add this group to the global check target
-add_dependencies(check check-UnitCL-group)
 
 if(NOT CA_CL_DISABLE_UNITCL_VECZ_CHECKS)
   add_ca_vecz_unitcl_check(UnitCL-vecz COMPILER
@@ -556,9 +556,6 @@ if(NOT CA_CL_DISABLE_UNITCL_VECZ_CHECKS)
     ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
                 "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
     ARGS --vecz-check)
-
-  # Add this group to the global check target
-  add_dependencies(check check-UnitCL-group-vecz)
 endif()
 
 if(OCL_EXTENSION_cl_intel_unified_shared_memory)

--- a/source/vk/test/CMakeLists.txt
+++ b/source/vk/test/CMakeLists.txt
@@ -19,4 +19,7 @@ set(VK_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/UnitVK)
 
-add_ca_check_group(vk DEPENDS check-spirv-ll-lit check-UnitVK)
+get_ock_check_name(unitvk_check_name UnitVK)
+get_ock_check_name(spirv_ll_check_name spirv-ll-lit)
+add_ca_check_group(vk NOGLOBAL
+  DEPENDS ${unitvk_check_name} ${spirv_ll_check_name})


### PR DESCRIPTION
This commit changes how we name check targets when OCK is built inside an LLVM tree. LLVM includes external projects before unconditionally trying to create a `check` target. If OCK has already created such a target, CMake errors out.

Thus we name the `check` target to `check-ock` and for consistency name all check sub-targets to `check-ock-*`.

This fixes a configure-time error building OCK inside an LLVM tree with tests enabled, and should better "namespace" OCK's own testing compared with the parent project.