### PR TITLE
[host] Add debug option to dump assembly.

### DIFF
--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -103,6 +103,16 @@ emitBinary(llvm::Module *module, llvm::TargetMachine *target_machine) {
   llvm::SmallVector<char, 1024> object_code_buffer;
   llvm::raw_svector_ostream stream(object_code_buffer);
 
+#ifndef NDEBUG
+  if (std::getenv("CA_HOST_DUMP_ASM")) {
+    auto result = compiler::emitCodeGenFile(
+        *module, target_machine, llvm::errs(), /*create_assembly=*/true);
+    if (result != compiler::Result::SUCCESS) {
+      return cargo::make_unexpected(result);
+    }
+  }
+#endif
+
   auto result = compiler::emitCodeGenFile(*module, target_machine, stream);
   if (result != compiler::Result::SUCCESS) {
     return cargo::make_unexpected(result);


### PR DESCRIPTION
# Overview

[host] Add debug option to dump assembly.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

With CA_HOST_DUMP_ASM=1, when a kernel binary is created, also dump it in text form to stderr for easier debugging.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
