### PR TITLE
Handle barriers with no successor

### DIFF
--- a/modules/compiler/test/lit/passes/work-item-loop-no-successor.ll
+++ b/modules/compiler/test/lit/passes/work-item-loop-no-successor.ll
@@ -1,0 +1,44 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify < %s | FileCheck %s
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define internal spir_kernel void @foo(ptr %an_arg) #0 {
+entry:
+  %mux_call = call i64 @__mux_get_local_id(i32 0) #12
+  br label %barrier
+
+barrier:                                          ; preds = %entry
+  call void @__mux_work_group_barrier(i32 1, i32 2, i32 912) #12
+  tail call void @llvm.trap()
+  unreachable
+}
+
+declare i64 @__mux_get_local_id(i32)
+
+declare void @__mux_work_group_barrier(i32, i32, i32)
+
+declare void @llvm.trap()
+
+declare void @llvm.assume(i1)
+
+attributes #0 = { "mux-kernel"="entry-point" }
+
+; CHECK: exitIR12:                                         ; preds = %exitIR11
+; CHECK:   call void @llvm.trap()
+; CHECK:   unreachable


### PR DESCRIPTION
Currently code similar to 
```
define internal spir_kernel void @__vecz_v8__ZTSZZN8orderingclEvENKUlRN4sycl3_V17handlerEE_clES3_EUlT_E_(ptr addrspace(3) noundef align 1 %_arg_arr_acc, ptr addrspace(3) noundef align 4 %_arg_local_acc,
ptr addrspace(1) noundef align 1 %_arg_res_acc, ptr noundef align 8 %_arg_res_acc9) local_unnamed_addr #7 !srcloc !10 !kernel_arg_buffer_location !11 !kernel_arg_runtime_aligned !12 !kernel_arg_exclusive
_ptr !12 !sycl_fixed_targets !13 !sycl_kernel_omit_args !14 !codeplay_ca_vecz.derived !21 {
entry:
  %mux_call7 = call i64 @__mux_get_num_groups(i32 0) #12
  %mux_call9 = call i64 @__mux_get_local_size(i32 0) #12
  %mux_call11 = call i64 @__mux_get_local_size(i32 0) #12
  %mux_call8 = call i64 @__mux_get_num_groups(i32 0) #12
  %mux_call13 = call i64 @__mux_get_group_id(i32 0) #12
  %mux_call12 = call i64 @__mux_get_group_id(i32 0) #12
  %mux_call10 = call i64 @__mux_get_local_size(i32 0) #12
  %mux_call5 = call i64 @__mux_get_local_id(i32 0) #12
  %mux_call = call i64 @__mux_get_global_offset(i32 0) #12
  %mux_call6 = call i64 @__mux_get_local_id(i32 0) #12
  %.splatinsert1 = insertelement <8 x i64> poison, i64 %mux_call6, i64 0
  %.splat2 = shufflevector <8 x i64> %.splatinsert1, <8 x i64> poison, <8 x i32> zeroinitializer
  %0 = add <8 x i64> %.splat2, <i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7>
  %mux_call4 = call i64 @__mux_get_global_offset(i32 0) #12
  %arrayidx.i = getelementptr inbounds i8, ptr addrspace(3) %_arg_arr_acc, i64 %mux_call6
  %arrayidx.ascast.i = addrspacecast ptr addrspace(3) %arrayidx.i to ptr
  store <8 x i8> zeroinitializer, ptr %arrayidx.ascast.i, align 1
  br label %barrier

barrier:                                          ; preds = %entry
  call void @__mux_work_group_barrier(i32 1, i32 2, i32 912) #12
  store <8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>, ptr %arrayidx.ascast.i, align 1
  %cmp.i3 = icmp ult <8 x i64> %0, <i64 2147483648, i64 2147483648, i64 2147483648, i64 2147483648, i64 2147483648, i64 2147483648, i64 2147483648, i64 2147483648>
  %1 = extractelement <8 x i1> %cmp.i3, i64 0
  %2 = extractelement <8 x i1> %cmp.i3, i64 1
  %3 = extractelement <8 x i1> %cmp.i3, i64 2
  %4 = extractelement <8 x i1> %cmp.i3, i64 3
  %5 = extractelement <8 x i1> %cmp.i3, i64 4
  %6 = extractelement <8 x i1> %cmp.i3, i64 5
  %7 = extractelement <8 x i1> %cmp.i3, i64 6
  %8 = extractelement <8 x i1> %cmp.i3, i64 7
  call void @llvm.assume(i1 %1)
  call void @llvm.assume(i1 %2)
  call void @llvm.assume(i1 %3)
  call void @llvm.assume(i1 %4)
  call void @llvm.assume(i1 %5)
  call void @llvm.assume(i1 %6)
  call void @llvm.assume(i1 %7)
  call void @llvm.assume(i1 %8)
  %conv.i = trunc i64 %mux_call6 to i32
  store atomic volatile i32 %conv.i, ptr addrspace(3) %_arg_local_acc unordered, align 4
  tail call void @llvm.trap()
  unreachable
}
```
Leads to a crash in `makeWrapperFunction`. This PR tries to address this by adding a call to `llvm.trap` in the basic block that terminates the wrapper function for the barrier region.