### PR TITLE
Added some relative relocations for RISC-V

### DIFF
--- a/modules/loader/include/loader/relocation_types.h
+++ b/modules/loader/include/loader/relocation_types.h
@@ -471,6 +471,7 @@ namespace RISCV {
 enum Type : uint32_t {
   R_RISCV_NONE = 0,
   R_RISCV_64 = 2,
+  R_RISCV_BRANCH = 16,
   R_RISCV_CALL = 18,
   R_RISCV_CALL_PLT = 19,
   R_RISCV_PCREL_HI20 = 23,
@@ -480,6 +481,8 @@ enum Type : uint32_t {
   R_RISCV_LO12_I = 27,
   R_RISCV_ADD32 = 35,
   R_RISCV_SUB32 = 39,
+  R_RISCV_ALIGN = 43,
+  R_RISCV_RVC_JUMP = 45,
 };
 }  // namespace RISCV
 

--- a/modules/loader/source/relocations.cpp
+++ b/modules/loader/source/relocations.cpp
@@ -684,14 +684,15 @@ uint32_t getLo12(uint64_t addr) {
   return static_cast<uint32_t>(getBitRange(addr, 0, 12));
 }
 
+// Sign extends a number in the bottom 'b' bits of a 64-bit number back up to
+// a 64-bit number.
+int64_t signExtendN(uint64_t val, unsigned b) {
+  CARGO_ASSERT(b > 0, "bit-width cannot be zero");
+  CARGO_ASSERT(b <= 64, "bit-width out of range");
+  return static_cast<int64_t>(val << (64 - b)) >> (64 - b);
+}
+
 cargo::optional<uint32_t> getHi20(int64_t addr) {
-  // Sign extends a number in the bottom 'b' bits of a 64-bit number back up to
-  // a 64-bit number.
-  auto signExtendN = [](uint64_t val, unsigned b) {
-    CARGO_ASSERT(b > 0, "bit-width cannot be zero");
-    CARGO_ASSERT(b <= 64, "bit-width out of range");
-    return static_cast<int64_t>(val << (64 - b)) >> (64 - b);
-  };
   // See documentation for why we add 0x800 here:
   // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#absolute-addresses
   // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#pc-relative-symbol-addresses
@@ -710,6 +711,14 @@ cargo::optional<uint32_t> getHi20(int64_t addr) {
 // assumes little-endian RISCV
 bool resolveRISCV(const loader::Relocation &r, loader::ElfMap &map,
                   const std::vector<loader::Relocation> &relocations) {
+  // The ALIGN relocation is special and is related to keeping alignment with
+  // nops after linking. Currently skip this as we believe this is not required.
+  // Additionally it has no symbol which decomposeRelocation does not handle, so
+  // this would need fixed if this is ever implemented.
+  if (r.type == loader::RelocationTypes::RISCV::R_RISCV_ALIGN) {
+    // TODO: Check that we fit the alignment constraints as is.
+    return true;
+  }
   const auto relocation_data = decomposeRelocation<uint64_t>(r, map);
   if (!relocation_data) {
     return false;
@@ -832,6 +841,68 @@ bool resolveRISCV(const loader::Relocation &r, loader::ElfMap &map,
       writeITypeImm(getLo12(relative_value), relocation_address + 4);
       break;
     }
+    case R_RISCV_BRANCH: {
+      // R_RISCV_BRANCH immediate is for B-Type instructions and is split
+      // across 12 bits spread across the instruction and skips the bottom bit
+      // of the input relative offset. See conditional branches in the isa spec.
+
+      // Check that the value, when sign-extended back up to a 64-bit number
+      // will not lose bits.
+      if (signExtendN(relative_value, 13) !=
+          static_cast<int64_t>(relative_value & (~1))) {
+#ifndef NDEBUG
+        auto name =
+            map.getSymbolName(r.symbol_index).value_or("<unknown symbol>");
+        (void)fprintf(stderr,
+                      "Error: relocation R_RISCV_BRANCH branch > 13 bits or "
+                      "not even for symbol '%.*s'\n",
+                      (int)name.size(), name.data());
+#endif
+        return false;
+      }
+      uint32_t value;
+      const uint32_t trunc_value = static_cast<uint32_t>(relative_value);
+      cargo::read_little_endian(&value, relocation_address);
+      // imm bits 1-4 at bit 8
+      value = setBitRange(value, trunc_value >> 1, 8, 4);
+      // imm bits 5-10 at bit 25
+      value = setBitRange(value, trunc_value >> 5, 25, 6);
+      // imm bit 11 at bit 7
+      value = setBitRange(value, trunc_value >> 11, 7, 1);
+      // imm bit 12 at bit 31
+      value = setBitRange(value, trunc_value >> 12, 31, 1);
+      cargo::write_little_endian(value, relocation_address);
+      break;
+    }
+
+    case R_RISCV_RVC_JUMP: {
+      // R_RISCV_RVC_JUMP is for compressed instructions and fits in bits 2-12
+      // of a 16 bit value and skips the bottom bit of the input. See CJ format
+      // in the isa spec.
+
+      // Check that the value, when sign-extended back up to a 64-bit number
+      // will not lose bits.
+      if (signExtendN(relative_value, 12) !=
+          static_cast<int64_t>(relative_value & (~1))) {
+#ifndef NDEBUG
+        auto name =
+            map.getSymbolName(r.symbol_index).value_or("<unknown symbol>");
+        (void)fprintf(stderr,
+                      "Error: relocation R_RISCV_RVC_JUMP > 12 bits or not "
+                      "even for symbol '%.*s'\n",
+                      (int)name.size(), name.data());
+#endif
+        return false;
+      }
+
+      uint16_t value;
+      cargo::read_little_endian(&value, relocation_address);
+      const uint16_t offset_16 = static_cast<uint16_t>(relative_value) >> 1;
+      value = setBitRange(value, offset_16, 2, 11);
+      cargo::write_little_endian(value, relocation_address);
+      break;
+    }
+
     case R_RISCV_ADD32: {
       // 32-bit label addition: V + S + A
       uint32_t value;


### PR DESCRIPTION
# Overview

Added RISCV_BRANCH and RISCV_RVC_JUMP relocations. 

# Reason for change

This is useful for debugging where we assemble the output assembly for testing purposes, but could in theory happen regardless.
# Description of change

Added RISCV_BRANCH and RISCV_RVC_JUMP relocations, as well as skipping RISCV_ALIGN relocations.
