### PR TITLE
Fix MinGW builds.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,4 +13,7 @@ IncludeCategories:
 DerivePointerAlignment: false
 QualifierAlignment: Left
 PointerAlignment: Right
+Macros:
+  - CL_LAMBDA_CALLBACK=[[]]
+  - VK_LAMBDA_CALLBACK=[[]]
 ...

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -111,7 +111,7 @@ jobs:
           # we've installed clang-format-16 in the docker via pip, which just installs it as clang-format,
           # so just use clang-format-diff and -b clang-format directly
           git fetch origin ${{ github.base_ref }}
-          git diff -U0 --no-color origin/${{ github.base_ref }} | \
+          git diff --no-color origin/${{ github.base_ref }} | \
             clang-format-diff.py -p1 -regex \
             "^(?!(.+\\/)*(external|cookie)\\/).*\\.(c|cc|cxx|cpp|h|hh|hxx|hpp)$" -b clang-format \
             > clang-format.diff

--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -137,7 +137,7 @@ if(CA_USE_LINKER)
     message(WARNING "CA_USE_LINKER ignored for non-unix targets")
   endif()
 endif()
-if(CMAKE_SYSTEM_NAME STREQUAL Linux OR ANDROID OR MINGW)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR ANDROID)
   # 1. We don't need executable stacks and we don't want them infecting consuming
   # programs which might have strict security requirements. This ensures we're
   # not the cause of an executable stack further down the line
