### PR TITLE
Update for LLVM 19.

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/basicblock_helper.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/basicblock_helper.h
@@ -1,0 +1,41 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef MULTI_LLVM_BASICBLOCK_HELPER_H_INCLUDED
+#define MULTI_LLVM_BASICBLOCK_HELPER_H_INCLUDED
+
+#include <llvm/IR/BasicBlock.h>
+#include <multi_llvm/llvm_version.h>
+
+namespace multi_llvm {
+inline void insertBefore(llvm::Instruction *const I,
+                         const llvm::BasicBlock::iterator InsertPos) {
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+  I->insertBefore(InsertPos);
+#else
+  I->insertBefore(&*InsertPos);
+#endif
+}
+
+inline llvm::BasicBlock::iterator getFirstNonPHIIt(llvm::BasicBlock *const BB) {
+#if LLVM_VERSION_GREATER_EQUAL(18, 0)
+  return BB->getFirstNonPHIIt();
+#else
+  return BB->getFirstNonPHI()->getIterator();
+#endif
+}
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_BASICBLOCK_HELPER_H_INCLUDED

--- a/modules/compiler/source/base/source/target.cpp
+++ b/modules/compiler/source/base/source/target.cpp
@@ -95,6 +95,12 @@ Result BaseTarget::init(uint32_t builtins_capabilities) {
         builtins_module_from_file->getTargetTriple()) {
       return Result::FAILURE;
     }
+
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    if (UseNewDbgInfoFormat && !builtins_module_from_file->IsNewDbgInfoFormat) {
+      builtins_module_from_file->convertToNewDbgValues();
+    }
+#endif
   }
 
   return initWithBuiltins(std::move(builtins_module_from_file));

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -99,6 +99,12 @@ compiler::Result HostTarget::initWithBuiltins(
     return compiler::Result::FAILURE;
   }
   builtins_host = std::move(loadedModule.get());
+
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  if (UseNewDbgInfoFormat && !builtins_host->IsNewDbgInfoFormat) {
+    builtins_host->convertToNewDbgValues();
+  }
+#endif
 #endif
 
   // initialize LLVM targets

--- a/modules/compiler/targets/riscv/test/lit/CLC/add.cl
+++ b/modules/compiler/targets/riscv/test/lit/CLC/add.cl
@@ -32,11 +32,9 @@
 // RUN: llvm-objdump --mattr=%vattr -d %t.o > %t_1s_v
 // RUN: FileCheck --check-prefixes 1S_V < %t_1s_v %s
 
-// Check that no vector flags will not produce a risc-v-v vsetvli instruction
-// Also check that it does not add more load word instruction than the two generated
-// without vectorization
+// Check that vector flags do not add more load word instruction than the two
+// generated without vectorization
 
-// NOVEC-NOT: vsetvli
 // NOVEC-COUNT-2: lw
 // NOVEC-NOT: lw
 
@@ -45,7 +43,7 @@
 // We want to ensure that standard vector width of 4 mode still produces the
 // same "add" name
 // V4: <__vecz_v4_add.mux-kernel-wrapper>
-// V4: vsetivli zero, 4, e32
+// V4: vsetivli zero, {{(0x)?}}4, e32
 
 // Check for vectorize factor of 1,S
 // This means that we use vscale x 1 in LLVM IR terms

--- a/modules/compiler/targets/riscv/test/lit/passes/link-builtins.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/link-builtins.ll
@@ -20,7 +20,7 @@ target triple = "spir64-unknown-unknown"
 target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; We don't really care *what* the abs function looks like, but check it's been materialized
-; CHECK: define {{.*}}spir_func i32 @_Z3absi(i32 {{.*%.+}}){{.*}} {
+; CHECK: define {{.*}}spir_func{{.*}} i32 @_Z3absi(i32 {{.*%.+}}){{.*}} {
 ; CHECK:   ret i32 {{.*}}
 ; CHECK: }
 

--- a/modules/compiler/utils/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/utils/include/compiler/utils/barrier_regions.h
@@ -29,6 +29,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
+#include <multi_llvm/llvm_version.h>
 
 #include "pass_functions.h"
 
@@ -154,6 +155,12 @@ class Barrier {
     return debug_intrinsics_;
   }
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  using debug_dp_values_t =
+      llvm::SmallVector<std::pair<llvm::DPValue *, unsigned>, 4>;
+  const debug_dp_values_t &getDebugDPValues() const { return debug_dp_values_; }
+#endif
+
   /// @brief gets the original function
   llvm::Function &getFunc() { return func_; }
   const llvm::Function &getFunc() const { return func_; }
@@ -256,6 +263,10 @@ class Barrier {
   debug_stub_map_t barrier_stub_call_map_;
   /// @brief List of debug intrinsics and byte offsets into live variable struct
   debug_intrinsics_t debug_intrinsics_;
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  /// @brief List of debug DPValues and byte offsets into live variable struct
+  debug_dp_values_t debug_dp_values_;
+#endif
 
   size_t size_t_bytes;
 

--- a/modules/compiler/utils/source/barrier_regions.cpp
+++ b/modules/compiler/utils/source/barrier_regions.cpp
@@ -982,6 +982,12 @@ void compiler::utils::Barrier::MakeLiveVariableMemType() {
         debug_intrinsics_.push_back(std::make_pair(dbgDeclare, offset));
       }
     }
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    const auto DPVDeclares = findDPVDeclares(member.value);
+    for (auto *const DPVDeclare : DPVDeclares) {
+      debug_dp_values_.push_back(std::make_pair(DPVDeclare, offset));
+    }
+#endif
     offset += member.size;
     live_variable_index_map_[std::make_pair(member.value, member.member_idx)] =
         field_tys.size();

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -107,6 +107,12 @@ IRBuilder<> buildAfter(Value *V, Function &F, bool IsPhi) {
       ++Next;
     } while (!IsPhi && (Next != End) &&
              (isa<PHINode>(Next) || isa<AllocaInst>(Next)));
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    // If there is debug info between this instruction and the next, insert
+    // before the debug info. This is required for PHIs and makes sense for
+    // other instructions too.
+    Next.setHeadBit(true);
+#endif
     return {I->getParent(), Next};
   }
   // Else find the first point in the function after any allocas.

