### PR TITLE
[LLVM 19] Drop debug info format conversions

### DIFF
--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -3585,16 +3585,6 @@ Function *CLBuiltinLoader::materializeBuiltin(StringRef BuiltinName,
       return nullptr;
     }
 
-#if LLVM_VERSION_GREATER_EQUAL(19, 0)
-    if (Current->IsNewDbgInfoFormat != BuiltinModule->IsNewDbgInfoFormat) {
-      if (BuiltinModule->IsNewDbgInfoFormat) {
-        Current->convertToNewDbgValues();
-      } else {
-        Current->convertFromNewDbgValues();
-      }
-    }
-#endif
-
     // Find any callees in the function and add them to the list.
     for (BasicBlock &BB : *Current) {
       for (Instruction &I : BB) {

--- a/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
@@ -138,16 +138,6 @@ void compiler::utils::LinkBuiltinsPass::cloneBuiltins(
 
     assert(!Error && "Bitcode materialization failed!");
 
-#if LLVM_VERSION_GREATER_EQUAL(19, 0)
-    if (BuiltinFn->IsNewDbgInfoFormat != BuiltinsModule.IsNewDbgInfoFormat) {
-      if (BuiltinsModule.IsNewDbgInfoFormat) {
-        BuiltinFn->convertToNewDbgValues();
-      } else {
-        BuiltinFn->convertFromNewDbgValues();
-      }
-    }
-#endif
-
     // Find any callees in the function and add them to the list.
     for (auto &BB : *BuiltinFn) {
       for (auto &I : BB) {

--- a/modules/compiler/source/base/source/target.cpp
+++ b/modules/compiler/source/base/source/target.cpp
@@ -100,12 +100,6 @@ Result BaseTarget::init(uint32_t builtins_capabilities) {
         builtins_module_from_file->getTargetTriple()) {
       return Result::FAILURE;
     }
-
-#if LLVM_VERSION_GREATER_EQUAL(19, 0)
-    if (UseNewDbgInfoFormat && !builtins_module_from_file->IsNewDbgInfoFormat) {
-      builtins_module_from_file->convertToNewDbgValues();
-    }
-#endif
   }
 
   return initWithBuiltins(std::move(builtins_module_from_file));

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -123,12 +123,6 @@ compiler::Result HostTarget::initWithBuiltins(
     return compiler::Result::FAILURE;
   }
   builtins_host = std::move(loadedModule.get());
-
-#if LLVM_VERSION_GREATER_EQUAL(19, 0)
-  if (UseNewDbgInfoFormat && !builtins_host->IsNewDbgInfoFormat) {
-    builtins_host->convertToNewDbgValues();
-  }
-#endif
 #endif
 
   // initialize LLVM targets


### PR DESCRIPTION
# Overview

[LLVM 19] Drop debug info format conversions

# Reason for change

We were converting between LLVM's old and new debug info format to work around the incomplete new debug info format implementation in LLVM 19. Now that it is (mostly) done, we no longer need that.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
