### PR TITLE
DRAFT: Just to show ideas: Try out having a directory which only build compiler-pipeline etc.

### DIFF
--- a/compiler_utils/CMakeLists.txt
+++ b/compiler_utils/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (C) Codeplay Software Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+project(ock_compiler_utils VERSION 1.0.0 LANGUAGES C CXX ASM)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
+
+set(OCK_IN_LLVM_TREE FALSE)
+if (TARGET LLVMCore)
+  set(OCK_IN_LLVM_TREE TRUE)
+endif()
+include(AddCA)
+
+if(NOT OCK_IN_LLVM_TREE)
+  include(../cmake/ImportLLVM.cmake)
+  include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
+endif()
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/compiler/multi_llvm ${CMAKE_CURRENT_BINARY_DIR}/multi_llvm)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/compiler/utils ${CMAKE_CURRENT_BINARY_DIR}/utils)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/compiler/vecz ${CMAKE_CURRENT_BINARY_DIR}/vecz)

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -133,46 +133,46 @@ if(TARGET LLVMCore)
   target_link_libraries(compiler-pipeline PUBLIC LLVMCore)
 endif()
 
-add_ca_library(compiler-binary-metadata STATIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_metadata_pass.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_analysis.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_hooks.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_analysis.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_hooks.cpp)
+# add_ca_library(compiler-binary-metadata STATIC
+#   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/add_metadata_pass.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_analysis.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/metadata_hooks.h
+#   ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_analysis.cpp
+#   ${CMAKE_CURRENT_SOURCE_DIR}/source/metadata_hooks.cpp)
 
-target_include_directories(compiler-binary-metadata PUBLIC
-$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+# target_include_directories(compiler-binary-metadata PUBLIC
+# $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-target_compile_definitions(compiler-binary-metadata PRIVATE
-  $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
-  $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
-  $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
-  $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
-  $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
+# target_compile_definitions(compiler-binary-metadata PRIVATE
+#   $<$<BOOL:${CA_PLATFORM_LINUX}>:CA_PLATFORM_LINUX>
+#   $<$<BOOL:${CA_PLATFORM_WINDOWS}>:CA_PLATFORM_WINDOWS>
+#   $<$<BOOL:${CA_PLATFORM_MAC}>:CA_PLATFORM_MAC>
+#   $<$<BOOL:${CA_PLATFORM_ANDROID}>:CA_PLATFORM_ANDROID>
+#   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 
-target_link_libraries(compiler-binary-metadata PUBLIC
-  md_handler multi_llvm LLVMPasses LLVMTransformUtils)
-if(TARGET LLVMCore)
-  target_link_libraries(compiler-binary-metadata PUBLIC LLVMCore)
-endif()
+# target_link_libraries(compiler-binary-metadata PUBLIC
+#   md_handler multi_llvm LLVMPasses LLVMTransformUtils)
+# if(TARGET LLVMCore)
+#   target_link_libraries(compiler-binary-metadata PUBLIC LLVMCore)
+# endif()
 
 
-# Determine whether LLVM was built with LLD, in which case add a support
-# library that exposes lld to ComputeMux compiler targets.
-if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
-  list(APPEND CMAKE_MODULE_PATH ${CA_LLVM_INSTALL_DIR}/lib/cmake/lld)
-  include(LLDConfig)
+# # Determine whether LLVM was built with LLD, in which case add a support
+# # library that exposes lld to ComputeMux compiler targets.
+# if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
+#   list(APPEND CMAKE_MODULE_PATH ${CA_LLVM_INSTALL_DIR}/lib/cmake/lld)
+#   include(LLDConfig)
 
-  add_ca_library(compiler-linker-utils STATIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/lld_linker.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/source/lld_linker.cpp
-  )
+#   add_ca_library(compiler-linker-utils STATIC
+#     ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/lld_linker.h
+#     ${CMAKE_CURRENT_SOURCE_DIR}/source/lld_linker.cpp
+#   )
 
-  target_include_directories(compiler-linker-utils PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  )
+#   target_include_directories(compiler-linker-utils PUBLIC
+#     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#   )
 
-  target_link_libraries(compiler-linker-utils PUBLIC
-    cargo multi_llvm lldELF lldCommon
-  )
-endif()
+#   target_link_libraries(compiler-linker-utils PUBLIC
+#     cargo multi_llvm lldELF lldCommon
+#   )
+# endif()


### PR DESCRIPTION


# Overview

Add compiler_utils top level directory which includes what it needs.

Locally if not OCK in tree call the import llvm (just to test it) comment out the metadata stuff etc to not drag in more - I think these could easily be split into a separate directory I had to include AddCA, which drags in stuff a bit (I get some warnings)

# Reason for change

TBD

# Description of change

TBD