### PR TITLE
Fix quick cts testing for latest OpenCL-CTS

### DIFF
--- a/scripts/jenkins/cts_summary/opencl_conformance_tests_wimpy_very_quick.csv
+++ b/scripts/jenkins/cts_summary/opencl_conformance_tests_wimpy_very_quick.csv
@@ -2,8 +2,7 @@
 # The following are very quick, take less that a minute
 #######################################################
 
-Basic,basic/test_basic explicit_s2v_long
-Basic,basic/test_basic explicit_s2v_ulong
+Basic,basic/test_basic explicit_s2v
 
 Common Functions,commonfns/test_commonfns maxf
 Common Functions,commonfns/test_commonfns minf


### PR DESCRIPTION

# Overview

Changed to call explicit_2sv as the parameter of test_basic,

# Reason for change

We have a csv file used for testing MRs where we run OpenCL-CTS test. Since updating OpenCL-CTS some tests have changed.

