### PR TITLE
Add missing atomic functions.

### DIFF
--- a/modules/compiler/builtins/include/builtins/builtins-3.0.h
+++ b/modules/compiler/builtins/include/builtins/builtins-3.0.h
@@ -137,222 +137,447 @@ void __CL_BUILTIN_ATTRIBUTES atomic_init(volatile atomic_double *obj,
 void __CL_BUILTIN_ATTRIBUTES atomic_work_item_fence(cl_mem_fence_flags flags,
                                                     memory_order order,
                                                     memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __local atomic_int *object,
+                                          int desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_int *object, int desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_int *object, int desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __local atomic_long *object,
+                                          long desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_long *object, long desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_long *object, long desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __local atomic_uint *object,
+                                          uint desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_uint *object, uint desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_uint *object, uint desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __local atomic_ulong *object,
+                                          ulong desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_ulong *object, ulong desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_ulong *object, ulong desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __local atomic_float *object,
+                                          float desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_float *object, float desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_float *object, float desired,
                       memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 void __CL_BUILTIN_ATTRIBUTES
+atomic_store(volatile __local atomic_double *object, double desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __local atomic_double *object, double desired, memory_order order);
+void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __local atomic_double *object, double desired,
                       memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __global atomic_int *object,
+                                          int desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __global atomic_int *object, int desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_int *object, int desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __global atomic_long *object,
+                                          long desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __global atomic_long *object, long desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_long *object, long desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile __global atomic_uint *object,
+                                          uint desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __global atomic_uint *object, uint desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_uint *object, uint desired,
                       memory_order order, memory_scope scope);
 void __CL_BUILTIN_ATTRIBUTES
+atomic_store(volatile __global atomic_ulong *object, ulong desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __global atomic_ulong *object, ulong desired, memory_order order);
+void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_ulong *object, ulong desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES
+atomic_store(volatile __global atomic_float *object, float desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile __global atomic_float *object, float desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_float *object, float desired,
                       memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 void __CL_BUILTIN_ATTRIBUTES
+atomic_store(volatile __global atomic_double *object, double desired);
+void __CL_BUILTIN_ATTRIBUTES
+atomic_store_explicit(volatile __global atomic_double *object, double desired,
+                      memory_order order);
+void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile __global atomic_double *object, double desired,
                       memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_int *object,
+                                          int desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_int *object,
+                                                   int desired,
+                                                   memory_order order);
 void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_int *object,
                                                    int desired,
                                                    memory_order order,
                                                    memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_long *object,
+                                          long desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_long *object,
+                                                   long desired,
+                                                   memory_order order);
 void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_long *object,
                                                    long desired,
                                                    memory_order order,
                                                    memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_uint *object,
+                                          uint desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_uint *object,
+                                                   uint desired,
+                                                   memory_order order);
 void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile atomic_uint *object,
                                                    uint desired,
                                                    memory_order order,
                                                    memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_ulong *object,
+                                          ulong desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile atomic_ulong *object, ulong desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile atomic_ulong *object, ulong desired,
                       memory_order order, memory_scope scope);
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_float *object,
+                                          float desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile atomic_float *object, float desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile atomic_float *object, float desired,
                       memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile atomic_double *object,
+                                          double desired);
+void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(
+    volatile atomic_double *object, double desired, memory_order order);
 void __CL_BUILTIN_ATTRIBUTES
 atomic_store_explicit(volatile atomic_double *object, double desired,
                       memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __local atomic_int *object);
+int __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __local atomic_int *object, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_int *object, memory_order order,
                      memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __local atomic_long *object);
+long __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __local atomic_long *object, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_long *object, memory_order order,
                      memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __local atomic_uint *object);
+uint __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __local atomic_uint *object, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_uint *object, memory_order order,
                      memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __local atomic_ulong *object);
+ulong __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __local atomic_ulong *object, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_ulong *object, memory_order order,
                      memory_scope scope);
+float __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __local atomic_float *object);
+float __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __local atomic_float *object, memory_order order);
 float __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_float *object, memory_order order,
                      memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 double __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __local atomic_double *object);
