### PR TITLE
Fix build with LLVM 19 again.

### DIFF
--- a/modules/compiler/compiler_pipeline/include/compiler/utils/simple_callback_pass.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/simple_callback_pass.h
@@ -24,6 +24,8 @@
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
 
+#include <functional>
+
 namespace compiler {
 namespace utils {
 
@@ -44,7 +46,7 @@ class SimpleCallbackPass : public llvm::PassInfoMixin<SimpleCallbackPass> {
   }
 
  private:
-  llvm::unique_function<CallbackFnTy> Callback;
+  std::function<CallbackFnTy> Callback;
 };
 
 }  // namespace utils

--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -23,6 +23,7 @@
 #include <llvm/ADT/SetOperations.h>
 #include <llvm/ADT/SetVector.h>
 #include <llvm/ADT/SmallSet.h>
+#include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringSet.h>
 #include <llvm/ADT/TinyPtrVector.h>
 #include <llvm/IR/Constants.h>


### PR DESCRIPTION
# Overview

Fix build with LLVM 19 again.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* Add missing header. We were using SmallString without including its header, relying on it being included implicitly through some other header. It no longer is included implicitly.
* Change llvm::unique_function to std::function. Again we were failing to include the appropriate header, but there was no reason for using llvm::unique_function in the first place. Though it has benefits over std::function in specific cases, that did not apply to what we were doing.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
