### PR TITLE
Unify check target names

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -45,11 +45,11 @@ jobs:
 
       - name: run just online lit
         run:
-          ninja -C build check-all-lit
+          ninja -C build check-ock-all-lit
 
       - name: run host online check
         run:
-          ninja -C build check-UnitCL
+          ninja -C build check-ock-UnitCL
 
       # use the previous build for online to get clc
       - name: build host x86_64 offline release
@@ -63,7 +63,7 @@ jobs:
 
       - name: run host x86_64 offline
         run:
-          ninja -C build_offline check-UnitCL
+          ninja -C build_offline check-ock-UnitCL
 
   # build and run riscv m1, execute UnitCL and lit tests
   run_riscv_m1:  
@@ -86,11 +86,11 @@ jobs:
 
       - name: run riscv M1 lit
         run:
-          ninja -C build check-all-lit
+          ninja -C build check-ock-all-lit
 
       - name: run riscv M1 UnitCL tests
         run:
-          ninja -C build check-UnitCL
+          ninja -C build check-ock-UnitCL
 
   # run clang-format-diff on the repo
   run_clang_format:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,27 +318,48 @@ add_to_group(ComputeAorta
   UnitCL UnitCargo UnitCore UnitMux UnitCompiler UnitVK UnitMD FuzzCL
   clVectorAddition vkVectorAddition veczc UnitUR urVectorAddition)
 
-# Create a ComputeAorta check target to alias the global build+test check
-# target.
-add_ca_check_group(ComputeAorta NOGLOBAL
-  DEPENDS ${OCK_CHECK_TARGET} ComputeAorta)
-
-# Create a tidy-ComputeAorta check target to build+test+tidy.
-get_ock_check_name(check_ComputeAorta_name ComputeAorta)
-add_ca_check_group(tidy-ComputeAorta NOGLOBAL
-  DEPENDS ${check_ComputeAorta_name} tidy)
-
-if(CMAKE_CROSSCOMPILING)
-  # Create a cross-ComputeAorta check target to build+test fast subset of checks.
-  set(check_deps ComputeAorta)
-  foreach(target host-lit;spirv-ll-lit;vecz-lit;UnitCargo;UnitMux;UnitCL-offline)
-    get_ock_check_name(check_name ${target})
-    list(APPEND check_deps ${check_name})
-  endforeach()
-  add_ca_check_group(cross-ComputeAorta NOGLOBAL DEPENDS ${check_deps})
-endif()
-
 if(CA_ENABLE_TESTS)
+  # Ensure we've created the global check target
+  if(NOT TARGET ${OCK_CHECK_TARGET})
+    message(FATAL_ERROR
+      "CA_ENABLE_TESTS is enabled but no OCK check target was created")
+  endif()
+
+  # Inject an extra dependency into the OCK global check target so that it
+  # builds the ComputeAorta target. This turns it into more of a build+test
+  # target than a pure test target.
+  add_dependencies(${OCK_CHECK_TARGET} ComputeAorta)
+  # Add a legacy target called 'check-ComputeAorta' which aliases the OCK
+  # global check target. This should be considered deprecated.
+  add_custom_target(check-ComputeAorta DEPENDS ${OCK_CHECK_TARGET})
+
+  if(TARGET tidy)
+    # Add an extra 'tidy' target which additionally depends on the tidy target
+    add_ca_check_group(tidy NOGLOBAL DEPENDS ${OCK_CHECK_TARGET} tidy)
+
+    # Add a legacy target called 'check-tidy-ComputeAorta' which aliases the OCK
+    # tidy target. This should be considered deprecated.
+    get_ock_check_name(tidy_check_name tidy)
+    add_custom_target(check-tidy-ComputeAorta DEPENDS ${tidy_check_name})
+  endif()
+
+  if(CMAKE_CROSSCOMPILING)
+    # Create an OCK cross check target to build+test fast subset of checks.
+    set(check_deps ComputeAorta)
+    foreach(target host-lit;spirv-ll-lit;vecz-lit;UnitCargo;UnitMux;UnitCL-offline)
+      if(TARGET ${target})
+        get_ock_check_name(check_name ${target})
+        list(APPEND check_deps ${check_name})
+      endif()
+    endforeach()
+    add_ca_check_group(cross NOGLOBAL DEPENDS ${check_deps})
+
+    # Add a legacy target called 'check-cross-ComputeAorta' which aliases the OCK
+    # cross target. This should be considered deprecated.
+    get_ock_check_name(cross_check_name cross)
+    add_custom_target(check-cross-ComputeAorta DEPENDS ${cross_check_name})
+  endif()
+
   # Close off the active set of 'all' lit suites
   ca_umbrella_lit_testsuite_close(all)
 