+double __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
+    volatile __local atomic_double *object, memory_order order);
+double __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __local atomic_double *object, memory_order order,
                      memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __global atomic_int *object);
+int __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __global atomic_int *object, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_int *object, memory_order order,
                      memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __global atomic_long *object);
+long __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __global atomic_long *object, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_long *object, memory_order order,
                      memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_load(volatile __global atomic_uint *object);
+uint __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile __global atomic_uint *object, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_uint *object, memory_order order,
                      memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __global atomic_ulong *object);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
+    volatile __global atomic_ulong *object, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_ulong *object, memory_order order,
                      memory_scope scope);
+float __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __global atomic_float *object);
+float __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
+    volatile __global atomic_float *object, memory_order order);
 float __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_float *object, memory_order order,
                      memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 double __CL_BUILTIN_ATTRIBUTES
+atomic_load(volatile __global atomic_double *object);
+double __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
+    volatile __global atomic_double *object, memory_order order);
+double __CL_BUILTIN_ATTRIBUTES
 atomic_load_explicit(volatile __global atomic_double *object,
                      memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_int *object);
+int __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_int *object,
+                                                 memory_order order);
 int __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_int *object,
                                                  memory_order order,
                                                  memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_long *object);
+long __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_long *object,
+                                                  memory_order order);
 long __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_long *object,
                                                   memory_order order,
                                                   memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_uint *object);
+uint __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_uint *object,
+                                                  memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile atomic_uint *object,
                                                   memory_order order,
                                                   memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_ulong *object);
+ulong __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile atomic_ulong *object, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
     volatile atomic_ulong *object, memory_order order, memory_scope scope);
+float __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_float *object);
+float __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile atomic_float *object, memory_order order);
 float __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
     volatile atomic_float *object, memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+double __CL_BUILTIN_ATTRIBUTES atomic_load(volatile atomic_double *object);
+double __CL_BUILTIN_ATTRIBUTES
+atomic_load_explicit(volatile atomic_double *object, memory_order order);
 double __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(
     volatile atomic_double *object, memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile __local atomic_int *object,
+                                            int desired);
+int __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_int *object, int desired, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_int *object, int desired,
                          memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __local atomic_long *object, long desired);
+long __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_long *object, long desired, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_long *object, long desired,
                          memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __local atomic_uint *object, uint desired);
+uint __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_uint *object, uint desired, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_uint *object, uint desired,
                          memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __local atomic_ulong *object, ulong desired);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_ulong *object, ulong desired, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_ulong *object, ulong desired,
                          memory_order order, memory_scope scope);
+float __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __local atomic_float *object, float desired);
+float __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_float *object, float desired, memory_order order);
 float __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_float *object, float desired,
                          memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
 double __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __local atomic_double *object, double desired);
+double __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __local atomic_double *object, double desired, memory_order order);
+double __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __local atomic_double *object, double desired,
                          memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
 int __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_int *object, int desired);
+int __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __global atomic_int *object, int desired, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __global atomic_int *object, int desired,
                          memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_long *object, long desired);
+long __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __global atomic_long *object, long desired, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __global atomic_long *object, long desired,
                          memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_uint *object, uint desired);
+uint __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __global atomic_uint *object, uint desired, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __global atomic_uint *object, uint desired,
                          memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_ulong *object, ulong desired);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __global atomic_ulong *object, ulong desired, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __global atomic_ulong *object, ulong desired,
                          memory_order order, memory_scope scope);
 float __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_float *object, float desired);
+float __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile __global atomic_float *object, float desired, memory_order order);
+float __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile __global atomic_float *object, float desired,
                          memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+double __CL_BUILTIN_ATTRIBUTES
+atomic_exchange(volatile __global atomic_double *object, double desired);
+double __CL_BUILTIN_ATTRIBUTES
+atomic_exchange_explicit(volatile __global atomic_double *object,
+                         double desired, memory_order order);
 double __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
     volatile __global atomic_double *object, double desired, memory_order order,
     memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_int *object,
+                                            int desired);
+int __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_int *object, int desired, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_int *object, int desired,
                          memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_long *object,
