### PR TITLE
Report availability of out of order exec mode.

### DIFF
--- a/source/cl/source/device.cpp
+++ b/source/cl/source/device.cpp
@@ -186,8 +186,12 @@ _cl_device_id::_cl_device_id(cl_platform_id platform,
       printf_buffer_size(compiler::PRINTF_BUFFER_SIZE),
       preferred_interop_user_sync(CL_TRUE),
       profile(),
-      profiling_timer_resolution(5),                // Get from Mux?
-      queue_properties(CL_QUEUE_PROFILING_ENABLE),  // Get from Mux?
+      profiling_timer_resolution(5),  // Get from Mux?
+      queue_properties(CL_QUEUE_PROFILING_ENABLE
+#ifdef CA_ENABLE_OUT_OF_ORDER_EXEC_MODE
+                       | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
+#endif
+                       ),  // Get from Mux?
       reference_count(1),  // All devices are root devices.
       single_fp_config(setOpenCLFromMux(mux_device->info->float_capabilities) |
                        CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT),

--- a/source/cl/test/UnitCL/source/clCreateUserEvent.cpp
+++ b/source/cl/test/UnitCL/source/clCreateUserEvent.cpp
@@ -114,7 +114,11 @@ TEST_F(clCreateUserEventTest, SubsequentCommandsWaitOnUserEvents) {
   ASSERT_SUCCESS(clReleaseCommandQueue(queue));
 }
 
-TEST_F(clCreateUserEventTest, OutOfOrderQueue) {
+// This test assumes clSetUserEventStatus can happen before clEnqueueReadBuffer
+// completes. If it cannot, it deadlocks. While we would like to let the
+// clSetUserEventStatus happen first, this is not required, not what our
+// implementation does, and not what all other implementations do either.
+TEST_F(clCreateUserEventTest, DISABLED_OutOfOrderQueue) {
   cl_command_queue_properties properties = 0;
 
   ASSERT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_QUEUE_PROPERTIES,

--- a/source/cl/test/UnitCL/source/clGetDeviceInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetDeviceInfo.cpp
@@ -1205,11 +1205,19 @@ TEST_F(clGetDeviceInfoTest, QUEUE_PROPERTIES) {
   ASSERT_SUCCESS(clGetDeviceInfo(device, CL_DEVICE_QUEUE_PROPERTIES, size,
                                  &payload, nullptr));
 
-  const cl_command_queue_properties expect = CL_QUEUE_PROFILING_ENABLE;
-  EXPECT_EQ(expect, CL_QUEUE_PROFILING_ENABLE & payload);
-  payload &= ~CL_QUEUE_PROFILING_ENABLE;
-  ASSERT_TRUE((0 == payload) ||
-              (CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE == payload));
+  {
+    const cl_command_queue_properties expect = CL_QUEUE_PROFILING_ENABLE;
+    EXPECT_EQ(expect, CL_QUEUE_PROFILING_ENABLE & payload);
+  }
+  {
+#ifdef CA_ENABLE_OUT_OF_ORDER_EXEC_MODE
+    const cl_command_queue_properties expect =
+        CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+#else
+    const cl_command_queue_properties expect = 0;
+#endif
+    EXPECT_EQ(expect, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE & payload);
+  }
 }
 
 #if defined(CL_VERSION_3_0)


### PR DESCRIPTION
# Overview

Report availability of out of order exec mode.

# Reason for change

If CA_ENABLE_OUT_OF_ORDER_EXEC_MODE is enabled (as it is by default), we accept CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE in queue properties, but do not report it as a property we support for queues.

# Description of change

This commit rectifies that.

# Anything else we should know?

This is not currently tested by OpenCL CTS, but will soon be.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
