### PR TITLE
Update for LLVM 19.

### DIFF
--- a/modules/compiler/utils/source/work_item_loops_pass.cpp
+++ b/modules/compiler/utils/source/work_item_loops_pass.cpp
@@ -415,7 +415,8 @@ struct ScheduleGenerator {
       preheader->moveAfter(block);
       exitBlock->moveAfter(preheader);
 
-      auto needLoop = new ICmpInst(*block, CmpInst::ICMP_NE, zero, totalSize);
+      auto *const needLoop = CmpInst::Create(
+          Instruction::ICmp, CmpInst::ICMP_NE, zero, totalSize, "", block);
 
       BranchInst::Create(preheader, exitBlock, needLoop, block);
 
@@ -551,8 +552,8 @@ struct ScheduleGenerator {
           tailUniformBlock =
               BasicBlock::Create(context, "ca_tail_uniform_load", func);
 
-          auto *const needTail =
-              new ICmpInst(*block, CmpInst::ICMP_EQ, totalSize, zero);
+          auto *const needTail = CmpInst::Create(
+              Instruction::ICmp, CmpInst::ICMP_EQ, totalSize, zero, "", block);
           BranchInst::Create(tailUniformBlock, mainUniformBlock, needTail,
                              block);
         }
@@ -694,8 +695,9 @@ struct ScheduleGenerator {
         subgroupMergePhi = PHINode::Create(i32Ty, 2, "", mainExitBB);
         subgroupMergePhi->addIncoming(i32Zero, block);
 
-        auto needMain =
-            new ICmpInst(*block, CmpInst::ICMP_NE, zero, mainLoopLimit);
+        auto *const needMain =
+            CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_NE, zero,
+                            mainLoopLimit, "", block);
 
         BranchInst::Create(mainPreheaderBB, mainExitBB, needMain, block);
       }
@@ -806,8 +808,8 @@ struct ScheduleGenerator {
         tailPreheaderBB->moveAfter(mainExitBB);
         tailExitBB->moveAfter(tailPreheaderBB);
 
-        auto needPeeling =
-            new ICmpInst(*mainExitBB, CmpInst::ICMP_NE, zero, peel);
+        auto *const needPeeling = CmpInst::Create(
+            Instruction::ICmp, CmpInst::ICMP_NE, zero, peel, "", mainExitBB);
 
         BranchInst::Create(tailPreheaderBB, tailExitBB, needPeeling,
                            mainExitBB);
@@ -1007,8 +1009,9 @@ struct ScheduleGenerator {
                       scanMergePhi->addIncoming(ivs1[1], block);
                     }
 
-                    auto needMain = new ICmpInst(*block, CmpInst::ICMP_NE, zero,
-                                                 mainLoopLimit);
+                    auto *const needMain =
+                        CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_NE,
+                                        zero, mainLoopLimit, "", block);
 
                     BranchInst::Create(mainPreheaderBB, mainExitBB, needMain,
                                        block);
@@ -1118,8 +1121,9 @@ struct ScheduleGenerator {
                     tailPreheaderBB->moveAfter(mainExitBB);
                     tailExitBB->moveAfter(tailPreheaderBB);
 
-                    auto needPeeling =
-                        new ICmpInst(*mainExitBB, CmpInst::ICMP_NE, zero, peel);
+                    auto *const needPeeling =
+                        CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_NE,
+                                        zero, peel, "", mainExitBB);
 
                     BranchInst::Create(tailPreheaderBB, tailExitBB, needPeeling,
                                        mainExitBB);
@@ -1642,7 +1646,8 @@ Function *compiler::utils::WorkItemLoopsPass::makeWrapperFunction(
             BasicBlock::Create(context, "barrier.branch", new_wrapper);
         auto *const ld_next_id = new LoadInst(index_type, nextID, "", br_block);
         auto *const cmp_id =
-            new ICmpInst(*br_block, CmpInst::ICMP_EQ, ld_next_id, bb_id);
+            CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ, ld_next_id,
+                            bb_id, "", br_block);
         BranchInst::Create(bbs[successors[0]], bbs[successors[1]], cmp_id,
                            br_block);
 

--- a/modules/compiler/vecz/source/control_flow_boscc.cpp
+++ b/modules/compiler/vecz/source/control_flow_boscc.cpp
@@ -760,9 +760,10 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
       BOSCCIndirTag.loop->loop->addBasicBlockToLoop(BOSCCIndir, *LI);
     }
 
-    ICmpInst *cond = new ICmpInst(
-        *runtimeCheckerBlock, CmpInst::ICMP_EQ,
-        PassState.getMaskInfo(uniformB).exitMasks.lookup(succ), trueCI);
+    auto *cond =
+        CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ,
+                        PassState.getMaskInfo(uniformB).exitMasks.lookup(succ),
+                        trueCI, "", runtimeCheckerBlock);
     BranchInst::Create(succ, BOSCCIndir, cond, runtimeCheckerBlock);
 
     if (i > 0) {
@@ -775,9 +776,10 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
   }
 
   BasicBlock *succ = succs[size - 1];
-  ICmpInst *cond = new ICmpInst(
-      *runtimeCheckerBlock, CmpInst::ICMP_EQ,
-      PassState.getMaskInfo(uniformB).exitMasks.lookup(succ), trueCI);
+  auto *cond =
+      CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ,
+                      PassState.getMaskInfo(uniformB).exitMasks.lookup(succ),
+                      trueCI, "", runtimeCheckerBlock);
 
   BasicBlock *connectionPoint = target;
 

--- a/modules/compiler/vecz/source/control_flow_roscc.cpp
+++ b/modules/compiler/vecz/source/control_flow_roscc.cpp
@@ -128,8 +128,8 @@ bool ControlFlowConversionState::ROSCCGadget::run(Function &F) {
 
     BasicBlock *ReturnBlock = Which ? SuccT : SuccF;
     Value *Cond = Branch->getCondition();
-    ICmpInst *newCond =
-        new ICmpInst(*BB, CmpInst::ICMP_EQ, Cond, Which ? falseCI : trueCI);
+    auto *newCond = CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ, Cond,
+                                    Which ? falseCI : trueCI, "", BB);
     newCond->setName(Twine(Cond->getName(), ".ROSCC"));
     BranchInst::Create(newBB, ReturnBlock, newCond, BB);
 


### PR DESCRIPTION
# Overview

Update for LLVM 19.

# Reason for change

LLVM 19 changes ICmpInst's constructor to take a BasicBlock * rather than a BasicBlock &.

# Description of change

Use CmpInst::Create instead which continues to work across versions.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
