### PR TITLE
Return correct clEnqueueCommandBufferKHR errors

### DIFF
--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
@@ -879,7 +879,7 @@ TEST_F(SubstituteCommandQueueTest, CompatibleQueueSimultaneousWithFlag) {
 TEST_F(SubstituteCommandQueueTest, NullQueues) {
   // Enqueue the command buffer substituting with null command queue parameter
   // but non-zero command queue length.
-  ASSERT_EQ_ERRCODE(CL_INVALID_COMMAND_QUEUE,
+  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
                     clEnqueueCommandBufferKHR(1, nullptr, command_buffer, 0,
                                               nullptr, nullptr));
 }
@@ -893,10 +893,9 @@ TEST_F(SubstituteCommandQueueTest, ZeroQueues) {
 
   // Enqueue the command buffer substituting with non-null command queue
   // parameter but zero command queue length.
-  ASSERT_EQ_ERRCODE(
-      CL_INVALID_COMMAND_QUEUE,
-      clEnqueueCommandBufferKHR(0, &compatible_command_queue, command_buffer, 0,
-                                nullptr, nullptr));
+  EXPECT_EQ_ERRCODE(CL_INVALID_VALUE, clEnqueueCommandBufferKHR(
+                                          0, &compatible_command_queue,
+                                          command_buffer, 0, nullptr, nullptr));
 
   // Cleanup resources.
   EXPECT_SUCCESS(clReleaseCommandQueue(compatible_command_queue));
@@ -917,7 +916,7 @@ TEST_F(SubstituteCommandQueueTest, InvalidNumberQueues) {
   // buffer creation.
   cl_command_queue command_queues[] = {first_compatible_command_queue,
                                        second_compatible_command_queue};
-  ASSERT_EQ_ERRCODE(CL_INVALID_COMMAND_QUEUE,
+  EXPECT_EQ_ERRCODE(CL_INVALID_VALUE,
                     clEnqueueCommandBufferKHR(2, command_queues, command_buffer,
                                               0, nullptr, nullptr));
 
@@ -936,8 +935,8 @@ TEST_F(SubstituteCommandQueueTest, IncompatibleQueueProperties) {
   EXPECT_SUCCESS(error);
 
   // Enqueue the command buffer substituting with incompatible command queue.
-  ASSERT_EQ_ERRCODE(
-      CL_INVALID_COMMAND_QUEUE,
+  EXPECT_EQ_ERRCODE(
+      CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
       clEnqueueCommandBufferKHR(1, &incompatible_command_queue, command_buffer,
                                 0, nullptr, nullptr));
 
@@ -1002,8 +1001,8 @@ TEST_F(SubstituteCommandQueueTest, IncompatibleQueueContext) {
   EXPECT_SUCCESS(error);
 
   // Enqueue the command buffer substituting with incompatible command queue.
-  ASSERT_EQ_ERRCODE(
-      CL_INVALID_COMMAND_QUEUE,
+  EXPECT_EQ_ERRCODE(
+      CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
       clEnqueueCommandBufferKHR(1, &incompatible_command_queue, command_buffer,
                                 0, nullptr, nullptr));
 


### PR DESCRIPTION
# Overview

We aren't returning the correct errors as specified by `clEnqueueCommandBufferKHR`.

Issues we're found based on testing of CTS PR https://github.com/KhronosGroup/OpenCL-CTS/pull/1931 that verifies these errors

# Reason for change

Non-conformant implementation of  `clEnqueueCommandBufferKHR`

# Description of change

1. Update some existing `clEnqueueCommandBufferKHR` return codes to the correct value.
2. Use helper function in `clEnqueueCommandBufferKHR` to verify event wait-list.
3. Add check for `CL_INVALID_COMMAND_QUEUE` to `clEnqueueCommandBufferKHR`.

# Anything else we should know?

- Updated UnitCL tests to check against the specification defined value.
- Modified these checks to use gtest `EXPECT` rather than `ASSERT` because if the `ASSERT` fails and returns immediately then we won't release the command-queue created by the test, resulting in a leak.
- Still one fail left when testing against CTS PR, for a spec related reason i've [commented on](https://github.com/KhronosGroup/OpenCL-CTS/pull/1931#discussion_r1557531816)

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
