### PR TITLE
Support -cl-fp32-correctly-rounded-divide-sqrt.

### DIFF
--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -711,13 +711,6 @@ Result BaseModule::parseOptions(cargo::string_view input_options,
     options.mad_enable = true;
   }
 
-  // TODO: CA-669 Change when we add support for this flag
-  if (options.fp32_correctly_rounded_divide_sqrt) {
-    addBuildError(
-        "Error compiling -cl-fp32-correctly-rounded-divide-sqrt not supported "
-        "on device.");
-    return invalid_options;
-  }
   return Result::SUCCESS;
 }
 
@@ -893,8 +886,6 @@ void BaseModule::populateCodeGenOpts(clang::CodeGenOptions &codeGenOpts) const {
     codeGenOpts.FP32DenormalMode = llvm::DenormalMode::getPositiveZero();
     codeGenOpts.FPDenormalMode = llvm::DenormalMode::getPositiveZero();
   }
-  // Currently this will always be true as we don't report support for the
-  // flag, and have not implemented the required sqrt builtin.  See CA-669.
   codeGenOpts.OpenCLCorrectlyRoundedDivSqrt =
       options.fp32_correctly_rounded_divide_sqrt;
 

--- a/source/cl/source/device.cpp
+++ b/source/cl/source/device.cpp
@@ -189,7 +189,8 @@ _cl_device_id::_cl_device_id(cl_platform_id platform,
       profiling_timer_resolution(5),                // Get from Mux?
       queue_properties(CL_QUEUE_PROFILING_ENABLE),  // Get from Mux?
       reference_count(1),  // All devices are root devices.
-      single_fp_config(setOpenCLFromMux(mux_device->info->float_capabilities)),
+      single_fp_config(setOpenCLFromMux(mux_device->info->float_capabilities) |
+                       CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT),
       type(),
       vendor_id(mux_device->info->khronos_vendor_id)
 #if defined(CL_VERSION_3_0)


### PR DESCRIPTION
# Overview

Support -cl-fp32-correctly-rounded-divide-sqrt.

# Reason for change

We previously had to disabled as our sqrt was not sufficiently accurate, but that was fixed by using LLVM's sqrt intrinsic. There does not seem to be anything else stopping us from supporting the option, so enable it.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

I have locally run the `divide_cr` and `sqrt_cr` single-precision OpenCL CTS tests with this change. Both pass.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
