### PR TITLE
[CMake] Fix check for LLVM_ENABLE_ZLIB, add _ZSTD.

### DIFF
--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -58,6 +58,7 @@ jobs:
               -DLLVM_ENABLE_DIA_SDK=OFF
               -DCMAKE_INSTALL_PREFIX=llvm_install
               -DLLVM_ENABLE_ZLIB=FALSE
+              -DLLVM_ENABLE_ZSTD=FALSE
               -DLLVM_ENABLE_Z3_SOLVER=FALSE
               -DLLVM_ENABLE_PROJECTS="clang;lld"
               -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;RISCV"

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -755,6 +755,7 @@ cmake . -GNinja \
   -DLLVM_HOST_TRIPLE=arm-unknown-linux-gnu \
   -DLLVM_DEFAULT_TARGET_TRIPLE=arm-unknown-linux-gnu \
   -DLLVM_ENABLE_ZLIB=OFF \
+  -DLLVM_ENABLE_ZSTD=OFF \
   -DLLVM_TABLEGEN=$LLVMNativeInstall/bin/llvm-tblgen \
   -DCLANG_TABLEGEN=$LLVMNativeBuild/bin/clang-tblgen
 ```
@@ -782,6 +783,7 @@ cmake . -GNinja \
   -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-gnu \
   -DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-linux-gnu \
   -DLLVM_ENABLE_ZLIB=OFF \
+  -DLLVM_ENABLE_ZSTD=OFF \
   -DLLVM_TABLEGEN=$LLVMNativeInstall/bin/llvm-tblgen \
   -DCLANG_TABLEGEN=$LLVMNativeBuild/bin/clang-tblgen
 ```


### PR DESCRIPTION
# Overview

[CMake] Fix check for LLVM_ENABLE_ZLIB, add _ZSTD.

# Reason for change

In cross builds, we check for a LLVM_ENABLE_ZLIB mismatch between host LLVM and target LLVM because it affects bitcode compatibility. This mismatch was not fully reliable: LLVM sometimes sets LLVM_ENABLE_ZLIB to other values than the values we check for, in particular it may set it to nothing.

In cross builds, LLVM_ENABLE_ZSTD has the same problem as LLVM_ENABLE_ZLIB: if the host LLVM has that enabled, the target LLVM needs it too.

# Description of change

This change allows any arbitrary value to be picked up and does the same check for LLVM_ENABLE_ZSTD.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
