### PR TITLE
Specify dependency on Abacus headers.

### DIFF
--- a/modules/compiler/builtins/abacus/source/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/source/CMakeLists.txt
@@ -50,10 +50,7 @@ target_compile_definitions(abacus_static PRIVATE
 
 # If extra ComputeAorta commands exist, use them.
 if(COMMAND add_ca_tidy)
-  add_ca_tidy(abacus_static ${abacus_sources_host})
-  if(TARGET tidy-abacus_static)
-    add_dependencies(tidy-abacus_static abacus_generate)
-  endif()
+  add_ca_tidy(abacus_static ${abacus_sources_host} DEPENDS abacus_generate)
 endif()
 
 target_include_directories(abacus_static PUBLIC

--- a/modules/compiler/builtins/libimg/CMakeLists.txt
+++ b/modules/compiler/builtins/libimg/CMakeLists.txt
@@ -77,10 +77,7 @@ add_library(image_library_host STATIC ${CODEPLAY_IMG_HOST_SOURCES})
 
 # If extra ComputeAorta commands exist, use them.
 if(COMMAND add_ca_tidy)
-  add_ca_tidy(image_library_host ${CODEPLAY_IMG_HOST_SOURCES})
-  if(TARGET tidy-image_library_host)
-    add_dependencies(tidy-image_library_host abacus_generate)
-  endif()
+  add_ca_tidy(image_library_host ${CODEPLAY_IMG_HOST_SOURCES} DEPENDS abacus_generate)
 endif()
 
 target_include_directories(image_library_host PUBLIC

--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -63,7 +63,7 @@ set(COMPILER_BASE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/source/program_metadata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/target.cpp)
 
-add_ca_library(compiler-base STATIC ${COMPILER_BASE_SOURCES})
+add_ca_library(compiler-base STATIC ${COMPILER_BASE_SOURCES} DEPENDS abacus_generate)
 target_include_directories(compiler-base PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/compiler/include>)
@@ -132,10 +132,3 @@ if(NOT ${BUILD_TYPE_UPPER} MATCHES "RELEASE")
 endif()
 target_compile_definitions(compiler-base PUBLIC
   CA_COMPILER_LLVM_VERSION=\"${CA_COMPILER_LLVM_VERSION}\")
-
-# Compiler passes in this module include abacus headers, so ensure they are
-# generated before this module starts to build.
-add_dependencies(compiler-base abacus_generate)
-if(TARGET tidy-compiler-base)
-  add_dependencies(tidy-compiler-base abacus_generate)
-endif()

--- a/source/cl/CMakeLists.txt
+++ b/source/cl/CMakeLists.txt
@@ -146,8 +146,10 @@ set(CL_SOURCE_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/source/exports-3.0.cpp)
 
 add_ca_library(CL SHARED
-  ${CL_SOURCE_FILES} $<$<PLATFORM_ID:Windows>:${BUILTINS_RC_FILE}>)
-add_ca_library(CL-static STATIC EXCLUDE_FROM_ALL ${CL_SOURCE_FILES})
+  ${CL_SOURCE_FILES} $<$<PLATFORM_ID:Windows>:${BUILTINS_RC_FILE}>
+  DEPENDS abacus_generate)
+add_ca_library(CL-static STATIC EXCLUDE_FROM_ALL ${CL_SOURCE_FILES}
+  DEPENDS abacus_generate)
 
 if(NOT CA_COMPILER_ENABLE_DYNAMIC_LOADER)
   target_resources(CL NAMESPACES ${BUILTINS_NAMESPACES})
@@ -324,7 +326,7 @@ if(CA_RUNTIME_COMPILER_ENABLED AND CA_COMPILER_ENABLE_DYNAMIC_LOADER)
 endif()
 
 if(TARGET tidy-CL)
-  add_dependencies(tidy-CL abacus_generate mux-config)
+  add_dependencies(tidy-CL mux-config)
 endif()
 
 install(TARGETS CL


### PR DESCRIPTION
# Overview

Specify dependency on Abacus headers.

# Reason for change

The previous fix was insufficient to avoid clang-tidy running before Abacus headers were generated.

# Description of change

This commit adds a DEPENDS keyword to add_ca_tidy, add_ca_library, and add_ca_executable. If specified, the dependencies are added to the main target, the tidy target, and the tidy target's symbolic files. Existing dependencies on abacus_generate are updated to use DEPENDS so that the clang-tidy commands will pick this up.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
