### PR TITLE
LLVM 19 fixes

### DIFF
--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -73,7 +73,11 @@ spirv_ll::Module::Module(
       WorkgroupSize({{1, 1, 1}}),
       BufferSizeArray(nullptr),
       deferredSpecConstantOps(),
-      ImplicitDebugScopes(true) {}
+      ImplicitDebugScopes(true) {
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  llvmModule->setIsNewDbgInfoFormat(false);
+#endif
+}
 
 spirv_ll::Module::Module(spirv_ll::Context &context,
                          llvm::ArrayRef<uint32_t> code)

--- a/modules/compiler/tools/muxc/muxc.cpp
+++ b/modules/compiler/tools/muxc/muxc.cpp
@@ -20,8 +20,10 @@
 #include <base/module.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <compiler/library.h>
-#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/Bitcode/BitcodeWriterPass.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/IRPrinter/IRPrintingPasses.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/CodeGen.h>
 #include <llvm/Support/Error.h>
@@ -157,11 +159,13 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  llvm::ModulePassManager printMPM;
   if (FileType == multi_llvm::CodeGenFileType::AssemblyFile) {
-    Out->os() << *M.get();
+    printMPM.addPass(llvm::PrintModulePass(Out->os()));
   } else {
-    WriteBitcodeToFile(*M.get(), Out->os());
+    printMPM.addPass(llvm::BitcodeWriterPass(Out->os()));
   }
+  printMPM.run(*M, PassMach->getMAM());
   Out->keep();
 
   return 0;

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -27,8 +27,9 @@
 #include <llvm/Analysis/CGSCCPassManager.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Bitcode/BitcodeReader.h>
-#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/Bitcode/BitcodeWriterPass.h>
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IRPrinter/IRPrintingPasses.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/InitializePasses.h>
 #include <llvm/MC/TargetRegistry.h>
@@ -443,11 +444,13 @@ int main(const int argc, const char *const argv[]) {
   }
 
   // Write the resulting module.
+  llvm::ModulePassManager printMPM;
   if (WriteTextual) {
-    Out->os() << *module;
+    printMPM.addPass(llvm::PrintModulePass(Out->os()));
   } else {
-    llvm::WriteBitcodeToFile(*module, Out->os());
+    printMPM.addPass(llvm::BitcodeWriterPass(Out->os()));
   }
+  printMPM.run(*module, passMach.getMAM());
 
   Out->keep();
 


### PR DESCRIPTION
# Overview

Both `muxc` and `veczc` were not using the LLVM passes to out assembly/bitcode, this PR addressed that. 
This PR also makes sure that a module is created with the old debug info format in `spirv-ll`.

# Reason for change

Not using the upstream passes means that we were missing out on any kind of logic that is added upstream when outputting IR, e.g. LLVM 19 is changing the debug info format, and `PrintModulePass` handles printing IR in a way that doesn't break `CHECK` directives for debug intrinsics.

# Description of change

Uses `PrintModulePass` and `BitcodeWriterPass` in `muxc` and `veczc`, sets old type of debug info format in `spirv-ll`.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
