### PR TITLE
Fix memory leak.

### DIFF
--- a/modules/mux/targets/host/include/host/command_buffer.h
+++ b/modules/mux/targets/host/include/host/command_buffer.h
@@ -40,13 +40,13 @@ namespace host {
 /// This struct later gets cast to `void*` and passed to the lambda that threads
 /// in the threadpool execute to actually run the range.
 struct ndrange_info_s {
-  ndrange_info_s(void *packed_args,
+  ndrange_info_s(mux::dynamic_array<uint8_t> &packed_args,
                  mux::dynamic_array<uint8_t *> &arg_addresses,
                  mux::dynamic_array<mux_descriptor_info_t> &descriptors,
                  std::array<size_t, 3> global_size,
                  std::array<size_t, 3> global_offset,
                  std::array<size_t, 3> local_size, size_t dimensions)
-      : packed_args(packed_args),
+      : packed_args(std::move(packed_args)),
         arg_addresses(std::move(arg_addresses)),
         descriptors(std::move(descriptors)),
         global_size(global_size),
@@ -55,7 +55,7 @@ struct ndrange_info_s {
         dimensions(dimensions) {}
 
   /// @brief Packed descriptors.
-  void *packed_args;
+  mux::dynamic_array<uint8_t> packed_args;
 
   /// @brief Addresses of arguments in packed descriptors.
   ///

--- a/modules/mux/targets/host/source/queue.cpp
+++ b/modules/mux/targets/host/source/queue.cpp
@@ -280,7 +280,7 @@ void commandNDRange(host::queue_s *queue, host::command_info_s *info) {
         schedule_info.work_dim =
             static_cast<uint32_t>(ndrange_info->dimensions);
 
-        kernel_variant->hook(ndrange_info->packed_args, &schedule_info);
+        kernel_variant->hook(ndrange_info->packed_args.data(), &schedule_info);
       },
       &variant, ndrange, signals, &queued, slices);
 


### PR DESCRIPTION
# Overview

Fix memory leak.

# Reason for change

In bf1b1eab5b, I cleared host->ndranges, but the result of that the loop in hostDestroyCommandBuffer to free the arguments no longer does anything useful: there is no longer any reference to the arguments.

# Description of change

Change packed_args to a mux::dynamic_array so that this is automatically taken care of for us.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
