### PR TITLE
Minor changes to cpu hal to enable wrapping for remote hal access

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'source/**'
+      - 'clik/**'
       - 'modules/**'
       - 'examples/**'
       - 'cmake/**'

--- a/clik/external/hal_cpu/include/cpu_hal.h
+++ b/clik/external/hal_cpu/include/cpu_hal.h
@@ -48,6 +48,10 @@ class cpu_hal final : public hal::hal_device_t {
   ~cpu_hal();
 #endif
 
+  // Set up the hal device info - this is done as a static so that other classes such
+  // as hal_client can set up the desired information directly
+  static hal::hal_device_info_t setup_cpu_hal_device_info();
+
   size_t get_word_size() const { return sizeof(uintptr_t); }
 
   // find a specific kernel function in a compiled program

--- a/clik/external/hal_cpu/include/device/program.lds
+++ b/clik/external/hal_cpu/include/device/program.lds
@@ -1,4 +1,0 @@
-/* Adding SECTIONS here seems to cause issues with LLD producing an ELF file that
-   fails on dlopen with "cannot change memory protections". As we don't need
-   any SECTION info here we leave it blank but keep the script as an example.
-*/

--- a/clik/external/hal_cpu/source/CMakeLists.txt
+++ b/clik/external/hal_cpu/source/CMakeLists.txt
@@ -34,11 +34,6 @@ target_include_directories(hal_cpu PRIVATE
 
 target_link_libraries(hal_cpu hal_common dl pthread)
 
-hal_add_baked_data(hal_cpu
-    hal_cpu_linker_script
-    linker_script.h
-    ${HAL_CPU_SOURCE_DIR}/include/device/program.lds)
-
 set_target_properties(hal_cpu PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
   

--- a/clik/external/hal_cpu/source/hal_main.cpp
+++ b/clik/external/hal_cpu/source/hal_main.cpp
@@ -17,7 +17,6 @@
 #include <mutex>
 
 #include "cpu_hal.h"
-#include "linker_script.h"
 
 namespace {
 
@@ -57,33 +56,8 @@ class cpu_hal_platform : public hal::hal_t {
   }
 
   cpu_hal_platform() {
-    const uint64_t global_ram_size = 256 << 20;
-    const uint64_t global_mem_max_over_allocation = 16 << 20;
-    const uint64_t local_ram_size = 8 << 20;
-    hal_device_info.type = hal::hal_device_type_riscv;
-    hal_device_info.word_size = sizeof(uintptr_t) * 8;
-    hal_device_info.target_name = "ock cpu";
-    hal_device_info.global_memory_avail =
-        global_ram_size - global_mem_max_over_allocation;
-    hal_device_info.shared_local_memory_size = local_ram_size;
-    hal_device_info.should_link = true;
-    hal_device_info.should_vectorize = false;
-    // TODO: This is slightly arbitrary and based on the "host" target
-    // default to 128 bit (16 bytes)
-    hal_device_info.preferred_vector_width = 128 / (8 * sizeof(uint8_t));
-    hal_device_info.supports_fp16 = false;
-    hal_device_info.supports_doubles = true;
-#if HAL_CPU_MODE == HAL_CPU_WG_MODE
-    hal_device_info.max_workgroup_size = 1024;
-#elif HAL_CPU_MODE == HAL_CPU_WI_MODE    
-    hal_device_info.max_workgroup_size = 16;
-#else
-#error HAL_CPU_MODE must be HAL_CPU_MODE_WG or HAL_CPU_MODE_WI.
-#endif
-    hal_device_info.is_little_endian = true;
-    hal_device_info.linker_script =
-        std::string(hal_cpu_linker_script, hal_cpu_linker_script_size);
-
+    hal_device_info = cpu_hal::setup_cpu_hal_device_info();
+ 
     constexpr static uint32_t implemented_api_version = 6;
     static_assert(implemented_api_version == hal_t::api_version,
                   "Implemented API version for CPU HAL does not match hal.h");


### PR DESCRIPTION
# Overview

Minor changes to cpu hal to enable wrapping for remote hal access

# Reason for change

Wrapping of the cpu hal with a server and remote access from a client requires some changes to make it work. 

# Description of change

The creation of the device info being a function that can be called externally through a static function. This allows us to use clc without having to use the client/server relation to get the device info.

Making the linker script (which is empty) defined within the static function rather than baking it. Technically we could bake it but we wanted to simplify the server and build the cpu hal files directly rather than having to build it as a shared library and complicate the dependencies.