+                                             long desired);
+long __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_long *object, long desired, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_long *object, long desired,
                          memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_uint *object,
+                                             uint desired);
+uint __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_uint *object, uint desired, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_uint *object, uint desired,
                          memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_ulong *object,
+                                              ulong desired);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_ulong *object, ulong desired, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_ulong *object, ulong desired,
                          memory_order order, memory_scope scope);
+float __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_float *object,
+                                              float desired);
+float __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_float *object, float desired, memory_order order);
 float __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_float *object, float desired,
                          memory_order order, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+double __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile atomic_double *object,
+                                               double desired);
+double __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(
+    volatile atomic_double *object, double desired, memory_order order);
 double __CL_BUILTIN_ATTRIBUTES
 atomic_exchange_explicit(volatile atomic_double *object, double desired,
                          memory_order order, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_long *object, __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_long *object,
+                               __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_long *object,
+                               __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure);
@@ -360,24 +585,34 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_uint *object, __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_uint *object,
+                               __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_uint *object,
+                               __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -385,12 +620,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_ulong *object,
+                               __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -398,6 +638,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_ulong *object,
+                               __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -405,6 +648,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_ulong *object,
+                               __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -412,12 +658,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_float *object,
+                               __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure);
@@ -425,6 +676,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_float *object,
+                               __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure);
@@ -432,6 +686,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_float *object,
+                               __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure);
@@ -439,6 +696,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -446,6 +705,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_double *object,
+                               __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure);
@@ -453,6 +715,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_double *object,
+                               __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure);
@@ -460,6 +725,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __local atomic_double *object,
+                               __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure);
@@ -467,6 +735,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __local atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -474,36 +744,50 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __local atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_long *object,
+                               __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_long *object,
+                               __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __global long *expected,
     long desired, memory_order success, memory_order failure);
@@ -511,6 +795,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __global long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_long *object,
+                               __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure);
@@ -518,18 +805,26 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_uint *object,
+                               __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_uint *object,
+                               __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __global uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -537,6 +832,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __global uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_uint *object,
+                               __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -544,12 +842,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_ulong *object,
+                               __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -557,6 +860,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_ulong *object,
+                               __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -564,6 +870,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_ulong *object,
+                               __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -571,12 +880,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_float *object,
+                               __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure);
@@ -584,6 +898,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_float *object,
+                               __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure);
@@ -591,6 +908,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_float *object,
+                               __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure);
@@ -598,6 +918,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -605,6 +927,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_double *object,
+                               __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure);
@@ -612,6 +937,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_double *object,
+                               __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure);
@@ -619,6 +947,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_strong(volatile __global atomic_double *object,
+                               __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure);
@@ -626,6 +957,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile __global atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -633,120 +966,160 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile __global atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_long *object, __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_long *object, __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_long *object, __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __private long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, __private long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_uint *object, __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_uint *object, __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_uint *object, __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __private uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, __private uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_ulong *object, __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __local ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __local ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_ulong *object, __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __global ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __global ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_ulong *object, __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __private ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, __private ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_float *object, __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __local float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __local float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_float *object, __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __global float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __global float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_float *object, __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __private float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, __private float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -754,24 +1127,32 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_double *object, __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __local double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __local double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_double *object, __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __global double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __global double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_double *object, __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __private double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, __private double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong(
+    volatile atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -779,42 +1160,58 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_strong_explicit(
     volatile atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_long *object, __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_long *object,
+                             __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_long *object,
+                             __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure);
@@ -822,24 +1219,34 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_uint *object, __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_uint *object,
+                             __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_uint *object,
+                             __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -847,12 +1254,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_ulong *object,
+                             __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -860,6 +1272,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_ulong *object,
+                             __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -867,6 +1282,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_ulong *object,
+                             __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -874,12 +1292,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_float *object,
+                             __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure);
@@ -887,6 +1310,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_float *object,
+                             __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure);
@@ -894,6 +1320,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_float *object,
+                             __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure);
@@ -901,6 +1330,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -908,6 +1339,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_double *object,
+                             __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure);
@@ -915,6 +1349,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_double *object,
+                             __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure);
@@ -922,6 +1359,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __local atomic_double *object,
+                             __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure);
@@ -929,6 +1369,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __local atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -936,36 +1378,50 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __local atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_long *object,
+                             __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_long *object,
+                             __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __global long *expected,
     long desired, memory_order success, memory_order failure);
