### PR TITLE
[NATIVECPU] Avoid specifying include path manually for multi_llvm and Native CPU

### DIFF
--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -116,9 +116,6 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/unique_opaque_structs_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/verify_reqd_sub_group_size_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/work_item_loops_pass.cpp)
-if(CA_NATIVE_CPU)
-  target_include_directories(compiler-pipeline PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../multi_llvm/include)
-endif()
 
 target_include_directories(compiler-pipeline PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
@@ -130,13 +127,8 @@ target_compile_definitions(compiler-pipeline PRIVATE
   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-if(CA_NATIVE_CPU)
-  target_link_libraries(compiler-pipeline PUBLIC
-    cargo md_handler LLVMPasses LLVMTransformUtils)
-else()
-  target_link_libraries(compiler-pipeline PUBLIC
-    cargo md_handler multi_llvm LLVMPasses LLVMTransformUtils)
-endif()
+target_link_libraries(compiler-pipeline PUBLIC
+  cargo md_handler multi_llvm LLVMPasses LLVMTransformUtils)
 
 if(TARGET LLVMCore)
   target_link_libraries(compiler-pipeline PUBLIC LLVMCore)
@@ -159,13 +151,8 @@ target_compile_definitions(compiler-binary-metadata PRIVATE
   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-if(CA_NATIVE_CPU)
-  target_link_libraries(compiler-binary-metadata PUBLIC
-    md_handler LLVMPasses LLVMTransformUtils)
-else()
-  target_link_libraries(compiler-binary-metadata PUBLIC
-    md_handler multi_llvm LLVMPasses LLVMTransformUtils)
-endif()
+target_link_libraries(compiler-binary-metadata PUBLIC
+  md_handler multi_llvm LLVMPasses LLVMTransformUtils)
 
 if(TARGET LLVMCore)
   target_link_libraries(compiler-binary-metadata PUBLIC LLVMCore)

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -186,11 +186,7 @@ target_compile_options(vecz PRIVATE ${VECZ_COMPILE_OPTIONS})
 target_compile_definitions(vecz PRIVATE
   ${VECZ_COMPILE_DEFINITIONS})
 
-if(CA_NATIVE_CPU)
-  target_link_libraries(vecz PRIVATE compiler-pipeline PUBLIC ${LLVM_LIBS})
-else()
-  target_link_libraries(vecz PRIVATE compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
-endif()
+target_link_libraries(vecz PRIVATE compiler-pipeline multi_llvm PUBLIC ${LLVM_LIBS})
 
 # intrinsics_gen uses tablegen to generate Attributes.inc, which is
 # (recursively) included by 'llvm/IR/Module.h', therefore this module depends


### PR DESCRIPTION
# Overview

We can avoid specifying the include path manually for `multi_llvm` when building OCK within DPC++.