### PR TITLE
Run AlignModuleStructsPass earlier.

### DIFF
--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -213,10 +213,6 @@ llvm::ModulePassManager RiscvPassMachinery::getLateTargetPasses() {
   PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
                                        llvm::Module>());
 
-  // This potentially fixes up any structs to match the spir alignment
-  // before we change to the backend layout
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-
   // Handle the generic address space
   PM.addPass(llvm::createModuleToFunctionPassAdaptor(
       compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -44,6 +44,7 @@
 #include <clang/Serialization/ASTReader.h>
 #include <clang/Serialization/ASTRecordReader.h>
 #include <compiler/limits.h>
+#include <compiler/utils/align_module_structs_pass.h>
 #include <compiler/utils/encode_builtin_range_metadata_pass.h>
 #include <compiler/utils/llvm_global_mutex.h>
 #include <compiler/utils/lower_to_mux_builtins_pass.h>
@@ -1674,6 +1675,7 @@ Result BaseModule::finalize(
           m.setDataLayout(DL);
           m.setTargetTriple(triple);
         }));
+    pm.addPass(compiler::utils::AlignModuleStructsPass());
   }
 
   pm.addPass(compiler::utils::VerifyReqdSubGroupSizeLegalPass());

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -240,13 +240,6 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
   PM.addPass(llvm::RequireAnalysisPass<compiler::utils::BuiltinInfoAnalysis,
                                        llvm::Module>());
 
-// Fix for alignment issues endemic on 32 bit ARM, but can also arise on 32 bit
-// X86. We want this pass to run early so it needs to process less instructions
-// and to avoid having to deal with the side effects of other passes.
-#if defined(UTILS_SYSTEM_32_BIT)
-  PM.addPass(compiler::utils::AlignModuleStructsPass());
-#endif
-
   // Handle the generic address space
   PM.addPass(llvm::createModuleToFunctionPassAdaptor(
       compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass()));

--- a/modules/compiler/targets/riscv/test/lit/passes/late-passes-pipeline.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/late-passes-pipeline.ll
@@ -24,7 +24,6 @@
 
 ; CHECK: Running pass: compiler::utils::TransferKernelMetadataPass on [module]
 
-; CHECK: Running pass: compiler::utils::AlignModuleStructsPass on [module]
 ; CHECK: Running pass: compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass on add (1 instruction)
 ; CHECK: Running pass: riscv::IRToBuiltinReplacementPass on [module]
 


### PR DESCRIPTION
# Overview

Run AlignModuleStructsPass earlier.

# Reason for change

The AlignModuleStructsPass patches up structs according to OpenCL alignment requirements so that they behave the same way on all implementations. We were already calling this, but we were calling it after running a number of upstream LLVM passes, so we were feeding them incorrect input and hoping we could correct that afterwards. A change has gone in on LLVM 19 that performs a valid optimization that we cannot correct afterwards.

# Description of change

Make sure we run AlignModuleStructsPass as soon as we know what target we are compiling for.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
