### PR TITLE
[CMake] Do not try to read missing files.

### DIFF
--- a/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
+++ b/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
@@ -66,6 +66,7 @@ function(find_builtins_tools tools_dir)
         "builtins tools installation does not have necessary cmake modules; "
         "cannot determine whether the builtins compiler generates "
         "${option}-compressed bitcode")
+      continue()
     endif()
     file(STRINGS ${BUILTINS_LLVM_CMAKE} option_set
       REGEX "^set\\(LLVM_ENABLE_${option} .*\\)$")


### PR DESCRIPTION
# Overview

[CMake] Do not try to read missing files.

# Reason for change

In #430, my changes to improve the processing of LLVMConfig.cmake missed out a continue() that resulted in errors when LLVMConfig.cmake could not be found.

# Description of change

This commit adds the missing line.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
