### PR TITLE
Fix UnitCL file descriptor leak.

### DIFF
--- a/modules/kts/source/stdout_capture.cpp
+++ b/modules/kts/source/stdout_capture.cpp
@@ -115,6 +115,7 @@ void StdoutCapture::RestoreStdout() {
 
   const int restored_fd = DUP2(original_fd, fileno(stdout));
   ASSERT_NE(-1, restored_fd);  // If this has failed stdout is not restored.
+  close(original_fd);
   original_fd = -1;
 }
 


### PR DESCRIPTION
# Overview

Fix UnitCL file descriptor leak.

# Reason for change

For testing printf, we were saving the original stdout in a new fd, redirecting stdout to a temporary file, running the test, restoring stdout from that fd, and reading from that file. What is missing here is closing that new fd after we are done with it, so we would open more and more and more file descriptors. On macOS, the file descriptor limit is lower than it is on Linux and we would run out of file descriptors.

# Description of change

Close file descriptor after we are done with it.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
