### PR TITLE
Fix aarch64 failure due to flags for non-jit path

### DIFF
--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -73,9 +73,19 @@ static llvm::TargetMachine *createTargetMachine(llvm::StringRef CPU,
     Options.MCOptions.ABIName = ABI;
   }
 
+  // Aarch64 fails on UnitCL test
+  // Execution/Execution.Barrier_02_Barrier_No_Duplicates/OfflineOpenCLC if we
+  // don't set `JIT` to true. JIT for x86_64 and Aarch64 set the large code
+  // model, which seems to be to do with lack of guarantees of how far away the
+  // JIT memory managers find a new page. Because we use a similar mechanism for
+  // loading on Host regardless of JIT, we set the flag here to set up the code
+  // models for the architecture.
+  // TODO: Investigate whether we can use a loader that does not have this
+  // issue.
   return LLVMTarget->createTargetMachine(
-      Triple, CPU, Features, Options, llvm::Reloc::Model::Static,
-      llvm::CodeModel::Small, multi_llvm::CodeGenOptLevel::Aggressive);
+      Triple, CPU, Features, Options, /*RM=*/std::nullopt,
+      /*CM=*/std::nullopt, multi_llvm::CodeGenOptLevel::Aggressive,
+      /*JIT=*/true);
 }
 
 HostTarget::HostTarget(const HostInfo *compiler_info,


### PR DESCRIPTION
# Overview

Fix aarch64 failure due to flags for non-jit path by making the creation of TargetMachine closer to the JIT path.
# Reason for change

The cross aarch64 "host" target was crashing when running the offline test
Execution/Execution.Barrier_02_Barrier_No_Duplicates/OfflineOpenCLC.

# Description of change

This was found to be due to the flags passed to the creation of the TargetMachine being different to what is passed from the JITTargetMachineBuilder. The main ones that seemed to matter was the CodeModel and the `JIT` parameter.

This change uses the defaults for the CodeModel and RelocationModel and also sets the JIT parameter. The need for the JIT parameter should be investigated to understand why the failure happens.
