### PR TITLE
Use PIC_ reloc model when link_shared is set in cookie target

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -227,7 +227,8 @@ static llvm::TargetMachine *createTargetMachine(const {{cookiecutter.target_name
 
   return llvm_target->createTargetMachine(
       target.llvm_triple, target.llvm_cpu, target.llvm_features, options,
-      llvm::Reloc::Model::Static, llvm::CodeModel::Small,
+      {{cookiecutter.link_shared}} ? llvm::Reloc::Model::PIC_ : llvm::Reloc::Model::Static,
+      llvm::CodeModel::Small,
       multi_llvm::CodeGenOptLevel::Aggressive);
 }
 


### PR DESCRIPTION
# Overview

For using a cpu model based on dlopen set the PIC_ relocation model when we create the target machine. This is based off the link_shared cookie option.

# Reason for change

Shared libraries requite PIC_
