### PR TITLE
Fix <windows.h> header name.

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -357,7 +357,7 @@ set(CA_COMPILE_DEFINITIONS
     _CRT_SECURE_NO_WARNINGS   # Disable deprecation warnings for standard C.
     _SCL_SECURE_NO_WARNINGS   # Disable deprecation warnings for standard C++.
     WIN32_LEAN_AND_MEAN       # Reduces number of files included.
-    NOMINMAX                  # Removes Windows.h min and max macros.
+    NOMINMAX                  # Removes windows.h min and max macros.
     $<$<BOOL:${CA_DISABLE_DEBUG_ITERATOR}>:
       _ITERATOR_DEBUG_LEVEL=0 # Disable STL iterator debugging.
     >

--- a/hal/source/hal_library.cpp
+++ b/hal/source/hal_library.cpp
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <dlfcn.h>
 #endif

--- a/modules/cargo/source/thread.cpp
+++ b/modules/cargo/source/thread.cpp
@@ -17,7 +17,7 @@
 #include "cargo/thread.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <array>

--- a/modules/compiler/loader/source/loader.cpp
+++ b/modules/compiler/loader/source/loader.cpp
@@ -20,7 +20,7 @@
 #if defined(CA_RUNTIME_COMPILER_ENABLED)
 #if defined(CA_COMPILER_ENABLE_DYNAMIC_LOADER)
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #define DEFAULT_LIBRARY_NAME "compiler.dll"
 #else
 #include <dlfcn.h>


### PR DESCRIPTION
# Overview

Fix <windows.h> header name.

# Reason for change

The header name is <windows.h>. In a few places, we referred to it as <Windows.h> which breaks on case sensitive file systems. This is not common on Windows, but important for cross compilation.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
