### PR TITLE
Add parsing of -cl-uniform-work-group-size and -cl-no-subgroup-ifp

### DIFF
--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -389,6 +389,12 @@ Result BaseModule::parseOptions(cargo::string_view input_options,
   // -cl-strict-aliasing is deprecated in OpenCL 1.1, so accept the argument,
   // but do nothing with the result (i.e. do not record it in options).
   bool cl_strict_aliasing = false;
+
+  // -cl-uniform-work-group-size and -cl-no-subgroup-ifp are accepted but at the
+  // moment we just ignore so don't record it in the options.
+  bool cl_uniform_work_group_size = false;
+  bool cl_no_subgroup_ifp = false;
+
   const cargo::string_view spir_std;
   const cargo::string_view x;
 
@@ -473,6 +479,13 @@ Result BaseModule::parseOptions(cargo::string_view input_options,
       return Result::OUT_OF_MEMORY;
     }
     if (parser.add_argument({"-cl-strict-aliasing", cl_strict_aliasing})) {
+      return Result::OUT_OF_MEMORY;
+    }
+    if (parser.add_argument(
+            {"-cl-uniform-work-group-size", cl_uniform_work_group_size})) {
+      return Result::OUT_OF_MEMORY;
+    }
+    if (parser.add_argument({"-cl-no-subgroup-ifp", cl_no_subgroup_ifp})) {
       return Result::OUT_OF_MEMORY;
     }
 

--- a/source/cl/test/UnitCL/source/clBuildProgram.cpp
+++ b/source/cl/test/UnitCL/source/clBuildProgram.cpp
@@ -368,7 +368,9 @@ INSTANTIATE_TEST_CASE_P(
                       Pair(CL_SUCCESS, "-cl-std=CL1.2"),
                       Pair(CL_SUCCESS, "-cl-kernel-arg-info"),
                       Pair(CL_SUCCESS, "-cl-denorms-are-zero"),
-                      Pair(CL_SUCCESS, "-cl-no-signed-zeros")));
+                      Pair(CL_SUCCESS, "-cl-no-signed-zeros"),
+                      Pair(CL_SUCCESS, "-cl-uniform-work-group-size"),
+                      Pair(CL_SUCCESS, "-cl-no-subgroup-ifp")));
 
 TEST_F(BuildOptionsTest, CompileWithOptionFP32CorrectlyRoundedDivideSqrt) {
   if (UCL::isInterceptLayerPresent()) {


### PR DESCRIPTION
# Overview

Add parsing for -cl-uniform-work-group-size and -cl-no-subgroup-ifp

# Reason for change

These flags were not recognised so if set in the build program we would get an error. See 
https://github.com/codeplaysoftware/oneapi-construction-kit/issues/476

# Description of change

This adds support for parsing them, but does nothing with the result as they are optimizations only.
