### PR TITLE
Set LLVM_DIR.

### DIFF
--- a/cmake/ImportLLVM.cmake
+++ b/cmake/ImportLLVM.cmake
@@ -60,6 +60,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH
   ${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm
   ${CA_LLVM_INSTALL_DIR}/lib/cmake/clang)
+set(LLVM_DIR ${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm)
 
 # Include LLVM.
 include(LLVMConfig)


### PR DESCRIPTION
# Overview

Set LLVM_DIR.

# Reason for change

When we import LLVM, we do so by including LLVMConfig directly, which works fine. However, we do the same for LLD, we include LLDConfig, but LLDConfig needs LLVM and does find_package(LLVM 19.0.0 [...]). Although it sets a hint path here that would pick up the previously included LLVM, the hint path is ignored in cross builds with CMAKE_FIND_ROOT_PATH_MODE_PACKAGE set to ONLY, which it normally should be set to because host packages cannot be used for the target.

# Description of change

By setting LLVM_DIR, we allow the cross LLVM to be found in the expected location, outside of CMAKE_FIND_ROOT_PATH.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
