### PR TITLE
[vecz] Fix dropped value analysis in OffsetInfo

### DIFF
--- a/modules/compiler/vecz/source/include/offset_info.h
+++ b/modules/compiler/vecz/source/include/offset_info.h
@@ -255,6 +255,12 @@ struct OffsetInfo {
   /// @param[in] Other the other OffsetInfo to copy from
   /// @return Reference to the current object for chaining.
   OffsetInfo &copyStrideFrom(const OffsetInfo &Other);
+
+  /// @brief Copies the stride and bitmask information from another OffsetInfo
+  /// into this one
+  /// @param[in] Other the other OffsetInfo to copy from
+  /// @return Reference to the current object for chaining.
+  OffsetInfo &copyStrideAndBitMaskFrom(const OffsetInfo &Other);
 };
 
 }  // namespace vecz

--- a/modules/compiler/vecz/source/include/offset_info.h
+++ b/modules/compiler/vecz/source/include/offset_info.h
@@ -75,7 +75,8 @@ struct OffsetInfo {
   uint64_t BitMask;
 
   /// @brief Construct a new offset information object from a general value
-  /// @param[in] B The StrideAnalysisResult used to retrieve other OffsetInfos.
+  /// @param[in] SAR The StrideAnalysisResult used to retrieve other
+  /// OffsetInfos.
   /// @param[in] V Offset value to analyze.
   OffsetInfo(StrideAnalysisResult &SAR, llvm::Value *V);
 
@@ -119,7 +120,7 @@ struct OffsetInfo {
   /// @brief Convert the bytewise stride into an element-wise stride based on
   /// the data type and data layout, as an integer.
   ///
-  /// @param[in] PtrTy The element data type.
+  /// @param[in] PtrEleTy The element data type.
   /// @param[in] DL The Data Layout.
   /// @return The memory stride as number of elements.
 
@@ -131,7 +132,7 @@ struct OffsetInfo {
   /// that the stride must be manifest first.
   ///
   /// @param[in] B an IRBuilder used for creating constants or instructions.
-  /// @param[in] PtrTy The element data type.
+  /// @param[in] PtrEleTy The element data type.
   /// @param[in] DL The Data Layout.
   /// @return The memory stride as number of elements.
   llvm::Value *buildMemoryStride(llvm::IRBuilder<> &B, llvm::Type *PtrEleTy,

--- a/modules/compiler/vecz/source/offset_info.cpp
+++ b/modules/compiler/vecz/source/offset_info.cpp
@@ -329,10 +329,10 @@ OffsetInfo &OffsetInfo::analyze(Value *Offset, StrideAnalysisResult &SAR) {
         return setKind(eOffsetUniformVariable);
       case compiler::utils::eBuiltinUniformityInstanceID:
         if (Builtin.properties & compiler::utils::eBuiltinPropertyLocalID) {
-          // If the local size is unknown (represented by zero), the
-          // resulting mask will be ~0ULL (all ones). Potentially, it is
-          // possible to use the CL_​DEVICE_​MAX_​WORK_​ITEM_​SIZES
-          // property as an upper bound in this case.
+          // If the local size is unknown (represented by zero), the resulting
+          // mask will be ~0ULL (all ones). Potentially, it is possible to use
+          // the CL_DEVICE_MAX_WORK_ITEM_SIZES property as an upper bound in
+          // this case.
           uint64_t LocalBitMask = SAR.UVR.VU.getLocalSize() - 1;
           LocalBitMask |= LocalBitMask >> 32;
           LocalBitMask |= LocalBitMask >> 16;

--- a/modules/compiler/vecz/source/offset_info.cpp
+++ b/modules/compiler/vecz/source/offset_info.cpp
@@ -275,6 +275,8 @@ OffsetInfo &OffsetInfo::analyze(Value *Offset, StrideAnalysisResult &SAR) {
     const auto RHS = SAR.analyze(Select->getOperand(2));
     if (LHS.hasStride() && RHS.hasStride() && LHS.StrideInt == RHS.StrideInt &&
         LHS.isStrideConstantInt()) {
+      // Merge the bitmasks from either source - we are selecting one of them.
+      BitMask = LHS.BitMask | RHS.BitMask;
       return copyStrideFrom(LHS);
     }
     return setMayDiverge();
@@ -282,13 +284,13 @@ OffsetInfo &OffsetInfo::analyze(Value *Offset, StrideAnalysisResult &SAR) {
 
   if (auto *Phi = dyn_cast<PHINode>(Offset)) {
     if (auto *const CVal = Phi->hasConstantValue()) {
-      return copyStrideFrom(SAR.analyze(CVal));
+      return copyStrideAndBitMaskFrom(SAR.analyze(CVal));
     }
 
     auto NumIncoming = Phi->getNumIncomingValues();
     if (NumIncoming == 1) {
       // LCSSA Phi, just go right through it..
-      return copyStrideFrom(SAR.analyze(Phi->getIncomingValue(0)));
+      return copyStrideAndBitMaskFrom(SAR.analyze(Phi->getIncomingValue(0)));
     } else if (NumIncoming == 2) {
       auto identifyIncrement = [&](Value *incoming) -> bool {
         if (auto *BOp = dyn_cast<BinaryOperator>(incoming)) {
@@ -306,9 +308,9 @@ OffsetInfo &OffsetInfo::analyze(Value *Offset, StrideAnalysisResult &SAR) {
 
       // Try the PHI node's incoming values both ways round.
       if (identifyIncrement(Phi->getIncomingValue(1))) {
-        return copyStrideFrom(SAR.analyze(Phi->getIncomingValue(0)));
+        return copyStrideAndBitMaskFrom(SAR.analyze(Phi->getIncomingValue(0)));
       } else if (identifyIncrement(Phi->getIncomingValue(0))) {
-        return copyStrideFrom(SAR.analyze(Phi->getIncomingValue(1)));
+        return copyStrideAndBitMaskFrom(SAR.analyze(Phi->getIncomingValue(1)));
       }
     }
     return setMayDiverge();
@@ -351,11 +353,11 @@ OffsetInfo &OffsetInfo::analyze(Value *Offset, StrideAnalysisResult &SAR) {
 
 OffsetInfo &OffsetInfo::analyzePtr(Value *Address, StrideAnalysisResult &SAR) {
   if (BitCastInst *BCast = dyn_cast<BitCastInst>(Address)) {
-    return copyStrideFrom(SAR.analyze(BCast->getOperand(0)));
+    return copyStrideAndBitMaskFrom(SAR.analyze(BCast->getOperand(0)));
   } else if (auto *ASCast = dyn_cast<AddrSpaceCastInst>(Address)) {
-    return copyStrideFrom(SAR.analyze(ASCast->getOperand(0)));
+    return copyStrideAndBitMaskFrom(SAR.analyze(ASCast->getOperand(0)));
   } else if (auto *IntPtr = dyn_cast<IntToPtrInst>(Address)) {
-    return copyStrideFrom(SAR.analyze(IntPtr->getOperand(0)));
+    return copyStrideAndBitMaskFrom(SAR.analyze(IntPtr->getOperand(0)));
   } else if (auto *Arg = dyn_cast<Argument>(Address)) {
     // 'Pointer return' arguments should be treated as having an implicit ItemID
     // offset. This allows memory operations to be packetized instead of
@@ -395,7 +397,7 @@ OffsetInfo &OffsetInfo::analyzePtr(Value *Address, StrideAnalysisResult &SAR) {
     // the IRBuilder insert point, we might not even be able to build the
     // offset expression instructions there.
     if (auto *const CVal = Phi->hasConstantValue()) {
-      return copyStrideFrom(SAR.analyze(CVal));
+      return copyStrideAndBitMaskFrom(SAR.analyze(CVal));
     }
 
     // In the simple case of a loop-incremented pointer using a GEP, we can
@@ -416,7 +418,7 @@ OffsetInfo &OffsetInfo::analyzePtr(Value *Address, StrideAnalysisResult &SAR) {
             return setMayDiverge();
           }
         }
-        return copyStrideFrom(SAR.analyze(Phi->getIncomingValue(0)));
+        return copyStrideAndBitMaskFrom(SAR.analyze(Phi->getIncomingValue(0)));
       }
     } else if (auto *const GEP =
                    dyn_cast<GetElementPtrInst>(Phi->getIncomingValue(0))) {
@@ -428,7 +430,7 @@ OffsetInfo &OffsetInfo::analyzePtr(Value *Address, StrideAnalysisResult &SAR) {
             return setMayDiverge();
           }
         }
-        return copyStrideFrom(SAR.analyze(Phi->getIncomingValue(1)));
+        return copyStrideAndBitMaskFrom(SAR.analyze(Phi->getIncomingValue(1)));
       }
     }
 
@@ -513,6 +515,8 @@ OffsetInfo &OffsetInfo::analyzePtr(Value *Address, StrideAnalysisResult &SAR) {
     // constant stride, the result will also have the same constant stride.
     if (LHS.hasStride() && RHS.hasStride() && LHS.StrideInt == RHS.StrideInt &&
         LHS.isStrideConstantInt()) {
+      // Merge the bitmasks from either source - we are selecting one of them.
+      BitMask = LHS.BitMask | RHS.BitMask;
       return copyStrideFrom(LHS);
     }
     return setMayDiverge();
@@ -1057,4 +1061,9 @@ OffsetInfo &OffsetInfo::copyStrideFrom(const OffsetInfo &Other) {
   StrideInt = Other.StrideInt;
   ManifestStride = Other.ManifestStride;
   return *this;
+}
+
+OffsetInfo &OffsetInfo::copyStrideAndBitMaskFrom(const OffsetInfo &Other) {
+  BitMask = Other.BitMask;
+  return copyStrideFrom(Other);
 }


### PR DESCRIPTION
There were several cases in the OffsetInfo analysis where the OffsetInfo
was told to copy the stride information from another value (typically
one of the instruction's source operands) but the bitmask was not
updated. This meant that the value analysis - which works backwards from
the leaf instruction - would "stop" at that point, and become incorrect
as it would not take into account the range of values that the source
may have.

This was problematic because the analysis would come to the conclusion
that a value has a safe range of values and a valid stride, when in fact
it was truncated from a larger value before being zero-extended, and
thus divergent.

This was found through a segfault/invalid access in one of ArrayFire's
CannyEdgeDetector kernels.

Oftentimes we want to copy the bitmask *and* stride information over, so
a convenience function has been introduced. Other times we need to be
careful to update the bitmask correctly before copying the stride
information.