### PR TITLE
Pass --no-show-signature.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ message(STATUS "oneAPI Construction Kit version: ${PROJECT_VERSION}")
 find_program(GIT_EXECUTABLE git${CA_HOST_EXECUTABLE_SUFFIX})
 if(NOT GIT_EXECUTABLE STREQUAL GIT_EXECUTABLE-NOTFOUND)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+    COMMAND ${GIT_EXECUTABLE} log -1 --no-show-signature --format=%h
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE CA_GIT_COMMIT)
   message(STATUS "oneAPI Construction Kit Git Commit: ${CA_GIT_COMMIT}")


### PR DESCRIPTION
# Overview

Pass --no-show-signature.

# Reason for change

git log may either show GPG signatures or not, depending on user settings, when neither --show-signature nor --no-show-signature is passed.

# Description of change

We are relying on not getting GPG signatures here, so explicitly pass --no-show-signature.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
