### PR TITLE
Fix build with LLVM 19 again.

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -1914,7 +1914,14 @@ llvm::Error DebugInfoBuilder::create<DebugDeclare>(const OpExtInst &opc) {
       module.llvmModule->getContext(), di_local->getLine(),
       /*Column=*/0, di_local->getScope());
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  assert(
+      !module.llvmModule->IsNewDbgInfoFormat &&
+      "Expected module to remain in old debug info format while being built");
+  llvm::DbgInstPtr dbg_declare;
+#else
   llvm::Instruction *dbg_declare;
+#endif
   if (insert_pt == insert_bb->end()) {
     dbg_declare = getDIBuilder(op).insertDeclare(
         /*Storage*/ variable, di_local, di_expr, di_loc, insert_bb);
@@ -1923,7 +1930,11 @@ llvm::Error DebugInfoBuilder::create<DebugDeclare>(const OpExtInst &opc) {
         /*Storage*/ variable, di_local, di_expr, di_loc, &*insert_pt);
   }
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  module.addID(opc.IdResult(), op, dbg_declare.get<llvm::Instruction *>());
+#else
   module.addID(opc.IdResult(), op, dbg_declare);
+#endif
   return llvm::Error::success();
 }
 
@@ -1978,7 +1989,14 @@ llvm::Error DebugInfoBuilder::create<DebugValue>(const OpExtInst &opc) {
 
   llvm::DIExpression *di_expr = expr_or_error.get();
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  assert(
+      !module.llvmModule->IsNewDbgInfoFormat &&
+      "Expected module to remain in old debug info format while being built");
+  llvm::DbgInstPtr dbg_value;
+#else
   llvm::Instruction *dbg_value;
+#endif
   if (insert_pt == insert_bb->end()) {
     dbg_value = getDIBuilder(op).insertDbgValueIntrinsic(
         variable, di_local, di_expr, di_loc, insert_bb);
@@ -1987,7 +2005,11 @@ llvm::Error DebugInfoBuilder::create<DebugValue>(const OpExtInst &opc) {
         variable, di_local, di_expr, di_loc, &*insert_pt);
   }
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  module.addID(opc.IdResult(), op, dbg_value.get<llvm::Instruction *>());
+#else
   module.addID(opc.IdResult(), op, dbg_value);
+#endif
   return llvm::Error::success();
 }
 


### PR DESCRIPTION
# Overview

Fix build with LLVM 19 again.

# Reason for change

LLVM 19 makes more debug info changes that we need to account for.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
