### PR TITLE
Add missing includes.

### DIFF
--- a/source/cl/test/MultiDevice/source/main.cpp
+++ b/source/cl/test/MultiDevice/source/main.cpp
@@ -16,6 +16,8 @@
 
 #include <common.h>
 
+#include <algorithm>
+
 namespace {
 static cl_platform_id selectedPlatform = nullptr;
 }  // namespace

--- a/source/vk/test/UnitVK/include/UnitVK.h
+++ b/source/vk/test/UnitVK/include/UnitVK.h
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <vulkan/vulkan.h>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
# Overview

Add missing includes.

# Reason for change

We use std::find without including <algorithm>. This previously worked as libstdc++ implicitly includes this header through other headers, but GCC 14 does this less and flags errors.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
