### PR TITLE
Another fix for LLVM 19.

### DIFF
--- a/modules/compiler/utils/source/cl_builtin_info.cpp
+++ b/modules/compiler/utils/source/cl_builtin_info.cpp
@@ -3584,6 +3584,16 @@ Function *CLBuiltinLoader::materializeBuiltin(StringRef BuiltinName,
       return nullptr;
     }
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    if (Current->IsNewDbgInfoFormat != BuiltinModule->IsNewDbgInfoFormat) {
+      if (BuiltinModule->IsNewDbgInfoFormat) {
+        Current->convertToNewDbgValues();
+      } else {
+        Current->convertFromNewDbgValues();
+      }
+    }
+#endif
+
     // Find any callees in the function and add them to the list.
     for (BasicBlock &BB : *Current) {
       for (Instruction &I : BB) {

--- a/modules/compiler/utils/source/link_builtins_pass.cpp
+++ b/modules/compiler/utils/source/link_builtins_pass.cpp
@@ -136,6 +136,16 @@ void compiler::utils::LinkBuiltinsPass::cloneBuiltins(
 
     assert(!Error && "Bitcode materialization failed!");
 
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    if (BuiltinFn->IsNewDbgInfoFormat != BuiltinsModule.IsNewDbgInfoFormat) {
+      if (BuiltinsModule.IsNewDbgInfoFormat) {
+        BuiltinFn->convertToNewDbgValues();
+      } else {
+        BuiltinFn->convertFromNewDbgValues();
+      }
+    }
+#endif
+
     // Find any callees in the function and add them to the list.
     for (auto &BB : *BuiltinFn) {
       for (auto &I : BB) {


### PR DESCRIPTION
# Overview

Another fix for LLVM 19.

# Reason for change

When we load modules, we convert them to the new debug info format as needed. However, this does not convert not-yet-materialized functions. Previously, this would work out but as LLVM reduces implicit conversions between old and new debug info format, we now need to convert explicitly.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
