### PR TITLE
Fix another bug in ldexp's earlier bugfix.

### DIFF
--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -430,9 +430,7 @@ struct HalfMathBuiltinsPow : HalfMathBuiltins {
   }
 };
 
-// The ldexp builtin is insufficiently precise - disable test until problems
-// are resolved.
-TEST_P(HalfMathBuiltins, DISABLED_Precision_08_Half_Ldexp) {
+TEST_P(HalfMathBuiltins, Precision_08_Half_Ldexp) {
   if (!UCL::hasHalfSupport(device)) {
     GTEST_SKIP();
   }
@@ -2232,12 +2230,12 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
   }
 
   if (!UCL::hasDenormSupport(device, CL_DEVICE_HALF_FP_CONFIG)) {
-    // All save one of the edge cases tested expect a denormal result,
+    // All save two of the edge cases tested expect a denormal result,
     // as the focus is on avoiding underflow to zero.
     GTEST_SKIP();
   }
 
-  const size_t N = 18;
+  const size_t N = 19;
   const std::pair<cl_half, cl_int> inputs[N] = {
       {0x21f8 /* 0.01165772 */, -17},
       {0x11f8 /* 0.0007286075 */, -13},
@@ -2257,6 +2255,7 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
       {0xfb93 /* -62048 */, -40},
       {0x7bed /* 64928 */, -40},
       {0xf934 /* -42624 */, -41},
+      {0x7287 /* 13368 */, 2},
   };
 
   const cl_half outputs[N] = {
@@ -2308,7 +2307,9 @@ TEST_P(ExecutionOpenCLC, Precision_90_Half_Ldexp_Edgecases) {
       // the lowest representable half rather than zero due to rounding.
       0x1, /* 5.960464477539063e-08 */
       // ldexp(-42624, -41) is too small to represent.
-      0x8000,
+      0x8000, /* -0.0 */
+      // ldexp(13368, 2) must not involve an infinite intermediate result.
+      0x7a87, /* 53472 */
   };
 
   AddInputBuffer(N, kts::Reference1D<cl_half>([&inputs](size_t i) {


### PR DESCRIPTION
# Overview

Fix another bug in ldexp's earlier bugfix.

# Reason for change

While 7a083327 noted that we should split -41 as -14, -14, -13, rather than -13, -13, -15, the way this was implemented was not quite right. It resulted in 2 being split into 2, 2, -2. The sign change here can lead to overflow in an intermediate result. Do this better and re-enable the disabled test.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
