### PR TITLE
Return a hal_device_info_riscv_t from cpu hal/remote hal

### DIFF
--- a/clik/external/hal_cpu/include/cpu_hal.h
+++ b/clik/external/hal_cpu/include/cpu_hal.h
@@ -50,7 +50,7 @@ class cpu_hal final : public hal::hal_device_t {
 
   // Set up the hal device info - this is done as a static so that other classes such
   // as hal_client can set up the desired information directly
-  static hal::hal_device_info_t setup_cpu_hal_device_info();
+  static hal::hal_device_info_t &setup_cpu_hal_device_info();
 
   size_t get_word_size() const { return sizeof(uintptr_t); }
 

--- a/clik/external/hal_cpu/source/cpu_hal.cpp
+++ b/clik/external/hal_cpu/source/cpu_hal.cpp
@@ -33,13 +33,15 @@
 #include <string>
 #include <thread>
 
+#include <hal_riscv.h>
+
 #include "device/device_if.h"
 
-hal::hal_device_info_t cpu_hal::setup_cpu_hal_device_info() {
+hal::hal_device_info_t &cpu_hal::setup_cpu_hal_device_info() {
   const uint64_t global_ram_size = 256 << 20;
   const uint64_t global_mem_max_over_allocation = 16 << 20;
   const uint64_t local_ram_size = 8 << 20;
-  hal::hal_device_info_t hal_device_info;
+  static riscv::hal_device_info_riscv_t hal_device_info;
   hal_device_info.type = hal::hal_device_type_riscv;
   hal_device_info.word_size = sizeof(uintptr_t) * 8;
   hal_device_info.target_name = "ock cpu";
@@ -47,6 +49,7 @@ hal::hal_device_info_t cpu_hal::setup_cpu_hal_device_info() {
       global_ram_size - global_mem_max_over_allocation;
   hal_device_info.shared_local_memory_size = local_ram_size;
   hal_device_info.should_link = true;
+  hal_device_info.link_shared = true;
   hal_device_info.should_vectorize = false;
   // TODO: This is slightly arbitrary and based on the "host" target
   hal_device_info.preferred_vector_width = 128 / (8 * sizeof(uint8_t));
@@ -61,6 +64,12 @@ hal::hal_device_info_t cpu_hal::setup_cpu_hal_device_info() {
 #endif
   hal_device_info.is_little_endian = true;
   hal_device_info.linker_script = "";
+
+  // Currently only has meaning for risc-v. These are slightly arbitrary
+  // and should be more programmatical.
+  hal_device_info.vlen = 0;
+  hal_device_info.extensions = riscv::rv_extension_G;
+  hal_device_info.abi = hal_device_info.word_size == 64 ? riscv::rv_abi_LP64D : riscv::rv_abi_ILP32D;
   return hal_device_info;
 }
 

--- a/clik/external/hal_cpu/source/hal_main.cpp
+++ b/clik/external/hal_cpu/source/hal_main.cpp
@@ -23,7 +23,7 @@ namespace {
 class cpu_hal_platform : public hal::hal_t {
  protected:
   hal::hal_info_t hal_info;
-  hal::hal_device_info_t hal_device_info;
+  hal::hal_device_info_t *hal_device_info;
   std::mutex lock;
 
  public:
@@ -36,7 +36,7 @@ class cpu_hal_platform : public hal::hal_t {
   // return generic target information
   const hal::hal_device_info_t *device_get_info(uint32_t index) override {
     std::lock_guard<std::mutex> locker(lock);
-    return &hal_device_info;
+    return hal_device_info;
   }
 
   // request the creation of a new hal
@@ -45,7 +45,7 @@ class cpu_hal_platform : public hal::hal_t {
     if (index > 0) {
       return nullptr;
     }
-    return new cpu_hal(&hal_device_info, lock);
+    return new cpu_hal(hal_device_info, lock);
   }
 
   // destroy a device instance
@@ -56,12 +56,12 @@ class cpu_hal_platform : public hal::hal_t {
   }
 
   cpu_hal_platform() {
-    hal_device_info = cpu_hal::setup_cpu_hal_device_info();
+    hal_device_info = &cpu_hal::setup_cpu_hal_device_info();
  
     constexpr static uint32_t implemented_api_version = 6;
     static_assert(implemented_api_version == hal_t::api_version,
                   "Implemented API version for CPU HAL does not match hal.h");
-    hal_info.platform_name = hal_device_info.target_name;
+    hal_info.platform_name = hal_device_info->target_name;
     hal_info.num_devices = 1;
     hal_info.api_version = implemented_api_version;
   }

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -46,8 +46,22 @@ If you wish to run on a non RISC-V machine, then `qemu` and the RISC-V toolchain
 
 ## Building the client
 
-We are looking to simplify this process, but currently we need to create an out
-of tree target. This is done as follows (for RISC-V):
+The client can built in-tree (for risc-v) as follows:
+
+```
+  cmake -Bbuild_client -GNinja \
+    -DCA_MUX_TARGETS_TO_ENABLE="riscv" \
+    -DCA_RISCV_ENABLED=ON \
+    -DCA_ENABLE_API=cl \
+    -DCA_LLVM_INSTALL_DIR=<path_to_llvm_install> \
+    -DCA_CL_ENABLE_ICD_LOADER=ON  \
+    -DCA_HAL_NAME=cpu_client
+   ninja -Cbuild_client
+```
+
+It is also possible to build out of tree using `create_target.py` and
+`scripts/new_target_templates/cpu_client_riscv.json`. This could also be modified to work
+for different architectures. For example:
 
 ```
   python <path_to_ock>/scripts/create_target.py <path_to_ock> \
@@ -66,6 +80,9 @@ of tree target. This is done as follows (for RISC-V):
     -DCA_EXTERNAL_CPU_CLIENT_HAL_DIR=<path_to_ock>/examples/hals/hal_cpu_client
    ninja -Cbuild_client
 ```
+
+The llvm install must have LLVM_ENABLE_PROJECT="lld;clang" and
+LLVM_TARGETS_TO_BUILD shoul include `RISCV` for a `RISC-V` target.
 
 This assumes building the ICD, but it is possible to build without this. Note
 also the script requires cookiecutter to be installed with `pip install
@@ -120,14 +137,14 @@ ssh -L <local_port>:127.0.0.1:<remote_port> user@destmachine
 Running the client is done similar to any normal `OCK` OpenCL target (or via
 SYCL OpenCL plugin). The environment variable `HAL_REMOTE_PORT` should be set to
 the local port number. You will also need to set LD_LIBRARY_PATH to
-$PWD/oneAPIConstructionKit/lib if you do not have an OpenCL ICD on your machine.
+the `lib` build directory if you do not have an OpenCL ICD on your machine.
 
-As a simple test try running a simple UnitCL test:
+As a simple test try running a simple UnitCL test (using the in-tree version):
 
 ```
   cd build_client
-  HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so.4.0 \
-    ./oneAPIConstructionKit/bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
+  HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWDlib/libCL.so.4.0 \
+    ./bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
 ```
 This should show as `PASSED`.
 
@@ -143,11 +160,11 @@ for more details). First of all start the server as above.
 Build and run simple-vector-add as follows from the build_client directory:-
 
 ```
-export LD_LIBRARY_PATH=<path_to_dpcpp_compiler_base>/lib:$PWD/oneAPIConstructionKit/lib:$LD_LIBRARY_PATH
-export OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so
+export LD_LIBRARY_PATH=<path_to_dpcpp_compiler_base>/lib:$PWD/lib:$LD_LIBRARY_PATH
+export OCL_ICD_FILENAMES=$PWD/lib/libCL.so
 export ONEAPI_DEVICE_SELECTOR=*:fpga
 <path_to_dpcpp_compiler_base>/bin/clang++ -fsycl <path_to_ock>/examples/applications/simple-vector-add.cpp -o simple-vector-add
-HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/oneAPIConstructionKit/lib/libCL.so.4.0 ./simple-vector-add
+HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./simple-vector-add
 ```
 
 This should show "The results are correct!".

--- a/examples/hals/hal_cpu_client/source/hal_main.cpp
+++ b/examples/hals/hal_cpu_client/source/hal_main.cpp
@@ -25,8 +25,8 @@ class hal_cpu_socket_client : public hal::hal_socket_client {
     static_assert(
         implemented_api_version == hal_t::api_version,
         "Implemented API version for hal_socket_client does not match hal.h");
-    hal_device_info = cpu_hal::setup_cpu_hal_device_info();
-    hal_info.platform_name = hal_device_info.target_name;
+    hal_device_info = &cpu_hal::setup_cpu_hal_device_info();
+    hal_info.platform_name = hal_device_info->target_name;
     hal_info.num_devices = 1;
     hal_info.api_version = implemented_api_version;
     uint32_t port = 0;
@@ -41,7 +41,7 @@ class hal_cpu_socket_client : public hal::hal_socket_client {
 
   // return generic target information
   const hal::hal_device_info_t *device_get_info(uint32_t index) override {
-    return &hal_device_info;
+    return hal_device_info;
   }
 };
 }  // namespace hal

--- a/hal/hal_remote/include/hal_remote/hal_client.h
+++ b/hal/hal_remote/include/hal_remote/hal_client.h
@@ -35,7 +35,7 @@ class hal_client : public hal::hal_t {
   std::mutex lock;
   bool made_connection = false;
   hal::hal_info_t hal_info;
-  hal::hal_device_info_t hal_device_info;
+  hal::hal_device_info_t *hal_device_info;
   uint16_t required_port;
 
  public:
@@ -49,9 +49,9 @@ class hal_client : public hal::hal_t {
     // matches our own, as the data protocol assumes that endianness matches
     const uint32_t one = 1U;
     bool is_little_endian = reinterpret_cast<const char *>(&one)[0] == 1;
-    assert(is_little_endian == hal_device_info.is_little_endian);
+    assert(is_little_endian == hal_device_info->is_little_endian);
 
-    if (is_little_endian != hal_device_info.is_little_endian) {
+    if (is_little_endian != hal_device_info->is_little_endian) {
       return nullptr;
     }
     if (index > 0) {
@@ -83,7 +83,7 @@ class hal_client : public hal::hal_t {
       }
       if (decoder.decode(command, payload.data(), payload.size())) {
         if (decoder.message.device_create_reply) {
-          return new hal::hal_device_client(&hal_device_info, lock,
+          return new hal::hal_device_client(hal_device_info, lock,
                                             &get_transmitter());
         }
       }

--- a/hal/include/hal_types.h
+++ b/hal/include/hal_types.h
@@ -176,6 +176,9 @@ struct hal_device_info_t {
 
   /// @brief Array of counter descriptions. Can be null if num_counters == 0.
   hal_counter_description_t *counter_descriptions = nullptr;
+
+  /// @brief Used to dictate whether to link as dynamic library.
+  bool link_shared = false;
 };
 
 struct hal_info_t {

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -99,6 +99,9 @@ compiler::Result RiscvModule::createBinary(
   // Set the entry point to the zero address to avoid a linker warning. The
   // entry point will not be used directly.
   lld_args.push_back("-e0");
+  if (getTarget().riscv_hal_device_info->link_shared) {
+    lld_args.push_back("--shared");
+  }
 
   const cargo::dynamic_array<uint8_t> finalizer_binary;
   {
@@ -190,8 +193,9 @@ static llvm::TargetMachine *createTargetMachine(
 
   return llvm_target->createTargetMachine(
       target.llvm_triple, target.llvm_cpu, target.llvm_features, options,
-      llvm::Reloc::Model::Static, llvm::CodeModel::Small,
-      multi_llvm::CodeGenOptLevel::Aggressive);
+      target.riscv_hal_device_info->link_shared ? llvm::Reloc::Model::PIC_
+                                                : llvm::Reloc::Model::Static,
+      llvm::CodeModel::Small, multi_llvm::CodeGenOptLevel::Aggressive);
 }
 
 llvm::TargetMachine *riscv::RiscvModule::getTargetMachine() {

--- a/modules/mux/targets/riscv/external/CMakeLists.txt
+++ b/modules/mux/targets/riscv/external/CMakeLists.txt
@@ -22,7 +22,8 @@ set(RISCV_TOOLCHAIN_DIR "${CA_LLVM_INSTALL_DIR}" CACHE PATH
   "Path to the clang RISC-V toolchain")
 
 # Iterate through all 'hal_*' sub-directories.
-file(GLOB HAL_DIR_NAMES FOLLOW_SYMLINKS LIST_DIRECTORIES true "hal_*")
+file(GLOB HAL_DIR_NAMES FOLLOW_SYMLINKS LIST_DIRECTORIES true "hal_*"
+     ${PROJECT_SOURCE_DIR}/examples/hals/hal_*)
 
 if (DEFINED CA_RISCV_EXTERNAL_HAL_DIR)
   list(APPEND HAL_DIR_NAMES ${CA_RISCV_EXTERNAL_HAL_DIR})


### PR DESCRIPTION
# Overview

Return a hal_device_info_riscv_t from cpu hal/remote hal

# Reason for change

Allow in-tree risc-v to support cpu hal/remote HAL

# Description of change

Change cpu hal to return a reference to the device info.
Fix assert when vlen = 0 in mux kernels.
Add link_shared to hal arguments.
Add the examples/hals directory to the list searched