### PR TITLE
[lld] Fix LLD library dependencies

### DIFF
--- a/modules/compiler/targets/riscv/CMakeLists.txt
+++ b/modules/compiler/targets/riscv/CMakeLists.txt
@@ -35,11 +35,7 @@ if(CA_RUNTIME_COMPILER_ENABLED)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
 
-  target_link_libraries(compiler-riscv PUBLIC
-    compiler-riscv-utils
-    compiler-linker-utils
-    LLVMCoverage LLVMDebugInfoCodeView LLVMExecutionEngine
-    LLVMVectorize LLVMipo multi_llvm)
+  target_link_libraries(compiler-riscv PUBLIC compiler-riscv-utils)
 
   add_mux_compiler_target(compiler-riscv
      COMPILER_INFO riscv::getInfos

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -159,14 +159,9 @@ endif()
 
 # Determine whether LLVM was built with LLD, in which case add a support
 # library that exposes lld to ComputeMux compiler targets.
-find_library(LLDELF_LIB lldELF PATHS
-            "${LLVM_INSTALL_PREFIX}/lib" NO_DEFAULT_PATH)
-
-if (LLDELF_LIB)
-  find_library(LLVMLTO_LIB LLVMLTO PATHS
-              "${LLVM_INSTALL_PREFIX}/lib" NO_DEFAULT_PATH)
-  find_library(LLDCOMMON_LIB lldCommon PATHS
-              "${LLVM_INSTALL_PREFIX}/lib" NO_DEFAULT_PATH)
+if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
+  list(APPEND CMAKE_MODULE_PATH ${CA_LLVM_INSTALL_DIR}/lib/cmake/lld)
+  include(LLDConfig)
 
   add_ca_library(compiler-linker-utils STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/lld_linker.h
@@ -174,21 +169,10 @@ if (LLDELF_LIB)
   )
 
   target_include_directories(compiler-linker-utils PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-
-  # The lld libraries require all llvm targets that are built under llvm to
-  # link their Codegen and AsmParser libraries.
-  set(lld_target_libs "")
-  foreach(llvm_sub_target ${LLVM_TARGETS_TO_BUILD})
-    foreach(component CodeGen AsmParser)
-      if("LLVM${llvm_sub_target}${component}" IN_LIST LLVM_AVAILABLE_LIBS)
-        list(APPEND lld_target_libs "LLVM${llvm_sub_target}${component}")
-      endif()
-    endforeach()
-  endforeach()
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
 
   target_link_libraries(compiler-linker-utils PUBLIC
-    cargo multi_llvm
-    ${LLDELF_LIB} ${LLDCOMMON_LIB} LLVMSupport ${lld_target_libs}
+    cargo multi_llvm lldELF lldCommon
   )
 endif()


### PR DESCRIPTION
The dependencies on the LLD libraries were not being resolved by CMake because we were linking against them not by their target names but by a string denoting their fully qualified path. This meant that CMake couldn't order the static libraries according to the dependency chains and it was random chance whether we managed to link successfully.

This issue was made manifest when building the host (with RISC-V enabled) and riscv targets together. The host compiler - being processed first - added a dependency on libLLVMRISCVCodeGen.a. The riscv target coming second then added a dependency on compiler-linker-utils which in turn had a dependency on libLLVMRISCVCodeGen.a.

Since a dependency on that library was already registered, it (and its dependencies like libLLVMCodeGen.a) came first in the link order before liblldCommon.a, which has a dependency on the same library. Manually ordering libLLVMCodeGen.a in compiler-linker-utils didn't work because CMake would prune the "duplicated" dependency.

By correctly linking using the libraries' target names, CMake can detect the dependencies and order libLLVMCodeGen.a after both of the libraries that depend on it.

Also while debugging the issue I noticed that the `compiler-riscv` library was linking against `compiler-riscv-utils` and a bunch of other libraries which `compiler-riscv-utils` itself was linking against. Since `compiler-riscv` doesn't use/export any symbols of its own, and it publicly links against `compiler-riscv-utils`, these dependencies are unnecessary.