### PR TITLE
[host] Remove invalid caching of object code.

### DIFF
--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -177,11 +177,6 @@ compiler::Result HostModule::createBinary(
     return compiler::Result::FINALIZE_PROGRAM_FAILURE;
   }
 
-  if (!object_code.empty()) {
-    buffer = cargo::array_view<std::uint8_t>(object_code);
-    return compiler::Result::SUCCESS;
-  }
-
   auto &host_target = static_cast<HostTarget &>(target);
 
   std::unique_ptr<llvm::Module> clonedModule;


### PR DESCRIPTION
# Overview

[host] Remove invalid caching of object code.

# Reason for change

As seen in clBuildProgramTwiceTest.RedefineMacro, we may reuse a HostModule to create a binary from a different LLVM module, or with different LLVM build options. We do not have sufficient information to determine whether we can re-use a prior result, and can reasonably assume that if createBinary is called a second time, it will be called a second time specifically because the caller does not want the prior result.

# Description of change

Remove the loading of the prior value of `object_code`.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
