### PR TITLE
Switch to llvm versions 17/18 as supported versions

### DIFF
--- a/.github/workflows/build_pr_cache.yml
+++ b/.github/workflows/build_pr_cache.yml
@@ -33,7 +33,7 @@ jobs:
         uses:  ./.github/actions/setup_ubuntu_build
         with:
           save: true
-          llvm_version: 17
+          llvm_version: 18
           llvm_build_type: RelAssert
 
       - name: build host x86_64 release

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_ubuntu_build
         with:
-          llvm_version: 17
+          llvm_version: 18
           llvm_build_type: RelAssert        
   
       # These need to match the configurations of build_pr_cache to use the cache effectively
@@ -79,7 +79,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_ubuntu_build
         with:
-          llvm_version: 17
+          llvm_version: 18
           llvm_build_type: RelAssert
 
       - name: build riscv M1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Upgrade guidance:
 * The `compiler::utils::createLoop` API has moved its list of `IVs` parameter
   into its `compiler::utils::CreateLoopOpts` parameter. It can now also set the
   IV names via a second `CreateLoopOpts` field.
-* Support for LLVM versions is now limited to LLVM 16 and LLVM 17. Support for
+* Support for LLVM versions is now limited to LLVM 17 and LLVM 18. Support for
   earlier LLVM versions has been removed.
 * Support for FMA (fused multiply-add) is required for the device. For the host
   device for x86-64, this means only x86-64-v3 and newer are supported. This

--- a/cmake/ImportLLVM.cmake
+++ b/cmake/ImportLLVM.cmake
@@ -76,8 +76,8 @@ include(DetectLLVMMSVCCRT)
   :cmake:variable:`LLVM_PACKAGE_VERSION` from the imported LLVM install is
   a supported version.
 #]=======================================================================]
-set(CA_LLVM_MINIMUM_VERSION 16.0.0)
-set(CA_LLVM_MAXIMUM_VERSION 17)
+set(CA_LLVM_MINIMUM_VERSION 17.0.0)
+set(CA_LLVM_MAXIMUM_VERSION 18)
 string(REPLACE ";" "', '" CA_LLVM_VERSIONS_PRETTY "${CA_LLVM_VERSIONS}")
 if("${LLVM_PACKAGE_VERSION}" VERSION_LESS "${CA_LLVM_MINIMUM_VERSION}")
   message(FATAL_ERROR

--- a/doc/overview/compiler/supported-llvm-versions.rst
+++ b/doc/overview/compiler/supported-llvm-versions.rst
@@ -8,5 +8,5 @@ All targets
 
 .. rubric:: Supported - tested daily
 
-- 16.0.6+
-- 17.0.3
+- 17.0.3+
+- 18.1.5+


### PR DESCRIPTION
# Overview

Switch min/max versions for OCK to be 17/18

# Reason for change

Require to support only two LLVM versions, and 18 is stable

# Description of change

Updated cmake checks and documentation
updated ci usage.