@@ -973,6 +1429,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __global long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_long *object,
+                             __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure);
@@ -980,18 +1439,26 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, __private long *expected,
     long desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_uint *object,
+                             __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_uint *object,
+                             __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __global uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -999,6 +1466,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __global uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_uint *object,
+                             __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure);
@@ -1006,12 +1476,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, __private uint *expected,
     uint desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_ulong *object,
+                             __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -1019,6 +1494,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __local ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_ulong *object,
+                             __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -1026,6 +1504,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __global ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_ulong *object,
+                             __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure);
@@ -1033,12 +1514,17 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, __private ulong *expected,
     ulong desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_float *object,
+                             __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure);
@@ -1046,6 +1532,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __local float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_float *object,
+                             __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure);
@@ -1053,6 +1542,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __global float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_float *object,
+                             __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure);
@@ -1060,6 +1552,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, __private float *expected,
     float desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -1067,6 +1561,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_double *object,
+                             __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure);
@@ -1074,6 +1571,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __local double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_double *object,
+                             __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure);
@@ -1081,6 +1581,9 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __global double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_compare_exchange_weak(volatile __global atomic_double *object,
+                             __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure);
@@ -1088,6 +1591,8 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, __private double *expected,
     double desired, memory_order success, memory_order failure,
     memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile __global atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -1095,120 +1600,160 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile __global atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_int *object, __local int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __local int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_int *object, __global int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __global int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_int *object, __private int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, __private int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_int *object, int *expected, int desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_int *object, int *expected, int desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_long *object, __local long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __local long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_long *object, __global long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __global long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_long *object, __private long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __private long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, __private long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_long *object, long *expected, long desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_long *object, long *expected, long desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_uint *object, __local uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __local uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_uint *object, __global uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __global uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_uint *object, __private uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __private uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, __private uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_uint *object, uint *expected, uint desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_uint *object, uint *expected, uint desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_ulong *object, __local ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __local ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __local ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_ulong *object, __global ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __global ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __global ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_ulong *object, __private ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __private ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, __private ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_ulong *object, ulong *expected, ulong desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_ulong *object, ulong *expected, ulong desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_float *object, __local float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __local float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __local float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_float *object, __global float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __global float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __global float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_float *object, __private float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __private float *expected, float desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, __private float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_float *object, float *expected, float desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure);
@@ -1216,24 +1761,32 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_float *object, float *expected, float desired,
     memory_order success, memory_order failure, memory_scope scope);
 #ifdef __CA_BUILTINS_DOUBLE_SUPPORT
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_double *object, __local double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __local double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __local double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_double *object, __global double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __global double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __global double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_double *object, __private double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __private double *expected, double desired,
     memory_order success, memory_order failure);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, __private double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak(
+    volatile atomic_double *object, double *expected, double desired);
 bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure);
@@ -1241,272 +1794,631 @@ bool __CL_BUILTIN_ATTRIBUTES atomic_compare_exchange_weak_explicit(
     volatile atomic_double *object, double *expected, double desired,
     memory_order success, memory_order failure, memory_scope scope);
 #endif  // __CA_BUILTINS_DOUBLE_SUPPORT
