### PR TITLE
Fix building of CL examples when CA_ENABLE_TESTS=OFF

### DIFF
--- a/modules/mux/targets/host/extension/example/CMakeLists.txt
+++ b/modules/mux/targets/host/extension/example/CMakeLists.txt
@@ -24,31 +24,33 @@ include(${ComputeAorta_SOURCE_DIR}/source/cl/cmake/AddCACL.cmake)
 add_ca_cl_executable(cl_ext_codeplay_example
   ${CMAKE_CURRENT_SOURCE_DIR}/main.c)
 
-add_ca_check_group(cl_ext_codeplay_example)
-get_ock_check_name(example_group_name cl_ext_codeplay_example)
+if(CA_ENABLE_TESTS)
+  add_ca_check_group(cl_ext_codeplay_example)
+  get_ock_check_name(example_group_name cl_ext_codeplay_example)
 
-# For each host device, create a check target running this example on that
-# device.
-foreach(device_name ${host_DEVICE_NAMES})
-  # Device names may have spaces and other awkward characters in them -
-  # convert to a name containing underscores.
-  string(REGEX REPLACE "[^A-Za-z0-9]" "_" underscore_device_name "${device_name}")
-  get_ock_check_name(device_example_name "cl_ext_codeplay_example-${underscore_device_name}")
-  # Do not automatically add this check to the global check target
-  # (NOGLOBAL) nor to the combined CL check target (NOGLOBALCL)
-  add_ca_cl_check(cl_ext_codeplay_example-${underscore_device_name}
-    NOGLOBAL NOGLOBALCL
-    COMMAND cl_ext_codeplay_example --platform ComputeAorta --device "${device_name}"
-    DEPENDS cl_ext_codeplay_example)
-  # Add this device-specific example to the more general group of this
-  # example on all devices.
-  add_dependencies(${example_group_name} ${device_example_name})
-endforeach()
+  # For each host device, create a check target running this example on that
+  # device.
+  foreach(device_name ${host_DEVICE_NAMES})
+    # Device names may have spaces and other awkward characters in them -
+    # convert to a name containing underscores.
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" underscore_device_name "${device_name}")
+    get_ock_check_name(device_example_name "cl_ext_codeplay_example-${underscore_device_name}")
+    # Do not automatically add this check to the global check target
+    # (NOGLOBAL) nor to the combined CL check target (NOGLOBALCL)
+    add_ca_cl_check(cl_ext_codeplay_example-${underscore_device_name}
+      NOGLOBAL NOGLOBALCL
+      COMMAND cl_ext_codeplay_example --platform ComputeAorta --device "${device_name}"
+      DEPENDS cl_ext_codeplay_example)
+    # Add this device-specific example to the more general group of this
+    # example on all devices.
+    add_dependencies(${example_group_name} ${device_example_name})
+  endforeach()
 
-# Add this example's group to the CL-specific group
-# Note that the CL-specific isn't a dependency of the global check target,
-# but the example group is.
-get_ock_check_name(check_cl_name cl)
-add_dependencies(${check_cl_name} ${example_group_name})
+  # Add this example's group to the CL-specific group
+  # Note that the CL-specific isn't a dependency of the global check target,
+  # but the example group is.
+  get_ock_check_name(check_cl_name cl)
+  add_dependencies(${check_cl_name} ${example_group_name})
+endif()
 
 install(TARGETS cl_ext_codeplay_example RUNTIME DESTINATION bin)

--- a/source/cl/examples/CMakeLists.txt
+++ b/source/cl/examples/CMakeLists.txt
@@ -31,42 +31,45 @@ function(add_ca_cl_example)
   target_include_directories(${ARGV0} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-  # Create a specific check target for each known device and add those to a
-  # group created for that example:
-  # * check-ock (and check-ock-cl)
-  #   * check-ock-example
-  #     * check-ock-example-device0
-  #     * check-ock-example-device1
-  # This way the example runs on each device when building the global check
-  # target, or the example's check target, but each device can be run
-  # individually if desired.
-  add_ca_check_group(${ARGV0})
-  get_ock_check_name(example_group_name ${ARGV0})
+  if (CA_ENABLE_TESTS)
+    # Create a specific check target for each known device and add those to a
+    # group created for that example:
+    # * check-ock (and check-ock-cl)
+    #   * check-ock-example
+    #     * check-ock-example-device0
+    #     * check-ock-example-device1
+    # This way the example runs on each device when building the global check
+    # target, or the example's check target, but each device can be run
+    # individually if desired.
+    add_ca_check_group(${ARGV0})
+    get_ock_check_name(example_group_name ${ARGV0})
 
-  foreach(target ${MUX_TARGET_LIBRARIES})
-    foreach(device_name ${${target}_DEVICE_NAMES})
-      # Device names may have spaces and other awkward characters in them -
-      # convert to a name containing underscores.
-      string(REGEX REPLACE "[^A-Za-z0-9]" "_" underscore_device_name "${device_name}")
-      # Do not automatically add this check to the global check target
-      # (NOGLOBAL) nor to the combined CL check target (NOGLOBALCL)
-      get_ock_check_name(device_example_name "${ARGV0}-${underscore_device_name}")
-      add_ca_cl_check("${ARGV0}-${underscore_device_name}"
-        NOGLOBAL NOGLOBALCL
-        COMMAND ${ARGV0} --platform ComputeAorta --device "${device_name}"
-        DEPENDS ${ARGV0})
+    foreach(target ${MUX_TARGET_LIBRARIES})
+      foreach(device_name ${${target}_DEVICE_NAMES})
+        # Device names may have spaces and other awkward characters in them -
+        # convert to a name containing underscores.
+        string(REGEX REPLACE "[^A-Za-z0-9]" "_" underscore_device_name "${device_name}")
+        # Do not automatically add this check to the global check target
+        # (NOGLOBAL) nor to the combined CL check target (NOGLOBALCL)
+        get_ock_check_name(device_example_name "${ARGV0}-${underscore_device_name}")
+        add_ca_cl_check("${ARGV0}-${underscore_device_name}"
+          NOGLOBAL NOGLOBALCL
+          COMMAND ${ARGV0} --platform ComputeAorta --device "${device_name}"
+          DEPENDS ${ARGV0})
 
-      # Add this device-specific example to the more general group of this
-      # example on all devices.
-      add_dependencies(${example_group_name} ${device_example_name})
+        # Add this device-specific example to the more general group of this
+        # example on all devices.
+        add_dependencies(${example_group_name} ${device_example_name})
+      endforeach()
     endforeach()
-  endforeach()
 
-  # Add this example's group to the CL-specific group
-  # Note that the CL-specific isn't a dependency of the global check target,
-  # but the example group is.
-  get_ock_check_name(check_cl_name cl)
-  add_dependencies(${check_cl_name} ${example_group_name})
+    # Add this example's group to the CL-specific group
+    # Note that the CL-specific isn't a dependency of the global check target,
+    # but the example group is.
+    get_ock_check_name(check_cl_name cl)
+    add_dependencies(${check_cl_name} ${example_group_name})
+
+  endif()
 
   install(TARGETS ${ARGV0}
     RUNTIME DESTINATION bin COMPONENT OCLExamples)


### PR DESCRIPTION
A previous change made the mistake of thinking that the examples weren't built at all when `CA_ENABLE_TESTS` was off, when in fact the examples are unconditionally built, but when `CA_ENABLE_TESTS` is off, the check targets are not built.

The trick is that `add_ca_cl_check` does nothing when `CA_ENABLE_TESTS` is off, so the targets that the group names depend on are not present.