### PR TITLE
Switch llvm builds in CI to 17/18

### DIFF
--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/create_llvm.yml'
   workflow_dispatch:
 
 jobs:
   create_llvm_cache:
     strategy:
       matrix:
-        version: [16, 17]
+        version: [17, 18]
         os: [ubuntu-22.04]
         build_type: [Release, RelAssert]
         include:


### PR DESCRIPTION
# Overview

As a first step towards the switch to 17/18 LLVM versions, the builds we do of llvm will switch to 17/18. This does not affect any running CI which only runs on 17.

# Reason for change

Only supporting two version is our policy. It is time to start the switch to 17/18

# Description of change

Change to build 17/18. Additionally changed running of the workflow to an overnight, rather than every merge.