+int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_add(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_or(volatile __local atomic_int *object,
+                                            int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __local atomic_int *object, int operand,
                          memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __global atomic_int *object, int operand,
                          memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_or(volatile atomic_int *object,
+                                            int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile atomic_int *object, int operand,
                          memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_and(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_min(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __local atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __local atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __local atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 int __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __global atomic_int *object, int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __global atomic_int *object, int operand, memory_order order);
+int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __global atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_max(volatile atomic_int *object,
+                                             int operand);
+int __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile atomic_int *object, int operand, memory_order order);
 int __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile atomic_int *object, int operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_add(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __local atomic_long *object, long operand,
                          memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __global atomic_long *object, long operand,
                          memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_or(volatile atomic_long *object,
+                                             long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile atomic_long *object, long operand,
                          memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_and(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_min(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __local atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __local atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __local atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 long __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __global atomic_long *object, long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __global atomic_long *object, long operand, memory_order order);
+long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __global atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_max(volatile atomic_long *object,
+                                              long operand);
+long __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile atomic_long *object, long operand, memory_order order);
 long __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile atomic_long *object, long operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_add(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __local atomic_uint *object, uint operand,
                          memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __global atomic_uint *object, uint operand,
                          memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_or(volatile atomic_uint *object,
+                                             uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile atomic_uint *object, uint operand,
                          memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_and(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_min(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __local atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __local atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __local atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 uint __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __global atomic_uint *object, uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __global atomic_uint *object, uint operand, memory_order order);
+uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __global atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_max(volatile atomic_uint *object,
+                                              uint operand);
+uint __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile atomic_uint *object, uint operand, memory_order order);
 uint __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile atomic_uint *object, uint operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_add(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_add(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_add_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_add_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_sub(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_sub_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_sub_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __local atomic_ulong *object, ulong operand,
                          memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_or(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile __global atomic_ulong *object, ulong operand,
                          memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_or(volatile atomic_ulong *object,
+                                              ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_or_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_or_explicit(volatile atomic_ulong *object, ulong operand,
                          memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_xor(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_xor_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_xor_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_and(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_and(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_and_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_and_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_min(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_min(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_min_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_min_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __local atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __local atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __local atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 ulong __CL_BUILTIN_ATTRIBUTES
+atomic_fetch_max(volatile __global atomic_ulong *object, ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile __global atomic_ulong *object, ulong operand, memory_order order);
+ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile __global atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_max(volatile atomic_ulong *object,
+                                               ulong operand);
+ulong __CL_BUILTIN_ATTRIBUTES atomic_fetch_max_explicit(
+    volatile atomic_ulong *object, ulong operand, memory_order order);
 ulong __CL_BUILTIN_ATTRIBUTES
 atomic_fetch_max_explicit(volatile atomic_ulong *object, ulong operand,
                           memory_order order, memory_scope scope);
 bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_test_and_set(volatile __local atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_test_and_set_explicit(
+    volatile __local atomic_flag *object, memory_order order);
+bool __CL_BUILTIN_ATTRIBUTES
 atomic_flag_test_and_set_explicit(volatile __local atomic_flag *object,
                                   memory_order order, memory_scope scope);
 bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_test_and_set(volatile __global atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_test_and_set_explicit(
+    volatile __global atomic_flag *object, memory_order order);
+bool __CL_BUILTIN_ATTRIBUTES
 atomic_flag_test_and_set_explicit(volatile __global atomic_flag *object,
                                   memory_order order, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_test_and_set(volatile atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_test_and_set_explicit(
+    volatile atomic_flag *object, memory_order order);
 bool __CL_BUILTIN_ATTRIBUTES atomic_flag_test_and_set_explicit(
     volatile atomic_flag *object, memory_order order, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_clear(volatile __local atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_clear_explicit(
+    volatile __local atomic_flag *object, memory_order order);
 bool __CL_BUILTIN_ATTRIBUTES
 atomic_flag_clear_explicit(volatile __local atomic_flag *object,
                            memory_order order, memory_scope scope);
 bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_clear(volatile __global atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_clear_explicit(
+    volatile __global atomic_flag *object, memory_order order);
+bool __CL_BUILTIN_ATTRIBUTES
 atomic_flag_clear_explicit(volatile __global atomic_flag *object,
                            memory_order order, memory_scope scope);
+bool __CL_BUILTIN_ATTRIBUTES atomic_flag_clear(volatile atomic_flag *object);
+bool __CL_BUILTIN_ATTRIBUTES
+atomic_flag_clear_explicit(volatile atomic_flag *object, memory_order order);
 bool __CL_BUILTIN_ATTRIBUTES atomic_flag_clear_explicit(
     volatile atomic_flag *object, memory_order order, memory_scope scope);
 #endif

--- a/modules/compiler/builtins/scripts/generate_header_30.sh
+++ b/modules/compiler/builtins/scripts/generate_header_30.sh
@@ -391,6 +391,8 @@ function all_atomic()
     for i in int long uint ulong float double
     do
       double_support_begin $i
+      echo "void __CL_BUILTIN_ATTRIBUTES atomic_store(volatile $k atomic_$i *object, $i desired);"
+      echo "void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile $k atomic_$i *object, $i desired, memory_order order);"
       echo "void __CL_BUILTIN_ATTRIBUTES atomic_store_explicit(volatile $k atomic_$i *object, $i desired, memory_order order, memory_scope scope);"
       double_support_end $i
     done
@@ -401,6 +403,8 @@ function all_atomic()
     for i in int long uint ulong float double
     do
       double_support_begin $i
+      echo "$i __CL_BUILTIN_ATTRIBUTES atomic_load(volatile $k atomic_$i *object);"
+      echo "$i __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile $k atomic_$i *object, memory_order order);"
       echo "$i __CL_BUILTIN_ATTRIBUTES atomic_load_explicit(volatile $k atomic_$i *object, memory_order order, memory_scope scope);"
       double_support_end $i
     done
@@ -411,12 +415,14 @@ function all_atomic()
     for i in int long uint ulong float double
     do
       double_support_begin $i
+      echo "$i __CL_BUILTIN_ATTRIBUTES atomic_exchange(volatile $k atomic_$i *object, $i desired);"
+      echo "$i __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(volatile $k atomic_$i *object, $i desired, memory_order order);"
       echo "$i __CL_BUILTIN_ATTRIBUTES atomic_exchange_explicit(volatile $k atomic_$i *object, $i desired, memory_order order, memory_scope scope);"
       double_support_end $i
     done
   done
 
-  for name in atomic_compare_exchange_strong_explicit atomic_compare_exchange_weak_explicit
+  for name in atomic_compare_exchange_strong atomic_compare_exchange_weak
   do
     for k1 in __local __global ""
     do
@@ -425,8 +431,9 @@ function all_atomic()
         double_support_begin $i
         for k2 in __local __global __private ""
         do
-          echo "bool __CL_BUILTIN_ATTRIBUTES $name(volatile $k1 atomic_$i *object, $k2 $i *expected, $i desired, memory_order success, memory_order failure);"
-          echo "bool __CL_BUILTIN_ATTRIBUTES $name(volatile $k1 atomic_$i *object, $k2 $i *expected, $i desired, memory_order success, memory_order failure, memory_scope scope);"
+          echo "bool __CL_BUILTIN_ATTRIBUTES $name(volatile $k1 atomic_$i *object, $k2 $i *expected, $i desired);"
+          echo "bool __CL_BUILTIN_ATTRIBUTES ${name}_explicit(volatile $k1 atomic_$i *object, $k2 $i *expected, $i desired, memory_order success, memory_order failure);"
+          echo "bool __CL_BUILTIN_ATTRIBUTES ${name}_explicit(volatile $k1 atomic_$i *object, $k2 $i *expected, $i desired, memory_order success, memory_order failure, memory_scope scope);"
         done
         double_support_end $i
       done
@@ -439,6 +446,8 @@ function all_atomic()
     do
       for addr in __local __global ""
       do
+        echo "$t __CL_BUILTIN_ATTRIBUTES atomic_fetch_${op}(volatile $addr atomic_$t *object, $t operand);"
+        echo "$t __CL_BUILTIN_ATTRIBUTES atomic_fetch_${op}_explicit(volatile $addr atomic_$t *object, $t operand, memory_order order);"
         echo "$t __CL_BUILTIN_ATTRIBUTES atomic_fetch_${op}_explicit(volatile $addr atomic_$t *object, $t operand, memory_order order, memory_scope scope);"
       done
     done
@@ -448,6 +457,8 @@ function all_atomic()
   do
     for addr in __local __global ""
     do
+      echo "bool __CL_BUILTIN_ATTRIBUTES atomic_flag_${op}(volatile $addr atomic_flag *object);"
+      echo "bool __CL_BUILTIN_ATTRIBUTES atomic_flag_${op}_explicit(volatile $addr atomic_flag *object, memory_order order);"
       echo "bool __CL_BUILTIN_ATTRIBUTES atomic_flag_${op}_explicit(volatile $addr atomic_flag *object, memory_order order, memory_scope scope);"
     done
   done

--- a/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_int.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_int.cl
@@ -20,8 +20,19 @@ __kernel void store_local_int(__global int *input_buffer,
   uint gid = get_global_id(0);
   uint lid = get_local_id(0);
 
-  atomic_store_explicit(local_buffer + lid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(local_buffer + lid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
   output_buffer[gid] = atomic_load_explicit(
       local_buffer + lid, memory_order_relaxed, memory_scope_work_item);
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_long.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_long.cl
@@ -20,8 +20,19 @@ __kernel void store_local_long(__global long *input_buffer,
   uint gid = get_global_id(0);
   uint lid = get_local_id(0);
 
-  atomic_store_explicit(local_buffer + lid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(local_buffer + lid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
   output_buffer[gid] = atomic_load_explicit(
       local_buffer + lid, memory_order_relaxed, memory_scope_work_item);
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_uint.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_uint.cl
@@ -20,8 +20,19 @@ __kernel void store_local_uint(__global uint *input_buffer,
   uint gid = get_global_id(0);
   uint lid = get_local_id(0);
 
-  atomic_store_explicit(local_buffer + lid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(local_buffer + lid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
   output_buffer[gid] = atomic_load_explicit(
       local_buffer + lid, memory_order_relaxed, memory_scope_work_item);
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_ulong.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.09_store_local_ulong.cl
@@ -20,8 +20,19 @@ __kernel void store_local_ulong(__global ulong *input_buffer,
   uint gid = get_global_id(0);
   uint lid = get_local_id(0);
 
-  atomic_store_explicit(local_buffer + lid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(local_buffer + lid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(local_buffer + lid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
   output_buffer[gid] = atomic_load_explicit(
       local_buffer + lid, memory_order_relaxed, memory_scope_work_item);
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_int.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_int.cl
@@ -17,6 +17,17 @@
 __kernel void store_global_int(__global int *input_buffer,
                                volatile __global atomic_int *output_buffer) {
   uint gid = get_global_id(0);
-  atomic_store_explicit(output_buffer + gid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(output_buffer + gid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_long.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_long.cl
@@ -17,6 +17,17 @@
 __kernel void store_global_long(__global long *input_buffer,
                                 volatile __global atomic_long *output_buffer) {
   uint gid = get_global_id(0);
-  atomic_store_explicit(output_buffer + gid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(output_buffer + gid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_uint.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_uint.cl
@@ -17,6 +17,17 @@
 __kernel void store_global_uint(__global uint *input_buffer,
                                 volatile __global atomic_uint *output_buffer) {
   uint gid = get_global_id(0);
-  atomic_store_explicit(output_buffer + gid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(output_buffer + gid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
 }

--- a/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_ulong.cl
+++ b/source/cl/test/UnitCL/kernels/c11atomics.10_store_global_ulong.cl
@@ -18,6 +18,17 @@ __kernel void store_global_ulong(
     __global ulong *input_buffer,
     volatile __global atomic_ulong *output_buffer) {
   uint gid = get_global_id(0);
-  atomic_store_explicit(output_buffer + gid, input_buffer[gid],
-                        memory_order_relaxed, memory_scope_work_item);
+  switch (gid & 3) {
+    case 0:
+      atomic_store(output_buffer + gid, input_buffer[gid]);
+      break;
+    case 1:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed);
+      break;
+    default:
+      atomic_store_explicit(output_buffer + gid, input_buffer[gid],
+                            memory_order_relaxed, memory_scope_work_item);
+      break;
+  }
 }


### PR DESCRIPTION
# Overview

Add missing atomic functions.

# Reason for change

We only implemented the *_explicit versions, and only the versions that take both memory_order and memory_scope parameters. The OpenCL specification tells us we also need overloads that only take memory_order, and non-explicit versions that do not take either.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

Tested by running OpenCL CTS's updated `test_generic_address_space` test, which previously failed, and now passes.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
