### PR TITLE
Round up memory_size.

### DIFF
--- a/modules/mux/targets/host/source/device.cpp
+++ b/modules/mux/targets/host/source/device.cpp
@@ -432,10 +432,10 @@ device_info_s::device_info_s(host::arch arch, host::os os, bool native,
   this->clock_frequency = native ? os_cpu_frequency() : 0;
   this->compute_units = native ? os_num_cpus() : 0;
   this->buffer_alignment = sizeof(uint64_t) * 16;
-  // TODO redmine(8386): Reported memory size is quartered in order to pass the
+  // TODO Reported memory size is quartered (rounded up) in order to pass the
   // OpenCL CTS however this probably should be an OCL specific fix and not in
   // the host target.
-  this->memory_size = native ? os_memory_bounded_size() / 4 : 0;
+  this->memory_size = native ? (os_memory_bounded_size() - 1) / 4 + 1 : 0;
   // All memory could be allocated at once.
   this->allocation_size = this->memory_size;
   this->cache_size = native ? os_cache_size() : 0;


### PR DESCRIPTION
# Overview

Round up memory_size.

# Reason for change

We calculate memory_size as os_memory_bounded_size() / 4, but on 32-bit platforms with more than 4GiB of memory, os_memory_bounded_size() is 0xffffffff, so we end up calculating memory_size as 0x3fffffff. Given that we are calculating memory_size this way specifically for OpenCL CTS which assumes that it sees a multiple of various pattern sizes it uses, make it more suitable for OpenCL CTS by rounding up.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
