### PR TITLE
Add missing dependency.

### DIFF
--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -136,3 +136,6 @@ target_compile_definitions(compiler-base PUBLIC
 # Compiler passes in this module include abacus headers, so ensure they are
 # generated before this module starts to build.
 add_dependencies(compiler-base abacus_generate)
+if(TARGET tidy-compiler-base)
+  add_dependencies(tidy-compiler-base abacus_generate)
+endif()


### PR DESCRIPTION
# Overview

Add missing dependency.

# Reason for change

When targets depend on abacus_generate, their corresponding tidy targets need to also depend on abacus_generate.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
