### PR TITLE
[RISC-V] Link FP64 and FP16 options to d and Zfh.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,19 @@ ca_option(CA_ENABLE_COVERAGE BOOL
 ca_option(CA_EXTERNAL_BUILTINS BOOL
   "Enable external builtins, always on during cross compilation"
   CMAKE_CROSSCOMPILING)
+if(CA_PLATFORM_WINDOWS)
+  ca_option(CA_HOST_ENABLE_FP64 BOOL "Enable host cl_khr_fp64" OFF)
+else()
+  ca_option(CA_HOST_ENABLE_FP64 BOOL "Enable host cl_khr_fp64" ON)
+endif()
+ca_option(CA_HOST_ENABLE_FP16 BOOL "Enable host cl_khr_fp16" OFF)
+set(fp16_supported_arches ARM64;ARM)
+if(CA_HOST_ENABLE_FP16)
+  set(arch ${CMAKE_SYSTEM_PROCESSOR})
+  if(NOT ${arch} IN_LIST fp16_supported_arches)
+    message(WARNING "half-precision is not supported on ${arch} targets")
+  endif()
+endif()
 ca_option(CA_ENABLE_DOCUMENTATION BOOL
   "Enable documentation generation" ON)
 ca_option(CA_MUX_TARGETS_TO_ENABLE STRING

--- a/modules/compiler/targets/host/CMakeLists.txt
+++ b/modules/compiler/targets/host/CMakeLists.txt
@@ -79,6 +79,12 @@ target_include_directories(compiler-host PUBLIC
 
 target_compile_definitions(compiler-host PUBLIC
   $<$<TARGET_EXISTS:resources-host>:CA_ENABLE_HOST_BUILTINS>)
+if(CA_HOST_ENABLE_FP64)
+  target_compile_definitions(compiler-host PRIVATE CA_HOST_ENABLE_FP64)
+endif()
+if(CA_HOST_ENABLE_FP16)
+  target_compile_definitions(compiler-host PRIVATE CA_HOST_ENABLE_FP16)
+endif()
 
 if(TARGET builtins-host)
   add_dependencies(compiler-host builtins-host)

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -300,7 +300,12 @@ compiler::Result HostTarget::initWithBuiltins(
     FeatureMap["m"] = true;  // Integer multiplication and division
     FeatureMap["f"] = true;  // Floating point support
     FeatureMap["a"] = true;  // Atomics
+#if defined(CA_HOST_ENABLE_FP64)
     FeatureMap["d"] = true;  // Double support
+#endif
+#if defined(CA_HOST_ENABLE_FP16)
+    FeatureMap["zfh"] = true;  // Half support
+#endif
   }
 
 #ifndef NDEBUG

--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -52,34 +52,6 @@ else()
 endif()
 
 #[=======================================================================[.rst:
-.. cmake:variable:: CA_HOST_ENABLE_FP64
-
-  Enable OpenCL 64-bit double support ``cl_khr_fp64``, enabled by default
-  except on Windows.
-#]=======================================================================]
-if(CA_PLATFORM_WINDOWS)
-  ca_option(CA_HOST_ENABLE_FP64 BOOL "Enable host cl_khr_fp64" OFF)
-else()
-  ca_option(CA_HOST_ENABLE_FP64 BOOL "Enable host cl_khr_fp64" ON)
-endif()
-
-#[=======================================================================[.rst:
-.. cmake:variable:: CA_HOST_ENABLE_FP16
-
-  Enable the OpenCL 16-bit half support extension ``cl_khr_f16``. We've been
-  testing fp16 on AArch64, but support is not guaranteed across all devices, so
-  this option uniformly remains off by default
-#]=======================================================================]
-ca_option(CA_HOST_ENABLE_FP16 BOOL "Enable host cl_khr_fp16" OFF)
-set(fp16_supported_arches ARM64;ARM)
-if(CA_HOST_ENABLE_FP16)
-  set(arch ${CMAKE_SYSTEM_PROCESSOR})
-  if(NOT ${arch} IN_LIST fp16_supported_arches)
-    message(WARNING "half-precision is not supported on ${arch} targets")
-  endif()
-endif()
-
-#[=======================================================================[.rst:
 .. cmake:variable:: CA_HOST_ENABLE_PAPI_COUNTERS
 
   Enable counter type query pools in Host, supported with PAPI. Requires an
@@ -177,13 +149,11 @@ endif()
 if(CA_HOST_ENABLE_FP64)
   list(APPEND hostCapabilities "fp64")
   target_compile_definitions(host PRIVATE CA_HOST_ENABLE_FP64)
-  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP64)
 endif()
 
 if(CA_HOST_ENABLE_FP16)
   list(APPEND hostCapabilities "fp16")
   target_compile_definitions(host PRIVATE CA_HOST_ENABLE_FP16)
-  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP16)
 endif()
 
 set(host_CA_HOST_CL_DEVICE_NAME)

--- a/modules/utils/targets/host/CMakeLists.txt
+++ b/modules/utils/targets/host/CMakeLists.txt
@@ -26,4 +26,11 @@ target_include_directories(host-utils PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/utils/include>)
 
+if(CA_HOST_ENABLE_FP64)
+  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP64)
+endif()
+if(CA_HOST_ENABLE_FP16)
+  target_compile_definitions(host-utils PRIVATE CA_HOST_ENABLE_FP16)
+endif()
+
 target_link_libraries(host-utils PUBLIC cargo)


### PR DESCRIPTION
# Overview

[RISC-V] Link FP64 and FP16 options to d and Zfh.

# Reason for change

Previously, our list of enabled extensions was hardcoded and when a user would set CA_HOST_ENABLE_FP16 on RISC-V, it would fail because it would use softfloat and attempt to use compiler-rt/libgcc functions that we do not provide. But presumably, when CA_HOST_ENABLE_FP16 is enabled, the user wants to use Zfh half-precision hardware instructions.

# Description of change

Enable the extension instead.

# Anything else we should know?

Do the same for FP64, where the extension was previously always enabled, but now gets linked to CA_HOST_ENABLE_FP64.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
