### PR TITLE
Reduce memory consumption.

### DIFF
--- a/modules/compiler/targets/host/CMakeLists.txt
+++ b/modules/compiler/targets/host/CMakeLists.txt
@@ -64,7 +64,8 @@ set(HOST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/source/target.cpp
     )
 
-add_ca_library(compiler-host STATIC ${HOST_SOURCES})
+add_ca_library(compiler-host STATIC ${HOST_SOURCES}
+  DEPENDS mux-config abacus_generate)
 
 target_include_directories(compiler-host PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -68,6 +68,7 @@ HostKernel::~HostKernel() {
         llvm::cantFail(es.removeJITDylib(*jit));
       }
     }
+    es.getSymbolStringPool()->clearDeadEntries();
   }
 }
 

--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -100,7 +100,8 @@ add_ca_library(host STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/query_pool.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/queue.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/semaphore.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/thread_pool.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/thread_pool.cpp
+  DEPENDS mux-config abacus_generate)
 
 target_include_directories(host PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -1189,6 +1189,9 @@ mux_result_t hostResetCommandBuffer(mux_command_buffer_t command_buffer) {
   const std::lock_guard<std::mutex> lock(host->mutex);
 
   host->commands.clear();
+  host->commands.shrink_to_fit();
+  host->ndranges.clear();
+  host->ndranges.shrink_to_fit();
 
   return mux_success;
 }


### PR DESCRIPTION
# Overview

Reduce memory consumption.

# Reason for change

On 32-bit platforms, OpenCL CTS's `test_conversions` test would fail after running out of memory.

# Description of change

* When destroying a HostKernel, clean up the string pool. The string pool contains the names of every symbol used by the kernel now freed. We do not want these to persist if there is nothing else still using them.
* When resetting a command buffer, do not just clear the commands, shrink the commands too. Otherwise, if enough commands were present that dynamic allocations were needed, this memory would not be freed until the command buffer got destroyed. But because we re-use command buffers, this would keep the allocations until long after we no longer need them.
* When resetting a command buffer, do not just clear and shrink the commands, also clear and shrink the ndranges. These too are no longer needed when a command buffer is reused.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
