### PR TITLE
Fix syntax in ock_demo workflow

### DIFF
--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Get Intel OneAPI Nightly Release
         run: |
-        # Update the nightly release from intel/llvm from 2024-03-04 to daily once
-        # everything has stablized
-        wget "https://github.com/intel/llvm/releases/download/nightly-2024-03-04/sycl_linux.tar.gz"
-        mkdir linux_nightly_release
-        tar -xzf sycl_linux.tar.gz -C linux_nightly_release
+          # Update the nightly release from intel/llvm from 2024-03-04 to daily once
+          # everything has stablized
+          wget "https://github.com/intel/llvm/releases/download/nightly-2024-03-04/sycl_linux.tar.gz"
+          mkdir linux_nightly_release
+          tar -xzf sycl_linux.tar.gz -C linux_nightly_release
 
       - name: Test RSICV examples
         run: |


### PR DESCRIPTION

# Reason for change

As the spacing and syntax is not checked if the workflow is not run in the PR, this went in without raising any errors.

