### PR TITLE
[NFC] buildAfter: return IRBuilder<>.

### DIFF
--- a/modules/compiler/vecz/source/include/transform/packetization_helpers.h
+++ b/modules/compiler/vecz/source/include/transform/packetization_helpers.h
@@ -41,11 +41,11 @@ namespace vecz {
 class TargetInfo;
 struct SimdPacket;
 
-/// @brief Provides the insertion point after the value V. Intended to be used
-/// in IRBuilder constructor. If V has a position in the function, (e.g., an
-/// Instruction), this method will return the next point after that. If V has
-/// no position (e.g., a Constant or an Argument) then this method will return
-/// a suitable insertion point at the beginning of the function.
+/// @brief Determines the insertion point after the value V. If V has a position
+/// in the function, (e.g., an Instruction), this method will return an
+/// IRBuilder set to the next point after that. If V has no position (e.g., a
+/// Constant or an Argument) then this method will return an IRBuilder set to a
+/// suitable insertion point at the beginning of the function.
 ///
 /// @param[in] V Value to insert instructions after, if an llvm::Instruction.
 /// @param[in] F Function to insert instructions into, if V is not an
@@ -53,9 +53,9 @@ struct SimdPacket;
 /// @param[in] IsPhi true if the instructions to insert are phis, false if the
 /// insertion point should be after all phis in the basic block.
 ///
-/// @return Insertion Point.
-llvm::Instruction *buildAfter(llvm::Value *V, llvm::Function &F,
-                              bool IsPhi = false);
+/// @return IRBuilder set to a suitable insertion point.
+llvm::IRBuilder<> buildAfter(llvm::Value *V, llvm::Function &F,
+                             bool IsPhi = false);
 
 /// @brief Utility function for building a shufflevector instruction, absorbing
 /// its operands where possible.

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -99,7 +99,7 @@ Value *createFixedBroadcastOfScalableVector(const vecz::TargetInfo &TI,
 }  // namespace
 
 namespace vecz {
-Instruction *buildAfter(Value *V, Function &F, bool IsPhi) {
+IRBuilder<> buildAfter(Value *V, Function &F, bool IsPhi) {
   if (auto *const I = dyn_cast<Instruction>(V)) {
     BasicBlock::iterator Next = I->getIterator();
     const BasicBlock::iterator End = Next->getParent()->end();
@@ -107,14 +107,14 @@ Instruction *buildAfter(Value *V, Function &F, bool IsPhi) {
       ++Next;
     } while (!IsPhi && (Next != End) &&
              (isa<PHINode>(Next) || isa<AllocaInst>(Next)));
-    return &*Next;
+    return {I->getParent(), Next};
   }
   // Else find the first point in the function after any allocas.
   auto it = F.getEntryBlock().begin();
   while (isa<AllocaInst>(*it)) {
     ++it;
   }
-  return &*it;
+  return {&F.getEntryBlock(), it};
 }
 
 Constant *getShuffleMask(ShuffleVectorInst *shuffle) {

--- a/modules/compiler/vecz/source/transform/packetizer.cpp
+++ b/modules/compiler/vecz/source/transform/packetizer.cpp
@@ -1935,7 +1935,13 @@ Value *Packetizer::Impl::packetizeMaskVarying(Instruction *I) {
     // pressure, and to make it easier for CSE/GVN to combine them if there
     // are multiple uses of the same value (we could cache these?)
     auto *maskInst = dyn_cast<Instruction>(vecMask);
-    IRBuilder<> B(maskInst ? buildAfter(maskInst, F) : I);
+    IRBuilder<> B = [&] {
+      if (maskInst) {
+        return buildAfter(maskInst, F);
+      } else {
+        return IRBuilder<>(I);
+      }
+    }();
 
     Value *anyOfMask =
         createMaybeVPTargetReduction(B, TTI, vecMask, RecurKind::Or, VL);


### PR DESCRIPTION
# Overview

[NFC] buildAfter: return IRBuilder<>.

# Reason for change

In LLVM 19, we will no longer be able to use instruction pointers to keep track of insertion points. This change prepares for that by making a helper function that is only ever used to construct an IRBuilder<> return an IRBuilder<> directly.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
