### PR TITLE
Update tests for LLVM 19.

### DIFF
--- a/modules/compiler/test/lit/passes/barriers-dbg.ll
+++ b/modules/compiler/test/lit/passes/barriers-dbg.ll
@@ -134,28 +134,28 @@ if.end:                                           ; preds = %if.then, %entry
 ;
 ; The pass non-determinism also affects the placement of padding elements which
 ; further complicates the issue since this too impacts the offsets. See CA-119.
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
-; CHECK-GE17: call void @llvm.dbg.value(metadata ptr undef
-; CHECK-LT17: call void @llvm.dbg.value(metadata ptr [[LIVE_VAR_GEP]]
+; CHECK-GE19: #dbg_value(ptr undef
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr undef
 ; CHECK-SAME: !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{0|[1-9][0-9]*}}
 ;
 ; Debug info for first kernel scope

--- a/modules/compiler/test/lit/passes/replace-local-module-scope-vars-dbg-2.ll
+++ b/modules/compiler/test/lit/passes/replace-local-module-scope-vars-dbg-2.ll
@@ -21,7 +21,8 @@
 ; info entries should reference into that struct but retain the original
 ; function's scope.
 
-; RUN: muxc --passes "replace-module-scope-vars,verify" -S %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: muxc --passes "replace-module-scope-vars,verify" -S %s | FileCheck %t
 
 ; TODO: It's not clear why @helper_kernel has one dbg.declare but @local_array
 ; has two. See CA-4534.
@@ -40,10 +41,11 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 declare void @llvm.dbg.value(metadata, metadata, metadata) #0
 
 ; CHECK: define void @helper_kernel.mux-local-var-wrapper(
-; CHECK: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}}
-; CHECK-SAME: metadata [[HK_DI_CACHE_VAR:![0-9]+]],
-; CHECK-SAME: metadata !DIExpression(DW_OP_plus_uconst, 0)),
-; CHECK-SAME: !dbg [[HK_DI_CACHE_LOCATION:![0-9]+]]
+; CHECK-GE19: #dbg_declare({{(ptr|%localVarTypes\*)}} %{{[0-9]+}}
+; CHECK-LT19: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}}
+; CHECK-SAME: [[HK_DI_CACHE_VAR:![0-9]+]],
+; CHECK-SAME: !DIExpression(DW_OP_plus_uconst, 0)
+; CHECK-SAME: [[HK_DI_CACHE_LOCATION:![0-9]+]]
 
 ; Function Attrs: nounwind
 define void @helper_kernel() #1 !dbg !27 {
@@ -53,15 +55,17 @@ define void @helper_kernel() #1 !dbg !27 {
 }
 
 ; CHECK: define void @local_array.mux-local-var-wrapper(
-; CHECK: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
-; CHECK-SAME: metadata [[LA_DI_DATA_VAR:![0-9]+]],
-; CHECK-SAME: metadata !DIExpression(DW_OP_plus_uconst, 0)),
-; CHECK-SAME: !dbg [[LA_DI_DATA_LOCATION:![0-9]+]]
+; CHECK-GE19: #dbg_declare({{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
+; CHECK-LT19: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
+; CHECK-SAME: [[LA_DI_DATA_VAR:![0-9]+]],
+; CHECK-SAME: !DIExpression(DW_OP_plus_uconst, 0)
+; CHECK-SAME: [[LA_DI_DATA_LOCATION:![0-9]+]]
 