@@ -355,4 +376,3 @@ if(${CA_ENABLE_COVERAGE})
   add_coverage_xml_input()
   add_coverage_custom_target()
 endif()
-

--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -45,19 +45,18 @@ set(CA_CL_PLATFORM_VERSION_MINOR 0)
 
 # Set up a variable which both defines the global check target *and* the prefix
 # with which all of our sub-check targets are named.
-#
-# This variable is usually `check` - `check`, `check-UnitCL`, etc., as that is
-# familiar to most developers.
-#
-# However, if we build inside an LLVM tree, we define `check-ock` -
-# `check-ock`, `check-ock-UnitCL`, etc. While we may wish to add our tests to
-# the global set in an ideal world, LLVM calls into our code and then tries to
-# unconditionally define a 'check' target. This errors if we have already
-# created one.
-if (NOT OCK_IN_LLVM_TREE)
-  set(OCK_CHECK_TARGET check)
-else()
-  set(OCK_CHECK_TARGET check-ock)
+set(OCK_CHECK_TARGET check-ock)
+
+# Add the check-ock target to run all registered checks, see add_ca_check()
+# below, if cmake:variable:`CA_ENABLE_TESTS` is enabled.
+if (CA_ENABLE_TESTS)
+  add_custom_target(${OCK_CHECK_TARGET} COMMENT "OCK checks.")
+  # Add 'check' as an alias for 'check-ock', unless we're in tree, in which
+  # case the parent project may be defining its own top-level 'check' target.
+  if (NOT OCK_IN_LLVM_TREE)
+    add_custom_target(check)
+    add_dependencies(check check-ock)
+  endif()
 endif()
 
 if(NOT MSVC AND (CA_BUILD_32_BITS OR CMAKE_SIZEOF_VOID_P EQUAL 4) AND
@@ -703,12 +702,6 @@ macro(get_target_link_libraries variable target)
   get_target_link_libraries_recursive(${target})
 endmacro()
 
-# Add the check target to run all registered checks, see add_ca_check() below, if
-# cmake:variable:`CA_ENABLE_TESTS` is enabled.
-if (CA_ENABLE_TESTS)
-  add_custom_target(${OCK_CHECK_TARGET} COMMENT "ComputeAorta checks.")
-endif()
-
 if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
   message(WARNING "ComputeAorta check targets disabled as "
     "CMAKE_CROSSCOMPILING_EMULATOR was not specified")
@@ -886,7 +879,7 @@ endfunction()
 
   .. code:: CMake
 
-    add_ca_check_group(foo DEPENDS bar check-foo)
+    add_ca_check_group(foo DEPENDS bar check-ock-foo)
 #]=======================================================================]
 function(add_ca_check_group name)
   if (NOT CA_ENABLE_TESTS)
@@ -1549,17 +1542,17 @@ endfunction()
 
   Produces the following check targets, from most outermost to innermost:
 
-  ``check-all-lit:      foo, bar, baz``
+  ``check-ock-all-lit:      foo, bar, baz``
 
-  ``check-compiler-lit: bar, baz``
+  ``check-ock-compiler-lit: bar, baz``
 
-  ``check-foo-lit:      foo``
+  ``check-ock-foo-lit:      foo``
 
-  ``check-bar-lit:      bar``
+  ``check-ock-bar-lit:      bar``
 
-  ``check-baz-lit:      baz``
+  ``check-ock-baz-lit:      baz``
 
-  ``check-special-lit:  special``
+  ``check-ock-special-lit:  special``
 
 #]=======================================================================]
 

--- a/doc/cmake/AddCA.rst
+++ b/doc/cmake/AddCA.rst
@@ -65,12 +65,12 @@ parameterized ``prefix``.
 
 
 A case study of this is our helper function :cmake:command:`add_ca_check`,
-generating ``check`` and ``check-<name>`` build targets used by continuous
-integration to verify a baseline of correctness. :cmake:command:`add_ca_check`
-takes a single positional argument ``name``, for the target to generate a test
-for. A new testing target called ``check-${name}`` is created from the ``name``
-argument and a dependency on ``check-${name}`` is added to the ``check``
-target.
+generating ``check-ock`` and ``check-ock-<name>`` build targets used by
+continuous integration to verify a baseline of correctness.
+:cmake:command:`add_ca_check` takes a single positional argument ``name``, for
+the target to generate a test for. A new testing target called
+``check-ock-${name}`` is created from the ``name`` argument and a dependency on
+``check-ock-${name}`` is added to the ``check`` target.
 
 Additional :cmake:command:`add_ca_check` options to configure the testing
 target are parsed by forwarding on ``$ARGN`` `arguments`_ to

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -348,12 +348,10 @@ The builtin CMake options used when invoking CMake on the command line.
 
 * `ComputeAorta`: Build the OpenCL and Vulkan libraries, if present, and all
   their test suites.
-* `check`/`check-<target>`: Build and run all short running test suites, this
-  selection of testing is used by continuous integration to verify a baseline of
-  correctness, individual test suites can also be tested in isolation by
-  specifying the target to test.
-  * Note that when building inside an LLVM tree, all `check-*` targets are
-    instead names `check-ock-*`.
+* `check-ock`/`check-ock-<target>`: Build and run all short running test
+  suites, this selection of testing is used by continuous integration to verify
+  a baseline of correctness, individual test suites can also be tested in
+  isolation by specifying the target to test.
 * `internal_builtins`: Builds the compiler builtins functions, this target can
   be used even if automatically building the builtins was disabled with
   `CA_EXTERNAL_BUILTINS`, although this target will fail in cross compile
@@ -378,7 +376,7 @@ The builtin CMake options used when invoking CMake on the command line.
 * `CL`: Build only the OpenCL library, only available when OpenCL is enabled.
 * `UnitCL`: Build the UnitCL test suite, as well as the OpenCL library.
 * `OpenCLCTS`: Build the OpenCL library and all the CTS binaries.
-* `check-cl`: Build and run various OpenCL test suites, primarily UnitCL and
+* `check-ock-cl`: Build and run various OpenCL test suites, primarily UnitCL and
   selected short running OpenCL CTS tests.
 
 ##### oneAPI Construction Kit Vulkan CMake Build Targets
@@ -386,7 +384,7 @@ The builtin CMake options used when invoking CMake on the command line.
 * `VK`: Build only the Vulkan library, only available when Vulkan is enabled.
 * `UnitVK`: Build the UnitVK test suite, as well as the Vulkan library.
 * `VKICDManifest`: Generates the Vulkan ICD manifest, Linux only.
-* `check-vk`: Build and run UnitVK and spirv-ll lit tests.
+* `check-ock-vk`: Build and run UnitVK and spirv-ll lit tests.
 
 ## Compiling
 

--- a/doc/modules/mux/targets/host/lit.md
+++ b/doc/modules/mux/targets/host/lit.md
@@ -81,7 +81,7 @@ A third way is by invoking the CMake `check` target.
 Sample usage:
 
 ```console
-$ ninja check-host-lit
+$ ninja check-ock-host-lit
 [1/1] Running host-lit checks
 ```
 

--- a/doc/source/cl/extension.rst
+++ b/doc/source/cl/extension.rst
@@ -263,7 +263,7 @@ external OpenCL-Headers repository.
 
 USM functionality is tested in UnitCL by the tests found in the directory
 ``source/cl_intel_unified_shared_memory`` of UnitCL, which can be run with
-``--gtest_filter=*USM*`` or build target ``ninja check-UnitCL-USM``.
+``--gtest_filter=*USM*`` or build target ``ninja check-ock-UnitCL-USM``.
 
 Support for ``clHostMemAllocINTEL()`` is an optional feature of the extension
 which may be queried for using ``CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL``.

--- a/doc/source/cl/test/unitcl.rst
+++ b/doc/source/cl/test/unitcl.rst
@@ -205,16 +205,16 @@ Test provides:
 Default Test Variations
 -----------------------
 
-When running UnitCL via the oneAPI Construction Kit ``check-UnitCL*`` CMake
+When running UnitCL via the oneAPI Construction Kit ``check-ock-UnitCL*`` CMake
 targets, various compiler configurations will be run. For example, there is a
-configuration that sets ``-cl-opt-disable`` (``check-UnitCL-opt-disable``), one
-that sets ``-cl-wfv=always`` (``check-UnitCL-vecz``), etc. Some of these
-variations may have no effect on some customer targets. E.g., if a ComputeMux
-target does not use Vecz, then the ``check-UnitCL*`` CMake targets testing Vecz
-will effectively duplicate the ``check-UnitCL*`` CMake targets that don't test
-Vecz.
+configuration that sets ``-cl-opt-disable`` (``check-ock-UnitCL-opt-disable``),
+one that sets ``-cl-wfv=always`` (``check-ock-UnitCL-vecz``), etc. Some of
+these variations may have no effect on some customer targets. E.g., if a
+ComputeMux target does not use Vecz, then the ``check-ock-UnitCL*`` CMake
+targets testing Vecz will effectively duplicate the ``check-ock-UnitCL*`` CMake
+targets that don't test Vecz.
 
-To reduce the amount of duplicated testing, many of these ``check-UnitCL*``
+To reduce the amount of duplicated testing, many of these ``check-ock-UnitCL*``
 CMake targets run UnitCL with a filter of common compiler-related words.  This
 way, only tests that match one of these keywords are run more than once.  The
 filter used is a good match for the default UnitCL tests, but it is only
@@ -222,17 +222,11 @@ convention. It is possible that additional tests are added by a customer team
 for a specific ComputeMux target that *do* test the compiler but *do not* match
 any of the filter words.
 
-.. note::
-
-  When building the oneAPI Construction Kit inside an LLVM tree, the
-  ``check-*`` targets are instead prefixed ``check-ock-``: `check-ock-UnitCL`,
-  etc.
-
 .. warning::
 
   If the intent of a UnitCL test is to test the compiler and the various
   compiler configurations, then the test name **must** include one of the
-  compiler-related keywords. Otherwise, the ``check-UnitCL*`` CMake targets
+  compiler-related keywords. Otherwise, the ``check-ock-UnitCL*`` CMake targets
   will not run the test.
 
 .. note::

--- a/doc/tutorials/adding-a-custom-builtins-extension.rst
+++ b/doc/tutorials/adding-a-custom-builtins-extension.rst
@@ -374,6 +374,7 @@ way to how the LLVM tool ``opt`` can be used. Create the following file
 intrinsics ``llvm.riscv.clmul*``.
 
 All of the lit tests for the ``refsi-tutorial`` target can be run with building the
-``check-refsi-tutorial-lit`` target. If you use the create script for building new
-targets the target name will be used instead of ``refsi-tutorial``.
+``check-ock-refsi-tutorial-lit`` target. If you use the create script for
+building new targets the target name will be used instead of
+``refsi-tutorial``.
 

--- a/modules/compiler/spirv-ll/test/README.md
+++ b/modules/compiler/spirv-ll/test/README.md
@@ -1,6 +1,6 @@
 # spirv-ll lit tests
 
-To invoke this test suite use the `check-spirv-ll-lit` CMake target to run
+To invoke this test suite use the `check-ock-spirv-ll-lit` CMake target to run
 [lit][lit] on the configured test inputs residing in the build directory.
 
 ## Modes

--- a/source/cl/cmake/Options.cmake
+++ b/source/cl/cmake/Options.cmake
@@ -116,7 +116,7 @@ ca_option(CA_CL_EXTERNAL_INTERCEPT_LAYER_SOURCE_DIR PATH
 .. cmake:variable:: CA_CL_ENABLE_VECZ_VP_CHECK
 
   A boolean CMake option to enable vector-predication checks, including the
-  `check-UnitCL-prevec-vecz-vp-partial-scalarization` target.
+  `check-ock-UnitCL-prevec-vecz-vp-partial-scalarization` target.
 
   Default value
     ``OFF``
@@ -125,7 +125,7 @@ ca_option(CA_CL_EXTERNAL_INTERCEPT_LAYER_SOURCE_DIR PATH
 # and below (meaning it's not interesting) but on LLVM 13 it crashes the LLVM
 # (RVV) backend. We need to build LLVM with extra patches for this to work.
 ca_option(CA_CL_ENABLE_VECZ_VP_CHECK BOOL
-        "Enable check-UnitCL targets covering vecz vector predication" OFF)
+        "Enable check-ock-UnitCL targets covering vecz vector predication" OFF)
 
 #[=======================================================================[.rst:
 .. cmake:variable:: CA_CL_ENABLE_OFFLINE_KERNEL_TESTS


### PR DESCRIPTION
This commit attempts to streamline and make consistent our check target names, so that they are unconditionally named `check-ock-*` in all build configurations.

The generic `check` target still exists, but now it is an alias of the new global `check-ock` target, which depends on all the internal check targets such as `check-ock-UnitCL` etc.

This makes it easier to splice out the `check` target, and have everything remain internally consistent. It also means users and developers can consistently run `check-ock-*` targets without worrying about which build configuration they are in.

Notable exceptions are the now legacy `check-ComputeAorta`-style targets, which now alias (possibly new) `check-ock` versions:

* `check-ComputeAorta` aliases `check-ock`
* `check-tidy-ComputeAorta` aliases `check-ock-tidy`
* `check-cross-ComputeAorta` aliases `check-ock-cross`

We couldn't afford to rename `check-ComputeAorta` as `check-ock-ComputeAorta` using the same internal helper functions, so these old targets are now handled specially via custom targets.

This should help us slowly move to the new targets and eventually remove the 'ComputeAorta' styling, as it is no longer the official name of the OCK.

I've also made it so the `check-ock-tidy` target now requires the `tidy` target to be present and the `check-ock-cross` target now also requires all of its dependencies to exist, which should fix build issues in certain configurations.

All documentation which referred to `check-` or `check-ock` can now be unified to assume `check-ock`. I've still left in the internal lack of assumptions about the precise name, since we have the infrastructure for it and it should make the build system less brittle, but in documentation it is probably better to spell out explicitly, on balance.