### PR TITLE
[LLVM 19] Adjust tests for llvm.ct* intrinsics.

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/intrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/intrinsics.ll
@@ -166,18 +166,18 @@ declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_nxv2_ctpop
-; CTPOP: = call <vscale x 2 x i32> @llvm.ctpop.nxv2i32(<vscale x 2 x i32> %{{.*}})
-; CTPOP: = call <vscale x 4 x i8> @llvm.ctpop.nxv4i8(<vscale x 4 x i8> %{{.*}})
+; CTPOP: = call {{.*}}<vscale x 2 x i32> @llvm.ctpop.nxv2i32(<vscale x 2 x i32> %{{.*}})
+; CTPOP: = call {{.*}}<vscale x 4 x i8> @llvm.ctpop.nxv4i8(<vscale x 4 x i8> %{{.*}})
 
 ; CTLZ: void @__vecz_nxv4_ctlz
 ; ... but it does widen ctlz
-; CTLZ: = call <vscale x 4 x i32> @llvm.ctlz.nxv4i32(<vscale x 4 x i32> %{{.*}}, i1 false)
-; CTLZ: = call <vscale x 8 x i8> @llvm.ctlz.nxv8i8(<vscale x 8 x i8> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<vscale x 4 x i32> @llvm.ctlz.nxv4i32(<vscale x 4 x i32> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<vscale x 8 x i8> @llvm.ctlz.nxv8i8(<vscale x 8 x i8> %{{.*}}, i1 false)
 
 ; CTTZ: void @__vecz_nxv8_cttz
 ; ... and cttz
-; CTTZ: = call <vscale x 8 x i32> @llvm.cttz.nxv8i32(<vscale x 8 x i32> %{{.*}}, i1 false)
-; CTTZ: = call <vscale x 16 x i8> @llvm.cttz.nxv16i8(<vscale x 16 x i8> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<vscale x 8 x i32> @llvm.cttz.nxv8i32(<vscale x 8 x i32> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<vscale x 16 x i8> @llvm.cttz.nxv16i8(<vscale x 16 x i8> %{{.*}}, i1 false)
 
 ; SADD_SAT: void @__vecz_nxv2_sadd_sat
 ; SADD_SAT: = call <vscale x 2 x i32> @llvm.sadd.sat.nxv2i32(

--- a/modules/compiler/vecz/test/lit/llvm/intrinsics-scalarize.ll
+++ b/modules/compiler/vecz/test/lit/llvm/intrinsics-scalarize.ll
@@ -172,19 +172,19 @@ declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_v2_ctpop
-; CTPOP: = call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})
-; CTPOP: = call <2 x i8> @llvm.ctpop.v2i8(<2 x i8> %{{.*}})
-; CTPOP: = call <2 x i8> @llvm.ctpop.v2i8(<2 x i8> %{{.*}})
+; CTPOP: = call {{.*}}<2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})
+; CTPOP: = call {{.*}}<2 x i8> @llvm.ctpop.v2i8(<2 x i8> %{{.*}})
+; CTPOP: = call {{.*}}<2 x i8> @llvm.ctpop.v2i8(<2 x i8> %{{.*}})
 
 ; CTLZ: void @__vecz_v4_ctlz
-; CTLZ: = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %{{.*}}, i1 false)
-; CTLZ: = call <4 x i8> @llvm.ctlz.v4i8(<4 x i8> %{{.*}}, i1 false)
-; CTLZ: = call <4 x i8> @llvm.ctlz.v4i8(<4 x i8> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<4 x i32> @llvm.ctlz.v4i32(<4 x i32> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<4 x i8> @llvm.ctlz.v4i8(<4 x i8> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<4 x i8> @llvm.ctlz.v4i8(<4 x i8> %{{.*}}, i1 false)
 
 ; CTTZ: void @__vecz_v8_cttz
-; CTTZ: = call <8 x i32> @llvm.cttz.v8i32(<8 x i32> %{{.*}}, i1 false)
-; CTTZ: = call <8 x i8> @llvm.cttz.v8i8(<8 x i8> %{{.*}}, i1 false)
-; CTTZ: = call <8 x i8> @llvm.cttz.v8i8(<8 x i8> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<8 x i32> @llvm.cttz.v8i32(<8 x i32> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<8 x i8> @llvm.cttz.v8i8(<8 x i8> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<8 x i8> @llvm.cttz.v8i8(<8 x i8> %{{.*}}, i1 false)
 
 ; SADD_SAT: void @__vecz_v2_sadd_sat
 ; SADD_SAT: = call <2 x i32> @llvm.sadd.sat.v2i32(

--- a/modules/compiler/vecz/test/lit/llvm/intrinsics.ll
+++ b/modules/compiler/vecz/test/lit/llvm/intrinsics.ll
@@ -172,16 +172,16 @@ declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 declare i64 @__mux_get_global_id(i32)
 
 ; CTPOP: void @__vecz_v2_ctpop
-; CTPOP: = call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})
-; CTPOP: = call <4 x i8> @llvm.ctpop.v4i8(<4 x i8> %{{.*}})
+; CTPOP: = call {{.*}}<2 x i32> @llvm.ctpop.v2i32(<2 x i32> %{{.*}})
+; CTPOP: = call {{.*}}<4 x i8> @llvm.ctpop.v4i8(<4 x i8> %{{.*}})
 
 ; CTLZ: void @__vecz_v4_ctlz
-; CTLZ: = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %{{.*}}, i1 false)
-; CTLZ: = call <8 x i8> @llvm.ctlz.v8i8(<8 x i8> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<4 x i32> @llvm.ctlz.v4i32(<4 x i32> %{{.*}}, i1 false)
+; CTLZ: = call {{.*}}<8 x i8> @llvm.ctlz.v8i8(<8 x i8> %{{.*}}, i1 false)
 
 ; CTTZ: void @__vecz_v8_cttz
-; CTTZ: = call <8 x i32> @llvm.cttz.v8i32(<8 x i32> %{{.*}}, i1 false)
-; CTTZ: = call <16 x i8> @llvm.cttz.v16i8(<16 x i8> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<8 x i32> @llvm.cttz.v8i32(<8 x i32> %{{.*}}, i1 false)
+; CTTZ: = call {{.*}}<16 x i8> @llvm.cttz.v16i8(<16 x i8> %{{.*}}, i1 false)
 
 ; SADD_SAT: void @__vecz_v2_sadd_sat
 ; SADD_SAT: = call <2 x i32> @llvm.sadd.sat.v2i32(

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_reductions_spv_khr_uniform_group_instructions.ll
@@ -177,7 +177,7 @@ entry:
 }
 
 ; CHECK-LABEL: @__vecz_v4_reduce_logical_xor(
-; CHECK: [[X:%.*]] = call i4 @llvm.ctpop.i4(i4 {{%.*}})
+; CHECK: [[X:%.*]] = call {{.*}}i4 @llvm.ctpop.i4(i4 {{%.*}})
 ; CHECK: %call2 = tail call spir_func i1 @__mux_sub_group_reduce_logical_xor_i1(i1 [[T:%.*]])
 ; CHECK: [[E:%.*]] = zext i1 %call2 to i32
 ; CHECK: store i32 [[E]], ptr addrspace(1) {{%.*}}, align 4


### PR DESCRIPTION
# Overview

[LLVM 19] Adjust tests for llvm.ct* intrinsics.

# Reason for change

LLVM 19 adds the range attribute to the return type of llvm.ct* intrinsics. No code changes are needed to deal with this, but it appears in a few tests that did not allow attributes.

# Description of change

This commit updates the tests to allow {{.*}} for attributes of affected functions.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
