### PR TITLE
[host] Specify dependency on Mux/Abacus headers

### DIFF
--- a/modules/compiler/targets/host/CMakeLists.txt
+++ b/modules/compiler/targets/host/CMakeLists.txt
@@ -64,7 +64,8 @@ set(HOST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/source/target.cpp
     )
 
-add_ca_library(compiler-host STATIC ${HOST_SOURCES})
+add_ca_library(compiler-host STATIC ${HOST_SOURCES}
+  DEPENDS mux-config abacus_generate)
 
 target_include_directories(compiler-host PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -100,7 +100,8 @@ add_ca_library(host STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/query_pool.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/queue.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/semaphore.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/thread_pool.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/thread_pool.cpp
+  DEPENDS mux-config abacus_generate)
 
 target_include_directories(host PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)


### PR DESCRIPTION
# Overview

[host] Specify dependency on Mux/Abacus headers

# Reason for change

These headers are used directly by host, so should be referenced so that we do not implicitly rely on some dependency having caused them to be generated.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
