### PR TITLE
Install ignore list in cts_summary.

### DIFF
--- a/source/cl/CMakeLists.txt
+++ b/source/cl/CMakeLists.txt
@@ -362,4 +362,8 @@ if(CA_ENABLE_TESTS)
     ${PROJECT_SOURCE_DIR}/scripts/jenkins/cts_summary
     DESTINATION share COMPONENT OCLTest
     FILES_MATCHING PATTERN *.csv)
+  install(DIRECTORY
+    scripts/
+    DESTINATION share/cts_summary COMPONENT OCLTest
+    FILES_MATCHING PATTERN *.csv)
 endif()


### PR DESCRIPTION
# Overview

Install ignore list in cts_summary.
# Reason for change

We have our OpenCL CTS runner CSV files spread out over two directories and only install them from one of them.

# Description of change

In order to use cts-3.0-online-ignore-linux-*.csv in CI reliably as well, install these too.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
