### PR TITLE
Fix op_group_f_mul invalid test.

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/op_group_f_mul.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_f_mul.spvasm
@@ -17,16 +17,19 @@
 ; REQUIRES: spirv-as-v2023.5+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c GroupUniformArithmeticKHR %spv_file_s | FileCheck %s
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c GroupUniformArithmeticKHR -e SPV_KHR_uniform_group_instructions %spv_file_s | FileCheck %s
 
                                OpCapability Addresses
                                OpCapability Kernel
                                OpCapability Groups
                                OpCapability GroupUniformArithmeticKHR
+                               OpExtension "SPV_KHR_uniform_group_instructions"
 
                                OpMemoryModel Physical64 OpenCL
 
                                OpEntryPoint Kernel %sub_group_reduction_fcn "sub_group_reduction"
+
+                               OpName %sub_group_reduction_in "a"
 
                   %float_ty  = OpTypeFloat 32
                   %uint_ty   = OpTypeInt 32 0
@@ -35,8 +38,6 @@
                      %fcn_ty = OpTypeFunction %void_ty %ptr_CrossWorkgroup_float_ty
 
             %sub_group_scope = OpConstant %uint_ty 3
-
-                               OpName %sub_group_reduction_in "a"
 
 ; CHECK-LABEL: define spir_kernel void @sub_group_reduction(
     %sub_group_reduction_fcn = OpFunction %void_ty None %fcn_ty


### PR DESCRIPTION
# Overview

Fix op_group_f_mul invalid test.

# Reason for change

Newer spirv-tools point out that the GroupUniformArithmeticKHR capability requires the SPV_KHR_uniform_group_instructions extension, and the OpName is in the wrong place.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