-; CHECK: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
-; CHECK-SAME: metadata [[LA_DI_CACHE_VAR:![0-9]+]],
-; CHECK-SAME: metadata !DIExpression(DW_OP_plus_uconst, 16)),
-; CHECK-SAME: !dbg [[LA_DI_CACHE_LOCATION:![0-9]+]]
+; CHECK-GE19: #dbg_declare({{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
+; CHECK-LT19: call void @llvm.dbg.declare(metadata {{(ptr|%localVarTypes\*)}} %{{[0-9]+}},
+; CHECK-SAME: [[LA_DI_CACHE_VAR:![0-9]+]],
+; CHECK-SAME: !DIExpression(DW_OP_plus_uconst, 16)
+; CHECK-SAME: [[LA_DI_CACHE_LOCATION:![0-9]+]]
 
 ; Function Attrs: nounwind
 define void @local_array() #1 !dbg !34 {

--- a/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
@@ -16,7 +16,8 @@
 
 ; Check VECZ debug info for inlined DILocation metadata nodes
 
-; RUN: veczc -k functions_one -vecz-passes=builtin-inlining -vecz-simd-width=4 -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -k functions_one -vecz-passes=builtin-inlining -vecz-simd-width=4 -S < %s | FileCheck %t
 
 ; ModuleID = '/tmp/inlined_function.ll'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
@@ -130,8 +131,10 @@ attributes #4 = { nobuiltin }
 
 ; CHECK: %[[LOAD1:[0-9]+]] = load i32, ptr addrspace(1) %{{.*}}, align 4
 ; CHECK: %[[LOAD2:[0-9]+]] = load i32, ptr addrspace(1) %{{.*}}, align 4
-; CHECK: call void @llvm.dbg.value(metadata i32 %[[LOAD1]], metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg [[DI_LOC1:![0-9]+]]
-; CHECK: call void @llvm.dbg.value(metadata i32 %[[LOAD2]], metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg [[DI_LOC1]]
+; CHECK-GE19: #dbg_value(i32 %[[LOAD1]], !{{[0-9]+}}, !DIExpression(), [[DI_LOC1:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata i32 %[[LOAD1]], metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg [[DI_LOC1:![0-9]+]]
+; CHECK-GE19: #dbg_value(i32 %[[LOAD2]], !{{[0-9]+}}, !DIExpression(), [[DI_LOC1]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata i32 %[[LOAD2]], metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg [[DI_LOC1]]
 ; CHECK: %{{.*}} = mul nsw i32 %[[LOAD1]], %[[LOAD2]], !dbg [[DI_LOC2:![0-9]+]]
 
 ; CHECK: [[HELPER_SUBPROGRAM:![0-9]+]] = distinct !DISubprogram(name: "k_one",

--- a/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
@@ -18,7 +18,8 @@
 ; intrinsics across all lanes even when scalarization masks disable some
 ; of the lanes. This occurs when we scalarize insertelement instructions.
 
-; RUN: veczc -k unaligned_load -vecz-passes="function(instcombine,adce),scalarize,packetizer,instcombine" -vecz-simd-width=4 -vecz-choices=FullScalarization -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -k unaligned_load -vecz-passes="function(instcombine,adce),scalarize,packetizer,instcombine" -vecz-simd-width=4 -vecz-choices=FullScalarization -S < %s | FileCheck %t
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
@@ -49,8 +50,10 @@ entry:
 ; FIXME: This llvm.dbg.value marks a 'kill location' and denotes the
 ; termination of the previous value assigned to %tmp - we could probably do
 ; better here by manifesting a vectorized value?
-; CHECK: call void @llvm.dbg.value(metadata i32 {{(poison|undef)}}, metadata [[VAR:![0-9]+]],
-; CHECK-SAME:   metadata !DIExpression({{.*}})), !dbg !{{[0-9]+}}
+; CHECK-GE19: #dbg_value(i32 {{(poison|undef)}}, [[VAR:![0-9]+]],
+; CHECK-LT19: call void @llvm.dbg.value(metadata i32 {{(poison|undef)}}, metadata [[VAR:![0-9]+]],
+; CHECK-SAME:   !DIExpression({{.*}}),
+; CHECK-SAME:   !{{[0-9]+}}
   %1 = load i32, i32* %tid, align 4, !dbg !32
   %mul = mul nsw i32 3, %1, !dbg !32
   %idx.ext = sext i32 %mul to i64, !dbg !32

--- a/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
@@ -17,7 +17,8 @@
 ; Check that debug info is preserved in the vectorized kernel.
 ; Specifically that the packetization pass creates vector types
 ; in the DI for the variables.
-; RUN: veczc -k add -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -k add -S < %s | FileCheck %t
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
@@ -35,32 +36,38 @@ entry:
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   store i32 addrspace(1)* %in1, i32 addrspace(1)** %in1.addr, align 8
-; CHECK: call void @llvm.dbg.value(metadata ptr addrspace(1) %in1, metadata [[DI_IN1:![0-9]+]], metadata [[EXPR:!DIExpression()]]
-; CHECK-SAME: !dbg [[PARAM_LOC:![0-9]+]]
+; CHECK-GE19: #dbg_value(ptr addrspace(1) %in1, [[DI_IN1:![0-9]+]], [[EXPR:!DIExpression()]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr addrspace(1) %in1, metadata [[DI_IN1:![0-9]+]], metadata [[EXPR:!DIExpression()]]
+; CHECK-SAME: [[PARAM_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %in1.addr, metadata !11, metadata !29), !dbg !30
   store i32 addrspace(1)* %in2, i32 addrspace(1)** %in2.addr, align 8
-; CHECK: call void @llvm.dbg.value(metadata ptr addrspace(1) %in2, metadata [[DI_IN2:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[PARAM_LOC]]
+; CHECK-GE19: #dbg_value(ptr addrspace(1) %in2, [[DI_IN2:![0-9]+]], [[EXPR]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr addrspace(1) %in2, metadata [[DI_IN2:![0-9]+]], metadata [[EXPR]]
+; CHECK-SAME: [[PARAM_LOC]]
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %in2.addr, metadata !12, metadata !29), !dbg !30
   store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
-; CHECK: call void @llvm.dbg.value(metadata ptr addrspace(1) %out, metadata [[DI_OUT:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[PARAM_LOC]]
+; CHECK-GE19: #dbg_value(ptr addrspace(1) %out, [[DI_OUT:![0-9]+]], [[EXPR]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata ptr addrspace(1) %out, metadata [[DI_OUT:![0-9]+]], metadata [[EXPR]]
+; CHECK-SAME: [[PARAM_LOC]]
   call void @llvm.dbg.declare(metadata i32 addrspace(1)** %out.addr, metadata !13, metadata !29), !dbg !30
-; CHECK: call void @llvm.dbg.value(metadata i64 %call, metadata [[DI_TID:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[TID_LOC:![0-9]+]]
+; CHECK-GE19: #dbg_value(i64 %call, [[DI_TID:![0-9]+]], [[EXPR]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata i64 %call, metadata [[DI_TID:![0-9]+]], metadata [[EXPR]]
+; CHECK-SAME: [[TID_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
   %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
-; CHECK: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_A:![0-9]+]], metadata !DIExpression())
-; CHECK-SAME: !dbg [[A_LOC:![0-9]+]]
+; CHECK-GE19: #dbg_value(i32 undef, [[DI_A:![0-9]+]], !DIExpression(),
+; CHECK-LT19: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_A:![0-9]+]], metadata !DIExpression())
+; CHECK-SAME: [[A_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
   %0 = load i64, i64* %tid, align 8, !dbg !32
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %in1.addr, align 8, !dbg !32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %0, !dbg !32
   %2 = load i32, i32 addrspace(1)* %arrayidx, align 4, !dbg !32
   store i32 %2, i32* %a, align 4, !dbg !32
-; CHECK: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_B:![0-9]+]], metadata !DIExpression())
-; CHECK-SAME: !dbg [[B_LOC:![0-9]+]]
+; CHECK-GE19: #dbg_value(i32 undef, [[DI_B:![0-9]+]], !DIExpression(),
+; CHECK-LT19: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_B:![0-9]+]], metadata !DIExpression())
+; CHECK-SAME: [[B_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %b, metadata !20, metadata !29), !dbg !33
   %3 = load i64, i64* %tid, align 8, !dbg !33
   %4 = load i32 addrspace(1)*, i32 addrspace(1)** %in2.addr, align 8, !dbg !33

--- a/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
@@ -17,7 +17,8 @@
 ; Check that debug info intrinsics are correctly placed after
 ; phi nodes.
 
-; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %t
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
@@ -47,8 +48,10 @@ entry:
 
 ; CHECK: for.cond:
 ; CHECK: %[[PHI1:.+]] = phi {{i[0-9]+}} [ %{{.+}}, %entry ], [ %{{.+}}, %for.cond ]
-; CHECK: call void @llvm.dbg.value(metadata i64 %[[PHI1]], metadata !{{[0-9]+}},
-; CHECK-SAME: metadata !DIExpression({{.*}})), !dbg !{{[0-9]+}}
+; CHECK-GE19: #dbg_value(i64 %[[PHI1]], !{{[0-9]+}},
+; CHECK-LT19: call void @llvm.dbg.value(metadata i64 %[[PHI1]], metadata !{{[0-9]+}},
+; CHECK-SAME: !DIExpression({{.*}}),
+; CHECK-SAME: !{{[0-9]+}}
 ; Check we haven't inserted a llvm.dbg.value intrinsic before the last of the PHIs.
 ; CHECK-NOT: phi
 for.cond:                                         ; preds = %for.inc, %entry

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
@@ -18,7 +18,8 @@
 ; Specifically that the scalarization pass doesn't destroy DI
 ; intrinsics attached to the vector instructions it scalarizes.
 
-; RUN: veczc -k mul2 -vecz-passes="scalarize,function(mem2reg)" -vecz-choices=FullScalarization -S < %s | FileCheck %s
+; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
+; RUN: veczc -k mul2 -vecz-passes="scalarize,function(mem2reg)" -vecz-choices=FullScalarization -S < %s | FileCheck %t
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
@@ -131,26 +132,33 @@ attributes #3 = { nobuiltin }
 ; CHECK: @__vecz_v[[WIDTH:[0-9]+]]_mul2({{.*}} !dbg [[VECZ_SUBPROG:![0-9]+]]
 
 ; Check that intrinsics for user variable locations are still present
-; CHECK: call void @llvm.dbg.value(metadata {{.*}} %in1, metadata [[DI_IN1:![0-9]+]], metadata [[EXPR:!DIExpression()]]
-; CHECK-SAME: !dbg [[PARAM_LOC:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata {{.*}} %in1, metadata [[DI_IN1:![0-9]+]], metadata [[EXPR:!DIExpression()]]
+; CHECK-GE19: #dbg_value({{.*}} %in1, [[DI_IN1:![0-9]+]], [[EXPR:!DIExpression()]]
+; CHECK-SAME: [[PARAM_LOC:![0-9]+]]
 
-; CHECK: call void @llvm.dbg.value(metadata {{.*}} %in2, metadata [[DI_IN2:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[PARAM_LOC]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata {{.*}} %in2, metadata [[DI_IN2:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_value({{.*}} %in2, [[DI_IN2:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[PARAM_LOC]]
 
-; CHECK: call void @llvm.dbg.value(metadata {{.*}} %out, metadata [[DI_OUT:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[PARAM_LOC]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata {{.*}} %out, metadata [[DI_OUT:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_value({{.*}} %out, [[DI_OUT:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[PARAM_LOC]]
 
-; CHECK: call void @llvm.dbg.value(metadata i64 %call, metadata [[DI_TID:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME: !dbg [[TID_LOC:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.value(metadata i64 %call, metadata [[DI_TID:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_value(i64 %call, [[DI_TID:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[TID_LOC:![0-9]+]]
 
-; CHECK: call void @llvm.dbg.declare(metadata ptr %a, metadata [[DI_A:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME:!dbg [[A_LOC:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.declare(metadata ptr %a, metadata [[DI_A:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_declare(ptr %a, [[DI_A:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[A_LOC:![0-9]+]]
 
-; CHECK: call void @llvm.dbg.declare(metadata ptr %b, metadata [[DI_B:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME:!dbg [[B_LOC:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.declare(metadata ptr %b, metadata [[DI_B:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_declare(ptr %b, [[DI_B:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[B_LOC:![0-9]+]]
 
-; CHECK: call void @llvm.dbg.declare(metadata ptr %tmp, metadata [[DI_TMP:![0-9]+]], metadata [[EXPR]]
-; CHECK-SAME:!dbg [[TMP_LOC:![0-9]+]]
+; CHECK-LT19: call void @llvm.dbg.declare(metadata ptr %tmp, metadata [[DI_TMP:![0-9]+]], metadata [[EXPR]]
+; CHECK-GE19: #dbg_declare(ptr %tmp, [[DI_TMP:![0-9]+]], [[EXPR]]
+; CHECK-SAME: [[TMP_LOC:![0-9]+]]
 
 ; Debug info metadata entries
 ; CHECK:[[PTR_TYPE:![0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DI_INT2:![0-9]+]], size: 64, align: 64)

--- a/modules/lit/ca-lit.in
+++ b/modules/lit/ca-lit.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """ A convenience testing wrapper which allows running of lit tests directly


### PR DESCRIPTION
# Overview

Update tests for LLVM 19.

# Reason for change

LLVM 19 now prints in the new debug info format by default.

# Description of change

Update tests to account for this.

# Anything else we should know?

Also update ca-lit to call python3 rather than python. The latter is less likely to be available, and even if available, may be Python 2 rather than Python 3.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
