### PR TITLE
Fix vkEnumerateInstanceExtensionProperties.

### DIFF
--- a/source/vk/source/instance.cpp
+++ b/source/vk/source/instance.cpp
@@ -177,15 +177,21 @@ void DestroyInstance(vk::instance instance, const vk::allocator allocator) {
 VkResult EnumerateInstanceExtensionProperties(
     const char *, uint32_t *pPropertyCount,
     VkExtensionProperties *pProperties) {
+  VkResult result = VK_SUCCESS;
+  uint32_t propertyCount;
   if (pProperties) {
+    propertyCount = *pPropertyCount;
+    if (propertyCount >= vk::instance_extensions.size()) {
+      propertyCount = vk::instance_extensions.size();
+    } else {
+      result = VK_INCOMPLETE;
+    }
     std::copy(vk::instance_extensions.begin(),
-              std::min(vk::instance_extensions.begin() + *pPropertyCount,
-                       vk::instance_extensions.end()),
-              pProperties);
-
+              vk::instance_extensions.begin() + propertyCount, pProperties);
   } else {
-    *pPropertyCount = vk::instance_extensions.size();
+    propertyCount = vk::instance_extensions.size();
   }
-  return VK_SUCCESS;
+  *pPropertyCount = propertyCount;
+  return result;
 }
 }  // namespace vk

--- a/source/vk/test/UnitVK/source/CreateInstance.cpp
+++ b/source/vk/test/UnitVK/source/CreateInstance.cpp
@@ -85,10 +85,22 @@ TEST_F(CreateInstance, DefaultExtension) {
                                    nullptr, &extensionCount, nullptr));
 
   if (0 < extensionCount) {
+    uint32_t storedExtensionCount;
     std::vector<VkExtensionProperties> extensionProperties(extensionCount);
-    ASSERT_EQ_RESULT(VK_SUCCESS,
-                     vkEnumerateInstanceExtensionProperties(
-                         nullptr, &extensionCount, extensionProperties.data()));
+
+    storedExtensionCount = 0;
+    ASSERT_EQ_RESULT(VK_INCOMPLETE, vkEnumerateInstanceExtensionProperties(
+                                        nullptr, &storedExtensionCount,
+                                        extensionProperties.data()));
+    ASSERT_EQ(0, storedExtensionCount);
+
+    // Test that we do not overflow, not even on 32-bit platforms, by
+    // effectively treating this as -1.
+    storedExtensionCount = 0xffffffff;
+    ASSERT_EQ_RESULT(VK_SUCCESS, vkEnumerateInstanceExtensionProperties(
+                                     nullptr, &storedExtensionCount,
+                                     extensionProperties.data()));
+    ASSERT_EQ(extensionCount, storedExtensionCount);
 
     createInfo.enabledExtensionCount = 1;
     const char *enabledExtensionNames[] = {


### PR DESCRIPTION
# Overview

Fix vkEnumerateInstanceExtensionProperties.

# Reason for change

GCC 13 rightly complains about an out of bounds pointer: when *pPropertyCount > vk::instance_extensions.size(), merely computing vk::instance_extensions.begin() + *pPropertyCount has undefined behavior and trying to cover that up via std::min afterwards is too late and not guaranteed to do what is intended.

# Description of change

Check correctly.

While looking into this I also found that we did not match the spec in that we did not return VK_INCOMPLETE when the passed in size was too small, and did not set *pPropertyCount when the passed in size was too large.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
