### PR TITLE
Fix compiler breakage on llvm 20 for createSimpleTargetReduction.

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/loop_utils.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/loop_utils.h
@@ -24,7 +24,10 @@ namespace multi_llvm {
 inline llvm::Value *createSimpleTargetReduction(
     llvm::IRBuilderBase &B, const llvm::TargetTransformInfo *TTI,
     llvm::Value *Src, llvm::RecurKind RdxKind) {
-#if LLVM_VERSION_MAJOR >= 18
+#if LLVM_VERSION_MAJOR >= 20
+  (void)TTI;
+  return llvm::createSimpleReduction(B, Src, RdxKind);
+#elif LLVM_VERSION_MAJOR >= 18
   (void)TTI;
   return llvm::createSimpleTargetReduction(B, Src, RdxKind);
 #else


### PR DESCRIPTION
# Overview

This has been renamed in llvm to createSimpleReduction, so modify multi_llvm.

# Reason for change

llvm 20 change causes a breakage in ock build

# Description of change

Update in multi_llvm.
