### PR TITLE
add support for a hal remote library

### DIFF
--- a/examples/hal_cpu_remote_server/CMakeLists.txt
+++ b/examples/hal_cpu_remote_server/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+
+project(hal_cpu_remote_server VERSION 1.0.0 LANGUAGES C CXX ASM)
+
+set(HAL_CPU_REMOTE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../clik/external/hal_cpu)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../hal ${CMAKE_CURRENT_BINARY_DIR}/hal)
+
+# Add the files in directly, rather than drag in as a shared library or take
+# all the extra clik code
+add_executable(hal_cpu_server_bin 
+  hal_cpu_executable.cpp
+  ${HAL_CPU_REMOTE_SOURCE_DIR}/source/cpu_hal.cpp
+  ${HAL_CPU_REMOTE_SOURCE_DIR}/source/hal_main.cpp
+)
+
+target_compile_definitions(hal_cpu_server_bin PUBLIC -DHAL_CPU_MODE=HAL_CPU_WG_MODE)
+target_include_directories(hal_cpu_server_bin PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${HAL_CPU_REMOTE_SOURCE_DIR}/include
+)
+
+target_link_libraries(hal_cpu_server_bin hal_remote hal_common dl pthread)
+
+
+install(TARGETS hal_cpu_server_bin
+        LIBRARY DESTINATION bin
+)

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -1,0 +1,127 @@
+# Hal server
+
+## Introduction
+
+This supports a remote CPU based HAL which uses a socket connection to
+communicate with a remote client. This can be cross-compiled as needed. It is a
+small program which can be modified to use different ways of
+transmission or different underlying HAL interfaces.
+
+It should be paired with a built `oneapi-construction-kit` OpenCL interface using
+the HAL socket client, which resides under `examples/hal_cpu_client`. Details of
+how to build this target will be given below.
+
+## Security
+
+We recommend not running this program as root to reduce any likelihood of a
+malicious actor, as this gives a protocol for running programs. The customer
+should consider a specific user account just for running the server that has
+limited access or using dockers to limit access.
+
+We also recommend using ssh port forwarding. Note that we do not add any
+additional encryption of the executables that are sent.
+
+## Building the server
+
+This can be done as follows:
+
+```
+  cmake -GNinja <path_to_ock>/examples/hal_cpu_remote_server -Bbuild_server
+  ninja
+```
+
+If cross-compilation (for example RISC-V) is needed the following additional arguments are needed:
+
+```
+   -DCMAKE_TOOLCHAIN_FILE=<path_to_ock>/platform/riscv64-linux/riscv64-gcc-toolchain.cmake -DCMAKE_CROSSCOMPILING=TRUE
+```
+
+Note this requires the RISC-V toolchain to be installed as follows on Ubuntu:
+
+```
+  sudo apt-get install --yes gcc-9-riscv64-linux-gnu g++-9-riscv64-linux-gnu
+```
+
+If you wish to run on a non RISC-V machine, then `qemu` and the RISC-V toolchain will need to be installed.
+
+## Building the client
+
+We are looking to simplify this process, but currently we need to create an out
+of tree target. This is done as follows (for RISC-V):
+
+```
+  python <path_to_ock>/scripts/create_target.py <path_to_ock> \
+    <path_to_ock>/scripts/new_target_templates/cpu_client_riscv.json \
+    --external-dir <new_target_dir>
+
+  cd <new_target_dir>
+
+  cmake -Bbuild_client -GNinja \
+    -DCA_MUX_TARGETS_TO_ENABLE="cpu_client" \
+    -DCA_CPU_CLIENT_ENABLED=ON \
+    -DCA_ENABLE_API=cl \
+    -DCA_LLVM_INSTALL_DIR=<path_to_llvm_install> \
+    -DCA_CL_ENABLE_ICD_LOADER=ON  \
+    -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=<path_to_ock> 
+    -DCA_EXTERNAL_CPU_CLIENT_HAL_DIR=<path_to_ock>/examples/hals/hal_cpu_client
+   ninja -Cbuild_client
+```
+
+This assumes building the ICD, but it is possible to build without this.
+
+Note if we just wish a quick test then we could target `UnitCL` with the ninja
+line. Also if the server is running on a different architecture the LLVM build
+will need to enable that architecture.
+
+# Running the server
+
+The server requires a port which will be listened on. This can be any free user
+port. It also will only accept connections from specified nodes. This can be an
+ip address or host name e.g. "127.0.0.1" or "localhost". This defaults to
+"127.0.0.1", assuming that ports will be forwarded if the client is not run on
+the same machine.
+
+The server can be run as follows:
+
+```
+   cd build_server
+   ./hal_cpu_server_bin <port>
+```
+The node can also set with `-n`. It supports `-h` for info.
+
+The server will accept one connection, which when completed will end the
+program. This is to avoid programs putting the cpu into a bad state.
+
+The server can easily be run in a loop though or repeatedly started through a service manager e.g.
+
+```
+ while qemu-riscv64 -L/usr/riscv64-linux-gnu ./hal_cpu_server_bin <port>; do :; done
+```
+
+The environment variable `HAL_DEBUG_SERVER` can be set to 1 to give more debug output.
+
+We recommend this is never run as root as it runs executables sent over tcp/ip.
+
+# Running the client
+
+The client currently supports a socket connection only to the current node and
+it expects the server to be running on the same machine. However, if the
+customer desires to be able to run the server on a different machine (for
+example where we have a RISC-V device running Ubuntu), then the customer may
+consider using ssh port forwarding as suggested above. The recommended way of
+using port forwarding would be as follows:
+
+```
+ssh -L <local_port>:destmachine:<remote_port> user@destmachine
+```
+
+Running the client is done similar to any normal `OCK` OpenCL target (or via
+SYCL OpenCL plugin). The environment variable `HAL_REMOTE_PORT` should be set to
+the local port number. As a simple test try running a simple UnitCL test:
+
+```
+  cd build_client
+  HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so.4.0 \
+    ./oneAPIConstructionKit/bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
+```
+This should show as `PASSED`.

