### PR TITLE
Fix build with LLVM 19 again.

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_mux_builtin_info.cpp
@@ -18,6 +18,7 @@
 #include <compiler/utils/pass_functions.h>
 #include <compiler/utils/scheduling.h>
 #include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/Module.h>
 #include <refsi_g1_wi/refsi_mux_builtin_info.h>
 
 #include <cstdint>

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_wg_loop_pass.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/refsi_wg_loop_pass.cpp
@@ -21,6 +21,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 #include <refsi_g1_wi/refsi_wg_loop_pass.h>
 
 using namespace llvm;

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
@@ -17,6 +17,7 @@
 #include <compiler/utils/dma.h>
 #include <compiler/utils/pass_functions.h>
 #include <llvm/ADT/StringSwitch.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/Operator.h>
 #include <multi_llvm/llvm_version.h>
 #include <refsi_m1/refsi_mux_builtin_info.h>

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_wrapper_pass.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_wrapper_pass.cpp
@@ -19,6 +19,7 @@
 #include <compiler/utils/scheduling.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 #include <refsi_m1/refsi_wrapper_pass.h>
 
 using namespace llvm;

--- a/modules/compiler/compiler_pipeline/include/compiler/utils/align_module_structs_pass.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/align_module_structs_pass.h
@@ -21,6 +21,7 @@
 #ifndef COMPILER_UTILS_ALIGN_MODULE_STRUCTS_PASS_H_INCLUDED
 #define COMPILER_UTILS_ALIGN_MODULE_STRUCTS_PASS_H_INCLUDED
 
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/PassManager.h>
 
 namespace compiler {

--- a/modules/compiler/compiler_pipeline/include/compiler/utils/fixup_calling_convention_pass.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/fixup_calling_convention_pass.h
@@ -21,6 +21,7 @@
 #ifndef COMPILER_UTILS_FIXUP_CALLING_CONVENTION_PASS_H_INCLUDED
 #define COMPILER_UTILS_FIXUP_CALLING_CONVENTION_PASS_H_INCLUDED
 
+#include <llvm/IR/CallingConv.h>
 #include <llvm/IR/PassManager.h>
 
 namespace compiler {

--- a/modules/compiler/compiler_pipeline/include/compiler/utils/sub_group_usage_pass.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/sub_group_usage_pass.h
@@ -23,6 +23,7 @@
 
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/sub_group_analysis.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 
 namespace compiler {

--- a/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
@@ -23,6 +23,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/builtin_info.cpp
@@ -22,6 +22,7 @@
 #include <compiler/utils/scheduling.h>
 #include <llvm/ADT/StringExtras.h>
 #include <llvm/ADT/StringSwitch.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -24,6 +24,7 @@
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/Compiler.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/Error.h>

--- a/modules/compiler/compiler_pipeline/source/compute_local_memory_usage_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/compute_local_memory_usage_pass.cpp
@@ -20,6 +20,7 @@
 #include <compiler/utils/metadata.h>
 #include <llvm/ADT/PriorityWorklist.h>
 #include <llvm/Analysis/LazyCallGraph.h>
+#include <llvm/IR/Module.h>
 
 #define DEBUG_TYPE "compute-local-memory-usage"
 

--- a/modules/compiler/compiler_pipeline/source/define_mux_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/define_mux_builtins_pass.cpp
@@ -16,6 +16,7 @@
 
 #include <compiler/utils/builtin_info.h>
 #include <compiler/utils/define_mux_builtins_pass.h>
+#include <llvm/IR/Module.h>
 
 #define DEBUG_TYPE "define-mux-builtins"
 

--- a/modules/compiler/compiler_pipeline/source/define_mux_dma_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/define_mux_dma_pass.cpp
@@ -16,6 +16,7 @@
 
 #include <compiler/utils/builtin_info.h>
 #include <compiler/utils/define_mux_dma_pass.h>
+#include <llvm/IR/Module.h>
 
 #define DEBUG_TYPE "define-mux-dma"
 

--- a/modules/compiler/compiler_pipeline/source/encode_builtin_range_metadata_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/encode_builtin_range_metadata_pass.cpp
@@ -18,6 +18,7 @@
 #include <compiler/utils/encode_builtin_range_metadata_pass.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/encode_kernel_metadata_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/encode_kernel_metadata_pass.cpp
@@ -17,6 +17,7 @@
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/encode_kernel_metadata_pass.h>
 #include <compiler/utils/metadata.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/fixup_calling_convention_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/fixup_calling_convention_pass.cpp
@@ -17,6 +17,7 @@
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/fixup_calling_convention_pass.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/link_builtins_pass.cpp
@@ -38,6 +38,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringSet.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/Error.h>
 #include <llvm/TargetParser/Triple.h>
 #include <llvm/Transforms/Utils/Cloning.h>

--- a/modules/compiler/compiler_pipeline/source/lower_to_mux_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/lower_to_mux_builtins_pass.cpp
@@ -16,6 +16,7 @@
 
 #include <compiler/utils/builtin_info.h>
 #include <compiler/utils/lower_to_mux_builtins_pass.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/make_function_name_unique_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/make_function_name_unique_pass.cpp
@@ -16,6 +16,7 @@
 
 #include <compiler/utils/attributes.h>
 #include <compiler/utils/make_function_name_unique_pass.h>
+#include <llvm/IR/Function.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/mux_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/mux_builtin_info.cpp
@@ -23,6 +23,7 @@
 #include <compiler/utils/scheduling.h>
 #include <compiler/utils/target_extension_types.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/ModRef.h>
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/multi_llvm.h>

--- a/modules/compiler/compiler_pipeline/source/optimal_builtin_replacement_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/optimal_builtin_replacement_pass.cpp
@@ -26,6 +26,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
 #include <llvm/TargetParser/Triple.h>
 #include <multi_llvm/vector_type_helper.h>
 

--- a/modules/compiler/compiler_pipeline/source/prepare_barriers_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/prepare_barriers_pass.cpp
@@ -19,6 +19,7 @@
 #include <compiler/utils/prepare_barriers_pass.h>
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <multi_llvm/multi_llvm.h>
 

--- a/modules/compiler/compiler_pipeline/source/remove_exceptions_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/remove_exceptions_pass.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <compiler/utils/remove_exceptions_pass.h>
+#include <llvm/IR/Function.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/replace_atomic_funcs_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_atomic_funcs_pass.cpp
@@ -18,6 +18,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <multi_llvm/multi_llvm.h>
 
 #include <map>

--- a/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
@@ -25,6 +25,7 @@
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <multi_llvm/vector_type_helper.h>
 

--- a/modules/compiler/compiler_pipeline/source/replace_target_ext_tys_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_target_ext_tys_pass.cpp
@@ -18,6 +18,7 @@
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/replace_target_ext_tys_pass.h>
 #include <compiler/utils/target_extension_types.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
 #include <multi_llvm/llvm_version.h>

--- a/modules/compiler/compiler_pipeline/source/replace_wgc_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_wgc_pass.cpp
@@ -32,6 +32,7 @@
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <multi_llvm/multi_llvm.h>
 

--- a/modules/compiler/compiler_pipeline/source/scheduling.cpp
+++ b/modules/compiler/compiler_pipeline/source/scheduling.cpp
@@ -20,6 +20,7 @@
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 #include <sys/types.h>
 
 using namespace llvm;

--- a/modules/compiler/compiler_pipeline/source/sub_group_analysis.cpp
+++ b/modules/compiler/compiler_pipeline/source/sub_group_analysis.cpp
@@ -19,6 +19,7 @@
 #include <compiler/utils/sub_group_analysis.h>
 #include <llvm/ADT/PriorityWorklist.h>
 #include <llvm/ADT/SetOperations.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/compiler_pipeline/source/unique_opaque_structs_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/unique_opaque_structs_pass.cpp
@@ -23,6 +23,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Cloning.h>

--- a/modules/compiler/riscv/source/passes/IRToBuiltinsPass.cpp
+++ b/modules/compiler/riscv/source/passes/IRToBuiltinsPass.cpp
@@ -19,6 +19,7 @@
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/vector_type_helper.h>
 #include <riscv/ir_to_builtins_pass.h>

--- a/modules/compiler/source/base/include/base/target.h
+++ b/modules/compiler/source/base/include/base/target.h
@@ -21,6 +21,7 @@
 #include <compiler/target.h>
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/Module.h>
 #include <mux/mux.h>
 
 namespace compiler {

--- a/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
+++ b/modules/compiler/source/base/source/check_for_ext_funcs_pass.cpp
@@ -17,6 +17,7 @@
 #include <base/check_for_ext_funcs_pass.h>
 #include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 
 using namespace llvm;
 

--- a/modules/compiler/source/base/source/set_convergent_attr_pass.cpp
+++ b/modules/compiler/source/base/source/set_convergent_attr_pass.cpp
@@ -19,6 +19,7 @@
 #include <llvm/ADT/PriorityWorklist.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 
 #define DEBUG_TYPE "set-convergent-attr"
 

--- a/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
+++ b/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
@@ -25,6 +25,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicsARM.h>
 #include <llvm/IR/IntrinsicsX86.h>
+#include <llvm/IR/Module.h>
 #include <llvm/TargetParser/Triple.h>
 
 using namespace llvm;

--- a/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
+++ b/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
@@ -18,6 +18,7 @@
 #include <compiler/utils/pass_functions.h>
 #include <compiler/utils/scheduling.h>
 #include <host/host_mux_builtin_info.h>
+#include <llvm/IR/Module.h>
 
 #include <optional>
 

--- a/modules/compiler/vecz/include/vecz/pass.h
+++ b/modules/compiler/vecz/include/vecz/pass.h
@@ -22,6 +22,7 @@
 #define VECZ_PASS_H
 
 #include <compiler/utils/vectorization_factor.h>
+#include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 
 #include <cstdint>

--- a/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
@@ -24,6 +24,10 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/PassManager.h>
 
+namespace llvm {
+class Value;
+}
+
 namespace vecz {
 
 /// @brief Determines whether vectorization of a function is possible.

--- a/modules/compiler/vecz/source/include/memory_operations.h
+++ b/modules/compiler/vecz/source/include/memory_operations.h
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 
 #include <optional>
 

--- a/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
+++ b/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
@@ -27,7 +27,9 @@
 #include <memory>
 
 namespace llvm {
+class BasicBlock;
 class Function;
+class Instruction;
 class Value;
 class DominatorTree;
 class PostDominatorTree;

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -29,6 +29,7 @@
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriterPass.h>
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IRPrinter/IRPrintingPasses.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/InitializePasses.h>


### PR DESCRIPTION
# Overview

Fix build with LLVM 19 again.

# Reason for change

We were using types such as llvm::Module without explicitly including <llvm/IR/Module.h>, relying on some other header including that implicitly. As a result of changes to LLVM 19's headers, we no longer get the same implicit includes.

# Description of change

Include the required headers (or add the required declarations) explicitly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
