### PR TITLE
[host] Ensure clock_frequency is at least 1.

### DIFF
--- a/modules/mux/targets/host/source/device.cpp
+++ b/modules/mux/targets/host/source/device.cpp
@@ -429,7 +429,10 @@ device_info_s::device_info_s(host::arch arch, host::os os, bool native,
   this->max_work_group_size_y = this->max_concurrent_work_items;
   this->max_work_group_size_z = this->max_concurrent_work_items;
   this->max_work_width = 64;
-  this->clock_frequency = native ? os_cpu_frequency() : 0;
+  // Tests for CL_DEVICE_MAX_CLOCK_FREQUENCY check that it is non-zero. For lack
+  // of a better alternative, if we cannot figure it out, choose 1.
+  this->clock_frequency =
+      std::max<uint32_t>(native ? os_cpu_frequency() : 0, 1);
   this->compute_units = native ? os_num_cpus() : 0;
   this->buffer_alignment = sizeof(uint64_t) * 16;
   // TODO Reported memory size is quartered (rounded up) in order to pass the


### PR DESCRIPTION
# Overview

[host] Ensure clock_frequency is at least 1.

# Reason for change

CL_DEVICE_MAX_CLOCK_FREQUENCY has been deprecated by OpenCL 2.2, but there are still tests that it returns a non-zero value. For various reasons, it can currently return 0.

# Description of change

Clamp that to 1 instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
