### PR TITLE
Added some SYCL testing to the Remote HAL README, fixed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ The following simple-vector-add sample code serves as an introductory example, s
 #include <array>
 #include <iostream>
 
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
+
+constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
+constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 
 /* This is the class used to name the kernel for the runtime.
  * This must be done when the kernel is expressed as a lambda. */
@@ -261,12 +262,12 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
   cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
   cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
 
-  deviceQueue.submit([&](cl::sycl::handler &cgh) {
+  deviceQueue.submit([&](sycl::handler &cgh) {
     auto accessorA = bufferA.template get_access<sycl_read>(cgh);
     auto accessorB = bufferB.template get_access<sycl_read>(cgh);
     auto accessorC = bufferC.template get_access<sycl_write>(cgh);
 
-    auto kern = [=](cl::sycl::id<1> wiID) {
+    auto kern = [=](sycl::id<1> wiID) {
       accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
     };
     cgh.parallel_for<class SimpleVadd<T>>(numOfItems, kern);

--- a/examples/applications/simple-vector-add.cpp
+++ b/examples/applications/simple-vector-add.cpp
@@ -26,13 +26,13 @@
 /* This example is a very small one designed to show how compact SYCL code
  * can be. That said, it includes no error checking and is rather terse. */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <array>
 #include <iostream>
 
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
+constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
+constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 
 /* This is the class used to name the kernel for the runtime.
  * This must be done when the kernel is expressed as a lambda. */
@@ -42,18 +42,18 @@ class SimpleVadd;
 template <typename T, size_t N>
 void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
                  std::array<T, N> &VC) {
-  cl::sycl::queue deviceQueue;
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
+  sycl::queue deviceQueue;
+  sycl::range<1> numOfItems{N};
+  sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
+  sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
+  sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
 
-  deviceQueue.submit([&](cl::sycl::handler &cgh) {
+  deviceQueue.submit([&](sycl::handler &cgh) {
     auto accessorA = bufferA.template get_access<sycl_read>(cgh);
     auto accessorB = bufferB.template get_access<sycl_read>(cgh);
     auto accessorC = bufferC.template get_access<sycl_write>(cgh);
 
-    auto kern = [=](cl::sycl::id<1> wiID) {
+    auto kern = [=](sycl::id<1> wiID) {
       accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
     };
     cgh.parallel_for<class SimpleVadd<T>>(numOfItems, kern);
@@ -62,10 +62,10 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
 
 int main() {
   const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
+  std::array<sycl::opencl::cl_int, array_size> A = {{1, 2, 3, 4}},
+                                               B = {{1, 2, 3, 4}}, C;
+  std::array<sycl::opencl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
+                                                 E = {{1.f, 2.f, 3.f, 4.f}}, F;
   simple_vadd(A, B, C);
   simple_vadd(D, E, F);
   for (unsigned int i = 0; i < array_size; i++) {

--- a/examples/applications/vector_addition-load-store.cpp
+++ b/examples/applications/vector_addition-load-store.cpp
@@ -18,13 +18,11 @@
  * @File: vector_addition.cpp
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
-
-using namespace cl;
 
 void vecAdd(const float *a, const float *b, float *c, size_t id) {
   c[id] = a[id] + b[id];
@@ -41,13 +39,12 @@ int main(int argc, char *argv[]) {
 
   // Initialize input data
   {
-    const auto dwrite_t = sycl::access::mode::discard_write;
+    sycl::host_accessor h_a{bufA, sycl::write_only};
+    sycl::host_accessor h_b{bufB, sycl::write_only};
 
-    auto h_a = bufA.get_access<dwrite_t>();
-    auto h_b = bufB.get_access<dwrite_t>();
     for (int i = 0; i < N; i++) {
-      h_a[i] = sin(i) * sin(i);
-      h_b[i] = cos(i) * cos(i);
+      h_a[i] = sycl::sin((float)i) * sycl::sin((float)i);
+      h_b[i] = sycl::cos((float)i) * sycl::cos((float)i);
     }
   }
 
@@ -55,12 +52,9 @@ int main(int argc, char *argv[]) {
 
   // Command Group creation
   auto cg = [&](sycl::handler &h) {
-    const auto read_t = sycl::access::mode::read;
-    const auto write_t = sycl::access::mode::write;
-
-    auto a = bufA.get_access<read_t>(h);
-    auto b = bufB.get_access<read_t>(h);
-    auto c = bufC.get_access<write_t>(h);
+    sycl::accessor a{bufA, h, sycl::read_only};
+    sycl::accessor b{bufB, h, sycl::read_only};
+    sycl::accessor c{bufC, h, sycl::write_only};
 
     h.parallel_for<vec_add>(
         VecSize, [=](sycl::id<1> i) { vecAdd(&a[0], &b[0], &c[0], i[0]); });
@@ -69,8 +63,8 @@ int main(int argc, char *argv[]) {
   myQueue.submit(cg);
 
   {
-    const auto read_t = sycl::access::mode::read;
-    auto h_c = bufC.get_access<read_t>();
+    sycl::host_accessor h_c{bufC, sycl::read_only};
+
     float sum = 0.0f;
     for (int i = 0; i < N; i++) {
       sum += h_c[i];

--- a/examples/applications/vector_addition-masked-store.cpp
+++ b/examples/applications/vector_addition-masked-store.cpp
@@ -18,13 +18,11 @@
  * @File: vector_addition.cpp
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
-
-using namespace cl;
 
 void vecAdd(const float *a, const float *b, float *c, size_t id) {
   float v = a[id] + b[id];
@@ -44,13 +42,14 @@ int main(int argc, char *argv[]) {
 
   // Initialize input data
   {
-    const auto dwrite_t = sycl::access::mode::discard_write;
+    sycl::host_accessor h_a{bufA, sycl::write_only};
+    sycl::host_accessor h_b{bufB, sycl::write_only};
+    sycl::host_accessor h_c{bufC, sycl::write_only};
 
-    auto h_a = bufA.get_access<dwrite_t>();
-    auto h_b = bufB.get_access<dwrite_t>();
     for (int i = 0; i < N; i++) {
-      h_a[i] = sin(i) * sin(i);
-      h_b[i] = cos(i) * cos(i);
+      h_a[i] = sycl::sin((float)i);
+      h_b[i] = sycl::cos((float)i);
+      h_c[i] = 0.0;
     }
   }
 
@@ -58,12 +57,9 @@ int main(int argc, char *argv[]) {
 
   // Command Group creation
   auto cg = [&](sycl::handler &h) {
-    const auto read_t = sycl::access::mode::read;
-    const auto write_t = sycl::access::mode::write;
-
-    auto a = bufA.get_access<read_t>(h);
-    auto b = bufB.get_access<read_t>(h);
-    auto c = bufC.get_access<write_t>(h);
+    sycl::accessor a{bufA, h, sycl::read_only};
+    sycl::accessor b{bufB, h, sycl::read_only};
+    sycl::accessor c{bufC, h, sycl::write_only};
 
     h.parallel_for<vec_add>(
         VecSize, [=](sycl::id<1> i) { vecAdd(&a[0], &b[0], &c[0], i[0]); });
@@ -72,8 +68,7 @@ int main(int argc, char *argv[]) {
   myQueue.submit(cg);
 
   {
-    const auto read_t = sycl::access::mode::read;
-    auto h_c = bufC.get_access<read_t>();
+    sycl::host_accessor h_c{bufC, sycl::read_only};
     float sum = 0.0f;
     for (int i = 0; i < N; i++) {
       sum += h_c[i];

--- a/examples/applications/vector_addition-predicated.cpp
+++ b/examples/applications/vector_addition-predicated.cpp
@@ -18,13 +18,11 @@
  * @File: vector_addition.cpp
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
-
-using namespace cl;
 
 void vecAdd(const float *a, const float *b, float *c, size_t id) {
   float v = a[id] + b[id];
@@ -45,13 +43,11 @@ int main(int argc, char *argv[]) {
 
   // Initialize input data
   {
-    const auto dwrite_t = sycl::access::mode::discard_write;
-
-    auto h_a = bufA.get_access<dwrite_t>();
-    auto h_b = bufB.get_access<dwrite_t>();
+    sycl::host_accessor h_a{bufA, sycl::write_only};
+    sycl::host_accessor h_b{bufB, sycl::write_only};
     for (int i = 0; i < N; i++) {
-      h_a[i] = sin(i) * sin(i);
-      h_b[i] = cos(i) * cos(i);
+      h_a[i] = sycl::sin((float)i);
+      h_b[i] = sycl::cos((float)i);
     }
   }
 
@@ -59,12 +55,9 @@ int main(int argc, char *argv[]) {
 
   // Command Group creation
   auto cg = [&](sycl::handler &h) {
-    const auto read_t = sycl::access::mode::read;
-    const auto write_t = sycl::access::mode::write;
-
-    auto a = bufA.get_access<read_t>(h);
-    auto b = bufB.get_access<read_t>(h);
-    auto c = bufC.get_access<write_t>(h);
+    sycl::accessor a{bufA, h, sycl::read_only};
+    sycl::accessor b{bufB, h, sycl::read_only};
+    sycl::accessor c{bufC, h, sycl::write_only};
 
     h.parallel_for<vec_add>(
         VecSize, [=](sycl::id<1> i) { vecAdd(&a[0], &b[0], &c[0], i[0]); });
@@ -73,8 +66,7 @@ int main(int argc, char *argv[]) {
   myQueue.submit(cg);
 
   {
-    const auto read_t = sycl::access::mode::read;
-    auto h_c = bufC.get_access<read_t>();
+    sycl::host_accessor h_c{bufC, sycl::read_only};
     float sum = 0.0f;
     for (int i = 0; i < N; i++) {
       sum += h_c[i];

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -119,7 +119,10 @@ ssh -L <local_port>:127.0.0.1:<remote_port> user@destmachine
 
 Running the client is done similar to any normal `OCK` OpenCL target (or via
 SYCL OpenCL plugin). The environment variable `HAL_REMOTE_PORT` should be set to
-the local port number. As a simple test try running a simple UnitCL test:
+the local port number. You will also need to set LD_LIBRARY_PATH to
+$PWD/oneAPIConstructionKit/lib if you do not have an OpenCL ICD on your machine.
+
+As a simple test try running a simple UnitCL test:
 
 ```
   cd build_client
@@ -127,3 +130,24 @@ the local port number. As a simple test try running a simple UnitCL test:
     ./oneAPIConstructionKit/bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
 ```
 This should show as `PASSED`.
+
+# Running the client with a SYCL example
+
+The `OneAPI Construction Kit` has some simple `SYCL` examples. To compile a
+simple vector add test you will need a `clang++` which has been built for
+`SYCL`. This can be downloaded from https://github.com/intel/llvm/releases,
+built from that repo or from the base toolkit (see
+https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/README.md
+for more details). First of all start the server as above.
+
+Build and run simple-vector-add as follows from the build_client directory:-
+
+```
+export LD_LIBRARY_PATH=<path_to_dpcpp_compiler_base>/lib:$PWD/oneAPIConstructionKit/lib:$LD_LIBRARY_PATH
+export OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so
+export ONEAPI_DEVICE_SELECTOR=*:fpga
+<path_to_dpcpp_compiler_base>/bin/clang++ -fsycl <path_to_ock>/examples/applications/simple-vector-add.cpp -o simple-vector-add
+HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so.4.0 ./simple-vector-add
+```
+
+This should show "The results are correct!".


### PR DESCRIPTION
# Overview

Added some SYCL testing to the README for the remote server. The SYCL tests inside OCK were also out of date and have been updated to work with the latest SYCL.

# Reason for change

We wanted an example of running SYCL tests with remote HAL. The tests as is are out of date.

# Description of change

Fixed tests to use latest SYCL. Added SYCL instructions to hal server  README.
