### PR TITLE
Fix Python 3.12 SyntaxWarning

### DIFF
--- a/clik/test/profile.py
+++ b/clik/test/profile.py
@@ -36,7 +36,7 @@ class Profile(object):
         self.add_options(parser)
         args = parser.parse_args(argv)
         if args.timeout:
-            m = re.match("^(?:(\d{2,}):)?(\d{2}):(\d{2})$", args.timeout)
+            m = re.match("^(?:(\\d{2,}):)?(\\d{2}):(\\d{2})$", args.timeout)
             if not m:
                 raise Exception("Invalid timeout value. Format: [HH:]MM:SS")
             hours = int(m.group(1) or 0)

--- a/modules/compiler/builtins/scripts/ll_stripper.py
+++ b/modules/compiler/builtins/scripts/ll_stripper.py
@@ -47,13 +47,13 @@ def strip(in_file, out_file, half_support):
     replace_hidden = compile('define hidden')
     replace_df16 = compile('DF16_')
     replace_spir_version = compile(
-        '!opencl\.spir\.version = !{!([0-9]*), [!0-9, ]*}')
+        '!opencl\\.spir\\.version = !{!([0-9]*), [!0-9, ]*}')
     replace_ocl_version = compile(
-        '!opencl\.ocl\.version = !{!([0-9]*), [!0-9, ]*}')
-    replace_llvm_metadata = compile('!llvm\.ident = !{!([0-9]*), [!0-9, ]*}')
+        '!opencl\\.ocl\\.version = !{!([0-9]*), [!0-9, ]*}')
+    replace_llvm_metadata = compile('!llvm\\.ident = !{!([0-9]*), [!0-9, ]*}')
     find_spirfuncDF16 = compile('spir_func .*DF16_[^(]*')
     find_spirfuncDecl = compile('declare (hidden )?spir_func .*Dh[^(]*')
-    find_comdatDF16 = compile('\$.*DF16_[^ ]* = comdat any')
+    find_comdatDF16 = compile('\\$.*DF16_[^ ]* = comdat any')
 
     with open(out_file, 'w') as f:
         for line in in_file:

--- a/scripts/coverage/modules/gcovr.py
+++ b/scripts/coverage/modules/gcovr.py
@@ -48,7 +48,7 @@ def gcovrGenerateXmlFile(args, obj_path, source_path):
     else:
         # else set the source filter from ".." where all other source lives
         source_path_filter = os.path.relpath(source_path, '..')
-        source_path_filter = '^\.\./' + source_path_filter + '/.*'
+        source_path_filter = '^\\.\\./' + source_path_filter + '/.*'
 
     gcovr_output_file = os.path.join('coverage_' + gcovr_file_tag + '_' +
                  v.TEST_SUITE_NAME + '-' + str(v.TEST_SUITE_NAME_COUNTER) +

--- a/scripts/linux_perf_support/perf_jit/disassembly.py
+++ b/scripts/linux_perf_support/perf_jit/disassembly.py
@@ -174,7 +174,7 @@ class Extract_Asm(Disassembly):
     #list of lines for that function from the object file
     def pickle_asm(self):
         func_hdr_match = re.compile(
-            '^\s*(?P<address>[0-9a-fA-F]+)\s+<(?P<symbol>[^>]*)>:\s*$')
+            '^\\s*(?P<address>[0-9a-fA-F]+)\\s+<(?P<symbol>[^>]*)>:\\s*$')
         search_for_function = True
         func_name = None
         func_address = None

--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -43,11 +43,11 @@ class CTSTestRun(TestRunBase):
         stream = io.BytesIO(self.output)
         # Extended pass_single_pattern. See Redmine issue #6542.
         pass_single_pattern = re.compile(
-            b"^(PASSED .+\.|.+PASSED\.?|passed .+\.|.+passed\.?)$")
-        pass_pair_pattern = re.compile(b"^PASSED (\d+) of (\d+) tests\.$")
-        fail_single_pattern = re.compile(b"^(FAILED .+\.|.+FAILED\.?)$")
-        fail_pair_pattern = re.compile(b"^FAILED (\d+) of (\d+) tests\.$")
-        doubles_unsupported_pattern = re.compile(b".*Has Double\? NO$")
+            b"^(PASSED .+\\.|.+PASSED\\.?|passed .+\\.|.+passed\\.?)$")
+        pass_pair_pattern = re.compile(b"^PASSED (\\d+) of (\\d+) tests\\.$")
+        fail_single_pattern = re.compile(b"^(FAILED .+\\.|.+FAILED\\.?)$")
+        fail_pair_pattern = re.compile(b"^FAILED (\\d+) of (\\d+) tests\\.$")
+        doubles_unsupported_pattern = re.compile(b".*Has Double\\? NO$")
 
         # Individual SPIR tests use yet another format to report test results.
         # To avoid false positive we want to match the current test name.
@@ -59,7 +59,7 @@ class CTSTestRun(TestRunBase):
                     spir_test_name = argument
                     break
             if spir_test_name:
-                spir_pass_expr = "^%s passed\.$" % spir_test_name
+                spir_pass_expr = "^%s passed\\.$" % spir_test_name
                 spir_pass_pattern = re.compile(spir_pass_expr.encode("utf8"))
 
         self.status = "SKIP"

--- a/scripts/testing/city_runner/profiles/gtest.py
+++ b/scripts/testing/city_runner/profiles/gtest.py
@@ -141,7 +141,7 @@ class GTestProfile(SSHProfile):
         test_bin_args = bin_args[:] + ["--gtest_filter=%s" % test_name]
 
         # Expand special patterns in the ccommand line options
-        test_name_subbed = re.sub(r'/|\.', '_', test_name)
+        test_name_subbed = re.sub(r'/|\\.', '_', test_name)
         test_bin_args_expanded = [
             arg.replace("${TEST_NAME}", test_name_subbed)
             for arg in test_bin_args
@@ -301,9 +301,9 @@ class GoogleTestRun(SSHTestRun):
 
         # Regex expressions to match
         total_tests_pattern = re.compile(
-               b".*?(\d+) (test cases?|tests? from \d+ test suites?) ran\." )
-        pass_pattern = re.compile(b"^\[  PASSED  \] (\d+) tests?\.$")
-        skip_pattern = re.compile(b"^\[  SKIPPED \] (\d+) tests?")
+               b".*?(\\d+) (test cases?|tests? from \\d+ test suites?) ran\\." )
+        pass_pattern = re.compile(b"^\\[  PASSED  \\] (\\d+) tests?\\.$")
+        skip_pattern = re.compile(b"^\\[  SKIPPED \\] (\\d+) tests?")
 
         total_tests = 0
         pass_num = 0


### PR DESCRIPTION
# Overview

Fix Python 3.12 SyntaxWarning

# Reason for change

Python has emitted a DeprecationWarning for unescaped backslashes in non-raw string literals for a while, but only when DeprecationWarnings are requested (when -Wd is used). Python 3.12 promotes this to a SyntaxWarning and emits them by default.

# Description of change

When we want a literal \ in a string, escape it as \\.

# Anything else we should know?

Code in eternal/ is intentionally left unmodified.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
