### PR TITLE
Fix replace_local_module_scope_variables mempcy bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Upgrade guidance:
   `CA_HOST_TARGET_AARCH64_CPU` and `CA_HOST_TARGET_RISCV64_CPU`. The environment variable
   `CA_HOST_TARGET_CPU` remains the same name. Note that `CA_HOST_TARGET_CPU_NATIVE` is no longer
   supported but can be achieved by using `native` as a value for the variants.
+* The utility function `addParamToAllFunctions` has been moved to
+  `ReplaceLocalModuleScopeVariablesPass` and renamed as it is only used there.
 
 ## Version 3.0.0
 

--- a/modules/compiler/compiler_pipeline/include/compiler/utils/pass_functions.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/pass_functions.h
@@ -159,26 +159,6 @@ bool cloneFunctionsAddArg(
 void remapClonedCallsites(llvm::Function &oldFunc, llvm::Function &newFunc,
                           bool extraArg);
 
-/// @brief Clone all functions in a module, appending an extra parameter to
-/// them.
-///
-/// @param module llvm module containing the functions
-/// @param newParamType Type of the parameter to be added
-/// @param newParamAttrs Parameter attributes of the parameter to be added
-/// @param updateMetaDataCallback if set, is invokved with the old function,
-/// new function and new argument index.
-///
-/// @return bool if the module has changed (currently always true)
-///
-/// This iterates through all the functions in a module and clones all
-/// functions with a body and adds the extra param at the end of their parameter
-/// lists. Simpler version of `cloneFunctionsAddArg()` where the use case is
-/// more limited.
-bool addParamToAllFunctions(
-    llvm::Module &module, llvm::Type *const newParamType,
-    const llvm::AttributeSet &newParamAttrs,
-    const UpdateMDCallbackFn &updateMetaDataCallback = nullptr);
-
 using CreateLoopBodyFn = std::function<llvm::BasicBlock *(
     llvm::BasicBlock *, llvm::Value *, llvm::ArrayRef<llvm::Value *>,
     llvm::MutableArrayRef<llvm::Value *>)>;

--- a/modules/compiler/compiler_pipeline/source/pass_functions.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_functions.cpp
@@ -469,25 +469,6 @@ void remapClonedCallsites(llvm::Function &oldFunc, llvm::Function &newFunc,
   }
 }
 
-bool addParamToAllFunctions(llvm::Module &module,
-                            llvm::Type *const newParamType,
-                            const llvm::AttributeSet &newParamAttrs,
-                            const UpdateMDCallbackFn &updateMetaDataCallback) {
-  return cloneFunctionsAddArg(
-      module,
-      [newParamType, newParamAttrs](llvm::Module &) {
-        return ParamTypeAttrsPair{newParamType, newParamAttrs};
-      },
-      [](const llvm::Function &func, bool &ClonedWithBody, bool &ClonedNoBody) {
-        // don't clone and add arg to special functions starting with __llvm.
-        // These are reserved for clang generated functions such as profile
-        // related ones
-        ClonedWithBody = !func.getName().starts_with("__llvm");
-        ClonedNoBody = false;
-      },
-      updateMetaDataCallback);
-}
-
 llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
                              llvm::Value *indexStart, llvm::Value *indexEnd,
                              const CreateLoopOpts &opts,

