### PR TITLE
Auto-disable deferred compilation.

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/info.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/info.cpp
@@ -36,7 +36,6 @@ namespace {{cookiecutter.target_name}} {
   device_info = mux_device_info;
   vectorizable = true;
   dma_optimizable = true;
-  supports_deferred_compilation = false;
   scalable_vector_support = {{cookiecutter.scalable_vector}};
   kernel_debug = true;
 

--- a/modules/compiler/include/compiler/info.h
+++ b/modules/compiler/include/compiler/info.h
@@ -56,10 +56,6 @@ struct Info {
   /// @brief Mux device info that this compiler will target. Must not be
   /// `nullptr`.
   mux_device_info_t device_info = nullptr;
-  /// @brief Is `true` if the compiler supports deferred compilation (i.e.
-  /// compiler::Module::getKernel() and the compiler::Kernel class are
-  /// implemented), `false` otherwise.
-  bool supports_deferred_compilation = false;
   /// @brief A semicolon-separated, null-terminated list with static lifetime
   /// duration, of this Mux device's custom compile options.
   ///
@@ -131,6 +127,11 @@ struct Info {
 
     return caps;
   }
+
+  /// @brief Returns `true` if the compiler supports deferred compilation (i.e.
+  /// compiler::Module::getKernel() and the compiler::Kernel class are
+  /// implemented), `false` otherwise.
+  virtual bool supports_deferred_compilation() const { return false; }
 };
 
 /// @brief A functor which is called when a target wants to expose a compiler.

--- a/modules/compiler/riscv/source/info.cpp
+++ b/modules/compiler/riscv/source/info.cpp
@@ -39,7 +39,6 @@ RiscvInfo::RiscvInfo(mux_device_info_t mux_device_info,
 
   vectorizable = false;
   dma_optimizable = true;
-  supports_deferred_compilation = false;
   kernel_debug = true;
 }
 

--- a/modules/compiler/targets/host/include/host/info.h
+++ b/modules/compiler/targets/host/include/host/info.h
@@ -66,6 +66,12 @@ struct HostInfo : compiler::Info {
 
   /// @brief Bitfield of all `host::arch`'s being targeted.
   static uint8_t arches;
+
+  bool supports_deferred_compilation() const override;
+
+ private:
+  bool deferred_compilation_enabled;
+  mutable const char *deferred_compilation_warning;
 };
 
 }  // namespace host

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -416,7 +416,7 @@ compiler::Result HostTarget::initWithBuiltins(
     Features = std::move(NativeFeatures);
   }
 
-  if (compiler_info->supports_deferred_compilation) {
+  if (compiler_info->supports_deferred_compilation()) {
     llvm::orc::JITTargetMachineBuilder TMBuilder(triple);
     TMBuilder.setCPU(CPU);
     TMBuilder.setCodeGenOptLevel(multi_llvm::CodeGenOptLevel::Aggressive);

--- a/modules/compiler/test/common.h
+++ b/modules/compiler/test/common.h
@@ -319,7 +319,7 @@ static inline std::string printDeviceName(
 static inline std::vector<const compiler::Info *> deferrableCompilers() {
   std::vector<const compiler::Info *> deferrable_compilers;
   for (const compiler::Info *compiler : compiler::compilers()) {
-    if (compiler->supports_deferred_compilation) {
+    if (compiler->supports_deferred_compilation()) {
       deferrable_compilers.emplace_back(compiler);
     }
   }

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -166,7 +166,7 @@ bool cl::device_program::finalize(cl_device_id device) {
 
     // If the compiler does not support deferred compilation, we get the final
     // binary from the module and initialize a mux_kernel_cache.
-    if (!device->compiler_info->supports_deferred_compilation) {
+    if (!device->compiler_info->supports_deferred_compilation()) {
       // Get the Mux binary.
       auto binary_result = compiler_module.getOrCreateMuxBinary();
       if (!binary_result) {
@@ -223,7 +223,7 @@ cl::device_program::createKernel(cl_device_id device,
     } break;
 
     case cl::device_program_type::COMPILER_MODULE: {
-      if (device->compiler_info->supports_deferred_compilation) {
+      if (device->compiler_info->supports_deferred_compilation()) {
         compiler::Kernel *deferred_kernel =
             compiler_module.module->getKernel(kernel_name);
         if (!deferred_kernel) {


### PR DESCRIPTION
# Overview

Auto-disable deferred compilation.

# Reason for change

CA_HOST_DUMP_ASM=1 and deferred compilation are incompatible. Our current behavior is that CA_HOST_DUMP_ASM is effectively silently ignored, making for a poor user experience.

# Description of change

With this change, when CA_HOST_DUMP_ASM=1 is set and deferred compilation would normally be implicitly enabled, deferred compilation will be disabled and a warning is printed for it.

If an explicit CA_HOST_DEFERRED_COMPILATION=1 is set, deferred compilation can be forced. This still works and results in no assembly being printed.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
