### PR TITLE
Fix curly brackets clang-tidy error

### DIFF
--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -393,8 +393,9 @@ compiler::Result HostTarget::initWithBuiltins(
     llvm::StringMap<bool> FeatureMap;
     llvm::sys::getHostCPUFeatures(FeatureMap);
 #endif
-    for (auto &[FeatureName, IsEnabled] : FeatureMap)
+    for (auto &[FeatureName, IsEnabled] : FeatureMap) {
       NativeFeatures.AddFeature(FeatureName, IsEnabled);
+    }
 
     NativeFeatures.addFeaturesVector(Features.getFeatures());
     Features = std::move(NativeFeatures);


### PR DESCRIPTION
# Overview

Adding some extra curly brackets due to clang-tidy

# Reason for change

Fix clang-tidy fail
