### PR TITLE
Update for LLVM 19: account for getHostCPUFeatures API change.

### DIFF
--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -316,8 +316,12 @@ compiler::Result HostTarget::initWithBuiltins(
 
   if (CPUName == "native") {
     CPUName = llvm::sys::getHostCPUName();
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    FeatureMap = llvm::sys::getHostCPUFeatures();
+#else
     FeatureMap.clear();
     llvm::sys::getHostCPUFeatures(FeatureMap);
+#endif
   }
 
   if (compiler_info->supports_deferred_compilation) {


### PR DESCRIPTION
# Overview

Update for LLVM 19.

# Reason for change

LLVM 19 changes llvm::sys::getHostCPUFeatures() to return by value.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
