### PR TITLE
[host] Add initial support for RISC-V relocations

### DIFF
--- a/modules/loader/include/loader/elf.h
+++ b/modules/loader/include/loader/elf.h
@@ -54,7 +54,8 @@ enum class Machine : uint16_t {
   MIPS = 0x08,
   ARM = 0x28,
   X86_64 = 0x3E,
-  AARCH64 = 0xB7
+  AARCH64 = 0xB7,
+  RISCV = 0xF3,
 };
 /// @brief Type of code the file contains.
 enum class Type : uint16_t {

--- a/modules/loader/include/loader/relocation_types.h
+++ b/modules/loader/include/loader/relocation_types.h
@@ -465,6 +465,23 @@ enum Type : uint32_t {
   R_AARCH64_P32_IRELATIVE = 0x0bc,
 };
 }
+
+// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#relocations
+namespace RISCV {
+enum Type : uint32_t {
+  R_RISCV_NONE = 0,
+  R_RISCV_64 = 2,
+  R_RISCV_CALL = 18,
+  R_RISCV_CALL_PLT = 19,
+  R_RISCV_PCREL_HI20 = 23,
+  R_RISCV_PCREL_LO12_I = 24,
+  R_RISCV_HI20 = 26,
+  R_RISCV_LO12_I = 27,
+  R_RISCV_ADD32 = 35,
+  R_RISCV_SUB32 = 39,
+};
+}  // namespace RISCV
+
 }  // namespace RelocationTypes
 }  // namespace loader
 

--- a/modules/loader/include/loader/relocations.h
+++ b/modules/loader/include/loader/relocations.h
@@ -51,6 +51,7 @@ struct Relocation {
       uint64_t value;
       uint64_t target;
     };
+    void reset() { stubs.clear(); }
     cargo::small_vector<Entry, 4> stubs;
     cargo::optional<uint64_t> getTarget(uint64_t value) const;
   };
@@ -78,7 +79,8 @@ struct Relocation {
   /// @note @p map must contain host CPU addresses to writable memory.
   ///
   /// @return Returns whether the relocation succeeded.
-  bool resolve(ElfFile &file, ElfMap &map, StubMap &stubs);
+  bool resolve(ElfFile &file, ElfMap &map, StubMap &stubs,
+               const std::vector<loader::Relocation> &relocations);
 };
 
 template <>
@@ -103,6 +105,15 @@ Relocation Relocation::fromElfEntry<Relocation::EntryType::Elf64RelA>(
 ///
 /// @return Returns whether all the relocations succeeded.
 bool resolveRelocations(ElfFile &file, ElfMap &map);
+
+/// @brief Returns the relocations for the given section.
+
+/// @return The (possibly empty) list of relocations from the section
+template <loader::Relocation::EntryType ET32,
+          loader::Relocation::EntryType ET64>
+std::vector<Relocation> collectSectionRelocations(
+    ElfFile &file, ElfMap &map, const loader::ElfFile::Section &section,
+    cargo::string_view prefix, ElfFields::SectionType type);
 
 }  // namespace loader
 


### PR DESCRIPTION
This adds support for RISC-V relocations - enough to permit the running
of UnitCL (in the default configuration). There are obviously many other
relocations for RISC-V but without test coverage those have been left
for future work.

Note that relocation support is still incomplete. There is no support
yet for the PLT or GOT sections, so if the executable is loaded too far
away from external symbols, the relocation process will fail at program
load time, complaining of an unreachable symbol. This situation is
entirely down to the in-process memory of the OpenCL location and the
machine it's running on, so cannot be easily pre-determined.

Locally, at least, all (offline) UnitCL tests pass in isolation but fail
when run together, because the binary is loaded too far away from some
symbols such as memcpy.

The ADD32 and SUB32 relocations only seem to appear for the PIC
relocation model, which is not being used in main nor in this PR, but
they are simple enough that including them should be fairly obviously
correct.