### PR TITLE
Add support for returning an error for clSetCommandQueueProperty

### DIFF
--- a/source/cl/include/cl/command_queue.h
+++ b/source/cl/include/cl/command_queue.h
@@ -664,6 +664,22 @@ CL_API_ENTRY cl_int CL_API_CALL EnqueueBarrier(cl_command_queue queue);
 CL_API_ENTRY cl_int CL_API_CALL EnqueueMarker(cl_command_queue queue,
                                               cl_event *event);
 
+/// @brief Set a command queue property, deprecated in OpenCL 1.1 and
+/// unsupported
+///
+/// @param command_queue Command queue to enqueue the barrier on.
+/// @param properties Command queue properties to set.
+/// @param enable CL_TRUE specifies to enable property.
+/// @param old_properties old properties.
+///
+/// @return Return error code.
+///
+/// @see
+// https://registry.khronos.org/OpenCL/sdk/1.1/docs/man/xhtml/clSetCommandQueueProperty.html
+CL_API_ENTRY cl_int CL_API_CALL SetCommandQueueProperty(
+    cl_command_queue command_queue, cl_command_queue_properties properties,
+    cl_bool enable, cl_command_queue_properties *old_properties);
+
 /// @}
 }  // namespace cl
 

--- a/source/cl/source/command_queue.cpp
+++ b/source/cl/source/command_queue.cpp
@@ -1366,6 +1366,18 @@ cl::EnqueueMarker(cl_command_queue command_queue, cl_event *event) {
   return CL_SUCCESS;
 }
 
+CL_API_ENTRY cl_int CL_API_CALL cl::SetCommandQueueProperty(
+    cl_command_queue command_queue, cl_command_queue_properties properties,
+    cl_bool enable, cl_command_queue_properties *old_properties) {
+  const tracer::TraceGuard<tracer::OpenCL> guard("SetCommandQueueProperty");
+  // 	clSetCommandQueueProperty is deprecated by version 1.1.
+  (void)command_queue;
+  (void)properties;
+  (void)enable;
+  (void)old_properties;
+  return CL_INVALID_OPERATION;
+}
+
 #ifdef OCL_EXTENSION_cl_khr_command_buffer
 [[nodiscard]] cl_int _cl_command_queue::enqueueCommandBuffer(
     cl_command_buffer_khr command_buffer, cl_uint num_events_in_wait_list,

--- a/source/cl/source/export-apple.def
+++ b/source/cl/source/export-apple.def
@@ -111,3 +111,4 @@ _clSetProgramReleaseCallback
 _clSetContextDestructorCallback
 _clCreateBufferWithProperties
 _clCreateImageWithProperties
+_clSetCommandQueueProperty

--- a/source/cl/source/export-linux.map
+++ b/source/cl/source/export-linux.map
@@ -84,6 +84,7 @@ OPENCL_1.0 {
     clEnqueueBarrier;
     clUnloadCompiler;
     clGetExtensionFunctionAddress;
+    clSetCommandQueueProperty;
   local:
     *;
 };

--- a/source/cl/source/export-linux.sym
+++ b/source/cl/source/export-linux.sym
@@ -40,6 +40,7 @@ clGetEventInfo
 clRetainEvent
 clReleaseEvent
 clGetEventProfilingInfo
+clSetCommandQueueProperty
 clFlush
 clFinish
 clEnqueueReadBuffer

--- a/source/cl/source/export-windows.def.cmake
+++ b/source/cl/source/export-windows.def.cmake
@@ -88,6 +88,7 @@ EXPORTS
   clEnqueueBarrier
   clUnloadCompiler
   clGetExtensionFunctionAddress
+  clSetCommandQueueProperty
   ; Conditionalize the following?
   clIcdGetPlatformIDsKHR
   ; Required for debuggers to detect jitted code

--- a/source/cl/source/exports.cpp
+++ b/source/cl/source/exports.cpp
@@ -14,6 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Set this so we can get clSetCommandQueueProperty
+// as the expectation is we return an invalid operation.
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS 1
+
 #include <CL/cl.h>
 #include <cl/buffer.h>
 #include <cl/command_queue.h>
@@ -667,4 +671,11 @@ CL_API_ENTRY cl_int CL_API_CALL clGetEventProfilingInfo(
     void *param_value, size_t *param_value_size_ret) {
   return cl::GetEventProfilingInfo(event, param_name, param_value_size,
                                    param_value, param_value_size_ret);
+}
+
+CL_API_ENTRY cl_int CL_API_CALL clSetCommandQueueProperty(
+    cl_command_queue command_queue, cl_command_queue_properties properties,
+    cl_bool enable, cl_command_queue_properties *old_properties) {
+  return cl::SetCommandQueueProperty(command_queue, properties, enable,
+                                     old_properties);
 }

--- a/source/cl/source/extension/source/khr_icd.cpp
+++ b/source/cl/source/extension/source/khr_icd.cpp
@@ -110,7 +110,7 @@ const struct icd_dispatch_table_t {
   ICD_FUNCTION(RetainCommandQueue)
   ICD_FUNCTION(ReleaseCommandQueue)
   ICD_FUNCTION(GetCommandQueueInfo)
-  OCL_ICD_NOT_IMPLEMENTED(clSetCommandQueueProperty)
+  ICD_FUNCTION(SetCommandQueueProperty)
   ICD_FUNCTION(CreateBuffer)
   ICD_FUNCTION(CreateImage2D)
   ICD_FUNCTION(CreateImage3D)

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -165,6 +165,7 @@ add_ca_cl_executable(UnitCL
   source/clSetEventCallback.cpp
   source/clSetKernelArg.cpp
   source/clSetMemObjectDestructorCallback.cpp
+  source/clSetCommandQueueProperty.cpp
   source/clSetUserEventStatus.cpp
   source/clUnloadCompiler.cpp
   source/clUnloadPlatformCompiler.cpp

--- a/source/cl/test/UnitCL/source/clSetCommandQueueProperty.cpp
+++ b/source/cl/test/UnitCL/source/clSetCommandQueueProperty.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS 1
+#include "Common.h"
+
+class clSetCommandQueuePropertyTest : public ucl::CommandQueueTest {
+  void SetUp() override {
+    UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
+  }
+};
+
+TEST_F(clSetCommandQueuePropertyTest, NotImplemented) {
+  cl_command_queue_properties old_properties;
+  ASSERT_EQ_ERRCODE(CL_INVALID_OPERATION,
+                    clSetCommandQueueProperty(
+                        command_queue, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+                        CL_TRUE, &old_properties));
+}


### PR DESCRIPTION
# Overview

OpenCL CTS has been changed to accept a failure for clSetCommandQueueProperty rather than it not existing, so it is added as an error reporting function.

# Reason for change

CTS failure.

# Description of change

Added to exports, a test and a CL_INVALID_OPERATION return.
