### PR TITLE
[MSVC] Fix debug builds.

### DIFF
--- a/modules/compiler/builtins/abacus/source/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/source/CMakeLists.txt
@@ -85,9 +85,6 @@ target_compile_options(abacus_static
     /fp:precise   # enable precise floating point mode
     /fp:except-   # with no exceptions
   >
-  $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:MSVC>>:
-    /RTCc         # enable reporting value assigned to smaller data type
-  >
   $<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:MSVC>>:
     /Gy           # enable function-level linking
     /Ox           # enable full optimization


### PR DESCRIPTION
# Overview

[MSVC] Fix debug builds.

# Reason for change

We build Abacus in debug builds with /RTCc to flag out of range conversions, but this is a leftover from when Abacus was its own project. In oneAPI Construction Kit, it does not make sense and does not work, as the infrastructure to report such conversions is not available. It was also completely untested as it was only enabled in Debug builds, which we never ran.

# Description of change

Remove /RTCc.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
