### PR TITLE
city_runner: Do not exit early.

### DIFF
--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -47,12 +47,7 @@ class CTSTestRun(TestRunBase):
         pass_pair_pattern = re.compile(b"^PASSED (\d+) of (\d+) tests\.$")
         fail_single_pattern = re.compile(b"^(FAILED .+\.|.+FAILED\.?)$")
         fail_pair_pattern = re.compile(b"^FAILED (\d+) of (\d+) tests\.$")
-        skipped_pattern = re.compile(
-            b"(.*Skipping test\.+|skipping|SKIPPED.+)$")
-        zerorun_pattern = re.compile(b"^Tests completed: 0$")
         doubles_unsupported_pattern = re.compile(b".*Has Double\? NO$")
-        extension_unsupported_pattern = re.compile(
-            b"\w+ extension version \d\.\d is not supported by the device")
 
         # Individual SPIR tests use yet another format to report test results.
         # To avoid false positive we want to match the current test name.
@@ -67,88 +62,71 @@ class CTSTestRun(TestRunBase):
                 spir_pass_expr = "^%s passed\.$" % spir_test_name
                 spir_pass_pattern = re.compile(spir_pass_expr.encode("utf8"))
 
-        pass_single = False
-        fail_single = False
-        fail_pair = None
-        pass_pair = None
-        skipped = False
-        zero_tests_ran = False
-        doubles_supported = True
+        self.status = "SKIP"
+        self.passed_tests, self.total_tests = 0, 0
 
         # Look for specific patterns in the output text.
         for line in stream:
+            pass_single = False
+            fail_single = False
+            fail_pair = None
+            pass_pair = None
+
             line = line.rstrip()
             fail_pair_match = fail_pair_pattern.match(line)
             if fail_pair_match:
                 fail_pair = (int(fail_pair_match.group(1)),
                              int(fail_pair_match.group(2)))
-                break
             elif fail_single_pattern.match(line):
                 fail_single = True
-                break
-            elif doubles_unsupported_pattern.match(line):
-                doubles_supported = False
-            elif zerorun_pattern.match(line):
-                zero_tests_ran = True
-            elif extension_unsupported_pattern.match(line):
-                skipped = True
             else:
                 pass_pair_match = pass_pair_pattern.match(line)
                 if pass_pair_match:
                     pass_pair = (int(pass_pair_match.group(1)),
                                  int(pass_pair_match.group(2)))
-                    break
-                elif skipped_pattern.match(line):
-                    skipped = True
-                    break
                 elif pass_single_pattern.match(line):
                     pass_single = True
-                    break
                 elif spir_pass_pattern and spir_pass_pattern.match(line):
                     pass_single = True
 
-        # Analyze the results.
-        if fail_pair:
-            self.status = "FAIL"
-            # Frailties in how the CTS is implemented means we can end up with
-            # more failed tests than tests run. In the case where we've only
-            # run a single test we can reasonably set the number of fails to 1.
-            if fail_pair[0] > fail_pair[1]:
-                if fail_pair[1] == 1:
-                    fail_pair = (1, 1)
-                    stdout.write(
-                        "WARNING: More than a single fail, defaulting "
-                        "number of failing tests to 1.")
-                else:
-                    stdout.write("WARNING: Number of failed tests is greater "
-                                 "than the total tests run! This will cause "
-                                 "inaccuracies in calculated pass percentage.")
+            # Analyze the results.
+            if fail_pair:
+                status = "FAIL"
+                # Frailties in how the CTS is implemented means we can end up with
+                # more failed tests than tests run. In the case where we've only
+                # run a single test we can reasonably set the number of fails to 1.
+                if fail_pair[0] > fail_pair[1]:
+                    if fail_pair[1] == 1:
+                        fail_pair = (1, 1)
+                        stdout.write(
+                            "WARNING: More than a single fail, defaulting "
+                            "number of failing tests to 1.")
+                    else:
+                        stdout.write("WARNING: Number of failed tests is greater "
+                                     "than the total tests run! This will cause "
+                                     "inaccuracies in calculated pass percentage.")
 
-            self.total_tests = fail_pair[1]
-            self.passed_tests = self.total_tests - fail_pair[0]
-        elif fail_single:
-            self.status = "FAIL"
-        elif pass_pair:
-            if pass_pair[0] < pass_pair[1]:
-                self.status = "FAIL"
+                total_tests = fail_pair[1]
+                passed_tests = self.total_tests - fail_pair[0]
+            elif fail_single:
+                status = "FAIL"
+                passed_tests, total_tests = 0, 1
+            elif pass_pair:
+                if pass_pair[0] < pass_pair[1]:
+                    status = "FAIL"
+                else:
+                    status = "PASS"
+                passed_tests, total_tests = pass_pair
+            elif pass_single:
+                status = "PASS"
+                passed_tests, total_tests = 1, 1
             else:
-                self.status = "PASS"
-            self.passed_tests, self.total_tests = pass_pair
-        elif pass_single:
-            self.status = "PASS"
-        elif skipped:
-            self.status = "SKIP"
-            self.total_tests = 0  # There were no tests.
-        elif zero_tests_ran:
-            skip_double = "double" in self.test.name and not doubles_supported
-            if skip_double:
-                # We expected zero tests to run.
-                self.total_tests = 0
-                self.status = "SKIP"
-            else:
-                self.status = "FAIL"
-        else:
-            self.status = "FAIL"
+                continue
+
+            if self.status == "SKIP" or status == "FAIL":
+                self.status = status
+            self.passed_tests += passed_tests
+            self.total_tests += total_tests
 
         # Special cases.
         if self.return_code:
@@ -159,19 +137,3 @@ class CTSTestRun(TestRunBase):
             if self.test.executable.name.find("headers") >= 0:
                 # The 'headers' executable always returns zero.
                 self.status = "PASS"
-
-        # Detect the total number of tests.
-        if self.total_tests is None:
-            if self.test.executable.name.endswith("half"):
-                # 'half' tests either report 'FAILED x of 2 tests' or
-                # 'PASSED test' which is inconsistent.
-                self.total_tests = 2
-            else:
-                self.total_tests = 1
-
-        # Detect the number of passed tests.
-        if self.passed_tests is None:
-            if self.status in "PASS":
-                self.passed_tests = self.total_tests
-            else:
-                self.passed_tests = 0


### PR DESCRIPTION
# Overview

city_runner: Do not exit early.

# Reason for change

When running a full test executable, it will print results for each individual subtest. We want to get all the results.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
