### PR TITLE
[RefSi] Restore CMAKE_C(XX)_EXTENSIONS.

### DIFF
--- a/examples/refsi/hal_refsi/external/refsidrv/external/CMakeLists.txt
+++ b/examples/refsi/hal_refsi/external/refsidrv/external/CMakeLists.txt
@@ -14,6 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# The CMake default is to build with extensions enabled. We disable this in
+# AddCA.cmake, but cannot expect external projects to account for this.
+# Restore it for riscv-isa-sim.
+set(CMAKE_C_EXTENSIONS ON)
+set(CMAKE_CXX_EXTENSIONS ON)
+
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/riscv-isa-sim/CMakeLists.txt)
   add_subdirectory(riscv-isa-sim)
 else()


### PR DESCRIPTION
# Overview

[RefSi] Restore CMAKE_C(XX)_EXTENSIONS.

# Reason for change

We cannot expect external projects to account for our changes from CMake defaults.

# Description of change

Fixes:

    /builds/ComputeAorta/ci-github/oneapi-construction-kit/build/_deps/riscv-isa-sim-src/fdt/fdt_ro.c: In function ‘fdt_stringlist_count’: /builds/ComputeAorta/ci-github/oneapi-construction-kit/build/_deps/riscv-isa-sim-src/fdt/fdt_ro.c:711:12: warning: implicit declaration of function ‘strnlen’; did you mean ‘strlen’? [-Wimplicit-function-declaration]
      711 |   length = strnlen(list, end - list) + 1;
          |            ^~~~~~~
          |            strlen

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
