### PR TITLE
Cookie changes required to build offline including atomic64

### DIFF
--- a/modules/mux/cookie/hooks/post_gen_project.py
+++ b/modules/mux/cookie/hooks/post_gen_project.py
@@ -33,6 +33,9 @@ def copy_file_replace_riscv(src_dir, src_file, dst_dir, dst_file=None):
                 line = ("/// Copyright (C) Codeplay Software Limited. All Rights Reserved.\n")
                 if "{{cookiecutter.copyright_name}}" != "":
                     line += ("/// Additional changes Copyright (C) {{cookiecutter.copyright_name}}. All Rights\n/// Reserved.\n")
+            # Replace 64 bit for device_info.cpp since we currently copy risc-v base file
+            if "{{cookiecutter.capabilities_atomic64}}" == "false" and "device_info.cpp" in src_path:
+                line = line.replace(" | mux_atomic_capabilities_64bit", "")
             fout.write(line)
         #close input and output files
         fin.close()

--- a/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
+++ b/modules/mux/cookie/{{cookiecutter.target_name}}/CMakeLists.txt
@@ -130,9 +130,7 @@ target_link_libraries({{cookiecutter.target_name}}
   PUBLIC
   cargo
   tracer
-  compiler-pipeline
-  compiler-binary-metadata
-  utils
+  md_handler
 )
 target_link_libraries({{cookiecutter.target_name}} PUBLIC loader)
 if(NOT CA_HAL_{{cookiecutter.target_name_capitals}}_NAME STREQUAL "" AND TARGET "hal_${CA_HAL_{{cookiecutter.target_name_capitals}}_NAME}")
@@ -152,6 +150,9 @@ if({{cookiecutter.target_name_capitals}}_32_BITS)
 else()
   list(APPEND {{cookiecutter.target_name}}Capabilities "64bit")
 endif()
+{%- if cookiecutter.capabilities_atomic64 == "true" %}
+list(APPEND {{cookiecutter.target_name}}Capabilities "atomic64")
+{%- endif %}  
 
 if({{cookiecutter.target_name_capitals}}_FP64)
   list(APPEND {{cookiecutter.target_name}}Capabilities "fp64")

--- a/scripts/create_target.py
+++ b/scripts/create_target.py
@@ -49,6 +49,7 @@ Optional overrides:
         "bit_width"                 : 32 or 64 bits.
         "capabilities_fp16"         : true if has fp16 capability else false.
         "capabilities_fp64"         : true if has fp64 capability else false.
+        "capabilities_atomic64"     : true if has atomic64 capability else false (true default).
         "feature"                   : A list of features (normally tutorials) to enable as a ';' separated string
                                       Tutorials can be part finished e.g. clmul_1 or just clmul
                                       Current list is "replace_mem", "refsi_wrapper_pass" and "clmul"

--- a/scripts/default_target_cookie.json
+++ b/scripts/default_target_cookie.json
@@ -11,6 +11,7 @@
   "bit_width": "64",
   "capabilities_fp16": "false",
   "capabilities_fp64": "true",
+  "capabilities_atomic64": "true",
   "feature" : "",
   "copyright_name" : ""
 }


### PR DESCRIPTION

# Overview

Cookie changes required to build offline including atomic64, and library dependencies

# Reason for change

An offline target could not build offline for two reasons:
* atomic64 was enabled at the cpp level but not the cmake level and was not configurable either way
* The mux dependencies include compilers and did not include md_api.

# Description of change

Added a extra field for the cookie to allow the capability to atomic64
to be acted on and updated the post_gen_project.py to act on this to
update the .cpp file after copying.

CMake adjusted to act on the atomic64 change and correct the library
dependencies.