### PR TITLE
Update check for llvm.vector.splice

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans.ll
@@ -107,7 +107,7 @@ declare <vscale x 4 x i32> @__vecz_b_sub_group_scan_exclusive_add_u5nxv4j(<vscal
 ; CHECK:   %[[SCAN:.+]] = phi <vscale x 4 x i32> [ %[[NEWVEC]], %loop ]
 
 ;------- target-dependent slide-up code:
-; CHECK:   %[[SLIDE:.+]] = call <vscale x 4 x i32> @llvm.experimental.vector.splice.nxv4i32(<vscale x 4 x i32> undef, <vscale x 4 x i32> %[[SCAN]], i32 -1)
+; CHECK:   %[[SLIDE:.+]] = call <vscale x 4 x i32> @llvm{{(\.experimental)?}}.vector.splice.nxv4i32(<vscale x 4 x i32> undef, <vscale x 4 x i32> %[[SCAN]], i32 -1)
 ; CHECK:   %[[RESULT:.+]] = insertelement <vscale x 4 x i32> %[[SLIDE]], i32 0, {{i32|i64}} 0
 
 ; CHECK:   ret <vscale x 4 x i32> %[[RESULT]]

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans_vp.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans_vp.ll
@@ -111,7 +111,7 @@ declare <vscale x 4 x i32> @__vecz_b_sub_group_scan_exclusive_add_vp_u5nxv4jj(<v
 ; CHECK:   %[[SCAN:.+]] = phi <vscale x 4 x i32> [ %[[NEWVEC]], %loop ]
 
 ;------- target-dependent slide-up code:
-; CHECK:   %[[SLIDE:.+]] = call <vscale x 4 x i32> @llvm.experimental.vector.splice.nxv4i32(<vscale x 4 x i32> undef, <vscale x 4 x i32> %[[SCAN]], i32 -1)
+; CHECK:   %[[SLIDE:.+]] = call <vscale x 4 x i32> @llvm{{(\.experimental)?}}.vector.splice.nxv4i32(<vscale x 4 x i32> undef, <vscale x 4 x i32> %[[SCAN]], i32 -1)
 ; CHECK:   %[[RESULT:.+]] = insertelement <vscale x 4 x i32> %[[SLIDE]], i32 0, {{i32|i64}} 0
 
 ; CHECK:   ret <vscale x 4 x i32> %[[RESULT]]


### PR DESCRIPTION
# Overview

`llvm.vector.splice` is no longer experimental in LLVM 19, we need to update our lit tests.

# Reason for change

Lit tests that check for `llvm.experimental.vector.splice` are failing.

# Description of change

Update lit tests to optionally match `.experimental`.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
