### PR TITLE
LLVM 19 update: trunc to i1.

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -143,8 +143,7 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_and(
-; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
-; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.and.v4i1(i1 true, <4 x i1> [[T]], {{.*}})
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.and.v4i1(i1 true, <4 x i1> [[T:%.*]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_and_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
@@ -164,8 +163,7 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_or(
-; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
-; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.or.v4i1(i1 false, <4 x i1> [[T]], {{.*}})
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.or.v4i1(i1 false, <4 x i1> [[T:%.*]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_or_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4
@@ -185,8 +183,7 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_vp_reduce_logical_xor(
-; CHECK: [[T:%.*]] = icmp ne <4 x i32> {{%.*}}, zeroinitializer
-; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.xor.v4i1(i1 false, <4 x i1> [[T]], {{.*}})
+; CHECK: [[R:%.*]] = call i1 @llvm.vp.reduce.xor.v4i1(i1 false, <4 x i1> [[T:%.*]], {{.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[R]])
 ; CHECK: [[R:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[R]], ptr addrspace(1) {{%.*}}, align 4

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -178,9 +178,7 @@ entry:
 
 ; CHECK-LABEL: @__vecz_v4_reduce_logical_xor(
 ; CHECK: [[X:%.*]] = call i4 @llvm.ctpop.i4(i4 {{%.*}})
-; CHECK: [[T:%.*]] = and i4 [[X]], 1
-; CHECK: [[T0:%.*]] = icmp ne i4 [[T]], 0
-; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[T0]])
+; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[T:%.*]])
 ; CHECK: [[E:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[E]], ptr addrspace(1) {{%.*}}, align 4
 define spir_kernel void @reduce_logical_xor(ptr addrspace(1) %in, ptr addrspace(1) %out) {


### PR DESCRIPTION
# Overview

Update for LLVM 19.

# Reason for change

LLVM 19 uses trunc x to i1 as the canonical representation, rather than LLVM 18's icmp ne (and x, 1), 0, for truncations to i1.

# Description of change

As the purpose of these tests is not how that truncation is performed, allow anything.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
