### PR TITLE
Keep debug information.

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
@@ -51,18 +51,16 @@ entry:
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
   %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
-; FIXME: We're dropping the llvm.dbg.declare/llvm.dbg.value for %a here - we
-; could probably preserve it.
-; CHECK-NOT: call void @llvm.dbg.value(
+; CHECK: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_A:![0-9]+]], metadata !DIExpression())
+; CHECK-SAME: !dbg [[A_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
   %0 = load i64, i64* %tid, align 8, !dbg !32
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %in1.addr, align 8, !dbg !32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %0, !dbg !32
   %2 = load i32, i32 addrspace(1)* %arrayidx, align 4, !dbg !32
   store i32 %2, i32* %a, align 4, !dbg !32
-; FIXME: We're dropping the llvm.dbg.declare/llvm.dbg.value for %a here - we
-; could probably preserve it.
-; CHECK-NOT: call void @llvm.dbg.value(
+; CHECK: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_B:![0-9]+]], metadata !DIExpression())
+; CHECK-SAME: !dbg [[B_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %b, metadata !20, metadata !29), !dbg !33
   %3 = load i64, i64* %tid, align 8, !dbg !33
   %4 = load i32 addrspace(1)*, i32 addrspace(1)** %in2.addr, align 8, !dbg !33

--- a/modules/compiler/vecz/test/lit/llvm/undef_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/undef_debug_info.ll
@@ -114,7 +114,3 @@ attributes #3 = { nobuiltin }
 
 ; Vectorized kernel function
 ; CHECK: @__vecz_v[[WIDTH:[0-9]+]]_test_fn({{.*}} !dbg {{![0-9]+}}
-
-; Check that there is no intrinsics using undefs
-; CHECK-NOT: call void @llvm.dbg.value(metadata {{.*}} undef
-; CHECK-NOT: call void @llvm.dbg.declare(metadata {{.*}} undef


### PR DESCRIPTION
# Overview

Keep debug information.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

DeleteDebugInfoInstructions has a comment explaining that it intends to remove invalid debug info instructions, but the ones that it is removing seem perfectly valid. Given that Fraser recently removed other generation of invalid debug info instructions, hopefully this means we no longer have invalid debug info that we need to clean up.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