@@ -156,6 +156,8 @@ set(CA_COMPILE_OPTIONS
       -Werror             # Enable warnings as errors when not a subproject
     >
     -Wno-error=deprecated-declarations  # Disable: use of deprecated functions
+    -Wno-error=array-bounds  # Disable errors that vary heavily on compiler and
+    -Wno-error=uninitialized # optimization level and have false positives.
 
     -pedantic             # Enable warnings required by the C++ standard
     -Wall -Wextra         # Enable more warnings
@@ -233,11 +235,6 @@ set(CA_COMPILE_OPTIONS
 
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
     -Wthread-safety  # Enable clang thread safety analysis
-  >
-
-  $<$<BOOL:${MINGW}>:
-    -Wa,-mbig-obj              # Increase number of sections in .obj file.
-    -Wno-stringop-truncation   # Disable warnings on strncpy
   >
 
   $<$<BOOL:${MSVC}>:

--- a/hal/source/arg_pack.cpp
+++ b/hal/source/arg_pack.cpp
@@ -185,8 +185,8 @@ bool hal_argpack_t::expand(size_t num_bytes) {
     // Allocate in chunks so we don't continually reallocate
     pack_alloc_size =
         ((write_point + num_bytes) + chunk_size - 1) / chunk_size * chunk_size;
-#if defined(_MSC_VER)
-    // Visual studio does not properly support std::aligned_alloc
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+    // Visual Studio and MinGW do not properly support std::aligned_alloc
     uint8_t *replacement_pack =
         static_cast<uint8_t *>(_aligned_malloc(pack_alloc_size, alignment));
 #else
@@ -201,7 +201,7 @@ bool hal_argpack_t::expand(size_t num_bytes) {
         // copy from old to new and free old one
         std::memcpy(replacement_pack, pack, write_point);
       }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
       _aligned_free(pack);
 #else
       std::free(pack);

--- a/modules/cargo/CMakeLists.txt
+++ b/modules/cargo/CMakeLists.txt
@@ -25,18 +25,13 @@ endif()
 
 include(CheckSymbolExists)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  # Macros and flags necessary to find the pthread get/set name symbols.
-  set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-  set(CMAKE_REQUIRED_FLAGS -pthread)
-  # Check for specific symbols in case a platform, e.g. an RTOS, does not
-  # support them while otherwise supporting pthreads.
-  check_symbol_exists(pthread_setname_np "pthread.h" CARGO_HAS_PTHREAD_SETNAME_NP)
-  check_symbol_exists(pthread_getname_np "pthread.h" CARGO_HAS_PTHREAD_GETNAME_NP)
-else()
-  set(CARGO_HAS_PTHREAD_SETNAME_NP OFF)
-  set(CARGO_HAS_PTHREAD_GETNAME_NP OFF)
-endif()
+# Macros and flags necessary to find the pthread get/set name symbols.
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+set(CMAKE_REQUIRED_FLAGS -pthread)
+# Check for specific symbols in case a platform, e.g. an RTOS, does not
+# support them while otherwise supporting pthreads.
+check_symbol_exists(pthread_setname_np "pthread.h" CARGO_HAS_PTHREAD_SETNAME_NP)
+check_symbol_exists(pthread_getname_np "pthread.h" CARGO_HAS_PTHREAD_GETNAME_NP)
 
 add_ca_library(cargo STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/cargo/allocator.h

--- a/modules/cargo/include/cargo/mutex.h
+++ b/modules/cargo/include/cargo/mutex.h
@@ -36,7 +36,7 @@ namespace cargo {
 /// multi-threaded code.
 struct CARGO_TS_CAPABILITY("mutex") mutex {
   /// @brief Constructs the mutex.
-  constexpr mutex() noexcept = default;
+  mutex() noexcept = default;
 
   mutex(const mutex &) = delete;
   mutex &operator=(const mutex &) = delete;

--- a/modules/cargo/include/cargo/thread.h
+++ b/modules/cargo/include/cargo/thread.h
@@ -27,6 +27,12 @@
 #include "cargo/error.h"
 #include "cargo/thread_safety.h"
 
+// Assume that std::thread is based on pthread if <pthread.h> is implicitly
+// included.
+#ifdef PTHREAD_ONCE_INIT
+#define CARGO_HAS_PTHREAD
+#endif
+
 namespace cargo {
 /// @brief A std::thread wrapper with benefits.
 ///

--- a/modules/cargo/source/thread.cpp
+++ b/modules/cargo/source/thread.cpp
@@ -22,22 +22,10 @@
 
 #include <array>
 #include <cstdlib>
-
-#if CARGO_HAS_PTHREAD_SETNAME_NP || CARGO_HAS_PTHREAD_GETNAME_NP
-#include <pthread.h>
-#endif
-
 #include <cstring>
 
 cargo::result cargo::thread::set_name(const std::string &name) noexcept {
-#ifdef _WIN32
-  constexpr size_t len = 1024;
-  std::array<wchar_t, len> wname{};
-  std::mbstowcs(wname.data(), name.c_str(), len);
-  if (FAILED(SetThreadDescription(native_handle(), wname.data()))) {
-    return cargo::unknown_error;
-  }
-#elif CARGO_HAS_PTHREAD_SETNAME_NP
+#if defined(CARGO_HAS_PTHREAD) && CARGO_HAS_PTHREAD_SETNAME_NP
   switch (pthread_setname_np(native_handle(), name.c_str())) {
     case 0:
       break;
@@ -45,6 +33,13 @@ cargo::result cargo::thread::set_name(const std::string &name) noexcept {
       return cargo::out_of_bounds;
     default:
       return cargo::unknown_error;
+  }
+#elif defined(_WIN32)
+  constexpr size_t len = 1024;
+  std::array<wchar_t, len> wname{};
+  std::mbstowcs(wname.data(), name.c_str(), len);
+  if (FAILED(SetThreadDescription(native_handle(), wname.data()))) {
+    return cargo::unknown_error;
   }
 #else
   (void)name;
@@ -54,20 +49,20 @@ cargo::result cargo::thread::set_name(const std::string &name) noexcept {
 }
 
 [[nodiscard]] cargo::error_or<std::string> cargo::thread::get_name() noexcept {
-#if defined(_WIN32) || CARGO_HAS_PTHREAD_GETNAME_NP
+#if defined(CARGO_HAS_PTHREAD) || defined(_WIN32)
   constexpr size_t len = 1024;
   std::array<char, len> buffer;
-#ifdef _WIN32
+#if defined(CARGO_HAS_PTHREAD) && CARGO_HAS_PTHREAD_GETNAME_NP
+  if (pthread_getname_np(native_handle(), buffer.data(), len)) {
+    return cargo::unknown_error;
+  }
+#elif defined(_WIN32)
   std::array<wchar_t, len> wbuffer;
   auto *wbufptr = wbuffer.data();
   if (FAILED(GetThreadDescription(native_handle(), &wbufptr))) {
     return cargo::unknown_error;
   }
-  std::wcstombs(buffer.data(), wbuffer.data(), len);
-#elif CARGO_HAS_PTHREAD_GETNAME_NP
-  if (pthread_getname_np(native_handle(), buffer.data(), len)) {
-    return cargo::unknown_error;
-  }
+  std::wcstombs(buffer.data(), wbufptr, len);
 #endif
   return {buffer.data(), std::strlen(buffer.data())};
 #else

--- a/modules/compiler/CMakeLists.txt
+++ b/modules/compiler/CMakeLists.txt
@@ -122,10 +122,8 @@ if(CA_RUNTIME_COMPILER_ENABLED)
   # Debugging llvm becomes very frustrating without the `dump` methods which
   # are otherwise stripped. Don't strip public symbols for any *full* debug
   # builds
-  if(CA_PLATFORM_LINUX OR MINGW)
-    # Export API entry point symbols for Linux, or if we're using a GNU compiler
-    # on Windows.  I.e. a MinGW build on Windows uses the Linux symbol exports,
-    # not the Windows ones.
+  if(CA_PLATFORM_LINUX)
+    # Export API entry point symbols for Linux.
     set(COMPILER_EXPORT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/source/export-linux.sym)
     if (NOT CMAKE_BUILD_TYPE STREQUAL Debug)
       # Retain only the symbols listed in the file filename, discarding all others.
@@ -145,11 +143,20 @@ if(CA_RUNTIME_COMPILER_ENABLED)
       # libraries.
       string(APPEND COMPILER_LINK_FLAGS_RELEASE " -Xlinker --strip-debug")
     endif()
-  elseif(CA_PLATFORM_WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Set exports definition file for MSVC Windows (not MinGW, that takes the
-    # Linux equivalent path) and link flags to use it.
-    set(COMPILER_EXPORT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/source/export-windows.def)
-    string(APPEND COMPILER_LINK_FLAGS " /DEF:${COMPILER_EXPORT_FILE}")
+  elseif(CA_PLATFORM_WINDOWS)
+    # Set exports definition file for Windows and link flags to use it.
+    set(COMPILER_EXPORT_FILE "export-windows.def")
+    set(ExportLibraryName "${CMAKE_STATIC_LIBRARY_PREFIX}compiler")
+    configure_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/source/${COMPILER_EXPORT_FILE}.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/source/${COMPILER_EXPORT_FILE})
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      string(APPEND COMPILER_LINK_FLAGS
+        " /DEF:${CMAKE_CURRENT_BINARY_DIR}/source/${COMPILER_EXPORT_FILE}")
+    else()
+      string(APPEND COMPILER_LINK_FLAGS
+        " ${CMAKE_CURRENT_BINARY_DIR}/source/${COMPILER_EXPORT_FILE}")
+    endif()
   else()
     message(WARNING "Unhandled build environment.")
   endif()

--- a/modules/compiler/builtins/source/printf.cpp
+++ b/modules/compiler/builtins/source/printf.cpp
@@ -150,15 +150,6 @@ size_t ParseSpecifier(std::string str, size_t pos, size_t &w, size_t &p,
 /// @param[in] d The floating point valule to print.
 template <typename T>
 void PrintFloatingPoint(std::string partial, T d) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
-  // MinGW seems to follow MSVC pre-2015 formatting for %e/%E/%g/%G which did
-  // not match the C++11 specification.  There is however, this method to set
-  // conformant printing.  This method was removed in MSVC 2015 because it
-  // became conformant by default, so if a future version of MinGW removes this
-  // function then it is probably no longer required.
-  unsigned int old_printf_format = _set_output_format(_TWO_DIGIT_EXPONENT);
-#endif
-
   // manually format NaNs and Infinity as the system
   // printf doesn't format them properly on windows
   if (std::isnan(d) || std::isinf(d)) {
@@ -266,10 +257,6 @@ void PrintFloatingPoint(std::string partial, T d) {
     // Possible vulnerability when the printf format string comes from the user
     ::printf(partial.c_str(), d);
   }
-
-#if defined(__MINGW32__) || defined(__MINGW64__)
-  _set_output_format(old_printf_format);
-#endif
 }
 }  // namespace
 

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -102,7 +102,7 @@
 #include <sstream>
 #include <unordered_set>
 
-#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_MSC_VER)
 #define PATH_SEPARATOR "\\"
 #else
 #define PATH_SEPARATOR "/"

--- a/modules/compiler/source/export-windows.def.cmake
+++ b/modules/compiler/source/export-windows.def.cmake
@@ -1,4 +1,4 @@
-LIBRARY compiler
+LIBRARY ${ExportLibraryName}
 EXPORTS
     caCompilerLLVMVersion
     caCompilers

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -218,9 +218,15 @@ compiler::Result HostTarget::initWithBuiltins(
         case host::os::WINDOWS:
           // Using windows here ensures that _chkstk() is called which is
           // important for paging in the stack.
+#if defined(__MINGW32__) || defined(__MINGW64__)
+          triple = llvm::Triple(host::arch::X86 == host_device_info.arch
+                                    ? "i386-pc-windows-gnu-elf"
+                                    : "x86_64-w64-windows-gnu-elf");
+#else
           triple = llvm::Triple(host::arch::X86 == host_device_info.arch
                                     ? "i386-pc-windows-msvc-elf"
                                     : "x86_64-pc-windows-msvc-elf");
+#endif
           break;
         case host::os::MACOS:
           assert(host_device_info.native &&

--- a/modules/kts/source/stdout_capture.cpp
+++ b/modules/kts/source/stdout_capture.cpp
@@ -20,6 +20,8 @@
 #define DUP2 _dup2
 #else
 #include <unistd.h>
+
+#include <cstring>
 #define DUP dup
 #define DUP2 dup2
 #endif

--- a/modules/mux/targets/host/source/kernel.cpp
+++ b/modules/mux/targets/host/source/kernel.cpp
@@ -91,6 +91,7 @@ mux_result_t hostCreateBuiltInKernel(mux_device_t device, const char *name,
                                      uint64_t name_length,
                                      mux_allocator_info_t allocator_info,
                                      mux_kernel_t *out_kernel) {
+  (void)name_length;
   auto hostDeviceInfo = static_cast<host::device_info_s *>(device->info);
   mux::allocator allocator(allocator_info);
   const char *builtin_name = nullptr;

--- a/modules/mux/targets/host/source/query_pool.cpp
+++ b/modules/mux/targets/host/source/query_pool.cpp
@@ -28,6 +28,9 @@ cargo::expected<host::query_pool_s *, mux_result_t> host::query_pool_s::create(
 #ifdef CA_HOST_ENABLE_PAPI_COUNTERS
   auto host_device = static_cast<host::device_s *>(queue->device);
   auto thread_count = host_device->thread_pool.initialized_threads;
+#else
+  (void)query_configs;
+  (void)queue;
 #endif
   // Calculate the result storage offset past the end of the query_pool_s.
   // FIXME: This wastes sizeof(mux_query_duration_result_s) bytes when
@@ -378,6 +381,7 @@ mux_result_t hostGetQueryPoolResults(mux_queue_t queue,
                                      uint32_t query_index, uint32_t query_count,
                                      size_t size, void *data, size_t stride) {
   (void)queue;
+  (void)size;
   auto host_query_pool = static_cast<host::query_pool_s *>(query_pool);
 
   if (host_query_pool->type == mux_query_type_duration) {

--- a/modules/mux/targets/host/source/queue.cpp
+++ b/modules/mux/targets/host/source/queue.cpp
@@ -254,7 +254,7 @@ void commandNDRange(host::queue_s *queue, host::command_info_s *info) {
   std::array<std::atomic<bool>, signal_count> signals;
   std::atomic<uint32_t> queued(0);
   host_device->thread_pool.enqueue_range(
-      [](void *const in, void *const info, void *fence, size_t index) {
+      [](void *const in, void *const info, void *, size_t index) {
         auto *const kernel_variant = static_cast<host::kernel_variant_s *>(in);
         auto *const ndrange = static_cast<host::command_info_ndrange_s *>(info);
         auto *const ndrange_info = ndrange->ndrange_info;

--- a/modules/utils/targets/host/source/relocations.cpp
+++ b/modules/utils/targets/host/source/relocations.cpp
@@ -41,14 +41,22 @@
 // functions.
 extern "C" {
 
-#if defined(_MSC_VER)
 // Windows uses chkstk() to ensure there is enough stack space paged in.
+#if defined(_MSC_VER)
 #if defined(UTILS_SYSTEM_64_BIT)
 extern void __chkstk();
 #else
 extern void _chkstk();
 #endif
 #endif  // _MSC_VER
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(UTILS_SYSTEM_64_BIT)
+extern void ___chkstk_ms();
+#else
+extern void(_alloca)();
+#endif
+#endif
 
 #if defined(UTILS_SYSTEM_32_BIT)
 // On 32-bit (both x86 and Arm) long division is done in software.
@@ -162,6 +170,14 @@ std::vector<std::pair<std::string, uint64_t>> getRelocations() {
       {"__chkstk", reinterpret_cast<uint64_t>(&__chkstk)},
 #else
       {"_chkstk", reinterpret_cast<uint64_t>(&_chkstk)},
+#endif  // UTILS_SYSTEM_64_BIT
+#endif  // _MSC_VER
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(UTILS_SYSTEM_64_BIT)
+      {"___chkstk_ms", reinterpret_cast<uint64_t>(&___chkstk_ms)},
+#else
+      {"_alloca", reinterpret_cast<uint64_t>(&_alloca)},
 #endif  // UTILS_SYSTEM_64_BIT
 #endif  // _MSC_VER
 

--- a/source/cl/CMakeLists.txt
+++ b/source/cl/CMakeLists.txt
@@ -157,7 +157,6 @@ set(CL_LINK_FLAGS)
 set(CL_LINK_FLAGS_RELEASE)
 
 if(CA_PLATFORM_LINUX OR CA_PLATFORM_ANDROID OR
-    (CA_PLATFORM_WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
     CA_PLATFORM_QNX)
   # Set the OpenCL API entry point version map.
   string(APPEND CL_LINK_FLAGS " -Xlinker \
@@ -199,7 +198,7 @@ if(CA_PLATFORM_LINUX OR CA_PLATFORM_ANDROID OR
     string(APPEND CL_LINK_FLAGS_RELEASE
       " -Xlinker --icf=all -Xlinker --icf-iterations -Xlinker 5")
   endif()
-elseif(CA_PLATFORM_WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+elseif(CA_PLATFORM_WINDOWS)
   # Detect whether or not LLVMExecutionEngine is linked into the target.
   # This knowledge is needed to export JIT debug symbols, which will
   # cause an unresolved error if the library is not linked.
@@ -215,14 +214,19 @@ elseif(CA_PLATFORM_WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # In order to avoid unnessesary duplication of .def files depending on the
   # OPENCL_LIBRARY_NAME name we use CMake to configure these files before use.
   set(CA_CL_LIBRARY_DEF_FILE "export-windows.def")
-  set(ExportLibraryName ${CA_CL_LIBRARY_NAME})
+  set(ExportLibraryName "${CMAKE_STATIC_LIBRARY_PREFIX}${CA_CL_LIBRARY_NAME}")
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/source/${CA_CL_LIBRARY_DEF_FILE}.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/source/${CA_CL_LIBRARY_DEF_FILE})
-  # Lastly tell the linker to use the configured .def file
-  string(APPEND CL_LINK_FLAGS
-    " /DEF:${CMAKE_CURRENT_BINARY_DIR}/source/${CA_CL_LIBRARY_DEF_FILE}")
-  string(APPEND CL_LINK_FLAGS_RELEASE " /OPT:REF /OPT:ICF=5")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Lastly tell the linker to use the configured .def file
+    string(APPEND CL_LINK_FLAGS
+      " /DEF:${CMAKE_CURRENT_BINARY_DIR}/source/${CA_CL_LIBRARY_DEF_FILE}")
+    string(APPEND CL_LINK_FLAGS_RELEASE " /OPT:REF /OPT:ICF=5")
+  else()
+    string(APPEND CL_LINK_FLAGS
+      " ${CMAKE_CURRENT_BINARY_DIR}/source/${CA_CL_LIBRARY_DEF_FILE}")
+  endif()
 else()
   message(WARNING "Unhandled build environment.")
 endif()

--- a/source/cl/examples/CMakeLists.txt
+++ b/source/cl/examples/CMakeLists.txt
@@ -86,7 +86,9 @@ if(${OCL_EXTENSION_cl_khr_command_buffer})
 endif()
 
 if(${OCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch})
-  add_ca_cl_example(clMutableDispatchKHR
+  # Intentionally misnamed. Windows guesses that executables with "patch"
+  # in the file name are installers and need admin privileges.
+  add_ca_cl_example(clMutableDispathcKHR
     ${CMAKE_CURRENT_SOURCE_DIR}/MutableDispatchKHR/source/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/common.h)
 endif()

--- a/source/cl/include/cl/command_queue.h
+++ b/source/cl/include/cl/command_queue.h
@@ -377,9 +377,9 @@ struct _cl_command_queue final : public cl::base<_cl_command_queue> {
   /// @param[in] user_event The user event that has completed.
   /// @param[in] event_command_exec_status The completion status of the event.
   /// @param[in] user_data User data to pass to the callback.
-  static void userEventDispatch(cl_event user_event,
-                                cl_int event_command_exec_status,
-                                void *user_data);
+  static void CL_CALLBACK userEventDispatch(cl_event user_event,
+                                            cl_int event_command_exec_status,
+                                            void *user_data);
 
   struct dispatch_state_t {
     /// @brief Add new wait events to this dispatch.

--- a/source/cl/source/extension/include/CL/cl_ext_codeplay.h
+++ b/source/cl/source/extension/include/CL/cl_ext_codeplay.h
@@ -226,7 +226,7 @@ typedef cl_int cl_kernel_wfv_status_codeplay;
 /// by the OpenCL implementation on the device.
 /// * CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources required
 /// by the OpenCL implementation on the host.
-extern cl_int clGetKernelWFVInfoCODEPLAY(
+extern cl_int CL_API_CALL clGetKernelWFVInfoCODEPLAY(
     cl_kernel kernel, cl_device_id device, cl_uint work_dim,
     const size_t *global_work_size, const size_t *local_work_size,
     cl_kernel_wfv_info_codeplay param_name, size_t param_value_size,

--- a/source/cl/source/opencl-3.0.cpp
+++ b/source/cl/source/opencl-3.0.cpp
@@ -39,7 +39,7 @@
 CL_API_ENTRY cl_command_queue CL_API_CALL cl::CreateCommandQueueWithProperties(
     cl_context context, cl_device_id device,
     const cl_queue_properties *properties, cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard(
+  const tracer::TraceGuard<tracer::OpenCL> guard(
       "clCreateCommandQueueWithProperties");
 
   OCL_CHECK(!context, OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_CONTEXT);
@@ -62,7 +62,7 @@ CL_API_ENTRY cl_mem CL_API_CALL
 cl::CreatePipe(cl_context context, cl_mem_flags flags, cl_uint pipe_packet_size,
                cl_uint pipe_max_packets, const cl_pipe_properties *properties,
                cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreatePipe");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCreatePipe");
   // Optional in 3.0.
   (void)context;
   (void)flags;
@@ -78,7 +78,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetPipeInfo(cl_mem pipe,
                                                 size_t param_value_size,
                                                 void *param_value,
                                                 size_t *param_value_size_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetPipeInfo");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetPipeInfo");
   // Optional in 3.0.
   (void)pipe;
   (void)param_name;
@@ -91,7 +91,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetPipeInfo(cl_mem pipe,
 CL_API_ENTRY void *CL_API_CALL cl::SVMAlloc(cl_context context,
                                             cl_svm_mem_flags flags, size_t size,
                                             cl_uint alignment) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSVMAlloc");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clSVMAlloc");
   // Optional in 3.0.
   (void)context;
   (void)flags;
@@ -102,7 +102,7 @@ CL_API_ENTRY void *CL_API_CALL cl::SVMAlloc(cl_context context,
 
 CL_API_ENTRY void CL_API_CALL cl::SVMFree(cl_context context,
                                           void *svm_pointer) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSVMFree");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clSVMFree");
   // Optional in 3.0.
   (void)context;
   (void)svm_pointer;
@@ -112,7 +112,8 @@ CL_API_ENTRY void CL_API_CALL cl::SVMFree(cl_context context,
 CL_API_ENTRY cl_sampler CL_API_CALL cl::CreateSamplerWithProperties(
     cl_context context, const cl_sampler_properties *sampler_properties,
     cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreateSamplerWithProperties");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clCreateSamplerWithProperties");
   // TODO: Implement, see CA-2613.
   (void)context;
   (void)sampler_properties;
@@ -122,7 +123,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL cl::CreateSamplerWithProperties(
 
 CL_API_ENTRY cl_int CL_API_CALL cl::SetKernelArgSVMPointer(
     cl_kernel kernel, cl_uint arg_index, const void *arg_value) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSetKernelArgSVMPointer");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clSetKernelArgSVMPointer");
   // Optional in 3.0.
   (void)kernel;
   (void)arg_index;
@@ -133,12 +134,12 @@ CL_API_ENTRY cl_int CL_API_CALL cl::SetKernelArgSVMPointer(
 CL_API_ENTRY cl_int CL_API_CALL
 cl::SetKernelExecInfo(cl_kernel kernel, cl_kernel_exec_info param_name,
                       size_t param_value_size, const void *param_value) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSetKernelExecInfo");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clSetKernelExecInfo");
 
   OCL_CHECK(!kernel, return CL_INVALID_KERNEL);
 
-  cl_int err = extension::SetKernelExecInfo(kernel, param_name,
-                                            param_value_size, param_value);
+  const cl_int err = extension::SetKernelExecInfo(
+      kernel, param_name, param_value_size, param_value);
 
   // CL_INVALID_KERNEL is returned if the extension failed to set the argument,
   // if the kernel really was invalid a check above already caught it.
@@ -157,7 +158,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueSVMFree(
                                      void *svm_pointers[], void *user_data),
     void *user_data, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMFree");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMFree");
   // Optional in 3.0.
   (void)command_queue;
   (void)num_svm_pointers;
@@ -174,7 +175,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueSVMMemcpy(
     cl_command_queue command_queue, cl_bool blocking_copy, void *dst_ptr,
     const void *src_ptr, size_t size, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMemcpy");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMemcpy");
   // Optional in 3.0.
   (void)command_queue;
   (void)blocking_copy;
@@ -191,7 +192,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueSVMMemFill(
     cl_command_queue command_queue, void *svm_ptr, const void *pattern,
     size_t pattern_size, size_t size, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMemFill");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMemFill");
   // Optional in 3.0.
   (void)command_queue;
   (void)svm_ptr;
@@ -208,7 +209,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueSVMMap(
     cl_command_queue command_queue, cl_bool blocking_map, cl_map_flags flags,
     void *svm_ptr, size_t size, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMap");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMap");
   // Optional in 3.0.
   (void)command_queue;
   (void)blocking_map;
@@ -225,7 +226,7 @@ CL_API_ENTRY cl_int CL_API_CALL
 cl::EnqueueSVMUnmap(cl_command_queue command_queue, void *svm_ptr,
                     cl_uint num_events_in_wait_list,
                     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMUnmap");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMUnmap");
   // Optional in 3.0.
   (void)command_queue;
   (void)svm_ptr;
@@ -238,7 +239,8 @@ cl::EnqueueSVMUnmap(cl_command_queue command_queue, void *svm_ptr,
 // OpenCL-2.1 APIs
 CL_API_ENTRY cl_int CL_API_CALL cl::SetDefaultDeviceCommandQueue(
     cl_context context, cl_device_id device, cl_command_queue command_queue) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSetDefaultDeviceCommandQueue");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clSetDefaultDeviceCommandQueue");
   // Optional in 3.0.
   (void)context;
   (void)device;
@@ -248,7 +250,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::SetDefaultDeviceCommandQueue(
 
 CL_API_ENTRY cl_int CL_API_CALL cl::GetDeviceAndHostTimer(
     cl_device_id device, cl_ulong *device_timestamp, cl_ulong *host_timestamp) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetDeviceAndHostTimer");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetDeviceAndHostTimer");
   // Optional in 3.0.
   (void)device;
   (void)device_timestamp;
@@ -258,7 +260,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetDeviceAndHostTimer(
 
 CL_API_ENTRY cl_int CL_API_CALL cl::GetHostTimer(cl_device_id device,
                                                  cl_ulong *host_timestamp) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetHostTimer");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetHostTimer");
   // Optional in 3.0.
   (void)device;
   (void)host_timestamp;
@@ -267,7 +269,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetHostTimer(cl_device_id device,
 
 CL_API_ENTRY cl_program CL_API_CALL cl::CreateProgramWithIL(
     cl_context context, const void *il, size_t length, cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreateProgramWithIL");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCreateProgramWithIL");
   OCL_CHECK(nullptr == context,
             OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_CONTEXT);
             return nullptr);
@@ -292,7 +294,7 @@ CL_API_ENTRY cl_program CL_API_CALL cl::CreateProgramWithIL(
 
 CL_API_ENTRY cl_kernel CL_API_CALL cl::CloneKernel(cl_kernel source_kernel,
                                                    cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCloneKernel");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCloneKernel");
   if (!source_kernel) {
     OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_KERNEL);
     return nullptr;
@@ -310,7 +312,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::GetKernelSubGroupInfo(
     cl_kernel kernel, cl_device_id device, cl_kernel_sub_group_info param_name,
     size_t input_value_size, const void *input_value, size_t param_value_size,
     void *param_value, size_t *param_value_size_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clGetKernelSubGroupInfo");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clGetKernelSubGroupInfo");
 
   OCL_CHECK(!kernel, return CL_INVALID_KERNEL);
 
@@ -442,7 +444,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::EnqueueSVMMigrateMem(
     const void **svm_pointers, const size_t *sizes,
     cl_mem_migration_flags flags, cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list, cl_event *event) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMigrateMem");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clEnqueueSVMMigrateMem");
   // Optional in 3.0.
   (void)command_queue;
   (void)num_svm_pointers;
@@ -460,7 +462,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::SetProgramReleaseCallback(
     cl_program program,
     void(CL_CALLBACK *pfn_notify)(cl_program program, void *user_data),
     void *user_data) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clSetProgramReleaseCallback");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clSetProgramReleaseCallback");
   // Optional in 3.0.
   (void)program;
   (void)pfn_notify;
@@ -471,7 +473,7 @@ CL_API_ENTRY cl_int CL_API_CALL cl::SetProgramReleaseCallback(
 CL_API_ENTRY cl_int CL_API_CALL
 cl::SetProgramSpecializationConstant(cl_program program, cl_uint spec_id,
                                      size_t spec_size, const void *spec_value) {
-  tracer::TraceGuard<tracer::OpenCL> guard(
+  const tracer::TraceGuard<tracer::OpenCL> guard(
       "clSetProgramSpecializationConstant");
 
   OCL_CHECK(!program, return CL_INVALID_PROGRAM);
@@ -496,12 +498,13 @@ cl::SetProgramSpecializationConstant(cl_program program, cl_uint spec_id,
 CL_API_ENTRY cl_mem CL_API_CALL cl::CreateBufferWithProperties(
     cl_context context, const cl_mem_properties *properties, cl_mem_flags flags,
     size_t size, void *host_ptr, cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreateBufferWithProperties");
+  const tracer::TraceGuard<tracer::OpenCL> guard(
+      "clCreateBufferWithProperties");
 
   OCL_CHECK(!context, OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_CONTEXT);
             return nullptr);
 
-  cl_int error = cl::validate::MemFlags(flags, host_ptr);
+  const cl_int error = cl::validate::MemFlags(flags, host_ptr);
   OCL_CHECK(error, OCL_SET_IF_NOT_NULL(errcode_ret, error); return nullptr);
 
   OCL_CHECK(0 == size, OCL_SET_IF_NOT_NULL(errcode_ret, CL_INVALID_BUFFER_SIZE);
@@ -540,7 +543,7 @@ CL_API_ENTRY cl_mem CL_API_CALL cl::CreateImageWithProperties(
     cl_context context, const cl_mem_properties *properties, cl_mem_flags flags,
     const cl_image_format *image_format, const cl_image_desc *image_desc,
     void *host_ptr, cl_int *errcode_ret) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clCreateImageWithProperties");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clCreateImageWithProperties");
   // TODO: Implement, see CA-2610.
   (void)context;
   (void)properties;
@@ -561,6 +564,6 @@ CL_API_ENTRY cl_int CL_API_CALL cl::SetContextDestructorCallback(
   if (!pfn_notify) {
     return CL_INVALID_VALUE;
   }
-  std::lock_guard<std::mutex> lock(context->mutex);
+  const std::lock_guard<std::mutex> lock(context->mutex);
   return context->pushDestructorCallback(pfn_notify, user_data);
 }

--- a/source/cl/test/UnitCL/include/Common.h.in
+++ b/source/cl/test/UnitCL/include/Common.h.in
@@ -41,6 +41,17 @@
 
 #cmakedefine CA_ENABLE_OUT_OF_ORDER_EXEC_MODE
 
+// GCC lambdas are only convertible to function pointers of the specified
+// calling convention, and require the correct calling convention to be
+// specified. MSVC lambdas are convertible to function pointers of any calling
+// convention, and neither require nor allow the calling convention to be
+// specified.
+#ifdef __GNUC__
+#define CL_LAMBDA_CALLBACK CL_CALLBACK
+#else
+#define CL_LAMBDA_CALLBACK
+#endif  // __GNUC__
+
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 

--- a/source/cl/test/UnitCL/source/clCreateContext.cpp
+++ b/source/cl/test/UnitCL/source/clCreateContext.cpp
@@ -35,7 +35,8 @@ TEST_F(clCreateContextTest, Default) {
 TEST_F(clCreateContextTest, DefaultCallback) {
   struct callback_data_t {
   } callback_data;
-  auto callback = [](const char *, const void *, size_t, void *) {};
+  auto callback = [](const char *, const void *, size_t, void *)
+                      CL_LAMBDA_CALLBACK {};
   cl_int error;
   cl_context context =
       clCreateContext(nullptr, 1, &device, callback, &callback_data, &error);

--- a/source/cl/test/UnitCL/source/clCreateContextFromType.cpp
+++ b/source/cl/test/UnitCL/source/clCreateContextFromType.cpp
@@ -67,7 +67,8 @@ TEST_P(clCreateContextFromTypeGoodTest, Default) {
 TEST_P(clCreateContextFromTypeGoodTest, DefaultCallback) {
   struct callback_data_t {
   } callback_data;
-  auto callback = [](const char *, const void *, size_t, void *) {};
+  auto callback = [](const char *, const void *, size_t, void *)
+                      CL_LAMBDA_CALLBACK {};
   cl_int errcode;
   cl_context context = clCreateContextFromType(properties, GetParam(), callback,
                                                &callback_data, &errcode);

--- a/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
@@ -698,7 +698,7 @@ TEST_F(clEnqueueNDRangeKernelTest, ConcurrentBuildOptions) {
 // if newly enqueued commands internally reuse the signaling primitive but
 // also depend on the earlier commands now waiting on them to complete.
 TEST_F(clEnqueueNDRangeKernelTest, NoDeadlockDueToInternalEventCaching) {
-  auto possible_deadlock_callback = [](cl_event, cl_int, void *user_data) {
+  auto possible_deadlock_callback = [](cl_event, cl_int, void *user_data) CL_LAMBDA_CALLBACK {
     // Event should be from the predecessing command.
     cl_event predecessing_command_event = *(static_cast<cl_event *>(user_data));
     cl_int status = CL_QUEUED;

--- a/source/cl/test/UnitCL/source/clSetUserEventStatus.cpp
+++ b/source/cl/test/UnitCL/source/clSetUserEventStatus.cpp
@@ -54,7 +54,7 @@ TEST_F(clSetUserEventStatusTest, FromAnotherEventsCallback) {
 
   ASSERT_SUCCESS(clSetEventCallback(
       markerEvent, CL_COMPLETE,
-      [](cl_event, cl_int, void *user_data) {
+      [](cl_event, cl_int, void *user_data) CL_LAMBDA_CALLBACK {
         clSetUserEventStatus(static_cast<cl_event>(user_data), CL_COMPLETE);
       },
       event));
@@ -149,7 +149,7 @@ TEST_F(clSetUserEventStatusTest, EnsureTerminatedDependentCommandDidNothing) {
 TEST_F(clSetUserEventStatusTest, ReleaseUserEventInItsCallback) {
   cl_int releaseStatus;
 
-  auto func = [](cl_event event, cl_int, void *user_data) {
+  auto func = [](cl_event event, cl_int, void *user_data) CL_LAMBDA_CALLBACK {
     *static_cast<cl_int *>(user_data) = clReleaseEvent(event);
   };
 

--- a/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
+++ b/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
@@ -105,7 +105,7 @@ class KernelExecInfoCodeplayUSMPtrs : public USMKernelExecInfoCodeplayTest {
                                           nullptr, nullptr));
     }
 #elif INTPTR_MAX == INT32_MAX
-    const uint ptr_as_uint = reinterpret_cast<cl_uint>(usm_ptr);
+    const cl_uint ptr_as_uint = reinterpret_cast<cl_uint>(usm_ptr);
     if (device_pointer_size == 64u) {
       const cl_uint extended_ptr = static_cast<cl_ulong>(ptr_as_uint);
       SinglePointerWrapper64Bit ptr_wrapper = {extended_ptr};

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel_exec_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel_exec_info.cpp
@@ -170,7 +170,7 @@ struct USMIndirectAccessTest : public USMKernelTest {
                                           nullptr, nullptr));
     }
 #elif INTPTR_MAX == INT32_MAX
-    const uint ptr_as_uint = reinterpret_cast<cl_uint>(usm_ptr);
+    const cl_uint ptr_as_uint = reinterpret_cast<cl_uint>(usm_ptr);
     if (device_pointer_size == 64u) {
       const cl_uint extended_ptr = static_cast<cl_ulong>(ptr_as_uint);
       SinglePointerWrapper64Bit ptr_wrapper = {extended_ptr};
@@ -277,8 +277,8 @@ struct USMMultiIndirectAccessTest : public USMKernelTest {
                                           nullptr, nullptr));
     }
 #elif INTPTR_MAX == INT32_MAX
-    const uint ptrA_as_uint = reinterpret_cast<cl_uint>(usm_ptrA);
-    const uint ptrB_as_uint = reinterpret_cast<cl_uint>(usm_ptrB);
+    const cl_uint ptrA_as_uint = reinterpret_cast<cl_uint>(usm_ptrA);
+    const cl_uint ptrB_as_uint = reinterpret_cast<cl_uint>(usm_ptrB);
     if (device_pointer_size == 64u) {
       const cl_uint extended_ptrA = static_cast<cl_ulong>(ptrA_as_uint);
       const cl_uint extended_ptrB = static_cast<cl_ulong>(ptrB_as_uint);

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHRWithEvents.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHRWithEvents.cpp
@@ -1074,8 +1074,9 @@ class SetEventCallbackTest : public cl_khr_command_buffer_Test {
     cl_event event;
     cl_int status;
   };
-  static void event_callback(cl_event event, cl_int event_command_status,
-                             void *user_data) {
+  static void CL_CALLBACK event_callback(cl_event event,
+                                         cl_int event_command_status,
+                                         void *user_data) {
     auto event_status = static_cast<event_status_pair *>(user_data);
     event_status->event = event;
     event_status->status = event_command_status;

--- a/source/cl/tools/oclc/oclc.cpp
+++ b/source/cl/tools/oclc/oclc.cpp
@@ -34,6 +34,12 @@
 #include "cargo/string_algorithm.h"
 #include "oclc.h"
 
+#ifdef __GNUC__
+#define CL_LAMBDA_CALLBACK CL_CALLBACK
+#else
+#define CL_LAMBDA_CALLBACK
+#endif  // __GNUC__
+
 namespace {
 template <typename T>
 struct TypeConverter;
@@ -1108,7 +1114,7 @@ bool oclc::Driver::InitCL() {
   // Create a context.
   context_ = clCreateContext(
       nullptr, 1, &device_,
-      [](const char *errinfo, const void *, size_t, void *) {
+      [](const char *errinfo, const void *, size_t, void *) CL_LAMBDA_CALLBACK {
         (void)std::fprintf(stderr, "%s\n", errinfo);
       },
       nullptr, &err);

--- a/source/vk/CMakeLists.txt
+++ b/source/vk/CMakeLists.txt
@@ -111,7 +111,7 @@ if(TARGET LLVMSupport)
 endif()
 
 # Choose library linker options.
-if(CA_PLATFORM_LINUX OR MINGW)
+if(CA_PLATFORM_LINUX)
   # Export API entry point symbols for Linux, or if we're using a GNU compiler
   # on Windows.  I.e. a MinGW build on Windows uses the Linux symbol exports,
   # not the Windows ones.
@@ -124,11 +124,19 @@ if(CA_PLATFORM_LINUX OR MINGW)
   # Use internal library defined functions, required for vkGetInstanceProcAddr,
   # vkGetDeviceProcAddr, overriding new and delete.
   set(VK_LINK_FLAGS "${VK_LINK_FLAGS} -Xlinker -Bsymbolic")
-elseif(CA_PLATFORM_WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Set exports definition file for MSVC Windows (not MinGW, that takes the
-  # Linux equivalent path) and link flags to use it.
-  set(VK_EXPORT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/source/export-windows.def)
-  set(VK_LINK_FLAGS "${VK_LINK_FLAGS} /DEF:${VK_EXPORT_FILE}")
+elseif(CA_PLATFORM_WINDOWS)
+  set(CA_VK_LIBRARY_DEF_FILE export-windows.def)
+  set(ExportLibraryName ${CMAKE_STATIC_LIBRARY_PREFIX}${CA_VK_LIBRARY_NAME})
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/${CA_VK_LIBRARY_DEF_FILE}.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/source/${CA_VK_LIBRARY_DEF_FILE})
+  # Set exports definition file for Windows.
+  set(VK_EXPORT_FILE ${CMAKE_CURRENT_BINARY_DIR}/source/${CA_VK_LIBRARY_DEF_FILE})
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(APPEND VK_LINK_FLAGS " /DEF:\"${VK_EXPORT_FILE}\"")
+  else()
+    string(APPEND VK_LINK_FLAGS " \"${VK_EXPORT_FILE}\"")
+  endif()
 else()
   message(WARNING "Unhandled build environment.")
 endif()

--- a/source/vk/source/export-windows.def.cmake
+++ b/source/vk/source/export-windows.def.cmake
@@ -1,4 +1,4 @@
-LIBRARY VK
+LIBRARY ${ExportLibraryName}
 EXPORTS
   vk_icdNegotiateLoaderICDInterfaceVersion
   vk_icdGetInstanceProcAddr

--- a/source/vk/source/vulkan.cpp
+++ b/source/vk/source/vulkan.cpp
@@ -110,7 +110,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceMemoryProperties(
     return reinterpret_cast<PFN_vkVoidFunction>(function); \
   }
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
+extern "C" VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
 vk_icdGetInstanceProcAddr(VkInstance instance, const char *pName) {
   if (instance) {
     RETURN_FUNCTION(vkCreateDevice, pName);
@@ -1427,7 +1427,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceSparseImageFormatProperties2(
       pPropertyCount, pProperties);
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL
+extern "C" VKAPI_ATTR VkResult VKAPI_CALL
 vk_icdNegotiateLoaderICDInterfaceVersion(uint32_t *pSupportedVersion) {
   if (static_cast<int>(*pSupportedVersion) <
       MIN_SUPPORTED_LOADER_ICD_INTERFACE_VERSION) {

--- a/source/vk/test/UnitVK/source/UnitVK.cpp
+++ b/source/vk/test/UnitVK/source/UnitVK.cpp
@@ -18,6 +18,17 @@
 #include <stdio.h>
 #include <string.h>
 
+// GCC lambdas are only convertible to function pointers of the specified
+// calling convention, and require the correct calling convention to be
+// specified. MSVC lambdas are convertible to function pointers of any calling
+// convention, and neither require nor allow the calling convention to be
+// specified.
+#ifdef __GNUC__
+#define VK_LAMBDA_CALLBACK VKAPI_PTR
+#else
+#define VK_LAMBDA_CALLBACK
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__linux__) || defined(__APPLE__)
@@ -172,15 +183,21 @@ const VkAllocationCallbacks *defaultAllocator() {
 
 static const VkAllocationCallbacks nullAllocationCallBacks = {
     nullptr,
-    [](void *, size_t, size_t, VkSystemAllocationScope) -> void * {
+    [](void *, size_t, size_t, VkSystemAllocationScope)
+        VK_LAMBDA_CALLBACK -> void * {
       return nullptr;
     },
-    [](void *, void *, size_t, size_t, VkSystemAllocationScope) -> void * {
+    [](void *, void *, size_t, size_t, VkSystemAllocationScope)
+        VK_LAMBDA_CALLBACK -> void * {
       return nullptr;
     },
-    [](void *, void *) {},
-    [](void *, size_t, VkInternalAllocationType, VkSystemAllocationScope) {},
-    [](void *, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}};
+    [](void *, void *) VK_LAMBDA_CALLBACK {},
+    [](void *, size_t, VkInternalAllocationType, VkSystemAllocationScope)
+        VK_LAMBDA_CALLBACK {
+    },
+    [](void *, size_t, VkInternalAllocationType, VkSystemAllocationScope)
+        VK_LAMBDA_CALLBACK {
+    }};
 
 static VkAllocationCallbacks oneUseAllocationCallbacks = {
     nullptr,    &uvk::oneUseAlloc, &uvk::realloc,


### PR DESCRIPTION
# Overview

Fix MinGW builds.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* cmake/AddCA.cmake: Do not use unsupported flags.
* hal/source/arg_pack.cpp: std::aligned_alloc has the same issue on
  MinGW as on MSVC, use the same workaround.
* modules/cargo/CMakeLists.txt, modules/cargo/include/cargo/thread.h,
  modules/cargo/source/thread.cpp: Check for pthread even on non-Linux.
* modules/cargo/include/cargo/mutex.h: Remove unused constexpr.
* modules/cargo/source/thread.cpp: GetThreadDescription was used
  incorrectly, causing us to fail to retrieve thread names.
* modules/compiler/CMakeLists.txt, source/cl/CMakeLists.txt,
  source/vl/CMakeLists.txt: Use export file for MinGW too.
* modules/compiler/builtins/source/printf.cpp: Remove workaround for
  older MinGW, no longer needed.
* modules/compiler/source/base/source/module.cpp: Change
  PATH_SEPARATOR. getVirtualFileRef needs "/" even on Windows, on MinGW.
* modules/compiler/targets/host/source/target.cpp: Use MinGW triples
  rather than MSVC triples when on MinGW.
* modules/mux/targets/host/source/kernel.cpp,
  modules/mux/targets/host/source/query_pool.cpp,
  modules/mux/targets/host/source/queue.cpp: Silence warnings about
  unused parameters.
* modules/kts/source/stdout_capture.cpp: Add missing include.
* modules/utils/targets/host/source/relocations.cpp: Add special stack
  helper functions used on MinGW, similar to what is done for MSVC.
* source/cl/examples/CMakeLists.txt: Rename executable.
* source/cl/include/cl/command_queue.h,
  source/cl/source/extension/include/CL/cl_ext_codeplay.h,
  source/cl/test/UnitCL/source/clCreateContext.cpp,
  source/cl/test/UnitCL/source/clCreateContextFromType.cpp,
  source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp,
  source/cl/test/UnitCL/source/clSetUserEventStatus.cpp,
  source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp,
  source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHRWithEvents.cpp,
  source/cl/tools/oclc/oclc.cpp,
  source/vk/test/UnitVK/source/UnitVK.cpp, .clang-format:
  Ensure functions use correct ABI.
* source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel_exec_info.cpp:
  Correct uint name to cl_uint.
* source/vk/source/vulkan.cpp: Fix linkage of vk_icdGetInstanceProcAddr
  and vk_icdNegotiateLoaderICDInterfaceVersion, which are not declared
  in header files so cannot pick up the linkage from there.
* source/cl/source/opencl-3.0.cpp: Add const as suggested by clang-tidy.
* .github/workflows/run_pr_tests.yml: Include context when checking
  format.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