--- a/modules/compiler/vecz/source/transform/scalarizer.cpp
+++ b/modules/compiler/vecz/source/transform/scalarizer.cpp
@@ -688,33 +688,13 @@ void Scalarizer::scalarizeDI(Instruction *Original, const SimdPacket *Packet,
     return;
   }
 
-  auto *const MDV = MetadataAsValue::getIfExists(Original->getContext(), LAM);
-  if (!MDV) {
-    return;
-  }
-
   // Contains processed SIMD values for which we create scalar debug
   // instructions and is used to avoid duplicate LLVM dbg.value's.
   SmallPtrSet<Value *, 4> VectorElements;
 
   DIBuilder DIB(*Original->getModule(), false);
-  for (User *U : MDV->users()) {
-    DILocalVariable *DILocal = nullptr;
-    DebugLoc DILoc;
 
-    // These methods aren't virtual in DbgInfoIntrinsic for some reason
-    // TODO CA-1115 - Support llvm.dbg.addr() intrinsic
-    if (DbgValueInst *const DVI = dyn_cast<DbgValueInst>(U)) {
-      DILocal = DVI->getVariable();
-      DILoc = DVI->getDebugLoc();
-    } else if (DbgDeclareInst *const DDI = dyn_cast<DbgDeclareInst>(U)) {
-      DILocal = DDI->getVariable();
-      DILoc = DDI->getDebugLoc();
-    } else {
-      continue;
-    }
-
-    // Create new llvm.dbg.value() intrinsic across enabled SIMD lanes
+  auto CreateAndInsertDIExpr = [&](auto InsertDIExpr) {
     const auto bitSize = Original->getType()->getScalarSizeInBits();
     for (unsigned lane = 0; lane < Width; ++lane) {
       Value *LaneVal = Packet->at(lane);
@@ -732,12 +712,61 @@ void Scalarizer::scalarizeDI(Instruction *Original, const SimdPacket *Packet,
             DIExpression::createFragmentExpression(DIB.createExpression(),
                                                    lane * bitSize, bitSize);
         if (DIExpr) {
-          DIB.insertDbgValueIntrinsic(LaneVal, DILocal, *DIExpr, DILoc,
-                                      Original);
+          InsertDIExpr(LaneVal, *DIExpr);
           VectorElements.insert(LaneVal);
         }
       }
     }
+  };
+
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  for (DPValue *const DPV : LAM->getAllDPValueUsers()) {
+    DILocalVariable *DILocal = nullptr;
+    DebugLoc DILoc;
+
+    switch (DPV->getType()) {
+      case DPValue::LocationType::Value:
+      case DPValue::LocationType::Declare:
+        DILocal = DPV->getVariable();
+        DILoc = DPV->getDebugLoc();
+        break;
+      default:
+        continue;
+    }
+
+    // Create new DPValue across enabled SIMD lanes
+    CreateAndInsertDIExpr([&](Value *LaneVal, DIExpression *DIExpr) {
+      DIB.insertDbgValueIntrinsic(LaneVal, DILocal, DIExpr, DILoc, Original);
+    });
+  }
+#endif
+
+  auto *const MDV = MetadataAsValue::getIfExists(Original->getContext(), LAM);
+  if (!MDV) {
+    return;
+  }
+
+  for (User *U : MDV->users()) {
+    DILocalVariable *DILocal = nullptr;
+    DebugLoc DILoc;
+
+    // These methods aren't virtual in DbgInfoIntrinsic for some reason
+    // TODO CA-1115 - Support llvm.dbg.addr() intrinsic
+    if (DbgValueInst *const DVI = dyn_cast<DbgValueInst>(U)) {
+      DILocal = DVI->getVariable();
+      DILoc = DVI->getDebugLoc();
+    } else if (DbgDeclareInst *const DDI = dyn_cast<DbgDeclareInst>(U)) {
+      DILocal = DDI->getVariable();
+      DILoc = DDI->getDebugLoc();
+    } else {
+      continue;
+    }
+
+    // Create new llvm.dbg.value() intrinsic across enabled SIMD lanes
+    CreateAndInsertDIExpr([&](Value *const LaneVal,
+                              DIExpression *const DIExpr) {
+      DIB.insertDbgValueIntrinsic(LaneVal, DILocal, DIExpr, DILoc, Original);
+    });
   }
 }
 


### PR DESCRIPTION
# Overview

Update for LLVM 19.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* When using the new debug info format, make sure to actually use the new debug info format by converting the builtins module after loading.
* When checking debug info, make sure to check both the old and the new debug info formats.
* When inserting debug info, make sure to insert in the appropriate format.
* When inserting PHIs, ensure they are inserted before any debug info. We are also inconsistent in whether trying to insert PHIs before or after existing PHIs; this commit tries to preserve the existing insertion points as much as possible.
* In add.cl, do not check that no vsetvli is generated. Even if we do not generate it, LLVM 19 generates it itself. This is fine.

# Anything else we should know?

The changes in `scalarizer.cpp` are covered by the existing `llvm/insert_element_debug_info.ll` test.
The changes in `work_item_loops_pass.cpp` are covered the existing `passes/barriers-dbg.ll` test.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
