### PR TITLE
Improve for Visual Studio builds.

### DIFF
--- a/source/cl/CMakeLists.txt
+++ b/source/cl/CMakeLists.txt
@@ -40,12 +40,10 @@ if("${CA_CL_PLATFORM_VERSION}" STREQUAL "")
   # Version strings for non-release builds will have their build type and
   # shortened git commit hash in the version string.
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-  if(NOT ${BUILD_TYPE_UPPER} MATCHES "RELEASE")
-    string(APPEND CA_CL_PLATFORM_VERSION
-      " (${CMAKE_BUILD_TYPE}, ${CA_GIT_COMMIT})")
-  endif()
 endif()
 message(STATUS "OpenCL platform version: ${CA_CL_PLATFORM_VERSION}")
+
+set(CA_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
 # Platform informations can be overriden
 if("${CA_CL_PLATFORM_NAME}" STREQUAL "")

--- a/source/cl/include/cl/config.h.in
+++ b/source/cl/include/cl/config.h.in
@@ -29,7 +29,6 @@
 // If defined the host platform is Mac OS X
 #cmakedefine CA_PLATFORM_MAC
 
-
 // OpenCL platform version
 #define CA_CL_PLATFORM_VERSION "@CA_CL_PLATFORM_VERSION@"
 
@@ -55,12 +54,18 @@
 // OpenCL C version
 #define CA_CL_DEVICE_OPENCL_C_VERSION "@CA_CL_DEVICE_OPENCL_C_VERSION@"
 
-// ComputeAorta version number
+// oneAPI Construction Kit version number
 #define CA_VERSION "@PROJECT_VERSION@"
 
-// ComputeAorta host device name prefix. All ComputeAorta host devices
-// will have this prefix, which enables detection if a host device is used
-// even though it might encode extra information in the name.
+// oneAPI Construction Kit build type
+#cmakedefine CA_BUILD_TYPE "@CA_BUILD_TYPE@"
+
+// oneAPI Construction Kit Git commit
+#cmakedefine CA_GIT_COMMIT "@CA_GIT_COMMIT@"
+
+// oneAPI Construction Kit host device name prefix. All oneAPI Construction
+// Kit host devices will have this prefix, which enables detection if a host
+// device is used even though it might encode extra information in the name.
 #define CA_HOST_CL_DEVICE_NAME_PREFIX "@CA_HOST_CL_DEVICE_NAME_PREFIX@"
 
 // Whether we support out of order execution mode. Note that at the moment, this

--- a/source/cl/source/platform.cpp
+++ b/source/cl/source/platform.cpp
@@ -220,7 +220,22 @@ cl::GetPlatformInfo(cl_platform_id platform, cl_platform_info param_name,
       }
       OCL_SET_IF_NOT_NULL(param_value_size_ret, size);
     } break;
+#ifdef CA_BUILD_TYPE
+#ifdef CA_GIT_COMMIT
+      PLATFORM_INFO_CASE(CL_PLATFORM_VERSION, CA_CL_PLATFORM_VERSION
+                         " (" CA_BUILD_TYPE ", " CA_GIT_COMMIT ")");
+#else
+      PLATFORM_INFO_CASE(CL_PLATFORM_VERSION,
+                         CA_CL_PLATFORM_VERSION " (" CA_BUILD_TYPE ")");
+#endif  // CA_GIT_COMMIT
+#else   // CA_BUILD_TYPE
+#ifdef CA_GIT_COMMIT
+      PLATFORM_INFO_CASE(CL_PLATFORM_VERSION,
+                         CA_CL_PLATFORM_VERSION " (" CA_GIT_COMMIT ")");
+#else
       PLATFORM_INFO_CASE(CL_PLATFORM_VERSION, CA_CL_PLATFORM_VERSION);
+#endif  // CA_GIT_COMMIT
+#endif  // CA_BUILD_TYPE
       PLATFORM_INFO_CASE(CL_PLATFORM_NAME, CA_CL_PLATFORM_NAME);
       PLATFORM_INFO_CASE(CL_PLATFORM_VENDOR, CA_CL_PLATFORM_VENDOR);
 #if defined(CL_VERSION_3_0)

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -426,6 +426,8 @@ function(add_ca_unitcl_check name)
   endif()
   add_ca_cl_check(${name} GTEST
     COMMAND UnitCL "--unitcl_platform=Codeplay Software Ltd."
+    "--unitcl_kernel_directory=${PROJECT_BINARY_DIR}/share/kernels"
+    "--unitcl_test_include=${PROJECT_BINARY_DIR}/share/test_include"
     --gtest_output=xml:${PROJECT_BINARY_DIR}/${name}.xml ${args_ARGS} ${filter}
     ${environment} CLEAN ${PROJECT_BINARY_DIR}/${name}.xml NOGLOBAL DEPENDS UnitCL)
   get_ock_check_name(check_name ${name})


### PR DESCRIPTION
# Overview

Improve for Visual Studio builds.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* In the reported platform version, include build configuration only if available at CMake time. When building using a multi-config generator, it will not yet be known and the build type will be left out.
* In the reported platform version, always include Git commit if available, even for release builds. Non-Git builds will still be able to build as well: no Git commit will be included in that case.
* Explicitly pass kernel and include directory to UnitCL. We were relying on the UnitCL default of ../share which does not work in multi-config builds, as binaries are not one but two levels down. The UnitCL default, which is correct for the configurations we use more commonly, is kept so that we keep it easy to run UnitCL manually in those configurations.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
