### PR TITLE
[NATIVECPU] Specify include path for multi_llvm with vecz/native cpu

### DIFF
--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -188,6 +188,7 @@ target_compile_definitions(vecz PRIVATE
 
 if(CA_NATIVE_CPU)
   target_link_libraries(vecz PRIVATE compiler-pipeline PUBLIC ${LLVM_LIBS})
+  target_include_directories(vecz PRIVATE ../multi_llvm/include)
 else()
   target_link_libraries(vecz PRIVATE compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
 endif()


### PR DESCRIPTION
# Overview

Quick fix that manually specifies the include path for `multi_llvm` in the `vecz` component when building for Native CPU