--- a/examples/hal_cpu_remote_server/hal_cpu_executable.cpp
+++ b/examples/hal_cpu_remote_server/hal_cpu_executable.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <signal.h>
+#include <unistd.h>
+
+#include "hal_remote/hal_server.h"
+#include "hal_remote/hal_socket_client.h"
+#include "hal_remote/hal_socket_transmitter.h"
+
+void print_usage(FILE *f, const char *tool_name) {
+  fprintf(f, "usage: %s [-h] [-n node] port\n", tool_name);
+  fprintf(f,
+          "\tnote : node is an ip address or machine name e.g. \"127.0.0.1\" "
+          "(default) or \"localhost\"\n");
+  fprintf(f,
+          "\t       port is an integer non-zero address which will be listened "
+          "on\n");
+}
+
+hal::hal_socket_transmitter transmitter;
+
+bool process_terminated = false;
+void handle_sig(int signum) {
+  // Attempt to close down gracefully
+  transmitter.shutdown();
+  process_terminated = true;
+}
+
+// Note this should not be run as root for security reasons.
+// It will also run once per connection to avoid getting into a bad state
+// It should be rerun if desired to make more than one consecutive connection.
+int main(int argc, char **argv) {
+  std::string node = "127.0.0.1";
+  // Note this default will fail as we do not allow port 0
+  uint16_t port = 0;
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = handle_sig;
+  sigaction(SIGTERM, &action, NULL);
+
+  for (;;) {
+    switch (auto opt = getopt(argc, argv, "n:h")) {
+      case 'n':
+        node = optarg;
+        continue;
+
+      case 'h':
+        print_usage(stdout, argv[0]);
+        exit(0);
+      default:
+        fprintf(stderr, "Error: Unexpected options '%c'\n", (char)opt);
+        print_usage(stderr, argv[0]);
+        exit(1);
+
+      case -1:
+        break;
+    }
+
+    break;
+  }
+
+  if (optind >= argc) {
+    fprintf(stderr, "Error : requires port argument\n");
+    print_usage(stderr, argv[0]);
+    exit(1);
+  }
+  port = std::stoi(argv[optind]);
+
+  uint32_t api_version;
+  auto *hal = get_hal(api_version);
+
+  // hal::hal_socket_transmitter transmitter(port, node.c_str());
+  transmitter.set_node(node.c_str());
+  transmitter.set_port(port);
+
+  hal::hal_server::error_code last_error = hal::hal_server::status_success;
+  auto res = transmitter.start_server(true);
+  if (res != hal::hal_socket_transmitter::success) {
+    (void)fprintf(stderr,
+                  "Unable to start server on requested port %d, node %s\n",
+                  port, node.c_str());
+    return 1;
+  }
+
+  hal::hal_server server(&transmitter, hal);
+  last_error = server.process_commands();
+
+  if (process_terminated) {
+    fprintf(stderr, "Process Terminated\n");
+    exit(1);
+  }
+  // Check if the failure was due the transmitter, if so check if connection
+  // closed, otherwise we have a real error.
+  if (last_error == hal::hal_server::status_transmitter_failed) {
+    if (transmitter.get_last_error() !=
+        hal::hal_socket_transmitter::connection_closed) {
+      (void)fprintf(stderr, "Error with tcp/ip connection\n");
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  return 1;
+}

--- a/examples/hals/hal_cpu_client/CMakeLists.txt
+++ b/examples/hals/hal_cpu_client/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set_property(GLOBAL APPEND PROPERTY KNOWN_HAL_DEVICES "cpu_client")
+set_property(GLOBAL PROPERTY HAL_CPU_CLIENT_NAME "cpu_remote")
+set_property(GLOBAL PROPERTY HAL_CPU_CLIENT_DEVICE_NAME "ock cpu")
+
+add_subdirectory(source)

--- a/examples/hals/hal_cpu_client/source/CMakeLists.txt
+++ b/examples/hals/hal_cpu_client/source/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(HAL_CPU_REMOTE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../clik/external/hal_cpu)
+add_library(hal_cpu_client SHARED
+  # Even though it is remote we need hal_cpu.cpp to get the info
+  ${HAL_CPU_REMOTE_SOURCE_DIR}/source/cpu_hal.cpp
+  hal_main.cpp
+)
+
+set(HAL_CPU_WG_MODE ON)
+
+target_compile_definitions(hal_cpu_client PUBLIC -DBUILD_HAL_DLL)
+target_compile_definitions(hal_cpu_client PUBLIC -DHAL_CPU_MODE=HAL_CPU_WG_MODE)
+
+target_include_directories(hal_cpu_client PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${HAL_CPU_REMOTE_SOURCE_DIR}/include
+)
+
+target_link_libraries(hal_cpu_client hal_remote dl pthread)
+
+set_target_properties(hal_cpu_client PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+  
+install(TARGETS hal_cpu_client
+        LIBRARY DESTINATION lib
+)

--- a/examples/hals/hal_cpu_client/source/hal_main.cpp
+++ b/examples/hals/hal_cpu_client/source/hal_main.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cpu_hal.h>
+#include <hal_remote/hal_socket_client.h>
+
+namespace hal {
+class hal_cpu_socket_client : public hal::hal_socket_client {
+ public:
+  hal_cpu_socket_client() : hal_socket_client(0) {
+    constexpr static uint32_t implemented_api_version = 6;
+    static_assert(
+        implemented_api_version == hal_t::api_version,
+        "Implemented API version for hal_socket_client does not match hal.h");
+    hal_device_info = cpu_hal::setup_cpu_hal_device_info();
+    hal_info.platform_name = hal_device_info.target_name;
+    hal_info.num_devices = 1;
+    hal_info.api_version = implemented_api_version;
+    uint32_t port = 0;
+    if (const char *env = getenv("HAL_REMOTE_PORT")) {
+      port = atoi(env);
+    }
+    set_port(port);
+  }
+
+  // return generic platform information
+  const hal::hal_info_t &get_info() override { return hal_info; }
+
+  // return generic target information
+  const hal::hal_device_info_t *device_get_info(uint32_t index) override {
+    return &hal_device_info;
+  }
+};
+}  // namespace hal
+static hal::hal_cpu_socket_client hal_object;
+
+hal::hal_t *get_hal(uint32_t &api_version) {
+  api_version = hal_object.get_info().api_version;
+  return &hal_object;
+}

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -63,4 +63,5 @@ target_compile_definitions(hal_common PRIVATE
 
 target_link_libraries(hal_common PUBLIC $<$<PLATFORM_ID:Linux>:dl>)
 
+add_subdirectory(hal_remote)
 add_subdirectory(source/hal_null)

--- a/hal/hal_remote/CMakeLists.txt
+++ b/hal/hal_remote/CMakeLists.txt
@@ -15,10 +15,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set(HAL_SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_binary_encoder.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_binary_decoder.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_client.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_device_client.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_server.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_transmitter.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_device_client.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_server.cpp
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_client.h)
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_transmitter.h)
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_socket_transmitter.cpp)
 endif()

--- a/hal/hal_remote/CMakeLists.txt
+++ b/hal/hal_remote/CMakeLists.txt
@@ -16,11 +16,11 @@
 
 set(HAL_SOURCE
   ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_transmitter.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_socket_transmitter.cpp
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_transmitter.h)
+  list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_socket_transmitter.cpp)
 endif()
 
 add_library(

--- a/hal/hal_remote/CMakeLists.txt
+++ b/hal/hal_remote/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(HAL_SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_transmitter.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_socket_transmitter.cpp
+)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_transmitter.h)
+endif()
+
+add_library(
+  hal_remote STATIC ${HAL_SOURCE})
+target_include_directories(
+  hal_remote PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_target_properties(
+  hal_remote PROPERTIES LINKER_LANGUAGE CXX)
+
+target_link_libraries(hal_remote PUBLIC hal_common)

--- a/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
+++ b/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
@@ -1,0 +1,390 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_BINARY_DECODER_H
+#define _HAL_BINARY_DECODER_H
+
+#include <assert.h>
+#include <hal_remote/hal_binary_encoder.h>
+#include <hal_types.h>
+
+namespace hal {
+
+/// @brief Decoder for hal binary commands
+/// @note This decodes a command and can return information about the number of
+/// bytes needed or decode it into internal structure `message` which contains
+/// the information that can be used to call hal functions.
+class hal_binary_decoder {
+ public:
+  hal_binary_decoder() {}
+
+  static const uint32_t data_required_unknown = 0xffffffff;
+
+  /// @brief get the number of additional bytes needed for a command
+  /// @param command enum representing a command
+  /// @return number of bytes needed or data_required_unknown (0xffffffff) if
+  /// unknown command
+  uint32_t decode_command_data_required(hal_binary_encoder::COMMAND command) {
+    switch (command) {
+      case hal_binary_encoder::COMMAND::MEM_ALLOC:
+        return sizeof(message.alloc.size) + sizeof(message.alloc.alignment);
+      case hal_binary_encoder::COMMAND::MEM_FREE:
+        return sizeof(message.free.addr);
+      case hal_binary_encoder::COMMAND::MEM_WRITE:
+        return sizeof(message.write.dst) + sizeof(message.write.size);
+      case hal_binary_encoder::COMMAND::MEM_READ:
+        return sizeof(message.read.src) + sizeof(message.read.size);
+      case hal_binary_encoder::COMMAND::MEM_FILL:
+        return sizeof(message.fill.dst) + sizeof(message.fill.pattern_size) +
+               sizeof(message.fill.size);
+      case hal_binary_encoder::COMMAND::MEM_COPY:
+        return sizeof(message.copy.dst) + sizeof(message.read.src) +
+               sizeof(message.read.size);
+      case hal_binary_encoder::COMMAND::PROGRAM_FREE:
+        return sizeof(message.prog_free.program);
+      case hal_binary_encoder::COMMAND::PROGRAM_LOAD:
+        return sizeof(message.prog_load.size);
+      case hal_binary_encoder::COMMAND::FIND_KERNEL:
+        return sizeof(message.prog_find_kernel.kernel_name_size) +
+               sizeof(message.prog_find_kernel.program);
+      case hal_binary_encoder::COMMAND::MEM_ALLOC_REPLY:
+        return sizeof(message.alloc_reply);
+      case hal_binary_encoder::COMMAND::PROGRAM_LOAD_REPLY:
+        return sizeof(message.prog_load_reply);
+      case hal_binary_encoder::COMMAND::KERNEL_EXEC:
+        return sizeof(message.kernel_exec.program) +
+               // 8
+               sizeof(message.kernel_exec.kernel) +
+               // 16
+               sizeof(message.kernel_exec.num_args) +
+               // 20
+               sizeof(message.kernel_exec.nd_range.offset[0]) * 9 +
+               // 56
+
+               sizeof(message.kernel_exec.work_dim) +
+               sizeof(message.kernel_exec.args_data_size);
+        // 64
+      case hal_binary_encoder::COMMAND::DEVICE_CREATE:
+      case hal_binary_encoder::COMMAND::DEVICE_DELETE:
+        return 0;
+      case hal_binary_encoder::COMMAND::FIND_KERNEL_REPLY:
+        return sizeof(message.find_kernel_reply);
+      case hal_binary_encoder::COMMAND::MEM_READ_REPLY:
+      case hal_binary_encoder::COMMAND::MEM_WRITE_REPLY:
+      case hal_binary_encoder::COMMAND::MEM_FILL_REPLY:
+      case hal_binary_encoder::COMMAND::MEM_FREE_REPLY:
+      case hal_binary_encoder::COMMAND::MEM_COPY_REPLY:
+      case hal_binary_encoder::COMMAND::PROGRAM_FREE_REPLY:
+      case hal_binary_encoder::COMMAND::KERNEL_EXEC_REPLY:
+      case hal_binary_encoder::COMMAND::DEVICE_CREATE_REPLY:
+      case hal_binary_encoder::COMMAND::DEVICE_DELETE_REPLY:
+        return sizeof(uint32_t);  // bool as 32 bit
+      default:
+        fprintf(stderr, "Unknown command : %d\n", (int)command);
+        return 0;
+    }
+    return data_required_unknown;
+  }
+
+  /// @brief  decode a command given data of a particular sise
+  /// @param command
+  /// @param data
+  /// @param size length of data in bytes
+  /// @return true if succeeded otherwise false.
+  bool decode(hal_binary_encoder::COMMAND command, const void *data,
+              uint32_t size) {
+    const uint8_t *data_ptr = static_cast<const uint8_t *>(data);
+    uint32_t offset = 0;
+    bool ok = true;
+    // This assumes both the command and device have been read.
+    switch (command) {
+      case hal_binary_encoder::COMMAND::MEM_ALLOC: {
+        ok = ok && pull(message.alloc.size, data_ptr, offset, size);
+        ok = ok && pull(message.alloc.alignment, data_ptr, offset, size);
+        break;
+      }
+
+      case hal_binary_encoder::COMMAND::MEM_ALLOC_REPLY: {
+        ok = ok && pull(message.alloc_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_FREE: {
+        ok = ok && pull(message.free.addr, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_FREE_REPLY: {
+        ok = ok && pull(message.free_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_WRITE: {
+        ok = ok && pull(message.write.dst, data_ptr, offset, size);
+        ok = ok && pull(message.write.size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_WRITE_REPLY: {
+        ok = ok && pull(message.write_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_READ: {
+        ok = ok && pull(message.read.src, data_ptr, offset, size);
+        ok = ok && pull(message.read.size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_READ_REPLY: {
+        ok = ok && pull(message.read_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_COPY: {
+        ok = ok && pull(message.copy.dst, data_ptr, offset, size);
+        ok = ok && pull(message.copy.src, data_ptr, offset, size);
+        ok = ok && pull(message.copy.size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_COPY_REPLY: {
+        ok = ok && pull(message.copy_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::PROGRAM_FREE: {
+        ok = ok && pull(message.prog_free.program, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::PROGRAM_FREE_REPLY: {
+        ok = ok && pull(message.prog_free_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::PROGRAM_LOAD: {
+        ok = ok && pull(message.prog_load.size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::PROGRAM_LOAD_REPLY: {
+        ok = ok && pull(message.prog_load_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::FIND_KERNEL: {
+        ok = ok &&
+             pull(message.prog_find_kernel.program, data_ptr, offset, size);
+        ok = ok && pull(message.prog_find_kernel.kernel_name_size, data_ptr,
+                        offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::FIND_KERNEL_REPLY: {
+        ok = ok && pull(message.find_kernel_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::KERNEL_EXEC: {
+        ok = ok && pull(message.kernel_exec.program, data_ptr, offset, size);
+        ok = ok && pull(message.kernel_exec.kernel, data_ptr, offset, size);
+        ok = ok && pull(message.kernel_exec.num_args, data_ptr, offset, size);
+        for (uint32_t d = 0; d < 3; d++) {
+          ok = ok && pull(message.kernel_exec.nd_range.offset[d], data_ptr,
+                          offset, size);
+        }
+        for (uint32_t d = 0; d < 3; d++) {
+          ok = ok && pull(message.kernel_exec.nd_range.global[d], data_ptr,
+                          offset, size);
+        }
+        for (uint32_t d = 0; d < 3; d++) {
+          ok = ok && pull(message.kernel_exec.nd_range.local[d], data_ptr,
+                          offset, size);
+        }
+        ok = ok && pull(message.kernel_exec.work_dim, data_ptr, offset, size);
+        ok = ok &&
+             pull(message.kernel_exec.args_data_size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::KERNEL_EXEC_REPLY: {
+        ok = ok && pull(message.kernel_exec_reply, data_ptr, offset, size);
+        break;
+      }
+      // device index is implicit in all commands
+      case hal_binary_encoder::COMMAND::DEVICE_CREATE:
+      case hal_binary_encoder::COMMAND::DEVICE_DELETE:
+        break;
+      case hal_binary_encoder::COMMAND::DEVICE_CREATE_REPLY: {
+        ok = ok && pull(message.device_create_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::DEVICE_DELETE_REPLY: {
+        ok = ok && pull(message.device_delete_reply, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_FILL: {
+        ok = ok && pull(message.fill.dst, data_ptr, offset, size);
+        ok = ok && pull(message.fill.pattern_size, data_ptr, offset, size);
+        ok = ok && pull(message.fill.size, data_ptr, offset, size);
+        break;
+      }
+      case hal_binary_encoder::COMMAND::MEM_FILL_REPLY: {
+        ok = ok && pull(message.mem_fill_reply, data_ptr, offset, size);
+        break;
+      }
+      default:
+        assert(0 && "Unable to decode message");
+        return false;
+    }
+    assert(offset <= size);
+    return ok;
+  }
+
+  bool decode_kernel_exec_args(void *data, uint32_t num_args, uint32_t size) {
+    uint32_t offset = 0;
+    uint8_t *data_ptr = static_cast<uint8_t *>(data);
+    kernel_args.clear();
+    bool ok = true;
+    for (uint32_t a = 0; a < num_args; a++) {
+      hal::hal_arg_t arg;
+      uint32_t value;
+      ok = ok && pull(value, data_ptr, offset, size);
+      if (ok) {
+        arg.kind = static_cast<hal::hal_arg_kind_t>(value);
+      }
+      ok = ok && pull(value, data_ptr, offset, size);
+      if (ok) {
+        arg.space = static_cast<hal::hal_addr_space_t>(value);
+      }
+      ok = ok && pull(arg.size, data_ptr, offset, size);
+      if (ok) {
+        if (arg.kind == hal::hal_arg_kind_t::hal_arg_address) {
+          ok = ok && pull(arg.address, data_ptr, offset, size);
+        } else {
+          // point the pod_data to the allocated data.
+          arg.pod_data = data_ptr + offset;
+          offset += arg.size;
+        }
+      }
+      if (!ok) {
+        break;
+      }
+      kernel_args.push_back(arg);
+    }
+    return ok;
+  }
+
+  enum hal_binary_encoder::COMMAND command;
+  struct MemAlloc {
+    hal::hal_size_t size;
+    hal::hal_addr_t alignment;
+  };
+  struct MemWrite {
+    hal::hal_addr_t dst;
+    hal::hal_size_t size;
+    // We don't encode the actual data here which is expected to follow
+  };
+  struct MemRead {
+    hal::hal_addr_t src;
+    hal::hal_size_t size;
+  };
+  struct MemFill {
+    hal::hal_addr_t dst;
+    hal::hal_size_t pattern_size;
+    hal::hal_size_t size;
+    // We don't encode the actual pattern data here which is expected to follow
+  };
+  struct MemFree {
+    hal::hal_addr_t addr;
+  };
+  struct MemCopy {
+    hal::hal_addr_t dst;
+    hal::hal_addr_t src;
+    hal::hal_size_t size;
+  };
+  struct ProgramFree {
+    hal::hal_program_t program;
+  };
+  struct ProgramLoad {
+    hal::hal_size_t size;
+    // data to follow
+  };
+  struct ProgramFindKernel {
+    hal::hal_program_t program;
+    hal::hal_size_t kernel_name_size;
+  };
+  struct KernelExec {
+    hal::hal_program_t program;
+    hal::hal_kernel_t kernel;
+    hal::hal_ndrange_t nd_range;
+    uint32_t num_args;
+    uint32_t work_dim;
+    uint32_t args_data_size;
+    // actual args passed separately
+  };
+  struct DeviceCreate {
+    uint32_t size;
+    // data to follow
+  };
+  union {
+    MemAlloc alloc;
+    MemWrite write;
+    MemRead read;
+    MemFill fill;
+    MemFree free;
+    MemCopy copy;
+    ProgramFree prog_free;
+    ProgramLoad prog_load;
+    ProgramFindKernel prog_find_kernel;
+    KernelExec kernel_exec;
+    hal::hal_addr_t alloc_reply;
+    bool fill_reply;
+    bool write_reply;
+    bool read_reply;
+    bool free_reply;
+    bool copy_reply;
+    bool prog_free_reply;
+    bool kernel_exec_reply;
+    bool device_create_reply;
+    bool device_delete_reply;
+    bool mem_fill_reply;
+    hal::hal_program_t prog_load_reply;
+    hal::hal_kernel_t find_kernel_reply;
+  } message;
+  std::vector<hal::hal_arg_t> kernel_args;
+
+ private:
+  bool pull(uint64_t &value, const uint8_t *data, uint32_t &offset,
+            uint32_t size) {
+    const uint32_t size_required = sizeof(uint64_t);
+    if (offset + size_required > size) {
+      return false;
+    }
+    std::memcpy(&value, data + offset, size_required);
+    offset += size_required;
+    return true;
+  }
+  bool pull(uint32_t &value, const uint8_t *data, uint32_t &offset,
+            uint32_t size) {
+    const uint32_t size_required = sizeof(uint32_t);
+    if (offset + size_required > size) {
+      return false;
+    }
+    std::memcpy(&value, data + offset, sizeof(uint32_t));
+    offset += sizeof(uint32_t);
+    return true;
+  }
+  bool pull(bool &value, const uint8_t *data, uint32_t &offset, uint32_t size) {
+    const uint32_t size_required = sizeof(uint32_t);
+    uint32_t val32 = 0;
+    if (offset + size_required > size) {
+      return false;
+    }
+    std::memcpy(&val32, data + offset, sizeof(uint32_t));
+    value = static_cast<bool>(val32);
+    offset += sizeof(uint32_t);
+    return true;
+  }
+};
+}  // namespace hal
+
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_binary_encoder.h
+++ b/hal/hal_remote/include/hal_remote/hal_binary_encoder.h
@@ -1,0 +1,351 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_BINARY_ENCODER_H
+#define _HAL_BINARY_ENCODER_H
+
+#include <hal_types.h>
+
+#include <cstring>
+#include <vector>
+
+namespace hal {
+
+/// @brief A simple encoder class for converting hal related commands into a
+/// binary format. Note this does not encrypt in any way; if this is required
+/// this should be done on top of this.
+/// @note Unlike the decoder this also encodes the command and a device id for
+/// the non-reply commands.
+class hal_binary_encoder {
+ public:
+  enum class COMMAND : uint32_t {
+    UNKNOWN,  // To aid debugging, force a non-zero command for real commands
+    MEM_ALLOC = 1,
+    MEM_ALLOC_REPLY = 2,
+    MEM_WRITE = 3,
+    MEM_WRITE_REPLY = 4,
+    MEM_READ = 5,
+    MEM_READ_REPLY = 6,
+    MEM_FILL = 7,
+    MEM_FILL_REPLY = 8,
+    MEM_FREE = 9,
+    MEM_FREE_REPLY = 10,
+    MEM_COPY = 11,
+    MEM_COPY_REPLY = 12,
+    PROGRAM_FREE = 13,
+    PROGRAM_FREE_REPLY = 14,
+    KERNEL_EXEC = 15,
+    KERNEL_EXEC_REPLY = 16,
+    PROGRAM_LOAD = 17,
+    PROGRAM_LOAD_REPLY = 18,
+    FIND_KERNEL = 19,
+    FIND_KERNEL_REPLY = 20,
+    DEVICE_CREATE = 21,
+    DEVICE_CREATE_REPLY = 22,
+    DEVICE_DELETE = 23,
+    DEVICE_DELETE_REPLY = 24
+  };
+
+  hal_binary_encoder(uint32_t device = 0) { device = device; }
+
+  /// @brief encode mem alloc on a device
+  /// @param size
+  /// @param alignment
+  void encode_mem_alloc(hal::hal_size_t size, hal::hal_size_t alignment) {
+    push(COMMAND::MEM_ALLOC);
+    push(device);
+    push(size);
+    push(alignment);
+  }
+
+  /// @brief Encode mem alloc address as a reply
+  /// @param reply
+  void encode_mem_alloc_reply(hal::hal_addr_t reply) {
+    push(COMMAND::MEM_ALLOC_REPLY);
+    push(reply);
+  }
+
+  /// @brief encode device mem free
+  /// @param addr
+  void encode_mem_free(hal::hal_addr_t addr) {
+    push(COMMAND::MEM_FREE);
+    push(device);
+    push(addr);
+  }
+
+  /// @brief encode mem free reply of true/false
+  /// @param reply
+  void encode_mem_free_reply(bool reply) {
+    push(COMMAND::MEM_FREE_REPLY);
+    push(reply);
+  }
+
+  /// @brief encode device mem write
+  /// @param size
+  /// @param alignment
+  void encode_mem_write(hal::hal_addr_t dst, hal::hal_size_t size) {
+    push(COMMAND::MEM_WRITE);
+    push(device);
+    push(dst);
+    push(size);
+  }
+
+  /// @brief Encode mem write reply of true/false
+  /// @param reply
+  void encode_mem_write_reply(bool reply) {
+    push(COMMAND::MEM_WRITE_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device mem/fill
+  /// @param dst
+  /// @param pattern_size
+  /// @param size
+  /// @note that we need to encode the pattern data separately, which should
+  ///       be pushed as a `size` bytes
+  void encode_mem_fill(hal::hal_addr_t dst, hal::hal_size_t pattern_size,
+                       hal::hal_size_t size) {
+    push(COMMAND::MEM_FILL);
+    push(device);
+    push(dst);
+    push(pattern_size);
+    push(size);
+  }
+
+  /// @brief Encode mem fill reply as a boolean
+  /// @param reply
+  void encode_mem_fill_reply(bool reply) {
+    push(COMMAND::MEM_FILL_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device mem read
+  /// @param src
+  /// @param size
+  void encode_mem_read(hal::hal_addr_t src, hal::hal_size_t size) {
+    push(COMMAND::MEM_READ);
+    push(device);
+    push(src);
+    push(size);
+  }
+
+  /// @brief Encode mem read reply as a bool
+  /// @param reply
+  void encode_mem_read_reply(bool reply) {
+    push(COMMAND::MEM_READ_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device mem copy
+  /// @param dst
+  /// @param src
+  /// @param size
+  void encode_mem_copy(hal::hal_addr_t dst, hal::hal_addr_t src,
+                       hal::hal_size_t size) {
+    push(COMMAND::MEM_COPY);
+    push(device);
+    push(dst);
+    push(src);
+    push(size);
+  }
+
+  /// @brief Encode mem copy reply as a bool
+  /// @param reply
+  void encode_mem_copy_reply(bool reply) {
+    push(COMMAND::MEM_COPY_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device find kernel, the name_length should be the length of
+  /// the string + 1 for the null terminator
+  /// @param program
+  /// @param name_length
+  /// @note The name string should follow this, including the null terminator
+  void encode_find_kernel(hal::hal_program_t program,
+                          hal::hal_size_t name_length) {
+    push(COMMAND::FIND_KERNEL);
+    push(device);
+    push(program);
+    push(name_length);
+  }
+
+  /// @brief Encode find kernel reply as a `hal::hal_kernel_t`
+  /// @param reply
+  void encode_find_kernel_reply(hal::hal_kernel_t reply) {
+    push(COMMAND::FIND_KERNEL_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device program load, `size` should be the length of the
+  /// executable
+  /// @param size
+  /// @note The executable should be sent immediately after this. Note this does
+  /// no encryption, it is up to the user to encrypt if needed.
+  void encode_program_load(hal::hal_size_t size) {
+    push(COMMAND::PROGRAM_LOAD);
+    push(device);
+    push(size);
+  }
+
+  /// @brief Encode program load reply as a hal_program_t
+  /// @param reply
+  void encode_program_load_reply(hal::hal_program_t reply) {
+    push(COMMAND::PROGRAM_LOAD_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode device program free
+  /// @param program
+  void encode_program_free(hal::hal_program_t program) {
+    push(COMMAND::PROGRAM_FREE);
+    push(device);
+    push(program);
+  }
+
+  /// @brief encode program free reply as a boolean
+  /// @param reply
+  void encode_program_free_reply(bool reply) {
+    push(COMMAND::PROGRAM_FREE_REPLY);
+    push(reply);
+  }
+
+  /// @brief Encode
+  /// @param program
+  /// @param kernel
+  /// @param nd_range
+  /// @param num_args
+  /// @param work_dim
+  void encode_kernel_exec(hal::hal_program_t program, hal::hal_kernel_t kernel,
+                          const hal::hal_ndrange_t *nd_range, uint32_t num_args,
+                          uint32_t work_dim) {
+    encoding.clear();
+    push(COMMAND::KERNEL_EXEC);
+    push(device);
+    push(program);
+    push(kernel);
+    push(num_args);
+    for (uint32_t d = 0; d < 3; d++) {
+      push(nd_range->offset[d]);
+    }
+    for (uint32_t d = 0; d < 3; d++) {
+      push(nd_range->global[d]);
+    }
+    for (uint32_t d = 0; d < 3; d++) {
+      push(nd_range->local[d]);
+    }
+    push(work_dim);
+  }
+  void encode_kernel_exec_args(const hal::hal_arg_t *args, uint32_t num_args) {
+    /*
+      Encoding this information
+      hal::hal_arg_kind_t kind;
+      hal_addr_space_t space;
+      hal::hal_size_t size;
+      union {
+        hal::hal_addr_t address;
+        void *pod_data;
+      }
+  };*/
+    uint32_t bytes_required = 0;
+    uint32_t pod_data_required = 0;
+    for (uint32_t a = 0; a < num_args; a++) {
+      auto &arg = args[a];
+      // kind, space (32 bit) and size (64 bit)
+      bytes_required += sizeof(uint32_t) * 2 + sizeof(arg.size);
+      if (arg.kind == hal::hal_arg_kind_t::hal_arg_address) {
+        bytes_required += sizeof(arg.address);
+      } else {
+        pod_data_required += arg.size;
+      }
+    }
+    bytes_required += pod_data_required;
+    push(bytes_required);
+
+    for (uint32_t a = 0; a < num_args; a++) {
+      auto &arg = args[a];
+      push(static_cast<uint32_t>(arg.kind));
+      push(static_cast<uint32_t>(arg.space));
+      push(arg.size);
+      if (arg.kind == hal::hal_arg_kind_t::hal_arg_address) {
+        push(arg.address);
+      } else {
+        push(arg.pod_data, arg.size);
+      }
+    }
+  }
+  void encode_kernel_exec_reply(bool reply) {
+    push(COMMAND::KERNEL_EXEC_REPLY);
+    push(reply);
+  }
+
+  void encode_device_create() {
+    push(COMMAND::DEVICE_CREATE);
+    push(device);
+  }
+  void encode_device_create_reply(bool success) {
+    push(COMMAND::DEVICE_CREATE_REPLY);
+    push(success);
+  }
+  void encode_device_delete() {
+    push(COMMAND::DEVICE_DELETE);
+    push(device);
+  }
+  void encode_device_delete_reply(bool success) {
+    push(COMMAND::DEVICE_DELETE_REPLY);
+    push(success);
+  }
+
+  void *data() { return encoding.data(); }
+  uint32_t size() { return encoding.size(); }
+
+  void clear() { encoding.clear(); }
+
+ private:
+  void expand(uint32_t size) { encoding.resize(encoding.size() + size); }
+  void push(hal::hal_size_t size) {
+    const uint32_t offset = encoding.size();
+    expand(sizeof(hal::hal_size_t));
+    std::memcpy(encoding.data() + offset, &size, sizeof(hal::hal_size_t));
+  }
+
+  void push(uint32_t val) {
+    const uint32_t offset = encoding.size();
+    expand(sizeof(val));
+    std::memcpy(encoding.data() + offset, &val, sizeof(val));
+  }
+  void push(bool val) {
+    const uint32_t val32 = val;
+    push(val32);
+  }
+
+  void push(const void *data, uint32_t size) {
+    const uint32_t offset = encoding.size();
+    expand(size);
+    std::memcpy(encoding.data() + offset, data, size);
+  }
+
+  void push(enum COMMAND command) {
+    const uint32_t offset = encoding.size();
+    expand(sizeof(command));
+    std::memcpy(encoding.data() + offset, &command, sizeof(command));
+  }
+  std::vector<uint8_t> encoding;
+  uint32_t offset = 0;
+  uint32_t device = 0;
+};
+}  // namespace hal
+
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_client.h
+++ b/hal/hal_remote/include/hal_remote/hal_client.h
@@ -1,0 +1,124 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_CLIENT_H
+#define _HAL_CLIENT_H
+
+#include <hal.h>
+#include <hal_remote/hal_binary_decoder.h>
+#include <hal_remote/hal_binary_encoder.h>
+#include <hal_remote/hal_device_client.h>
+
+#include <mutex>
+
+namespace hal {
+
+/// @brief Base class for hal_client, is a type of `hal::hal_t`, which can be
+/// used to communicate with a remote server and will create `hal_device_client`
+/// when requested via requests to the server.
+/// @note It currently has the limitation of only supporting a single device.
+class hal_client : public hal::hal_t {
+ protected:
+  std::mutex lock;
+  bool made_connection = false;
+  hal::hal_info_t hal_info;
+  hal::hal_device_info_t hal_device_info;
+  uint16_t required_port;
+
+ public:
+  hal_client() {}
+  virtual bool make_connection() = 0;
+  virtual hal::hal_transmitter &get_transmitter() = 0;
+  // request the creation of a new hal
+  hal::hal_device_t *device_create(uint32_t index) override {
+    const std::lock_guard<std::mutex> locker(lock);
+    // Before we create a device check that the endianness described by the info
+    // matches our own, as the data protocol assumes that endianness matches
+    const uint32_t one = 1U;
+    bool is_little_endian = reinterpret_cast<const char *>(&one)[0] == 1;
+    assert(is_little_endian == hal_device_info.is_little_endian);
+
+    if (is_little_endian != hal_device_info.is_little_endian) {
+      return nullptr;
+    }
+    if (index > 0) {
+      return nullptr;
+    }
+
+    if (!made_connection) {
+      if (!make_connection()) {
+        return nullptr;
+      }
+      made_connection = true;
+    }
+
+    hal::hal_binary_encoder encoder(index);
+    hal::hal_binary_decoder decoder;
+    hal::hal_binary_encoder::COMMAND command;
+    encoder.encode_device_create();
+    get_transmitter().send(encoder.data(), encoder.size(), true);
+    bool ok = get_transmitter().receive(
+        &command, sizeof(hal::hal_binary_encoder::COMMAND));
+    if (command == hal::hal_binary_encoder::COMMAND::DEVICE_CREATE_REPLY) {
+      const uint32_t data_required = decoder.decode_command_data_required(
+          hal::hal_binary_encoder::COMMAND::DEVICE_CREATE_REPLY);
+      std::vector<uint8_t> payload(data_required);
+
+      ok = ok && get_transmitter().receive(payload.data(), data_required);
+      if (!ok) {
+        return nullptr;
+      }
+      if (decoder.decode(command, payload.data(), payload.size())) {
+        if (decoder.message.device_create_reply) {
+          return new hal::hal_device_client(&hal_device_info, lock,
+                                            &get_transmitter());
+        }
+      }
+    }
+    return nullptr;
+  }
+
+  // destroy a device instance
+  bool device_delete(hal::hal_device_t *device) override {
+    if (!made_connection) {
+      made_connection = true;
+
+      if (make_connection()) {
+        return false;
+      }
+    }
+
+    hal::hal_binary_encoder encoder(0);  // Assume is first device
+    hal::hal_binary_decoder decoder;
+    hal::hal_binary_encoder::COMMAND command;
+    encoder.encode_device_delete();  // Assume is first device
+    get_transmitter().send(encoder.data(), encoder.size(), true);
+    bool ok = get_transmitter().receive(
+        &command, sizeof(hal::hal_binary_encoder::COMMAND));
+    if (command == hal::hal_binary_encoder::COMMAND::DEVICE_DELETE_REPLY) {
+      const uint32_t data_required = decoder.decode_command_data_required(
+          hal::hal_binary_encoder::COMMAND::DEVICE_DELETE_REPLY);
+      std::vector<uint8_t> payload(data_required);
+      ok = ok && get_transmitter().receive(payload.data(), data_required);
+      ok = ok && decoder.decode(command, payload.data(), payload.size());
+      ok = ok && decoder.message.device_delete_reply;
+    }
+    delete static_cast<hal::hal_device_client *>(device);
+    return ok;
+  }
+};
+}  // namespace hal
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_device_client.h
+++ b/hal/hal_remote/include/hal_remote/hal_device_client.h
@@ -1,0 +1,99 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_DEVICE_CLIENT_H
+#define _HAL_DEVICE_CLIENT_H
+
+#include <hal.h>
+#include <hal_remote/hal_binary_decoder.h>
+#include <hal_remote/hal_transmitter.h>
+#include <hal_types.h>
+
+#include <mutex>
+
+namespace hal {
+
+/// @brief A hal device which will communicate with a remote server
+/// to perform the hal device actions.
+/// @note This will use a default encoding through the `hal_binary_encoder`
+/// class but all functions are overridable so that a user may encode
+/// in their own way. For example `kernel_exec` could encrypt the kernel.
+///
+/// @note This uses a `hal_transmitter` to send and receive the information
+/// This is a simple abstract class that could use different methods of
+/// communication e.g. sockets, file descriptors etc. Also it should be noted
+/// that this does not deal with device creation which should be done by the
+/// `hal` and use the same transmitter.
+class hal_device_client : public hal::hal_device_t {
+ public:
+  hal_device_client(hal::hal_device_info_t *info, std::mutex &hal_lock,
+                    hal::hal_transmitter *transmitter);
+
+  // @brief find program kernel based on `name`
+  hal::hal_kernel_t program_find_kernel(hal::hal_program_t program,
+                                        const char *name) override;
+
+  // @brief load an ELF file into target memory
+  // returns `hal_invalid_program` if the program could not be loaded
+  hal::hal_program_t program_load(const void *data,
+                                  hal::hal_size_t size) override;
+
+  // @brief execute a kernel on the target
+  bool kernel_exec(hal::hal_program_t program, hal::hal_kernel_t kernel,
+                   const hal::hal_ndrange_t *nd_range,
+                   const hal::hal_arg_t *args, uint32_t num_args,
+                   uint32_t work_dim) override;
+
+  // @brief unload a program from the target
+  bool program_free(hal::hal_program_t program) override;
+
+  // @brief allocate a memory range on the target
+  // @return allocated address or `hal_nullptr` if the operation was
+  // unsuccessful
+  hal::hal_addr_t mem_alloc(hal::hal_size_t size,
+                            hal::hal_size_t alignment) override;
+
+  // @brief copy memory between target buffers
+  bool mem_copy(hal::hal_addr_t dst, hal::hal_addr_t src,
+                hal::hal_size_t size) override;
+
+  // @brief free a memory range on the target
+  bool mem_free(hal::hal_addr_t addr) override;
+
+  // @brief fill memory with a pattern
+  bool mem_fill(hal::hal_addr_t dst, const void *pattern,
+                hal::hal_size_t pattern_size, hal::hal_size_t size) override;
+
+  // @brief read memory from the target to the host
+  bool mem_read(void *dst, hal::hal_addr_t src, hal::hal_size_t size) override;
+
+  // @brief write host memory to the target
+  bool mem_write(hal::hal_addr_t dst, const void *src,
+                 hal::hal_size_t size) override;
+  bool hal_debug() { return debug; }
+
+ protected:
+  /// @brief A small helper function to check the reply and download the related
+  /// data into `decoder`
+  /// @return true if the receive and decode worked.
+  bool receive_decode_reply(hal_binary_encoder::COMMAND expected_command,
+                            hal_binary_decoder &decoder);
+  hal::hal_transmitter *transmitter;
+  bool debug = false;
+  std::mutex &hal_lock;
+};
+}  // namespace hal
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_server.h
+++ b/hal/hal_remote/include/hal_remote/hal_server.h
@@ -1,0 +1,93 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_SERVER_H
+#define _HAL_SERVER_H
+
+#include <hal_remote/hal_binary_encoder.h>
+#include <hal_remote/hal_transmitter.h>
+
+#include <vector>
+
+namespace hal {
+class hal_t;
+class hal_device_t;
+
+/// @brief A server for taking binary data and translating into actions
+/// on a HAL and HAL devices
+/// @note This uses an abstract class `hal_transmitter` which can be used to
+/// read and write the binary data. This transmitter may use sockets for example
+/// but other approaches are possible. It is designed to only talk to one end
+/// point and it is expected that end point will only make a single request at a
+/// time and wait for the result. All requests to the server take a 4 byte
+/// command (which maps the hal_binary_encoder::COMMAND), and a 4 byte device
+/// id. The actual command will dictate how many more bytes are required using
+/// the hal_binary_decoder.
+///
+/// The actual command will be processed will be done in process_command.
+/// This will only process that first 8 bytes before calling one of the
+/// process_* functions, which are expected to fetch the rest, all of which can
+/// be overridden This takes a hal as an input, but is currently only able to
+/// handle hals which support a single device. This could be remedied by storing
+/// more than a single `hal_device` - and mapping indexes to devices and
+/// vice-versa
+///
+/// `process_commands()` provides a method of repeatedly calling
+/// `process_command()` until an error condition happens.
+///
+
+class hal_server {
+ public:
+  enum error_code {
+    status_success,
+    status_transmitter_failed,
+    status_device_not_supported,
+    status_unknown_command,
+    status_decode_failed
+  };
+  hal_server(hal::hal_transmitter *transmitter, hal::hal_t *hal);
+  ~hal_server();
+
+  virtual error_code process_commands();
+
+ protected:
+  virtual error_code process_command();
+  virtual hal_server::error_code process_mem_alloc(uint32_t device);
+  virtual hal_server::error_code process_mem_free(uint32_t device);
+  virtual hal_server::error_code process_mem_write(uint32_t device);
+  virtual hal_server::error_code process_mem_read(uint32_t device);
+  virtual hal_server::error_code process_mem_fill(uint32_t device);
+  virtual hal_server::error_code process_mem_copy(uint32_t device);
+  virtual hal_server::error_code process_program_free(uint32_t device);
+  virtual hal_server::error_code process_find_kernel(uint32_t device);
+  virtual hal_server::error_code process_program_load(uint32_t device);
+  virtual hal_server::error_code process_kernel_exec(uint32_t device);
+  virtual hal_server::error_code process_device_create(uint32_t device);
+  virtual hal_server::error_code process_device_delete(uint32_t device);
+
+  error_code receive_payload(hal_binary_encoder::COMMAND command,
+                             std::vector<uint8_t> &payload);
+  void *receive_data(uint32_t size);
+
+  hal::hal_t *hal;
+  hal::hal_device_t *hal_device = nullptr;
+  hal_transmitter *transmitter;
+  std::vector<uint8_t> payload;
+  bool debug = false;
+};
+}  // namespace hal
+
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_socket_client.h
+++ b/hal/hal_remote/include/hal_remote/hal_socket_client.h
@@ -1,0 +1,51 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_SOCKET_CLIENT_H
+#define _HAL_SOCKET_CLIENT_H
+
+#include <mutex>
+
+#include "hal.h"
+#include "hal_remote/hal_client.h"
+#include "hal_remote/hal_socket_transmitter.h"
+
+namespace hal {
+
+/// @brief A simple socket based version of `hal_client`.
+class hal_socket_client : public hal::hal_client {
+ protected:
+  hal::hal_socket_transmitter transmitter;
+  uint16_t required_port;
+
+ public:
+  hal_socket_client(uint16_t port) : hal_client() { required_port = port; }
+
+  void set_port(uint16_t port) { required_port = port; }
+
+  bool make_connection() {
+    transmitter.set_port(required_port);
+    const hal::hal_socket_transmitter::error_code res =
+        transmitter.make_connection();
+    if (res != hal::hal_socket_transmitter::success) {
+      return false;
+    }
+    return true;
+  }
+  hal::hal_transmitter &get_transmitter() { return transmitter; }
+};
+}  // namespace hal
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_socket_transmitter.h
+++ b/hal/hal_remote/include/hal_remote/hal_socket_transmitter.h
@@ -20,21 +20,30 @@
 #include <hal_remote/hal_transmitter.h>
 #include <netinet/in.h>
 
+#include <string>
+
 namespace hal {
 
 /// @brief A very simple socket based version of a hal_transmitter
 /// @note This supports both client and server mode, and the sure should use
-/// start_server() or make_connection() as appropriate. This supports the
-/// required port being 0 for a server allows it to find a free port. For
-/// some operations error_code enum will be used, but for `send` and `receive`
+/// start_server() or make_connection() as appropriate. This does not support
+/// the required port being 0 to allow a server to find a free port. For some
+/// operations the `error_code` enum will be used, but for `send` and `receive`
 /// these are derived functions, so get_last_error() can be used.
+///
+/// We highly recommend using port forwarding and a user process with this to
+/// reduce any security risk.
 class hal_socket_transmitter : public hal_transmitter {
  public:
-  hal_socket_transmitter(uint16_t port = 0) : port_requested(port) {}
+  /// @note the default port allows us to create the
+  hal_socket_transmitter(uint16_t port = 0, const char *node = "127.0.0.1")
+      : port_requested(port), node(node) {}
   ~hal_socket_transmitter();
 
   enum error_code {
     success,
+    socket_failed,
+    port_0_requested,
     bind_failed,
     connect_failed,
     connection_closed,
@@ -42,7 +51,8 @@ class hal_socket_transmitter : public hal_transmitter {
     accept_failed,
     send_error,
     recv_error,
-    getsockname_failed
+    getsockname_failed,
+    getaddrinfo_failed
   };
 
   /// @brief set port we wish to request on. This must be done before any calls
@@ -52,16 +62,22 @@ class hal_socket_transmitter : public hal_transmitter {
   ///       in some cases to default it initially and then set it later.
   void set_port(uint16_t port) { port_requested = port; }
 
+  /// @brief set node we wish to limit connections from.
+  /// @param node_in we wish to limit connections from
+  /// @note This duplicates the constructor argument but makes it easier
+  ///       in some cases to default it initially and then set it later.
+  void set_node(const char *node_in) { node = node_in; }
+
   /// @brief Start the server end
   /// @param print_port optionally print out that we are listening on a
   /// particular port
-  /// @return success if successful. If unsuccessful last_error also will
-  /// contain error
+  /// @return error_code::success if successful. If unsuccessful last_error
+  /// will also contain error
   error_code start_server(bool print_port);
 
   /// @brief make a connection to a server
-  /// @return success if successful. If unsuccessful last_error also will
-  /// contain error
+  /// @return error_code::success if successful. If unsuccessful last_error
+  /// will also contain the error
   error_code make_connection();
 
   /// @brief Indicates that a connection is live (either as server or as a
@@ -74,7 +90,7 @@ class hal_socket_transmitter : public hal_transmitter {
   bool connected() const { return is_connected; }
 
   /// @brief returns the last error from socket operations
-  /// @return last error reported from the socket
+  /// @return last error
   int get_last_error() const { return last_error; }
 
   ///  @brief Receive `size` bytes of data into `data`
@@ -84,34 +100,42 @@ class hal_socket_transmitter : public hal_transmitter {
   bool receive(void *data, uint32_t size) override;
 
   /// @brief Send `size` bytes of `data` with an optional flush
-  bool send(const void *data, uint32_t size, bool flush);
+  bool send(const void *data, uint32_t size, bool flush) override;
+
+  /// @brief Attempt to shut the connection down gracefully.
+  void shutdown();
 
  private:
   /// @brief connect to the remote server
-  /// @return error returned by connect socket function
+  /// @return error_code::success if successful
   error_code connect();
 
   /// @brief set up a connection basic ready for connect() or listen/accept
   ///        optionally adding a bind if being used as server and getting the
   ///        port number bound to.
   /// @param server in server mode, requiring a bind() call
-  /// @return 0 for success, anything else represents the error from bind or
-  ///         getsockname
+  /// @return error_code::success for success
   error_code setup_connection(bool server);
 
-  int listen();
-  int accept();
+  /// @brief call listen
+  /// @return true if listen succeeded
+  bool listen();
+
+  /// @brief Call accept
+  /// @return true if accept succeeded
+  bool accept();
 
   int get_port() { return current_port; }
 
   uint16_t port_requested;
   uint16_t current_port = 0;
-  sockaddr_in server_address;
-  int sock = 0;
-  int fd_to_use = 0;
+  sockaddr server_address;
+  int sock = -1;
+  int fd_to_use = -1;
   bool setup_connection_done = false;
   error_code last_error = error_code::success;
   bool is_connected = false;
+  std::string node;
 };
 }  // namespace hal
 #endif

--- a/hal/hal_remote/include/hal_remote/hal_socket_transmitter.h
+++ b/hal/hal_remote/include/hal_remote/hal_socket_transmitter.h
@@ -1,0 +1,117 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HAL_SOCKET_TRANSMITTER_H
+#define _HAL_SOCKET_TRANSMITTER_H
+
+#include <hal_remote/hal_transmitter.h>
+#include <netinet/in.h>
+
+namespace hal {
+
+/// @brief A very simple socket based version of a hal_transmitter
+/// @note This supports both client and server mode, and the sure should use
+/// start_server() or make_connection() as appropriate. This supports the
+/// required port being 0 for a server allows it to find a free port. For
+/// some operations error_code enum will be used, but for `send` and `receive`
+/// these are derived functions, so get_last_error() can be used.
+class hal_socket_transmitter : public hal_transmitter {
+ public:
+  hal_socket_transmitter(uint16_t port = 0) : port_requested(port) {}
+  ~hal_socket_transmitter();
+
+  enum error_code {
+    success,
+    bind_failed,
+    connect_failed,
+    connection_closed,
+    listen_failed,
+    accept_failed,
+    send_error,
+    recv_error,
+    getsockname_failed
+  };
+
+  /// @brief set port we wish to request on. This must be done before any calls
+  /// to start_server or make_connection.
+  /// @param port we wish to make request on
+  /// @note This duplicates the constructor argument but makes it easier
+  ///       in some cases to default it initially and then set it later.
+  void set_port(uint16_t port) { port_requested = port; }
+
+  /// @brief Start the server end
+  /// @param print_port optionally print out that we are listening on a
+  /// particular port
+  /// @return success if successful. If unsuccessful last_error also will
+  /// contain error
+  error_code start_server(bool print_port);
+
+  /// @brief make a connection to a server
+  /// @return success if successful. If unsuccessful last_error also will
+  /// contain error
+  error_code make_connection();
+
+  /// @brief Indicates that a connection is live (either as server or as a
+  /// client)
+  /// @note it may still be the case that the last send/receive was in error
+  ///       but we keep the connected flag live and report false in that case.
+  ///       If the connection was dropped, recv can receive 0 bytes which is
+  ///       what is used to set this to false.
+  /// @return true if connected.
+  bool connected() const { return is_connected; }
+
+  /// @brief returns the last error from socket operations
+  /// @return last error reported from the socket
+  int get_last_error() const { return last_error; }
+
+  ///  @brief Receive `size` bytes of data into `data`
+  ///  @return true if was able to receive the data. Note that false may
+  ///  indicate that the connection was dropped or there were errors. In this
+  ///  case check last_error for information (connection_closed if dropped)
+  bool receive(void *data, uint32_t size) override;
+
+  /// @brief Send `size` bytes of `data` with an optional flush
+  bool send(const void *data, uint32_t size, bool flush);
+
+ private:
+  /// @brief connect to the remote server
+  /// @return error returned by connect socket function
+  error_code connect();
+
+  /// @brief set up a connection basic ready for connect() or listen/accept
+  ///        optionally adding a bind if being used as server and getting the
+  ///        port number bound to.
+  /// @param server in server mode, requiring a bind() call
+  /// @return 0 for success, anything else represents the error from bind or
+  ///         getsockname
+  error_code setup_connection(bool server);
+
+  int listen();
+  int accept();
+
+  int get_port() { return current_port; }
+
+  uint16_t port_requested;
+  uint16_t current_port = 0;
+  sockaddr_in server_address;
+  int sock = 0;
+  int fd_to_use = 0;
+  bool setup_connection_done = false;
+  error_code last_error = error_code::success;
+  bool is_connected = false;
+};
+}  // namespace hal
+#endif

--- a/hal/hal_remote/include/hal_remote/hal_transmitter.h
+++ b/hal/hal_remote/include/hal_remote/hal_transmitter.h
@@ -1,0 +1,44 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdint>
+
+#ifndef _HAL_TRANSMITTER_H
+#define _HAL_TRANSMITTER_H
+
+namespace hal {
+
+///  @brief A simple class interface that can be used for transmitting and
+///  sending data - derive from this to support sockets, file descriptors etc.
+class hal_transmitter {
+ public:
+  /// @brief Send `size` bytes of `data` with an optional flush
+  /// @return true if the send succeeds
+  virtual bool send(const void *data, uint32_t size, bool flush) = 0;
+
+  /// Receive `size` bytes of data into `data`
+  /// @return true if the receive succeeds
+  virtual bool receive(void *data, uint32_t size) = 0;
+  virtual ~hal_transmitter(){};
+
+  void enable_debug(bool debug_enabled) { debug = debug_enabled; }
+  bool debug_enabled() { return debug; }
+
+ private:
+  bool debug = false;
+};
+}  // namespace hal
+#endif

--- a/hal/hal_remote/source/hal_device_client.cpp
+++ b/hal/hal_remote/source/hal_device_client.cpp
@@ -1,0 +1,253 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <assert.h>
+#include <hal_remote/hal_device_client.h>
+
+namespace hal {
+
+hal_device_client::hal_device_client(hal::hal_device_info_t *info,
+                                     std::mutex &hal_lock,
+                                     hal::hal_transmitter *transmitter)
+    : hal::hal_device_t(info), transmitter(transmitter), hal_lock(hal_lock) {
+  if (const char *env = getenv("CA_HAL_DEBUG")) {
+    if (*env == '1') debug = true;
+  }
+}
+
+hal::hal_addr_t hal_device_client::mem_alloc(hal::hal_size_t size,
+                                             hal::hal_size_t alignment) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+
+  encoder.encode_mem_alloc(size, alignment);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_ALLOC_REPLY,
+                                  decoder);
+
+  if (ok) {
+    return decoder.message.alloc_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_ALLOC_REPLY\n");
+    return 0;
+  }
+}
+
+bool hal_device_client::mem_write(hal::hal_addr_t dst, const void *src,
+                                  hal::hal_size_t size) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_mem_write(dst, size);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), false);
+  ok = ok && transmitter->send(src, size, true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_WRITE_REPLY,
+                                  decoder);
+
+  if (ok) {
+    return decoder.message.write_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_WRITE_REPLY\n");
+    return false;
+  }
+}
+
+bool hal_device_client::mem_fill(hal::hal_addr_t dst, const void *pattern,
+                                 hal::hal_size_t pattern_size,
+                                 hal::hal_size_t size) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_mem_fill(dst, pattern_size, size);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), false);
+  ok = ok && transmitter->send(pattern, pattern_size, true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_FILL_REPLY,
+                                  decoder);
+  if (ok) {
+    return decoder.message.fill_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_FILL_REPLY\n");
+    return false;
+  }
+}
+
+bool hal_device_client::program_free(hal::hal_program_t program) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_program_free(program);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(
+                 hal_binary_encoder::COMMAND::PROGRAM_FREE_REPLY, decoder);
+  if (ok) {
+    return decoder.message.free_reply;
+  } else {
+    assert(0 && "Error Failed to get PROGRAM_FREE_REPLY\n");
+    return false;
+  }
+}
+
+hal::hal_program_t hal_device_client::program_load(const void *data,
+                                                   hal::hal_size_t size) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+
+  encoder.encode_program_load(size);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), false);
+  ok = ok && transmitter->send(data, size, true);
+  ok = ok && receive_decode_reply(
+                 hal_binary_encoder::COMMAND::PROGRAM_LOAD_REPLY, decoder);
+  if (ok) {
+    return decoder.message.prog_load_reply;
+  } else {
+    assert(0 && "Error Failed to get PROGRAM_LOAD_REPLY\n");
+    return false;
+  }
+}
+
+hal::hal_kernel_t hal_device_client::program_find_kernel(
+    hal::hal_program_t program, const char *name) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  const uint32_t name_length = strlen(name) + 1;
+  encoder.encode_find_kernel(program, name_length);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), false);
+  ok = ok && transmitter->send(name, name_length, true);
+  ok = ok && receive_decode_reply(
+                 hal_binary_encoder::COMMAND::FIND_KERNEL_REPLY, decoder);
+  if (ok) {
+    return decoder.message.find_kernel_reply;
+  } else {
+    assert(0 && "Error Failed to get FIND_KERNEL_REPLY\n");
+    return false;
+  }
+}
+
+bool hal_device_client::mem_free(hal::hal_addr_t addr) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+
+  encoder.encode_mem_free(addr);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_FREE_REPLY,
+                                  decoder);
+
+  if (ok) {
+    return decoder.message.free_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_FREE_REPLY\n");
+    return false;
+  }
+}
+
+bool hal_device_client::mem_copy(hal::hal_addr_t dst, hal::hal_addr_t src,
+                                 hal::hal_size_t size) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_mem_copy(dst, src, size);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_COPY_REPLY,
+                                  decoder);
+
+  if (ok) {
+    return decoder.message.copy_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_COPY_REPLY\n");
+    return false;
+  }
+}
+
+bool hal_device_client::kernel_exec(hal::hal_program_t program,
+                                    hal::hal_kernel_t kernel,
+                                    const hal::hal_ndrange_t *nd_range,
+                                    const hal::hal_arg_t *args,
+                                    uint32_t num_args, uint32_t work_dim) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  if (hal_debug()) {
+    (void)fprintf(stderr,
+                  "hal_device_client::kernel_exec(kernel=0x%08lx, num_args=%d, "
+                  "global=<%ld:%ld:%ld>, local=<%ld:%ld:%ld>)\n",
+                  kernel, num_args, nd_range->global[0], nd_range->global[1],
+                  nd_range->global[2], nd_range->local[0], nd_range->local[1],
+                  nd_range->local[2]);
+  }
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_kernel_exec(program, kernel, nd_range, num_args, work_dim);
+  bool ok = transmitter->send(encoder.data(), encoder.size(), false);
+  encoder.clear();
+  encoder.encode_kernel_exec_args(args, num_args);
+  ok = ok && transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(
+                 hal_binary_encoder::COMMAND::KERNEL_EXEC_REPLY, decoder);
+
+  if (ok) {
+    return decoder.message.kernel_exec_reply;
+  } else {
+    assert(0 && "Error Failed to get KERNEL_EXEC_REPLY\n");
+    return false;
+  }
+}
+bool hal_device_client::mem_read(void *dst, hal::hal_addr_t src,
+                                 hal::hal_size_t size) {
+  const std::lock_guard<std::mutex> locker(hal_lock);
+  hal_binary_encoder encoder;
+  hal_binary_decoder decoder;
+  encoder.encode_mem_read(src, size);
+
+  bool ok = transmitter->send(encoder.data(), encoder.size(), true);
+  ok = ok && receive_decode_reply(hal_binary_encoder::COMMAND::MEM_READ_REPLY,
+                                  decoder);
+  if (ok) {
+    ok = ok && transmitter->receive(dst, size);
+    return ok && decoder.message.read_reply;
+  } else {
+    assert(0 && "Error Failed to get MEM_READ_REPLY\n");
+    return false;
+  }
+  return ok;
+}
+
+bool hal_device_client::receive_decode_reply(
+    hal_binary_encoder::COMMAND expected_command, hal_binary_decoder &decoder) {
+  hal_binary_encoder::COMMAND command;
+  bool ok = true;
+  ok =
+      ok && transmitter->receive(&command, sizeof(hal_binary_encoder::COMMAND));
+  assert(ok);
+  ok = ok && (command == expected_command);
+  assert(ok);
+  if (ok) {
+    const uint32_t data_required =
+        decoder.decode_command_data_required(command);
+    std::vector<uint8_t> payload(data_required);
+    ok = ok && transmitter->receive(payload.data(), data_required);
+    if (ok) {
+      ok = ok && decoder.decode(command, payload.data(), data_required);
+      assert(ok);
+    }
+  } else {
+    return false;
+  }
+  return ok;
+}
+
+}  // namespace hal

--- a/hal/hal_remote/source/hal_server.cpp
+++ b/hal/hal_remote/source/hal_server.cpp
@@ -1,0 +1,545 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <assert.h>
+#include <hal.h>
+#include <hal_remote/hal_binary_decoder.h>
+#include <hal_remote/hal_binary_encoder.h>
+#include <hal_remote/hal_server.h>
+
+#include <cstring>
+
+namespace hal {
+hal_server::hal_server(hal_transmitter *transmitter, hal::hal_t *hal)
+    : hal(hal), transmitter(transmitter) {
+  if (getenv("HAL_DEBUG_SERVER") && *getenv("HAL_DEBUG_SERVER") == '1') {
+    debug = true;
+  }
+}
+
+hal_server::~hal_server() {
+  if (hal_device) {
+    hal->device_delete(hal_device);
+  }
+}
+
+void *hal_server::receive_data(uint32_t size) {
+  payload.resize(size);
+  if (!transmitter->receive(payload.data(), size)) {
+    return nullptr;
+  }
+  return payload.data();
+}
+
+hal_server::error_code hal_server::process_commands() {
+  hal_server::error_code ret = hal_server::status_success;
+  do {
+    ret = process_command();
+  } while (ret == hal::hal_server::status_success);
+  return ret;
+}
+
+hal_server::error_code hal_server::receive_payload(
+    hal_binary_encoder::COMMAND command, std::vector<uint8_t> &payload) {
+  hal_binary_decoder decoder;
+  const uint32_t data_required = decoder.decode_command_data_required(command);
+  if (data_required == hal_binary_decoder::data_required_unknown) {
+    return hal_server::status_decode_failed;
+  }
+  payload.resize(data_required);
+  bool receive_ok = true;
+  if (data_required) {
+    receive_ok = transmitter->receive(payload.data(), data_required);
+  }
+  if (!receive_ok) {
+    return hal_server::status_transmitter_failed;
+  } else {
+    return hal_server::status_success;
+  }
+}
+
+hal_server::error_code hal_server::process_mem_alloc(uint32_t device) {
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_ALLOC, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  hal_binary_decoder decoder;
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_ALLOC, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+
+  auto res = hal_device->mem_alloc(decoder.message.alloc.size,
+                                   decoder.message.alloc.alignment);
+  if (debug) {
+    printf("Hal Server:: mem alloc %lu %lu -> %d\n", decoder.message.alloc.size,
+           decoder.message.alloc.alignment, (int)res);
+    (void)fflush(stdout);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_alloc_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_mem_free(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_FREE, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_FREE, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+
+  auto res = hal_device->mem_free(decoder.message.free.addr);
+  if (debug) {
+    printf("Hal Server:: mem free %lux -> %d\n", decoder.message.free.addr,
+           (int)res);
+    (void)fflush(stdout);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_free_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_mem_write(uint32_t device) {
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_WRITE, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  hal_binary_decoder decoder;
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_WRITE, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  const void *src_data = receive_data(decoder.message.write.size);
+  if (!src_data) {
+    return hal_server::status_transmitter_failed;
+  }
+
+  assert(src_data && "Src data must be non Null");
+  auto res = hal_device->mem_write(decoder.message.write.dst, src_data,
+                                   decoder.message.write.size);
+  if (debug) {
+    printf("Hal Server:: mem_write %lu %p %lu-> %d\n",
+           decoder.message.write.dst, src_data, decoder.message.write.size,
+           (int)res);
+    (void)fflush(stdout);
+  }
+
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_write_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_mem_fill(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_FILL, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_FILL, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  const void *pattern_data = receive_data(decoder.message.fill.pattern_size);
+  if (!pattern_data) {
+    return hal::hal_server::status_transmitter_failed;
+  }
+  auto res = hal_device->mem_fill(decoder.message.fill.dst, pattern_data,
+                                  decoder.message.fill.pattern_size,
+                                  decoder.message.fill.size);
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_fill_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_mem_read(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_READ, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_READ, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  std::vector<uint8_t> dst;
+  dst.resize(decoder.message.read.size);
+  auto res = hal_device->mem_read(dst.data(), decoder.message.read.src,
+                                  decoder.message.read.size);
+  if (debug) {
+    printf("Hal Server:: mem_read %p %lux %lu-> %d\n", dst.data(),
+           decoder.message.read.src, decoder.message.read.size, res);
+    (void)fflush(stdout);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_read_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  send_res = send_res &&
+             transmitter->send(dst.data(), decoder.message.read.size, true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_mem_copy(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::MEM_COPY, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::MEM_COPY, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  auto res =
+      hal_device->mem_copy(decoder.message.copy.dst, decoder.message.copy.src,
+                           decoder.message.copy.size);
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_mem_copy_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_program_free(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::PROGRAM_FREE, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status =
+      decoder.decode(hal_binary_encoder::COMMAND::PROGRAM_FREE, payload.data(),
+                     payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  auto res = hal_device->program_free(decoder.message.prog_free.program);
+  if (debug) {
+    printf("Hal Server:: program_free %lu -> %d\n",
+           decoder.message.prog_free.program, (int)res);
+    (void)fflush(stdout);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_program_free_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_find_kernel(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::FIND_KERNEL, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::FIND_KERNEL, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+
+  const void *name_data =
+      receive_data(decoder.message.prog_find_kernel.kernel_name_size);
+  if (!name_data) {
+    return hal::hal_server::status_transmitter_failed;
+  }
+
+  auto res = hal_device->program_find_kernel(
+      decoder.message.prog_find_kernel.program, (const char *)name_data);
+  if (debug) {
+    printf("Hal Server:: program_find_kernel %lx %s -> %d\n",
+           decoder.message.prog_find_kernel.program, (const char *)name_data,
+           (int)res);
+    (void)fflush(stdout);
+  }
+
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_find_kernel_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_program_load(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::PROGRAM_LOAD, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status =
+      decoder.decode(hal_binary_encoder::COMMAND::PROGRAM_LOAD, payload.data(),
+                     payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  const void *data = receive_data(decoder.message.prog_load.size);
+  if (!data) {
+    return hal::hal_server::status_transmitter_failed;
+  }
+
+  auto res = hal_device->program_load(data, decoder.message.prog_load.size);
+  if (debug) {
+    printf("Hal Server:: program_load %lu (%p) -> %lux\n",
+           decoder.message.prog_load.size, data, res);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_program_load_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_kernel_exec(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::KERNEL_EXEC, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  // Download and convert args
+  const bool decoder_status = decoder.decode(
+      hal_binary_encoder::COMMAND::KERNEL_EXEC, payload.data(), payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  void *data = nullptr;
+  if (decoder.message.kernel_exec.args_data_size) {
+    data = receive_data(decoder.message.kernel_exec.args_data_size);
+
+    const bool receive_ok = decoder.decode_kernel_exec_args(
+        data, decoder.message.kernel_exec.num_args,
+        decoder.message.kernel_exec.args_data_size);
+    if (!receive_ok) {
+      return hal_server::status_transmitter_failed;
+    }
+  }
+
+  auto res = hal_device->kernel_exec(
+      decoder.message.kernel_exec.program, decoder.message.kernel_exec.kernel,
+      &decoder.message.kernel_exec.nd_range, decoder.kernel_args.data(),
+      decoder.message.kernel_exec.num_args,
+      decoder.message.kernel_exec.work_dim);
+  if (debug) {
+    printf(
+        "Hal Server:: kernel_exec (%d) %lux %lux (%lu %lu %lu):(%lu %lu "
+        "%lu) %p %d %d-> %d\n",
+        decoder.message.kernel_exec.args_data_size,
+        decoder.message.kernel_exec.program, decoder.message.kernel_exec.kernel,
+        decoder.message.kernel_exec.nd_range.global[0],
+        decoder.message.kernel_exec.nd_range.global[1],
+        decoder.message.kernel_exec.nd_range.global[2],
+        decoder.message.kernel_exec.nd_range.local[0],
+        decoder.message.kernel_exec.nd_range.local[1],
+        decoder.message.kernel_exec.nd_range.local[2],
+        decoder.kernel_args.data(), decoder.message.kernel_exec.num_args,
+        decoder.message.kernel_exec.work_dim, res);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_kernel_exec_reply(res);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_device_create(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::DEVICE_CREATE, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  const bool decoder_status =
+      decoder.decode(hal_binary_encoder::COMMAND::DEVICE_CREATE, payload.data(),
+                     payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  hal_device = hal->device_create(device);
+  if (debug) {
+    printf("Hal Server:: device_create %u-> %p\n", device, hal_device);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_device_create_reply(hal_device ? true : false);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_device_delete(uint32_t device) {
+  hal_binary_decoder decoder;
+  auto payload_status =
+      receive_payload(hal_binary_encoder::COMMAND::DEVICE_DELETE, payload);
+  if (payload_status != hal_server::status_success) {
+    return payload_status;
+  }
+  // TODO - call delete with looked up device
+  const bool decoder_status =
+      decoder.decode(hal_binary_encoder::COMMAND::DEVICE_DELETE, payload.data(),
+                     payload.size());
+  if (!decoder_status) {
+    return hal::hal_server::status_decode_failed;
+  }
+  hal->device_delete(hal_device);
+  hal_device = nullptr;
+  if (debug) {
+    printf("Hal Server:: device_delete %u\n", device);
+  }
+  hal_binary_encoder encode_reply;
+  encode_reply.encode_device_delete_reply(true);
+  auto send_res =
+      transmitter->send(encode_reply.data(), encode_reply.size(), true);
+  if (!send_res) {
+    return hal_server::status_transmitter_failed;
+  }
+  return hal_server::status_success;
+}
+
+hal_server::error_code hal_server::process_command() {
+  struct __attribute__((packed)) {
+    hal_binary_encoder::COMMAND command;
+    uint32_t device;
+  } prefix;
+  static_assert(sizeof(prefix) == 8);
+
+  const bool receive_ok = transmitter->receive(&prefix, 8);
+  if (!receive_ok) {
+    return hal_server::status_transmitter_failed;
+  }
+  if (debug) {
+    printf("Hal Server:: received command %d\n", (int)prefix.command);
+    (void)fflush(stdout);
+  }
+  assert(prefix.device == 0);
+
+  // Don't support device != 0, so shutdown for now, we'll look to implement
+  // this further down the line.
+  if (prefix.device != 0) {
+    return hal_server::status_device_not_supported;
+  }
+
+  auto ret_val = hal_server::status_success;
+  switch (prefix.command) {
+    case hal_binary_encoder::COMMAND::MEM_ALLOC:
+      ret_val = process_mem_alloc(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::MEM_FREE:
+      ret_val = process_mem_free(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::MEM_WRITE:
+      ret_val = process_mem_write(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::MEM_READ:
+      ret_val = process_mem_read(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::MEM_FILL:
+      ret_val = process_mem_fill(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::MEM_COPY:
+      ret_val = process_mem_copy(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::PROGRAM_FREE:
+      ret_val = process_program_free(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::FIND_KERNEL:
+      ret_val = process_find_kernel(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::PROGRAM_LOAD:
+      ret_val = process_program_load(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::KERNEL_EXEC:
+      ret_val = process_kernel_exec(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::DEVICE_CREATE:
+      ret_val = process_device_create(prefix.device);
+      break;
+    case hal_binary_encoder::COMMAND::DEVICE_DELETE:
+      ret_val = process_device_delete(prefix.device);
+      break;
+    default:
+      assert(0 && "Unknown command");
+      return hal_server::status_unknown_command;
+  }
+  if (!receive_ok) {
+    return hal_server::status_transmitter_failed;
+  }
+
+  return ret_val;
+}
+}  // namespace hal

--- a/hal/hal_remote/source/hal_socket_transmitter.cpp
+++ b/hal/hal_remote/source/hal_socket_transmitter.cpp
@@ -1,0 +1,163 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <hal_remote/hal_socket_transmitter.h>
+#include <hal_remote/hal_transmitter.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdio>
+
+namespace hal {
+hal_socket_transmitter::~hal_socket_transmitter() {
+  if (sock) {
+    close(sock);
+  }
+  if (fd_to_use && fd_to_use != sock) {
+    close(fd_to_use);
+  }
+}
+
+hal_socket_transmitter::error_code hal_socket_transmitter::start_server(
+    bool print_port) {
+  if (!setup_connection_done) {
+    hal_socket_transmitter::error_code res = setup_connection(true);
+    if (res != 0) {
+      return res;
+    }
+    setup_connection_done = true;
+  }
+  if (listen() != 0) {
+    last_error = hal_socket_transmitter::listen_failed;
+    return last_error;
+  }
+  if (print_port) {
+    printf("Listening on port %d\n", get_port());
+    fflush(stdout);
+  }
+  if (accept() == -1) {
+    last_error = hal_socket_transmitter::accept_failed;
+    return last_error;
+  }
+  last_error = hal_socket_transmitter::success;
+  return last_error;
+}
+
+/// @brief make a connection to a server
+/// @return true if successful, otherwise will set last_error to errno
+hal_socket_transmitter::error_code hal_socket_transmitter::make_connection() {
+  if (!setup_connection_done) {
+    last_error = setup_connection(false);
+    if (last_error != hal_socket_transmitter::success) {
+      return last_error;
+    }
+    setup_connection_done = true;
+  }
+  last_error = connect();
+  return last_error;
+}
+
+bool hal_socket_transmitter::receive(void *data, uint32_t size) {
+  uint32_t data_to_read = size;
+  uint32_t offset = 0;
+
+  // repeatedly recv until `size` bytes is read.
+  do {
+    int res = recv(fd_to_use, ((char *)data) + offset, data_to_read, 0);
+    // If recv returns 0, this indicates the connection has been dropped
+    // It's not an error as such but we are not able to continue
+    if (res == 0) {
+      is_connected = false;
+      fd_to_use = 0;
+      last_error = hal_socket_transmitter::connection_closed;
+      return false;
+    }
+    if (res == -1) {
+      last_error = hal_socket_transmitter::recv_error;
+      return false;
+    }
+    data_to_read = data_to_read - res;
+    offset += res;
+  } while (data_to_read);
+  last_error = hal_socket_transmitter::success;
+  return true;
+}
+
+/// @brief Send `size` bytes of `data` with an optional flush
+bool hal_socket_transmitter::send(const void *data, uint32_t size, bool flush) {
+  const int ret = ::send(fd_to_use, data, size, 0);
+  if (ret == -1) {
+    last_error = hal_socket_transmitter::send_error;
+    return false;
+  }
+  last_error = hal_socket_transmitter::success;
+  return true;
+}
+
+hal_socket_transmitter::error_code hal_socket_transmitter::connect() {
+  int res = ::connect(sock, (struct sockaddr *)&server_address,
+                      sizeof(server_address));
+  if (res != -1) {
+    fd_to_use = sock;
+    is_connected = true;
+    return hal_socket_transmitter::success;
+  } else {
+    return hal_socket_transmitter::connect_failed;
+  }
+}
+
+hal_socket_transmitter::error_code hal_socket_transmitter::setup_connection(
+    bool server) {
+  // @return 0 if success, otherwise -1 and errno set
+  sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  server_address.sin_family = AF_INET;
+  server_address.sin_port = htons(port_requested);
+  server_address.sin_addr.s_addr = INADDR_ANY;
+  if (server) {
+    if (int res = bind(sock, (struct sockaddr *)&server_address,
+                       sizeof(server_address)) != 0) {
+      return hal_socket_transmitter::bind_failed;
+    }
+
+    struct sockaddr_in local_addr;
+    socklen_t len = sizeof(local_addr);
+    if (int res =
+            getsockname(sock, (struct sockaddr *)&local_addr, &len) != 0) {
+      return hal_socket_transmitter::getsockname_failed;
+    }
+    current_port = ntohs(local_addr.sin_port);
+  } else {
+    current_port = port_requested;
+  }
+  setup_connection_done = true;
+  return hal_socket_transmitter::success;
+}
+
+int hal_socket_transmitter::listen() {
+  if (int res = ::listen(sock, 1) != 0) {
+    return res;
+  }
+  return 0;
+}
+int hal_socket_transmitter::accept() {
+  int res = ::accept(sock, nullptr, nullptr);
+  if (res != -1) {
+    fd_to_use = res;
+  }
+  return res;
+}
+
+}  // namespace hal

--- a/hal/source/hal_library.cpp
+++ b/hal/source/hal_library.cpp
@@ -85,28 +85,30 @@ hal_t *load_hal_library(const char *library_path, uint32_t expected_api_version,
   // https://stackoverflow.com/questions/51209268/using-stdthread-in-a-library-loaded-with-dlopen-leads-to-a-sigsev
   handle = dlopen(library_path, RTLD_LAZY | RTLD_GLOBAL);
   if (!handle) {
-    fprintf(stderr, "error: could not load '%s'\n", library_path);
+    (void)fprintf(stderr, "error: could not load '%s' : '%s'\n", library_path,
+                  dlerror());
     return nullptr;
   }
   create_hal_fn hal_entry_fn = (create_hal_fn)dlsym(handle, "get_hal");
   if (!hal_entry_fn) {
-    fprintf(stderr, "error: could not find the HAL entry point function\n");
+    (void)fprintf(stderr,
+                  "error: could not find the HAL entry point function\n");
     dlclose(handle);
     return nullptr;
   }
   uint32_t reported_api_version = 0;
   hal_t *hal = hal_entry_fn(reported_api_version);
   if (!hal) {
-    fprintf(stderr, "error: creating the HAL failed\n");
+    (void)fprintf(stderr, "error: creating the HAL failed\n");
     dlclose(handle);
     return nullptr;
   }
   if (expected_api_version != 0 &&
       reported_api_version != expected_api_version) {
-    fprintf(stderr,
-            "error: expected HAL API version %" PRIu32 ", but %" PRIu32
-            " is the version reported by the loaded HAL\n",
-            expected_api_version, reported_api_version);
+    (void)fprintf(stderr,
+                  "error: expected HAL API version %" PRIu32 ", but %" PRIu32
+                  " is the version reported by the loaded HAL\n",
+                  expected_api_version, reported_api_version);
     dlclose(handle);
     return nullptr;
   }
@@ -149,13 +151,13 @@ hal_t *load_hal(const char *default_device, uint32_t expected_api_version,
                                       expected_api_version, handle)) {
       return hal;
     } else {
-      fprintf(stderr, "error: unable to load hal library from '%s'\n",
-              library_path.c_str());
+      (void)fprintf(stderr, "error: unable to load hal library from '%s'\n",
+                    library_path.c_str());
     }
   } else {
-    fprintf(stderr,
-            "error: no default device was specified and couldn't load "
-            "CA_HAL_DEVICE\n");
+    (void)fprintf(stderr,
+                  "error: no default device was specified and couldn't load "
+                  "CA_HAL_DEVICE\n");
   }
   return nullptr;
 }

--- a/scripts/new_target_templates/cpu_client_riscv.json
+++ b/scripts/new_target_templates/cpu_client_riscv.json
@@ -1,0 +1,9 @@
+{
+  "target_name": "cpu_client",
+  "llvm_name": "RISCV",
+  "llvm_cpu": "'generic-rv64'",
+  "llvm_features": "'+m,+f,+a,+d'",  
+  "llvm_triple": "'riscv64-unknown-elf'",
+  "link" : "true",
+  "link_shared": "true"
+}


### PR DESCRIPTION
# Overview

This adds support for generic client and server hal support to allow
sending commands as binary requests over a `hal_transmitter`.
    
# Reason for change

Required to support customer needs of talking to a remote cpu.

# Description of change

Added encoders and decoders for converting hal commands to binary format
    
Add hal_server base class which uses the encoders and decoders and a
hal_transmitter to receive hal commands remotely and act on the given
hal device.
    
Add a hal_client and hal_device_client base class which can be used with
a transmitter to send to a remote server binary commands.
    
Added a hal socket cpu client.
Added hal cpu socket based server program.


# Anything else we should know?

This currently only supports single device hals
