### PR TITLE
[cargo, host] Handle macOS.

### DIFF
--- a/modules/cargo/CMakeLists.txt
+++ b/modules/cargo/CMakeLists.txt
@@ -24,14 +24,18 @@ if(${CA_ENABLE_COVERAGE} AND ${CA_RUNTIME_COMPILER_ENABLED})
 endif()
 
 include(CheckSymbolExists)
+include(CheckSourceCompiles)
 
 # Macros and flags necessary to find the pthread get/set name symbols.
 set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 set(CMAKE_REQUIRED_FLAGS -pthread)
 # Check for specific symbols in case a platform, e.g. an RTOS, does not
 # support them while otherwise supporting pthreads.
-check_symbol_exists(pthread_setname_np "pthread.h" CARGO_HAS_PTHREAD_SETNAME_NP)
 check_symbol_exists(pthread_getname_np "pthread.h" CARGO_HAS_PTHREAD_GETNAME_NP)
+# Ensure pthread_setname_np exists and takes two arguments.
+check_source_compiles(CXX
+"#include <pthread.h>
+int main(void) { pthread_setname_np(0, 0); }" CARGO_HAS_PTHREAD_SETNAME_NP)
 
 add_ca_library(cargo STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/cargo/allocator.h


### PR DESCRIPTION
# Overview

[cargo, host] Handle macOS.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* pthread_setname_np only takes a single argument and can only set the thread name of the current thread. Where cargo optionally uses pthread_setname_np, it needs the two-argument version, so change the CMake check to reject the macOS version.
* For macOS/arm64, we need the same workaround as for macOS/x86, we need to generate ELF since Mach-O has restrictions on names that means our IR cannot be compiled for it. This makes things easier for us anyway as we already have an ELF loader.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