--- a/modules/compiler/test/lit/passes/replace-local-module-scope-mem_builtins.ll
+++ b/modules/compiler/test/lit/passes/replace-local-module-scope-mem_builtins.ll
@@ -1,0 +1,87 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes replace-module-scope-vars,verify -S %s  | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+
+%class.anon = type { i64, %"class.helper"}
+%"class.helper" = type { i64, i64 }
+
+@gen_local_struct = internal addrspace(3) global %class.anon undef, align 8
+@llvm.compiler.used = appending global [3 x ptr] [ptr @memcpy, ptr @memset, ptr @memmove], section "llvm.metadata"
+@a = internal addrspace(3) global i16 undef, align 2
+
+declare void @llvm.memcpy.p0.p3.i64(ptr noalias nocapture writeonly, ptr addrspace(3) noalias nocapture readonly, i64, i1 immarg)
+
+; CHECK: define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias nocapture noundef readonly %src, i64 noundef %num)
+; Function Attrs: mustprogress nofree norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
+define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias nocapture noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
+entry:
+  ret ptr %dst
+}
+
+; CHECK: define internal ptr @memset(ptr noalias noundef returned writeonly %dst,  i32 noundef %value, i64 noundef %num)
+; Function Attrs: mustprogress nofree norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
+define internal ptr @memset(ptr noalias noundef returned writeonly %dst,  i32 noundef %value, i64 noundef %num) local_unnamed_addr #7 {
+entry:
+  ret ptr %dst
+}
+
+; CHECK: define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias nocapture noundef readonly %src, i64 noundef %num)
+; Function Attrs: mustprogress nofree norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
+define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias nocapture noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
+entry:
+  ret ptr %dst
+}
+
+; CHECK-DAG: define spir_kernel void @baz.mux-local-var-wrapper(ptr addrspace(1) readonly %in, ptr byval(i32) %out)
+define spir_kernel void @baz(ptr addrspace(1) readonly %in, ptr byval(i32) %out) #0 {
+  call void @llvm.memcpy.p0.p3.i64(ptr %out, ptr addrspace(3) @a, i64 32, i1 false)
+  %ld = load i16, ptr addrspace(3) @a, align 2
+  ret void
+}
+
+; CHECK-DAG: define internal void @foo_called(ptr addrspace(1) readonly %in, ptr byval(i32) %out, ptr %0)
+define internal void @foo_called(ptr addrspace(1) readonly %in, ptr byval(i32) %out){
+  call void @llvm.memcpy.p0.p3.i64(ptr %out, ptr addrspace(3) @a, i64 32, i1 false)
+  %ld = load i16, ptr addrspace(3) @a, align 2
+  ret void
+}
+
+; CHECK-DAG: define internal spir_kernel void @foo_kernel(ptr addrspace(1) readonly %in, ptr byval(i32) %out, ptr %0)
+; CHECK-DAG: define spir_kernel void @foo_kernel.mux-local-var-wrapper(ptr addrspace(1) readonly %in, ptr byval(i32) %out)
+define spir_kernel void @foo_kernel(ptr addrspace(1) readonly %in, ptr byval(i32) %out) #0 {
+  call void @foo_called(ptr addrspace(1) readonly %in, ptr byval(i32) %out)
+  ret void
+}
+
+; CHECK-DAG: define internal void @dead_function(ptr addrspace(1) readonly %in, ptr byval(i32) %out, ptr %0)
+define internal void @dead_function(ptr addrspace(1) readonly %in, ptr byval(i32) %out) {
+  call void @foo_called(ptr addrspace(1) readonly %in, ptr byval(i32) %out)
+  ret void
+}
+
+; CHECK-DAG: define internal void @inbounds_gep(ptr %0, ptr %1)
+define internal void @inbounds_gep(ptr %0) {
+entry:
+  store ptr addrspace(4) addrspacecast (ptr addrspace(3) getelementptr inbounds (%class.anon, ptr addrspace(3) @gen_local_struct, i64 0, i32 1, i32 0) to ptr addrspace(4)), ptr %0, align 8
+  ret void
+}
+
+attributes #0 = { convergent norecurse nounwind "mux-kernel"="entry-point" }


### PR DESCRIPTION




# Overview

Rewrite replace_local_module_scope_variables to only add parameters where needed.

# Reason for change

replace_local_module_scope_variables was incorrectly trying to clone and delete the original of memcpy which was referenced in a llvm.compiler.used line to ensure it continued to exist.

# Description of change

This fixes this by looking at any globals and working back through the user chain until we find an Instruction and only cloning functions that actually require it, as well as all kernels. It also moves and modifies the `addParamToAllFunctions` to the ReplaceLocalModuleScopeVariablesPass as it is only used in there and we can make more appropriate changes.

This change puts it more in line with other similar add parameter pass_functions such as the scheduling parameters and is more efficient.
