### PR TITLE
Fix test IncrementKernelTwiceDifferentQueues

### DIFF
--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
@@ -125,7 +125,7 @@ TEST_F(CommandBufferEnqueueTest, IncrementKernelTwiceDifferentQueues) {
   // We need something we can check was enqueued twice.
   const char *code = R"OpenCLC(
   __kernel void increment_kernel(global int *counter) {
-    ++(counter[0]);
+    atomic_inc(&counter[0]);
   }
 )OpenCLC";
   const size_t code_length = std::strlen(code);


### PR DESCRIPTION
# Overview

Replaced the global value increment with an atomic_inc in UnitCL test IncrementKernelTwiceDifferentQueues

# Reason for change

This test started two queues at the same time and updated the same value. This could on occasion cause a race condition, exhibited on risc-v host.
