### PR TITLE
Disable remote HAL on non-Linux.

### DIFF
--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -63,5 +63,8 @@ target_compile_definitions(hal_common PRIVATE
 
 target_link_libraries(hal_common PUBLIC $<$<PLATFORM_ID:Linux>:dl>)
 
-add_subdirectory(hal_remote)
+if(CA_PLATFORM_LINUX)
+  add_subdirectory(hal_remote)
+endif()
+
 add_subdirectory(source/hal_null)


### PR DESCRIPTION
# Overview

Disable remote HAL on non-Linux.

# Reason for change

Remote HAL does not build with MSVC and is not expected to work on Windows in general. This may be revisited in the future, but for now, that is how it is.

# Description of change

For now, just disable the build except on Linux.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
