### PR TITLE
Enable cross compilation when building OCK in-tree.

### DIFF
--- a/modules/compiler/builtins/CMakeLists.txt
+++ b/modules/compiler/builtins/CMakeLists.txt
@@ -35,9 +35,13 @@ include(cmake/FindBuiltinsTools.cmake)
 if(NOT CA_EXTERNAL_BUILTINS AND CA_RUNTIME_COMPILER_ENABLED)
   if(NOT DEFINED CA_BUILTINS_TOOLS_DIR)
     if(CMAKE_CROSSCOMPILING)
-      message(FATAL_ERROR
-        "Cross compiled builds requires CA_EXTERNAL_BUILTINS or "
-        "CA_BUILTINS_TOOLS_DIR to be set!")
+      if(EXISTS ${LLVM_NATIVE_TOOL_DIR})
+        set(CA_BUILTINS_TOOLS_DIR ${LLVM_NATIVE_TOOL_DIR})
+      else()
+        message(FATAL_ERROR
+          "Cross compiled builds requires CA_EXTERNAL_BUILTINS or "
+          "CA_BUILTINS_TOOLS_DIR to be set!")
+      endif()
     # We might be in-tree and not be importing an LLVM directory, in which case
     # don't assume any builtins directory - we'll take the tools required to
     # build the builtins directly from the corresponding LLVM targets.

--- a/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
+++ b/modules/compiler/builtins/cmake/FindBuiltinsTools.cmake
@@ -60,7 +60,7 @@ function(find_builtins_tools tools_dir)
       )
       set(BUILTINS_LLVM_CMAKE ${BUILTINS_LLVM_CMAKE}/LLVMConfig.cmake)
     endif()
-    if(NOT EXISTS BUILTINS_LLVM_CMAKE)
+    if(NOT EXISTS ${BUILTINS_LLVM_CMAKE})
       message(
         WARNING
         "builtins tools installation does not have necessary cmake modules; "
@@ -96,12 +96,13 @@ function(find_builtins_tools tools_dir)
       IMPORTED_LOCATION ${BUILTINS_LINKER})
   endif()
 
+  set(llvm_version "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+
   # Check that the version of the compiler building the builtins matches the
   # version of the compiler linked into the runtime.
   execute_process(COMMAND ${BUILTINS_COMPILER} --version
     OUTPUT_VARIABLE version_string RESULT_VARIABLE result)
   if(result EQUAL 0)
-    string(REPLACE "svn" "" llvm_version ${LLVM_PACKAGE_VERSION})
     string(REGEX MATCH "clang version [0-9]+\\.[0-9]+\\.[0-9]"
       version_string ${version_string})
     string(REPLACE "clang version " "" version_string ${version_string})


### PR DESCRIPTION
# Overview

CMake changes that allow cross compiling OCK when building with LLVM in-tree.

# Reason for change

If `CMAKE_CROSSCOMPILING` is set and we are in-tree, it means that OCK is being cross compiled as part of LLVM, and so we can use `LLVM_NATIVE_TOOL_DIR` to find the tools required to compile the builtins. Moreover, since when building in tree we don't use `ImpotLLVM`, the `LLVM_PACKAGE_VERSION` variable was not defined, which lead to a configure error when checking the version string for the builtin tools.

# Description of change

Uses `LLVM_NATIVE_TOOL_DIR` to find builtin tools, sets `LLVM_PACKAGE_VERSION` when cross compiling in-tree.