### PR TITLE
Fix signed integer overflow in add_sat.

### DIFF
--- a/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
@@ -86,14 +86,18 @@ static T _(const T& x, const T& y) {
 
 template <typename T>
 struct add_sat_helper<T, true> {
-static T _(const T& x, const T& y) {
-  const T min = TypeTraits<T>::min();
-  const T max = TypeTraits<T>::max();
-  const T cond1 = (T)(x < (T)0) & (T)(y < (min - x));
-  const T cond2 = (T)(x >= (T)0) & (T)((max - x) < y);
-  const T add = x + y;
-  return relational::select(relational::select(add, min, cond1), max, cond2);
-}
+  static T _(const T &x, const T &y) {
+    typedef typename TypeTraits<T>::UnsignedType U;
+    const T min = TypeTraits<T>::min();
+    const T max = TypeTraits<T>::max();
+    // Unsigned subtraction cast back to signed is equivalent to signed
+    // subtraction with wraparound; use it to avoid undefined behavior that we
+    // cannot mask out.
+    const T cond1 = (T)(x < (T)0) & (T)(y < (T)((U)min - (U)x));
+    const T cond2 = (T)(x >= (T)0) & (T)((T)((U)max - (U)x) < y);
+    const T add = x + y;
+    return relational::select(relational::select(add, min, cond1), max, cond2);
+  }
 };
 
 template <typename T>


### PR DESCRIPTION
# Overview

Fix signed integer overflow in add_sat.

# Reason for change

This fixes an error seen in UBSAN builds. If x < (T)0, then min - x cannot overflow, but if x >= (T)0, it can. We were relying on the result of that overflow being ignored by masking it out, but it is undefined behavior to even perform the operation, so we need to avoid that.

# Description of change

Unsigned subtraction is well-defined for any values; we can use that instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
