### PR TITLE
Unify uses of debug environment variables

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -1110,9 +1110,10 @@ options without having to modify the source.
   options in the same manner as `CA_EXTRA_COMPILE_OPTS`.
 * `CA_LLVM_OPTIONS`: This environment variable allows the injection of LLVM
   flags **only** when either `NDEBUG` is not defined (i.e. `Debug` and
-  `ReleaseAssert` build configurations) or when the
-  `CA_ENABLE_LLVM_OPTIONS_IN_RELEASE` option is set in CMake. See
-  [below](#debugging-the-llvm-compiler) for example of how this can be used.
+  `ReleaseAssert` build configurations) or when the cmake variables
+  `CA_ENABLE_LLVM_OPTIONS_IN_RELEASE` or `CA_ENABLE_DEBUG_SUPPORT` is set in
+  CMake. See [below](#debugging-the-llvm-compiler) for example of how this can
+  be used.
 * `CA_HOST_NUM_THREADS`: Sets the maximum number of threads the `host` device
   will create. `host` may create fewer threads than this value.
 

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/{{cookiecutter.target_name}}_pass_machinery.cpp
@@ -152,7 +152,7 @@ llvm::ModulePassManager {{cookiecutter.target_name.capitalize()}}PassMachinery::
   llvm::ModulePassManager PM;
 
   std::optional<std::string> env_debug_prefix;
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_{{cookiecutter.target_name_capitals}}_DEMO_MODE)
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_{{cookiecutter.target_name_capitals}}_DEMO_MODE)
   env_debug_prefix = target.env_debug_prefix;
 #endif
 

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -134,7 +134,8 @@ compiler::Result RiscvModule::createBinary(
   }
 
 // copy the generated ELF file to a specified path if desired
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT) || \
+    defined(CA_RISCV_DEMO_MODE)
   if (!getTarget().env_debug_prefix.empty()) {
     const std::string env_name =
         getTarget().env_debug_prefix + "_SAVE_ELF_PATH";

--- a/modules/compiler/riscv/source/riscv_pass_machinery.cpp
+++ b/modules/compiler/riscv/source/riscv_pass_machinery.cpp
@@ -188,7 +188,8 @@ llvm::ModulePassManager RiscvPassMachinery::getLateTargetPasses() {
   llvm::ModulePassManager PM;
 
   std::optional<std::string> env_debug_prefix;
-#if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_RISCV_DEMO_MODE)
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT) || \
+    defined(CA_RISCV_DEMO_MODE)
   env_debug_prefix = target.env_debug_prefix;
 #endif
 

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1085,8 +1085,7 @@ void BaseModule::setDefaultOpenCLLangOpts(clang::LangOptions &lang_opts) const {
 std::string BaseModule::debugDumpKernelSource(
     llvm::StringRef source, llvm::ArrayRef<std::string> definitions) {
   std::string dbg_filename;
-
-#ifndef CA_ENABLE_DEBUG_SUPPORT
+#if defined(NDEBUG) && !defined(CA_ENABLE_DEBUG_SUPPORT)
   (void)source;
   (void)definitions;
 #else
@@ -1436,7 +1435,7 @@ std::unique_ptr<llvm::Module> BaseModule::compileOpenCLCToIR(
   // TODO(CA-608): Allow developers to inject LLVM options for debugging at
   // this point, formerly called OCL_LLVM_DEBUG was remove due to lack of use.
 
-#ifdef CA_ENABLE_DEBUG_SUPPORT
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT)
   const std::string dbg_filename =
       debugDumpKernelSource(source, options.definitions);
 #else

--- a/modules/compiler/targets/host/source/info.cpp
+++ b/modules/compiler/targets/host/source/info.cpp
@@ -78,6 +78,7 @@ HostInfo::HostInfo(host::arch arch, host::os os,
   // If the user wants to override, let them. This may be useful for testing the
   // non-deferred-compilation support, or may be useful for testing future LLVM
   // improvements that may provide RISC-V JIT support.
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT)
   if (const char *env = std::getenv("CA_HOST_DEFERRED_COMPILATION")) {
     char *end;
     const long val = std::strtol(env, &end, 10);
@@ -85,6 +86,7 @@ HostInfo::HostInfo(host::arch arch, host::os os,
       supports_deferred_compilation = val;
     }
   }
+#endif
 
   vectorizable = true;
   dma_optimizable = true;

--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -103,7 +103,7 @@ emitBinary(llvm::Module *module, llvm::TargetMachine *target_machine) {
   llvm::SmallVector<char, 1024> object_code_buffer;
   llvm::raw_svector_ostream stream(object_code_buffer);
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(CA_ENABLE_DEBUG_SUPPORT)
   if (std::getenv("CA_HOST_DUMP_ASM")) {
     auto result = compiler::emitCodeGenFile(
         *module, target_machine, llvm::errs(), /*create_assembly=*/true);

--- a/modules/compiler/utils/source/lld_linker.cpp
+++ b/modules/compiler/utils/source/lld_linker.cpp
@@ -138,7 +138,8 @@ Expected<std::unique_ptr<MemoryBuffer>> lldLinkToBinary(
 
   std::vector<std::string> args = {"ld.lld", objFile.getFileName()};
 
-#if !defined(NDEBUG) || defined(CA_ENABLE_LLVM_OPTIONS_IN_RELEASE)
+#if !defined(NDEBUG) || defined(CA_ENABLE_LLVM_OPTIONS_IN_RELEASE) || \
+    defined(CA_ENABLE_DEBUG_SUPPORT)
   if (auto *env = std::getenv("CA_LLVM_OPTIONS")) {
     auto split_llvm_options = cargo::split(env, " ");
     compiler::utils::appendMLLVMOptions(split_llvm_options, args);


### PR DESCRIPTION
# Overview

Unify uses of environment variables under NDEBUG or CA_ENABLE_DEBUG_SUPPORT
# Reason for change

There is some inconsistency in where environement variables are enabled either bug using !defined(NDEBUG) or defined(CA_ENABLE_DEBUG_SUPPORT). This change means that either will affect these environment variables.

# Description of change

Support both  !defined(NDEBUG) or defined(CA_ENABLE_DEBUG_SUPPORT) in use cases
This also moves CA_HOST_DEFERRED_COMPILATION under similar controls.
