### PR TITLE
Fix x86 compiler, disable test for macOS.

### DIFF
--- a/modules/compiler/targets/host/source/info.cpp
+++ b/modules/compiler/targets/host/source/info.cpp
@@ -130,11 +130,11 @@ void HostInfo::get(compiler::AddCompilerFn add_compiler) {
       HOST_CROSS_DEVICE_NAME_AARCH64));
 #endif
 #ifdef HOST_CROSS_X86
-  add_compiler(getCrossCompilerInfo<host::arch::X86, HOST_OS>(
+  add_compiler(getCrossCompilerInfo<host::arch::X86, host::os::LINUX>(
       HOST_CROSS_DEVICE_NAME_X86));
 #endif
 #ifdef HOST_CROSS_X86_64
-  add_compiler(getCrossCompilerInfo<host::arch::X86_64, HOST_OS>(
+  add_compiler(getCrossCompilerInfo<host::arch::X86_64, host::os::LINUX>(
       HOST_CROSS_DEVICE_NAME_X86_64));
 #endif
 #ifdef HOST_CROSS_RISCV32

--- a/source/cl/test/UnitCL/source/ktst_precision.cpp
+++ b/source/cl/test/UnitCL/source/ktst_precision.cpp
@@ -107,11 +107,9 @@ T Remquo7BitRef(T x, T y, cl_int &quo_out) {
 }
 }  // namespace
 
-#ifdef __arm__
-// TODO: CA-2730
-TEST_P(Execution, DISABLED_Precision_01_Pow_Func) {
-#elif defined(_WIN32)
-// TODO: CA-3492
+#if defined(__arm__) || defined(_WIN32) || defined(__APPLE__)
+// TODO This test has double precision reference results and we only pass when
+// we can pretend they are extended precision reference results.
 TEST_P(Execution, DISABLED_Precision_01_Pow_Func) {
 #else
 TEST_P(Execution, Precision_01_Pow_Func) {


### PR DESCRIPTION
# Overview

Fix x86 compiler, disable test for macOS.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* We were setting up the x86 compiler for the host OS, rather than for Linux, but we only support cross-compilation for Linux. For AArch64 and RISC-V, we were already forcing Linux, do the same for x86 so that we do not attempt to cross-compile from macOS/arm64 to macOS/x86.
* Disable Precision_01_Pow_Func on macOS. This test only passes when a sufficiently large long double type is available. On macOS/arm64, long double is the same as double.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
