### PR TITLE
Fix check-ComputeAorta depending on check-cross-ComputeAorta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ if(CMAKE_CROSSCOMPILING)
     get_ock_check_name(check_name ${target})
     list(APPEND check_deps ${check_name})
   endforeach()
-  add_ca_check_group(cross-ComputeAorta DEPENDS ${check_deps})
+  add_ca_check_group(cross-ComputeAorta NOGLOBAL DEPENDS ${check_deps})
 endif()
 
 if(CA_ENABLE_TESTS)


### PR DESCRIPTION
A recent refactor accidentally made the global `check` target depend on `check-cross-ComputeAorta` which, because `check-ComputeAorta` depends on `check`, running `check-ComputeAorta` would run `check-cross-ComputeAorta`.

This in theory shouldn't be a problem but the `check-cross-ComputeAorta` target looks to make incorrect assumptions about which test/check targets are available, and unconditionally depends on them even when they may not exist.

This is problematic and so we should look at fixing the 'cross' target, but in the meantime we need to reinstate the correct intended dependency chain on the two check targets.