### PR TITLE
Fix hal_remote to build for windows, fix other minor issues

### DIFF
--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -112,7 +112,7 @@ consider using ssh port forwarding as suggested above. The recommended way of
 using port forwarding would be as follows:
 
 ```
-ssh -L <local_port>:destmachine:<remote_port> user@destmachine
+ssh -L <local_port>:127.0.0.1:<remote_port> user@destmachine
 ```
 
 Running the client is done similar to any normal `OCK` OpenCL target (or via

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -63,8 +63,5 @@ target_compile_definitions(hal_common PRIVATE
 
 target_link_libraries(hal_common PUBLIC $<$<PLATFORM_ID:Linux>:dl>)
 
-if(CA_PLATFORM_LINUX)
-  add_subdirectory(hal_remote)
-endif()
-
+add_subdirectory(hal_remote)
 add_subdirectory(source/hal_null)

--- a/hal/hal_remote/CMakeLists.txt
+++ b/hal/hal_remote/CMakeLists.txt
@@ -25,7 +25,7 @@ set(HAL_SOURCE
   ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_server.cpp
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_client.h)
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/include/hal_remote/hal_socket_transmitter.h)
   list (APPEND HAL_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source/hal_socket_transmitter.cpp)

--- a/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
+++ b/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
@@ -21,6 +21,8 @@
 #include <hal_remote/hal_binary_encoder.h>
 #include <hal_types.h>
 
+#include <iostream>
+
 namespace hal {
 
 /// @brief Decoder for hal binary commands
@@ -93,7 +95,7 @@ class hal_binary_decoder {
       case hal_binary_encoder::COMMAND::DEVICE_DELETE_REPLY:
         return sizeof(uint32_t);  // bool as 32 bit
       default:
-        fprintf(stderr, "Unknown command : %d\n", (int)command);
+        std::cerr << "Unknown command : " << (uint32_t)command << "\n";
         return 0;
     }
     return data_required_unknown;

--- a/hal/hal_remote/source/hal_device_client.cpp
+++ b/hal/hal_remote/source/hal_device_client.cpp
@@ -182,12 +182,12 @@ bool hal_device_client::kernel_exec(hal::hal_program_t program,
                                     uint32_t num_args, uint32_t work_dim) {
   const std::lock_guard<std::mutex> locker(hal_lock);
   if (hal_debug()) {
-    (void)fprintf(stderr,
-                  "hal_device_client::kernel_exec(kernel=0x%08lx, num_args=%d, "
-                  "global=<%ld:%ld:%ld>, local=<%ld:%ld:%ld>)\n",
-                  kernel, num_args, nd_range->global[0], nd_range->global[1],
-                  nd_range->global[2], nd_range->local[0], nd_range->local[1],
-                  nd_range->local[2]);
+    std::cerr << "hal_device_client::kernel_exec(kernel=" << kernel
+              << " num_args=" << num_args << " global = <"
+              << nd_range->global[0] << ":" << nd_range->global[1] << ":"
+              << nd_range->global[2] << "> local = <" << nd_range->local[0]
+              << ":" << nd_range->local[1] << ":" << nd_range->local[2]
+              << ">\n";
   }
   hal_binary_encoder encoder;
   hal_binary_decoder decoder;

--- a/hal/hal_remote/source/hal_server.cpp
+++ b/hal/hal_remote/source/hal_server.cpp
@@ -21,6 +21,7 @@
 #include <hal_remote/hal_server.h>
 
 #include <cstring>
+#include <iostream>
 
 namespace hal {
 hal_server::hal_server(hal_transmitter *transmitter, hal::hal_t *hal)
@@ -87,9 +88,8 @@ hal_server::error_code hal_server::process_mem_alloc(uint32_t device) {
   auto res = hal_device->mem_alloc(decoder.message.alloc.size,
                                    decoder.message.alloc.alignment);
   if (debug) {
-    printf("Hal Server:: mem alloc %lu %lu -> %d\n", decoder.message.alloc.size,
-           decoder.message.alloc.alignment, (int)res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: mem alloc " << decoder.message.alloc.size << " "
+              << decoder.message.alloc.alignment << " -> " << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_mem_alloc_reply(res);
@@ -116,9 +116,8 @@ hal_server::error_code hal_server::process_mem_free(uint32_t device) {
 
   auto res = hal_device->mem_free(decoder.message.free.addr);
   if (debug) {
-    printf("Hal Server:: mem free %lux -> %d\n", decoder.message.free.addr,
-           (int)res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: mem free " << decoder.message.free.addr << " -> "
+              << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_mem_free_reply(res);
@@ -151,10 +150,9 @@ hal_server::error_code hal_server::process_mem_write(uint32_t device) {
   auto res = hal_device->mem_write(decoder.message.write.dst, src_data,
                                    decoder.message.write.size);
   if (debug) {
-    printf("Hal Server:: mem_write %lu %p %lu-> %d\n",
-           decoder.message.write.dst, src_data, decoder.message.write.size,
-           (int)res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: mem_write " << decoder.message.write.dst << " "
+              << src_data << " " << decoder.message.write.size << " -> " << res
+              << "\n";
   }
 
   hal_binary_encoder encode_reply;
@@ -213,9 +211,9 @@ hal_server::error_code hal_server::process_mem_read(uint32_t device) {
   auto res = hal_device->mem_read(dst.data(), decoder.message.read.src,
                                   decoder.message.read.size);
   if (debug) {
-    printf("Hal Server:: mem_read %p %lux %lu-> %d\n", dst.data(),
-           decoder.message.read.src, decoder.message.read.size, res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: mem_read " << dst.data() << " "
+              << decoder.message.read.src << " " << decoder.message.read.size
+              << " -> " << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_mem_read_reply(res);
@@ -270,9 +268,8 @@ hal_server::error_code hal_server::process_program_free(uint32_t device) {
   }
   auto res = hal_device->program_free(decoder.message.prog_free.program);
   if (debug) {
-    printf("Hal Server:: program_free %lu -> %d\n",
-           decoder.message.prog_free.program, (int)res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: program_free "
+              << decoder.message.prog_free.program << " -> " << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_program_free_reply(res);
@@ -307,10 +304,9 @@ hal_server::error_code hal_server::process_find_kernel(uint32_t device) {
   auto res = hal_device->program_find_kernel(
       decoder.message.prog_find_kernel.program, (const char *)name_data);
   if (debug) {
-    printf("Hal Server:: program_find_kernel %lx %s -> %d\n",
-           decoder.message.prog_find_kernel.program, (const char *)name_data,
-           (int)res);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: program_find_kernel "
+              << decoder.message.prog_find_kernel.program << " "
+              << (const char *)name_data << " -> " << res << "\n";
   }
 
   hal_binary_encoder encode_reply;
@@ -344,8 +340,8 @@ hal_server::error_code hal_server::process_program_load(uint32_t device) {
 
   auto res = hal_device->program_load(data, decoder.message.prog_load.size);
   if (debug) {
-    printf("Hal Server:: program_load %lu (%p) -> %lux\n",
-           decoder.message.prog_load.size, data, res);
+    std::cerr << "Hal Server:: program_load " << decoder.message.prog_load.size
+              << " (" << data << ") -> " << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_program_load_reply(res);
@@ -389,19 +385,19 @@ hal_server::error_code hal_server::process_kernel_exec(uint32_t device) {
       decoder.message.kernel_exec.num_args,
       decoder.message.kernel_exec.work_dim);
   if (debug) {
-    printf(
-        "Hal Server:: kernel_exec (%d) %lux %lux (%lu %lu %lu):(%lu %lu "
-        "%lu) %p %d %d-> %d\n",
-        decoder.message.kernel_exec.args_data_size,
-        decoder.message.kernel_exec.program, decoder.message.kernel_exec.kernel,
-        decoder.message.kernel_exec.nd_range.global[0],
-        decoder.message.kernel_exec.nd_range.global[1],
-        decoder.message.kernel_exec.nd_range.global[2],
-        decoder.message.kernel_exec.nd_range.local[0],
-        decoder.message.kernel_exec.nd_range.local[1],
-        decoder.message.kernel_exec.nd_range.local[2],
-        decoder.kernel_args.data(), decoder.message.kernel_exec.num_args,
-        decoder.message.kernel_exec.work_dim, res);
+    std::cerr << "Hal Server:: kernel_exec "
+              << decoder.message.kernel_exec.args_data_size << " "
+              << decoder.message.kernel_exec.program << " "
+              << decoder.message.kernel_exec.kernel << " "
+              << decoder.message.kernel_exec.nd_range.global[0] << " "
+              << decoder.message.kernel_exec.nd_range.global[1] << " "
+              << decoder.message.kernel_exec.nd_range.global[2] << " "
+              << decoder.message.kernel_exec.nd_range.local[0] << " "
+              << decoder.message.kernel_exec.nd_range.local[1] << " "
+              << decoder.message.kernel_exec.nd_range.local[2] << " "
+              << decoder.kernel_args.data() << " "
+              << decoder.message.kernel_exec.num_args << " "
+              << decoder.message.kernel_exec.work_dim << " -> " << res << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_kernel_exec_reply(res);
@@ -429,7 +425,8 @@ hal_server::error_code hal_server::process_device_create(uint32_t device) {
   }
   hal_device = hal->device_create(device);
   if (debug) {
-    printf("Hal Server:: device_create %u-> %p\n", device, hal_device);
+    std::cerr << "Hal Server:: device_create " << device << " -> " << hal_device
+              << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_device_create_reply(hal_device ? true : false);
@@ -459,7 +456,7 @@ hal_server::error_code hal_server::process_device_delete(uint32_t device) {
   hal->device_delete(hal_device);
   hal_device = nullptr;
   if (debug) {
-    printf("Hal Server:: device_delete %u\n", device);
+    std::cerr << "Hal Server:: device_delete " << device << "\n";
   }
   hal_binary_encoder encode_reply;
   encode_reply.encode_device_delete_reply(true);
@@ -472,7 +469,7 @@ hal_server::error_code hal_server::process_device_delete(uint32_t device) {
 }
 
 hal_server::error_code hal_server::process_command() {
-  struct __attribute__((packed)) {
+  struct {
     hal_binary_encoder::COMMAND command;
     uint32_t device;
   } prefix;
@@ -483,8 +480,8 @@ hal_server::error_code hal_server::process_command() {
     return hal_server::status_transmitter_failed;
   }
   if (debug) {
-    printf("Hal Server:: received command %d\n", (int)prefix.command);
-    (void)fflush(stdout);
+    std::cerr << "Hal Server:: received command " << (uint32_t)prefix.command
+              << "\n";
   }
   assert(prefix.device == 0);
 

--- a/hal/hal_remote/source/hal_socket_transmitter.cpp
+++ b/hal/hal_remote/source/hal_socket_transmitter.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <iostream>
 #include <string>
 
 namespace hal {
@@ -44,8 +45,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::start_server(
     return last_error;
   }
   if (print_port) {
-    (void)printf("Listening on port %d\n", get_port());
-    (void)fflush(stdout);
+    std::cerr << "Listening on port " << get_port() << "\n";
   }
   if (!accept()) {
     last_error = hal_socket_transmitter::accept_failed;
@@ -61,18 +61,16 @@ hal_socket_transmitter::error_code hal_socket_transmitter::make_connection() {
   if (!setup_connection_done) {
     last_error = setup_connection(false);
     if (last_error != hal_socket_transmitter::success) {
-      (void)fprintf(
-          stderr,
-          "Failed to set up connection to remote server (port=%d node=%s)\n",
-          port_requested, node.c_str());
+      std::cerr << "Failed to set up connection to remote server (port="
+                << port_requested << " node=" << node << "\n";
       return last_error;
     }
     setup_connection_done = true;
   }
   last_error = connect();
   if (last_error != hal_socket_transmitter::success) {
-    (void)fprintf(stderr, "Failed to connect to server (port=%d node=%s)\n",
-                  port_requested, node.c_str());
+    std::cerr << "Failed to connect to server (port=" << port_requested
+              << " node=" << node << "\n";
   }
   return last_error;
 }
@@ -131,8 +129,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::setup_connection(
   // don't support port 0
   if (port_requested == 0) {
     if (debug_enabled()) {
-      (void)fprintf(stderr,
-                    "port requested must be specified as a non-zero value\n");
+      std::cerr << "port requested must be specified as a non-zero value\n";
     }
     return hal_socket_transmitter::port_0_requested;
   }
@@ -154,7 +151,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::setup_connection(
   // one that matches.
   if (s != 0) {
     if (debug_enabled()) {
-      (void)fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
+      std::cerr << "getaddrinfo: " << gai_strerror(s) << "\n";
     }
     return hal_socket_transmitter::getaddrinfo_failed;
   } else {


### PR DESCRIPTION
# Overview

This fixes the build for windows so that it does not discard building hal_remote library.
There is also an update for the README to resolve the incorrect description on the ssh forwarding.

# Reason for change

Run through showed some minor issues, we also want to have windows capable of building most of the code.
