### PR TITLE
Fix remaining issues shown up in CI for remote hal

### DIFF
--- a/examples/hal_cpu_remote_server/CMakeLists.txt
+++ b/examples/hal_cpu_remote_server/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 project(hal_cpu_remote_server VERSION 1.0.0 LANGUAGES C CXX ASM)
-
+set(CMAKE_CXX_STANDARD 17)            # Enable C++17 mode
 set(HAL_CPU_REMOTE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../clik/external/hal_cpu)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../hal ${CMAKE_CURRENT_BINARY_DIR}/hal)

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -33,7 +33,7 @@ This can be done as follows:
 If cross-compilation (for example RISC-V) is needed the following additional arguments are needed:
 
 ```
-   -DCMAKE_TOOLCHAIN_FILE=<path_to_ock>/platform/riscv64-linux/riscv64-gcc-toolchain.cmake -DCMAKE_CROSSCOMPILING=TRUE
+   -DCMAKE_TOOLCHAIN_FILE=<path_to_ock>/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
 ```
 
 Note this requires the RISC-V toolchain to be installed as follows on Ubuntu:
@@ -67,7 +67,9 @@ of tree target. This is done as follows (for RISC-V):
    ninja -Cbuild_client
 ```
 
-This assumes building the ICD, but it is possible to build without this.
+This assumes building the ICD, but it is possible to build without this. Note
+also the script requires cookiecutter to be installed with `pip install
+cookiecutter`.
 
 Note if we just wish a quick test then we could target `UnitCL` with the ninja
 line. Also if the server is running on a different architecture the LLVM build

--- a/hal/hal_remote/source/hal_socket_transmitter.cpp
+++ b/hal/hal_remote/source/hal_socket_transmitter.cpp
@@ -62,7 +62,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::make_connection() {
     last_error = setup_connection(false);
     if (last_error != hal_socket_transmitter::success) {
       std::cerr << "Failed to set up connection to remote server (port="
-                << port_requested << " node=" << node << "\n";
+                << port_requested << " node=" << node << ")\n";
       return last_error;
     }
     setup_connection_done = true;
@@ -70,7 +70,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::make_connection() {
   last_error = connect();
   if (last_error != hal_socket_transmitter::success) {
     std::cerr << "Failed to connect to server (port=" << port_requested
-              << " node=" << node << "\n";
+              << " node=" << node << ")\n";
   }
   return last_error;
 }

--- a/scripts/create_target.py
+++ b/scripts/create_target.py
@@ -84,7 +84,7 @@ try:
 except:
     print(
         "Error: cookiecutter not installed. Please use pip install cookiecutter",
-        file=stderr)
+        file=stderr, flush=True)
     os._exit(1)
 
 


### PR DESCRIPTION
# Overview

Minor fixes required when testing remote HAL in CI

# Reason for change

CI showed up some more minor issues

# Description of change
* Fixed hal cpu server README CMAKE_CROSS_COMPILING
* Fixed CMAKE_CXX_STANDARD to 17 for hal cpu server build
* Fixed some brackets in the debug output for socket transmitter 
* Flushed print for no cookiecutter installed on create_target.py so error shows up in CI
