### PR TITLE
[X86] Expose __truncdfhf2.

### DIFF
--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -177,11 +177,13 @@ endif()
 if(CA_HOST_ENABLE_FP64)
   list(APPEND hostCapabilities "fp64")
   target_compile_definitions(host PRIVATE CA_HOST_ENABLE_FP64)
+  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP64)
 endif()
 
 if(CA_HOST_ENABLE_FP16)
   list(APPEND hostCapabilities "fp16")
   target_compile_definitions(host PRIVATE CA_HOST_ENABLE_FP16)
+  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP16)
 endif()
 
 set(host_CA_HOST_CL_DEVICE_NAME)

--- a/modules/utils/targets/host/source/relocations.cpp
+++ b/modules/utils/targets/host/source/relocations.cpp
@@ -61,6 +61,12 @@ extern void __fixdfdi();
 extern void __floatdidf();
 extern void __floatdisf();
 #endif
+
+#if defined(UTILS_SYSTEM_X86) && defined(CA_HOST_ENABLE_FP64) && \
+    defined(CA_HOST_ENABLE_FP16)
+// Truncation of fp64 to fp16 is done in software.
+extern void __truncdfhf2();
+#endif
 }
 
 namespace {
@@ -178,6 +184,12 @@ std::vector<std::pair<std::string, uint64_t>> getRelocations() {
       {"fminf", reinterpret_cast<uint64_t>(&fminf)},
       {"fmaxf", reinterpret_cast<uint64_t>(&fmaxf)},
 #endif  // defined(UTILS_SYSTEM_ARM) && defined(UTILS_SYSTEM_32_BIT)
+
+#if defined(UTILS_SYSTEM_X86) && defined(CA_HOST_ENABLE_FP64) && \
+    defined(CA_HOST_ENABLE_FP16)
+      {"__truncdfhf2", reinterpret_cast<uint64_t>(&__truncdfhf2)},
+#endif  // defined(UTILS_SYSTEM_X86) && defined(CA_HOST_ENABLE_FP64) &&
+        // defined(CA_HOST_ENABLE_FP16)
   }};
 }
 }  // namespace utils


### PR DESCRIPTION
# Overview

[X86] Expose __truncdfhf2.

# Reason for change

LLVM uses __truncdfhf2 for conversion from fp64 to fp16, because under the code generation options we use, there is no native instruction to perform this conversion directly, and emulating it by converting from fp64 to fp32 and then from fp32 to fp16 introduces rounding errors. We did not make this function available, resulting in errors when enabling both FP64 and FP16 on x86.

# Description of change

This change makes it available.

# Anything else we should know?

Although this change makes us pass tests on x86 with FP16 enabled, this change does not yet change its status to supported. In order to support it, we would need a bit more investigation to make sure that __truncdfhf2 is available on all X86 targets we aim to support, or introduce an alternative implementation if not.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
