### PR TITLE
city_runner improvements

### DIFF
--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -107,7 +107,7 @@ class CTSTestRun(TestRunBase):
                                      "inaccuracies in calculated pass percentage.")
 
                 total_tests = fail_pair[1]
-                passed_tests = self.total_tests - fail_pair[0]
+                passed_tests = total_tests - fail_pair[0]
             elif fail_single:
                 status = "FAIL"
                 passed_tests, total_tests = 0, 1

--- a/scripts/testing/city_runner/profile.py
+++ b/scripts/testing/city_runner/profile.py
@@ -108,7 +108,7 @@ class Profile(object):
          argument parser. """
         parser.add_argument(
             "-s",
-            "--test-source",
+            "--test-source", nargs="+",
             help="File containing a list of tests to run")
         parser.add_argument(
             "-d",
@@ -225,17 +225,17 @@ class Profile(object):
         """ Create a new test run from a test description.  """
         raise NotImplementedError()
 
-    def load_tests(self, csv_path, disabled_path, ignored_path):
+    def load_tests(self, csv_paths, disabled_path, ignored_path):
         """ Create the list of tests to run from a CSV. """
-        if not csv_path or not os.path.exists(csv_path):
+        if not csv_paths or any(not csv_path or not os.path.exists(csv_path) for csv_path in csv_paths):
             raise Exception("Test list file not specified or does not exist")
         if disabled_path and not os.path.exists(disabled_path):
             raise Exception("Disabled test list file does not exist")
         if ignored_path and not os.path.exists(ignored_path):
             raise Exception("Ignored test list file does not exist")
         tests = (TestList
-                   .from_file(csv_path, disabled_path, ignored_path, self.args.test_prefix)
-                   .filter(self.args.patterns))
+                 .from_file(csv_paths, disabled_path, ignored_path, self.args.test_prefix)
+                 .filter(self.args.patterns))
         return tests
 
     def init_workers_state(self, expected_num_entries):

--- a/scripts/testing/city_runner/profiles/basic.py
+++ b/scripts/testing/city_runner/profiles/basic.py
@@ -100,7 +100,7 @@ class BasicProfile(SSHProfile):
 
         return env
 
-    def load_tests(self, csv_path, disabled_path, ignored_path):
+    def load_tests(self, csv_paths, disabled_path, ignored_path):
         """ Find the list of tests from CSV. """
         if disabled_path:
             print("Warning: disabled list not supported for basic profile")
@@ -109,22 +109,24 @@ class BasicProfile(SSHProfile):
             print("Warning: ignored list not supported for basic profile")
 
         parsed_tests = []
-        # Load tests from CSV if one was provided
-        if csv_path:
-            if not os.path.exists(csv_path):
-                raise Exception("Test list file does not exist")
+        # Load tests from CSV if any were provided
+        if csv_paths:
+            for csv_path in csv_paths:
+                if not os.path.exists(csv_path):
+                    raise Exception("Test list file does not exist")
 
-            with open(csv_path, "r") as f:
-                for line in f:
-                    # Skip commented out lines
-                    if line.startswith('#'):
-                        continue
+                with open(csv_path, "r") as f:
+                    for line in f:
+                        # Skip commented out lines
+                        if line.startswith('#'):
+                            continue
 
-                    # The first field of the csv is the executable name, and
-                    # the following fields are the arguments
-                    test_binary = line.split(",")[0].strip()
-                    executable = TestExecutable(test_binary, test_binary)
-                    parsed_tests.append(TestInfo(test_binary, executable, line.split(",")[1:]))
+                        # The first field of the csv is the executable name, and
+                        # the following fields are the arguments
+                        test_binary = line.split(",")[0].strip()
+                        executable = TestExecutable(test_binary, test_binary)
+                        parsed_tests.append(
+                            TestInfo(test_binary, executable, line.split(",")[1:]))
 
         # Error if no tests were found
         if not parsed_tests:
@@ -168,7 +170,7 @@ class BasicRun(SSHTestRun):
         else:
             # Launch the binary locally
             exe_path = os.path.join(self.profile.args.binary_path,
-                self.test.executable.path)
+                                    self.test.executable.path)
             env_vars = self.profile.build_environment_vars()
             self.create_process(exe_path, self.test.arguments, env=env_vars)
 

--- a/scripts/testing/city_runner/profiles/gtest.py
+++ b/scripts/testing/city_runner/profiles/gtest.py
@@ -124,7 +124,8 @@ class GTestProfile(SSHProfile):
 
         if self.use_ssh():
             if not args.ssh_client:
-                raise Exception("A SSH client (--ssh-client) couldn't be found.")
+                raise Exception(
+                    "A SSH client (--ssh-client) couldn't be found.")
 
             # For SSH we want to default number of threads to 1
             if not args.jobs:
@@ -157,7 +158,8 @@ class GTestProfile(SSHProfile):
                              list_bin_args)
 
         test_list_info = TestInfo("", executable, list(filter_args))
-        test_list = GoogleTestRun(self, test_list_info, quiet=True).execute_and_output()
+        test_list = GoogleTestRun(
+            self, test_list_info, quiet=True).execute_and_output()
 
         # Parse output to create list of tests
         test_prefix = ""
@@ -193,7 +195,7 @@ class GTestProfile(SSHProfile):
 
         return test_names
 
-    def load_tests(self, csv_path, disabled_path, ignored_path):
+    def load_tests(self, csv_paths, disabled_path, ignored_path):
         """ Find the list of tests from CSV or fallback to gtest binary. """
         if disabled_path:
             print("Warning: disabled list not supported for gtest profile")
@@ -211,14 +213,15 @@ class GTestProfile(SSHProfile):
                 for test in tests:
                     f.write(test.name + "\n")
         # Load tests from CSV if one was provided
-        elif csv_path:
-            if not os.path.exists(csv_path):
-                raise Exception("Test list file does not exist")
+        elif csv_paths:
+            for csv_path in csv_paths:
+                if not os.path.exists(csv_path):
+                    raise Exception("Test list file does not exist")
 
-            tests = self.parse_gtest_csv(csv_path)
-            for test in tests:
-                parsed_tests.append(
-                    self.create_test_info(test, executable, bin_args))
+                tests = self.parse_gtest_csv(csv_path)
+                for test in tests:
+                    parsed_tests.append(
+                        self.create_test_info(test, executable, bin_args))
         else:
             parsed_tests = self.list_tests(executable, bin_args[:])
 
@@ -301,7 +304,7 @@ class GoogleTestRun(SSHTestRun):
 
         # Regex expressions to match
         total_tests_pattern = re.compile(
-               b".*?(\\d+) (test cases?|tests? from \\d+ test suites?) ran\\." )
+            b".*?(\\d+) (test cases?|tests? from \\d+ test suites?) ran\\.")
         pass_pattern = re.compile(b"^\\[  PASSED  \\] (\\d+) tests?\\.$")
         skip_pattern = re.compile(b"^\\[  SKIPPED \\] (\\d+) tests?")
 


### PR DESCRIPTION
# Overview

city_runner improvements

# Reason for change

These are two city_runner changes for the benefit of OpenCL CTS.

# Description of change

- Allow specifying multiple CSV files. When multiple CSV files are specified, their contents will be merged.
- Fix failure calculation. We were miscounting the number of total tests when we encountered a failure.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
