### PR TITLE
Do not mark events as running.

### DIFF
--- a/source/cl/source/command_queue.cpp
+++ b/source/cl/source/command_queue.cpp
@@ -737,11 +737,6 @@ _cl_command_queue::getCommandBufferPending(
       signal_semaphores_length = 1;
     }
 
-    // Set all events as running.
-    for (auto signal_event : finished.signal_events) {
-      signal_event->running();
-    }
-
     // Actually dispatch the command buffer.
     cargo::small_vector<mux_semaphore_t, 8> wait_semaphores_storage;
     for (auto s : dispatch.wait_semaphores) {


### PR DESCRIPTION
# Overview

Do not mark events as running.

# Reason for change

We were previously marking events as running before they were running. If we have commands A, B, with implicit dependencies, we would mark both of A, B as running once they were submitted. As OpenCL CTS test_events reveals, this is incorrect, because it allows an application to retrieve the execution status of B, determine that it is running, and then retrieve the execution status of A, and determine that it is running as well, when it is only possible for B to start running once A is completed.

# Description of change

Never marking commands as running is the minimal change to be a poor-quality conforming implementation (commands are never guaranteed to take long enough for the "running" state to be observed).

# Anything else we should know?

This is intended to be improved in a future commit so that we do mark events as running again, but only when they actually are running.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
