### PR TITLE
[host][AArch64] Fix R_AARCH64_ADR_PREL_PG_HI21 handling.

### DIFF
--- a/modules/loader/source/relocations.cpp
+++ b/modules/loader/source/relocations.cpp
@@ -592,6 +592,9 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
           relocation_address);
       break;
     // PC-relative page-granular 21-bit relocation
+    // From ELF for the Arm® 64-bit Architecture (AArch64) 2023Q3:
+    // "Set an ADRP immediate value to bits [32:12] of [the result of the
+    // relocation operation] X; check that -2^32 <= X < 2^32"
     case R_AARCH64_ADR_PREL_PG_HI21: {
       uint64_t page_difference = (symbol_target_address & ~0xFFFULL) -
                                  (relocation_target_address & ~0xFFFULL);
@@ -605,7 +608,7 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
           29, 2);
       value32 = setBitRange(
           value32, getBitRange(static_cast<uint32_t>(page_difference), 2, 19),
-          3, 19);
+          5, 19);
       cargo::write_little_endian(value32, relocation_address);
       break;
     }


### PR DESCRIPTION
# Overview

[host][AArch64] Fix R_AARCH64_ADR_PREL_PG_HI21 handling.

# Reason for change

R_AARCH64_ADR_PREL_PG_HI21 writes the page difference to the immediate operand of an ADRP instruction. We were this in bits 29-30 (low) and 3-21 (high), but the immediate operand is supposed to be encoded in bits 29-30 (low) and 5-23 (high).

# Description of change

Write to bits 5-23 instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
