### PR TITLE
Avoid StringRef.equals()

### DIFF
--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -877,7 +877,7 @@ BuiltinID CLBuiltinInfo::identifyBuiltin(const Function &F) const {
   const auto Version = getOpenCLVersion(*F.getParent());
   const StringRef DemangledName = Mangler.demangleName(Name);
   while (entry->ID != eBuiltinInvalid) {
-    if (Version >= entry->MinVer && DemangledName.equals(entry->OpenCLFnName)) {
+    if (Version >= entry->MinVer && DemangledName == entry->OpenCLFnName) {
       return entry->ID;
     }
     entry++;
@@ -1327,8 +1327,8 @@ Function *CLBuiltinInfo::getVectorEquivalent(const Builtin &B, unsigned Width,
   StringRef FirstChunk;
   Lexer L(BuiltinName);
   if (L.ConsumeUntil('_', FirstChunk)) {
-    const bool AsBuiltin = FirstChunk.equals("as");
-    const bool ConvertBuiltin = FirstChunk.equals("convert");
+    const bool AsBuiltin = FirstChunk == "as";
+    const bool ConvertBuiltin = FirstChunk == "convert";
     if (!L.Consume("_")) {
       return nullptr;
     }
@@ -1443,8 +1443,8 @@ Function *CLBuiltinInfo::getScalarEquivalent(const Builtin &B, Module *M) {
   StringRef FirstChunk;
   Lexer L(BuiltinName);
   if (L.ConsumeUntil('_', FirstChunk)) {
-    const bool AsBuiltin = FirstChunk.equals("as");
-    const bool ConvertBuiltin = FirstChunk.equals("convert");
+    const bool AsBuiltin = FirstChunk == "as";
+    const bool ConvertBuiltin = FirstChunk == "convert";
     if (!L.Consume("_")) {
       return nullptr;
     }

--- a/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
@@ -107,7 +107,7 @@ void compiler::utils::LinkBuiltinsPass::cloneStructs(
 
       // check if the names match (minus the suffix LLVM sometimes adds to
       // struct types to differentiate between them)
-      if (StructName.rtrim(Suffix).equals(BuiltinStructName.rtrim(Suffix))) {
+      if (StructName.rtrim(Suffix) == BuiltinStructName.rtrim(Suffix)) {
         if (StructTy->isOpaque() && !BuiltinStructTy->isOpaque()) {
           StructTy->setBody(BuiltinStructTy->elements(),
                             BuiltinStructTy->isPacked());

--- a/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
+++ b/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
@@ -36,7 +36,7 @@ PreservedAnalyses compiler::CheckForExtFuncsPass::run(Module &M,
                                                       ModuleAnalysisManager &) {
   for (const auto &F : M) {
     auto FName = F.getName();
-    if (F.isDeclaration() && !F.isIntrinsic() && !FName.equals("printf") &&
+    if (F.isDeclaration() && !F.isIntrinsic() && FName != "printf" &&
         !FName.starts_with("_Z") && !FName.starts_with("__")) {
       M.getContext().diagnose(DiagnosticInfoExternalFunc(FName));
     }

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -634,7 +634,7 @@ llvm::CallInst *spirv_ll::Builder::createBuiltinCall(
     function->setOnlyReadsMemory();
   }
   auto *const call = IRBuilder.CreateCall(function, args);
-  if (!name.equals(SAMPLER_INIT_FN)) {
+  if (name != SAMPLER_INIT_FN) {
     call->setCallingConv(llvm::CallingConv::SPIR_FUNC);
   }
   return call;


### PR DESCRIPTION
# Overview

Avoid StringRef.equals()

# Reason for change

LLVM 19 has deprecated StringRef::equals in favor of plain ==.

# Description of change

This has been supported by all versions of LLVM ever since StringRef was first added, so we can just change them as suggested.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
