### PR TITLE
Fix for printf("%s\n", "") and test.

### DIFF
--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -388,6 +388,9 @@ std::optional<std::string> getPointerToStringAsString(Value *op) {
   if (auto array_string = dyn_cast<ConstantDataSequential>(string_const)) {
     return array_string->getAsString().str();
   }
+  if (isa<ConstantAggregateZero>(string_const)) {
+    return "";
+  }
 
   return std::nullopt;
 }

--- a/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
+++ b/source/cl/test/UnitCL/kernels/kernel_source_list.cmake
@@ -238,6 +238,7 @@ set(KERNEL_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/printf.20_multiple_kernels.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/printf.21_float_with_double_conversion.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/printf.22_half_with_double_conversion.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/printf.24_empty_string_param.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.01_pointer_to_long_cast.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.02_work_dim.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/regression.03_shuffle_cast.cl

--- a/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.cl
+++ b/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.cl
@@ -1,0 +1,20 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Print nothing.
+__kernel void empty_string_param() {
+  printf("%s\n", "");
+}

--- a/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.spvasm32
+++ b/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.spvasm32
@@ -1,0 +1,43 @@
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 23
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %20 "empty_string_param" %_str %_str_1
+               OpSource OpenCL_C 102000
+               OpName %_str ".str"
+               OpName %_str_1 ".str.1"
+               OpName %entry "entry"
+               OpName %call "call"
+               OpDecorate %_str Constant
+               OpDecorate %_str Alignment 1
+               OpDecorate %_str_1 Constant
+               OpDecorate %_str_1 Alignment 1
+       %uint = OpTypeInt 32 0
+      %uchar = OpTypeInt 8 0
+     %uint_4 = OpConstant %uint 4
+   %uchar_37 = OpConstant %uchar 37
+  %uchar_115 = OpConstant %uchar 115
+   %uchar_10 = OpConstant %uchar 10
+    %uchar_0 = OpConstant %uchar 0
+     %uint_1 = OpConstant %uint 1
+%_arr_uchar_uint_4 = OpTypeArray %uchar %uint_4
+%_ptr_UniformConstant__arr_uchar_uint_4 = OpTypePointer UniformConstant %_arr_uchar_uint_4
+%_arr_uchar_uint_1 = OpTypeArray %uchar %uint_1
+%_ptr_UniformConstant__arr_uchar_uint_1 = OpTypePointer UniformConstant %_arr_uchar_uint_1
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+         %11 = OpConstantComposite %_arr_uchar_uint_4 %uchar_37 %uchar_115 %uchar_10 %uchar_0
+       %_str = OpVariable %_ptr_UniformConstant__arr_uchar_uint_4 UniformConstant %11
+         %16 = OpConstantNull %_arr_uchar_uint_1
+     %_str_1 = OpVariable %_ptr_UniformConstant__arr_uchar_uint_1 UniformConstant %16
+         %20 = OpFunction %void DontInline %19
+      %entry = OpLabel
+       %call = OpExtInst %uint %1 printf %_str %_str_1
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.spvasm64
+++ b/source/cl/test/UnitCL/kernels/printf.24_empty_string_param.spvasm64
@@ -1,0 +1,45 @@
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 24
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %20 "empty_string_param" %_str %_str_1
+               OpSource OpenCL_C 102000
+               OpName %_str ".str"
+               OpName %_str_1 ".str.1"
+               OpName %entry "entry"
+               OpName %call "call"
+               OpDecorate %_str Constant
+               OpDecorate %_str Alignment 1
+               OpDecorate %_str_1 Constant
+               OpDecorate %_str_1 Alignment 1
+      %ulong = OpTypeInt 64 0
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+    %ulong_4 = OpConstant %ulong 4
+   %uchar_37 = OpConstant %uchar 37
+  %uchar_115 = OpConstant %uchar 115
+   %uchar_10 = OpConstant %uchar 10
+    %uchar_0 = OpConstant %uchar 0
+    %ulong_1 = OpConstant %ulong 1
+%_arr_uchar_ulong_4 = OpTypeArray %uchar %ulong_4
+%_ptr_UniformConstant__arr_uchar_ulong_4 = OpTypePointer UniformConstant %_arr_uchar_ulong_4
+%_arr_uchar_ulong_1 = OpTypeArray %uchar %ulong_1
+%_ptr_UniformConstant__arr_uchar_ulong_1 = OpTypePointer UniformConstant %_arr_uchar_ulong_1
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+         %11 = OpConstantComposite %_arr_uchar_ulong_4 %uchar_37 %uchar_115 %uchar_10 %uchar_0
+       %_str = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_4 UniformConstant %11
+         %16 = OpConstantNull %_arr_uchar_ulong_1
+     %_str_1 = OpVariable %_ptr_UniformConstant__arr_uchar_ulong_1 UniformConstant %16
+         %20 = OpFunction %void DontInline %19
+      %entry = OpLabel
+       %call = OpExtInst %uint %1 printf %_str %_str_1
+               OpReturn
+               OpFunctionEnd

--- a/source/cl/test/UnitCL/source/ktst_printf.cpp
+++ b/source/cl/test/UnitCL/source/ktst_printf.cpp
@@ -1756,3 +1756,11 @@ TEST_P(PrintfExecutionSPIRV, Printf_23_String_DPCPP) {
   this->SetPrintfReference(1, ref);
   this->RunPrintf1D(1);
 }
+
+TEST_P(PrintfExecution, Printf_24_Empty_String_Param) {
+  fail_if_not_vectorized_ = false;
+  ReferencePrintfString ref = [](size_t) { return "\n"; };
+
+  this->SetPrintfReference(1, ref);
+  this->RunPrintf1D(1);
+}


### PR DESCRIPTION

# Overview

Added check for zero initializer and added a UnitCL test.

# Reason for change

OpenCL CTS showed a failure in test_printf. This is due to not recognizing a zero initializer as a string.
