### PR TITLE
Fix LLVM assertion about wrong debug info

### DIFF
--- a/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
+++ b/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
@@ -115,9 +115,8 @@ void configAarch64FP(Function &wrapper, Function &function) {
   }
 
   // call the function we are wrapping
-  auto *const ci = ir.CreateCall(&function, args);
-  ci->setCallingConv(function.getCallingConv());
-  ci->setAttributes(compiler::utils::getCopiedFunctionAttrs(function));
+  compiler::utils::createCallToWrappedFunction(
+      function, args, ir.GetInsertBlock(), ir.GetInsertPoint());
 
   // reset the FPCR to the original value
   ir.CreateCall(set_fpcr_asm, {original_fpcr});
@@ -166,9 +165,8 @@ void configArmFP(Function &wrapper, Function &function) {
   }
 
   // call the function we are wrapping
-  auto *const ci = ir.CreateCall(&function, args);
-  ci->setCallingConv(function.getCallingConv());
-  ci->setAttributes(compiler::utils::getCopiedFunctionAttrs(function));
+  compiler::utils::createCallToWrappedFunction(
+      function, args, ir.GetInsertBlock(), ir.GetInsertPoint());
 
   // reset the fpscr to the original
   ir.CreateCall(set_fpscr, {original_fpscr})


### PR DESCRIPTION
# Overview

Fix LLVM assertion about wrong debug info

# Reason for change

When an inlineable call is emitted in a function that has debug info, that call must itself have debug info. In AddFloatingPointControl, in configX86FP, we made sure to call a utility function that sets up the debug info, but in configAarch64FP and configArmFP we did not do the same, resulting in errors.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
