### PR TITLE
DRAFT: FOR COMMENTS Support verbosity in cmake output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,27 @@ endif()
 # Add cmake modules directory to the path.
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+set(CA_CMAKE_VERBOSE_LEVEL ""  CACHE STRING "cmake verbosity level 2 detailed (default), 1 summary, 0 none")
+set(OCK_CMAKE_VERBOSE_LEVEL "2")
+
+# Check if we are in an LLVM Tree.
+# This is done by checking for the LLVMCore target which does not exist
+# until we import LLVM.
+# This only happens of we have not imported or are fetched by LLVM via
+# FetchContent or as an external project. In this case we set a cmake
+# variable OCK_IN_LLVM_TREE to TRUE.
+set(OCK_IN_LLVM_TREE FALSE)
+if (TARGET LLVMCore)
+  set(OCK_IN_LLVM_TREE TRUE)
+  # We always reduce verbosity level if included in LLVM tree
+  set(OCK_CMAKE_VERBOSE_LEVEL "0")
+endif()
+
+# Even if in LLVM tree we support overriding of the verbosity level
+if (NOT CA_CMAKE_VERBOSE_LEVEL STREQUAL "")
+  set(OCK_CMAKE_VERBOSE_LEVEL ${CA_CMAKE_VERBOSE_LEVEL})
+endif()
+
 # Bring in our ca_option macro for declaring options.
 include(CAOption)
 
@@ -156,17 +177,6 @@ foreach(OPTIONS_MODULE ${OPTIONS_MODULES})
     include(${OPTIONS_MODULE})
   endif()
 endforeach()
-
-# Check if we are in an LLVM Tree.
-# This is done by checking for the LLVMCore target which does not exist
-# until we import LLVM.
-# This only happens of we have not imported or are fetched by LLVM via
-# FetchContent or as an external project. In this case we set a cmake
-# variable OCK_IN_LLVM_TREE to TRUE.
-set(OCK_IN_LLVM_TREE FALSE)
-if (TARGET LLVMCore)
-  set(OCK_IN_LLVM_TREE TRUE)
-endif()
 
 if(CA_RUNTIME_COMPILER_ENABLED AND NOT OCK_IN_LLVM_TREE)
   include(ImportLLVM)

--- a/cmake/CAOption.cmake
+++ b/cmake/CAOption.cmake
@@ -29,6 +29,7 @@ must be included like so:
 The following :cmake-command:`CMake macros<macro>` are defined by the module:
 #]=======================================================================]
 
+include(CAUtils)
 
 #[=======================================================================[.rst:
 .. cmake:command:: ca_option
@@ -71,11 +72,11 @@ macro(ca_option name type description default)
   # Setup the main option of this macro.
   if(${type} STREQUAL "BOOL")
     option(${name} ${description} ${default})
-    message(STATUS "oneAPI Construction Kit ${description}: ${${name}}")
+    ca_message(STATUS CA_VERBOSE_DETAIL "oneAPI Construction Kit ${description}: ${${name}}")
   else()
     set(${name} ${default} CACHE ${type} "${description}")
     if(NOT "${${name}}" STREQUAL "${default}")
-      message(STATUS "oneAPI Construction Kit ${description}: ${${name}}")
+      ca_message(STATUS CA_VERBOSE_DETAIL "oneAPI Construction Kit ${description}: ${${name}}")
     endif()
   endif()
 endmacro()

--- a/cmake/CAUtils.cmake
+++ b/cmake/CAUtils.cmake
@@ -1,0 +1,30 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# TODO Describe params and options
+function(ca_message mode verbosity_level ...)
+    set(CA_MESSAGE_VERBOSITY_LEVEL 0)
+    if (${verbosity_level} STREQUAL  "CA_VERBOSE_SUMMARY")
+        set(CA_MESSAGE_VERBOSITY_LEVEL 1)
+    elseif(${verbosity_level} STREQUAL  "CA_VERBOSE_DETAIL")
+        set(CA_MESSAGE_VERBOSITY_LEVEL 2)
+    endif()
+    list(REMOVE_AT ARGV 0)
+    list(REMOVE_AT ARGV 0)
+    if (${CA_MESSAGE_VERBOSITY_LEVEL} LESS_EQUAL ${OCK_CMAKE_VERBOSE_LEVEL})
+      message(${mode} ${ARGV})
+    endif()
+endfunction()


### PR DESCRIPTION
# Overview

For message cmake commands replace with ca_message and support a verbosity level which can be changed using CA_CMAKE_VERBOSE_LEVEL(0 none, 1 summary, 2 detail). Including from LLVM will by default set to 0.
# Reason for change

Including from LLVM was noisy
