### PR TITLE
[city_runner] Ignore whitespace.

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -138,7 +138,7 @@ class TestList(object):
                         device_filter = chunks.pop(0)
                     if len(chunks) < 2:
                         raise Exception("Not enough columns in the CSV file")
-                    argv = chunks[1]
+                    argv = chunks[1].strip()
                     serialized = json.dumps(chunks)
                     ignored = serialized in ignored_tests
                     disabled = serialized in disabled_tests


### PR DESCRIPTION
# Overview

[city_runner] Ignore whitespace.

# Reason for change

OpenCL CTS opencl_conformance_tests_full.csv contains lines where individual fields start with a space, rather than the whole line, as in:

Vectors, vectors/test_vectors

We want to run "vectors/test_vectors", not " vectors/test_vectors".

# Description of change

Call .strip() once more.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
