### PR TITLE
Support reqd_work_group_size with less than 3 operands

### DIFF
--- a/modules/compiler/utils/source/metadata.cpp
+++ b/modules/compiler/utils/source/metadata.cpp
@@ -293,14 +293,12 @@ std::optional<unsigned> isSchedulingParameter(const Function &f, unsigned idx) {
 std::optional<std::array<uint64_t, 3>> parseRequiredWGSMetadata(
     const Function &f) {
   if (auto mdnode = f.getMetadata(ReqdWGSizeMD)) {
-    auto *const op0 = mdconst::extract<ConstantInt>(mdnode->getOperand(0));
-    auto *const op1 = mdconst::extract<ConstantInt>(mdnode->getOperand(1));
-    auto *const op2 = mdconst::extract<ConstantInt>(mdnode->getOperand(2));
-
-    // KLOCWORK "UNINIT.STACK.ARRAY.MUST" possible false positive
-    // This is normal std::array initialization
-    std::array<uint64_t, 3> wgs = {
-        {op0->getZExtValue(), op1->getZExtValue(), op2->getZExtValue()}};
+    std::array<uint64_t, 3> wgs = {0, 1, 1};
+    assert(mdnode->getNumOperands() >= 1 && mdnode->getNumOperands() <= 3 &&
+           "Unsupported number of operands in reqd_work_group_size");
+    for (const auto &[idx, op] : enumerate(mdnode->operands())) {
+      wgs[idx] = mdconst::extract<ConstantInt>(op)->getZExtValue();
+    }
     return wgs;
   }
   return std::nullopt;


### PR DESCRIPTION
# Overview

Adds support for handling the `reqd_work_group_size` metadata node with less than three operands.

# Reason for change

This is needed for the SYCL Native CPU integration in DPC++. DPC++ may generate metadata nodes with less than 3 operands.

# Description of change

Defaults to 1 for the unspecified dimensions, similarly to what the `LLVM-SPIRV Translator` [does](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/747ef0f0ec03a25b5fb4edf5f5bf43e794503806/lib/SPIRV/PreprocessMetadata.cpp#L131).

Added a lit test for the `reqd_work_group_size` metadata with one and two operands.