### PR TITLE
Fix printf of %%.

### DIFF
--- a/modules/compiler/builtins/source/printf.cpp
+++ b/modules/compiler/builtins/source/printf.cpp
@@ -329,7 +329,13 @@ void builtins::printf::print(uint8_t *pack, size_t max_length,
 
       // if the call doesn't have any parameters just print the format string
       if (printf_desc.types.size() == 0) {
-        ::printf("%s", printf_desc.format_string.c_str());
+        // We cannot print using "%s" because the format string may contain
+        // "%%" which must be printed as "%", not as "%%". Calling printf with a
+        // non-constant format string results in a warning (and we build with
+        // warnings treated as errors). We have already checked that the format
+        // string does not consume any arguments though, so we can just add a
+        // dummy argument to suppress any warnings.
+        ::printf(printf_desc.format_string.c_str(), 0);
         continue;
       }
 


### PR DESCRIPTION
# Overview

Fix printf of %%.

# Reason for change

We were printing any non-argument-consuming parts of printf format strings literally, but that is not right: printf("%%") is supposed to print "%", not "%%".

# Description of change

We have already checked the format string, we already know that the format string consumes no arguments, so just pass it to printf to handle any embedded %%.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
