### PR TITLE
Fix risc-v memmove creating memcpy instrinsic

### DIFF
--- a/modules/compiler/builtins/source/builtins.cpp
+++ b/modules/compiler/builtins/source/builtins.cpp
@@ -658,12 +658,17 @@ void *memcpy(void *__restrict dst, const void *__restrict src, size_t num) {
   return dst;
 }
 
+// We don't want an llvm.memcpy intrinsic here as that complicates the handling
+// in the link-builtins pass
 void *memmove(void *dst, const void *src, size_t num) {
   if (reinterpret_cast<uintptr_t>(static_cast<char *>(dst) + num) <=
           reinterpret_cast<uintptr_t>(src) ||
       reinterpret_cast<uintptr_t>(static_cast<const char *>(src) + num) <=
           reinterpret_cast<uintptr_t>(dst)) {
-    return memcpy(dst, src, num);
+    return [&]() __attribute__((always_inline, no_builtin)) {
+      return memcpy(dst, src, num);
+    }
+    ();
   }
   if (reinterpret_cast<uintptr_t>(dst) < reinterpret_cast<uintptr_t>(src)) {
     auto *d = static_cast<unsigned char *>(dst);

--- a/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memcpy.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memcpy.ll
@@ -1,0 +1,51 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --device "%riscv_device" --passes link-builtins,verify -S %s | FileCheck %s
+
+target triple = "riscv64-unknown-unknown-elf"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+; CHECK: define linkonce dso_local spir_func noundef ptr @memcpy(
+
+define void @memcpy_kernel_32_p0(ptr %out, ptr %in, i32 %size) {
+entry:
+  call void @llvm.memcpy.p0.p0.i32(ptr %out, ptr %in, i32 %size, i1 false)
+  ret void
+}
+
+define void @memcpy_kernel_32_p1(ptr addrspace(1) %out, ptr addrspace(1) %in, i32 %size) {
+entry:
+  call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) %out, ptr addrspace(1) %in, i32 %size, i1 false)
+  ret void
+}
+
+define void @memcpy_kernel_64_p0_p2(ptr %out, ptr addrspace(2) %in, i64 %size) {
+entry:
+  call void @llvm.memcpy.p0.p2.i64(ptr %out, ptr addrspace(2) %in, i64 %size, i1 false)
+  ret void
+}
+
+define void @memcpy_kernel_32_p2_p1(ptr addrspace(2) %out, ptr addrspace(1) %in, i32 %size) {
+entry:
+  call void @llvm.memcpy.p2.p1.i32(ptr addrspace(2) %out, ptr addrspace(1) %in, i32 %size, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i32(ptr  noalias nocapture writeonly, ptr  noalias nocapture readonly, i32, i1 immarg)
+declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i32, i1 immarg)
+declare void @llvm.memcpy.p0.p2.i64(ptr  noalias nocapture writeonly, ptr addrspace(2) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memcpy.p2.p1.i32(ptr addrspace(2) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i32, i1 immarg)

--- a/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memmove.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memmove.ll
@@ -1,0 +1,53 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --device "%riscv_device" --passes link-builtins,verify -S %s | FileCheck %s
+
+target triple = "riscv64-unknown-unknown-elf"
+target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+; CHECK: define linkonce dso_local spir_func noundef ptr @memmove(
+; CHECK-NOT: tail call void @llvm.memcpy
+
+
+define void @memmove_kernel_32_p0(ptr %out, ptr %in, i32 %size) {
+entry:
+  call void @llvm.memmove.p0.p0.i32(ptr %out, ptr %in, i32 %size, i1 false)
+  ret void
+}
+
+define void @memmove_kernel_32_p1(ptr addrspace(1) %out, ptr addrspace(1) %in, i32 %size) {
+entry:
+  call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %out, ptr addrspace(1) %in, i32 %size, i1 false)
+  ret void
+}
+
+define void @memmove_kernel_64_p0_p2(ptr %out, ptr addrspace(2) %in, i64 %size) {
+entry:
+  call void @llvm.memmove.p0.p2.i64(ptr %out, ptr addrspace(2) %in, i64 %size, i1 false)
+  ret void
+}
+
+define void @memmove_kernel_32_p2_p1(ptr addrspace(2) %out, ptr addrspace(1) %in, i32 %size) {
+entry:
+  call void @llvm.memmove.p2.p1.i32(ptr addrspace(2) %out, ptr addrspace(1) %in, i32 %size, i1 false)
+  ret void
+}
+
+declare void @llvm.memmove.p0.p0.i32(ptr  noalias nocapture writeonly, ptr  noalias nocapture readonly, i32, i1 immarg)
+declare void @llvm.memmove.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i32, i1 immarg)
+declare void @llvm.memmove.p0.p2.i64(ptr  noalias nocapture writeonly, ptr addrspace(2) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memmove.p2.p1.i32(ptr addrspace(2) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i32, i1 immarg)

--- a/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memset.ll
+++ b/modules/compiler/targets/riscv/test/lit/passes/link-builtins-memset.ll
@@ -1,0 +1,46 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --device "%riscv_device" --passes link-builtins,verify -S %s | FileCheck %s
+
+target triple = "riscv64-unknown-unknown-elf"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+; CHECK: define linkonce dso_local spir_func noundef ptr @memset(
+
+define void @memset_kernel_32_p0(ptr %out, i8 %val, i32 %size) {
+entry:
+  call void @llvm.memset.p0.i32(ptr %out, i8 %val, i32 %size, i1 false)
+  ret void
+}
+
+define void @memset_kernel_32_p1(ptr addrspace(1) %out, i8 %val, i32 %size) {
+entry:
+  call void @llvm.memset.p1.i32(ptr addrspace(1) %out, i8 %val, i32 %size, i1 false)
+  ret void
+}
+
+define void @memset_kernel_64_p0_p2(ptr addrspace(2) %out, i8 %val, i64 %size) {
+entry:
+  call void @llvm.memset.p2.i64(ptr addrspace(2) %out, i8 %val, i64 %size, i1 false)
+  ret void
+}
+
+define void @memset_kernel_32_p2_p1(ptr addrspace(2) %out, i8 %val, i32 %size) {
+entry:
+  call void @llvm.memset.p2.i32(ptr addrspace(2) %out, i8 %val, i32 %size, i1 false)
+  ret void
+}


### PR DESCRIPTION



# Overview

Pass the attribute __attribute__((no_builtin)) to the memmove builtin and adds lit tests for memcpy,memmove and memset intrinsics.


# Reason for change

SYCL CTS test vector_load_store with host risc-v showed that memmove intrinsics could result in a linked builtin which then included memcpy instrinsics which could result in a linker error.

