### PR TITLE
[vecz] Clear getelementptr flags.

### DIFF
--- a/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/uniform_value_analysis.cpp
@@ -385,6 +385,14 @@ void UniformValueResult::markVaryingValues(Value *V, Value *From) {
       markVaryingValues(Alloca);
     }
   } else if (GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(VIns)) {
+    // We need to clear the flags because the initial address may be out of
+    // bounds but masked out.
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+    GEP->setNoWrapFlags(GEPNoWrapFlags::none());
+#else
+    GEP->setIsInBounds(false);
+#endif
+
     // Same as with the stores
     AllocaInst *Alloca = findAllocaFromPointer(GEP->getPointerOperand());
     if (Alloca) {

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/broadcast_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/broadcast_vector.ll
@@ -99,7 +99,7 @@ entry:
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
-; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> shufflevector (<vscale x 16 x float> insertelement (<vscale x 16 x float> {{(undef|poison)}}, float 0x7FF8000020000000, {{(i32|i64)}} 0), <vscale x 16 x float> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer), ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
 
@@ -113,17 +113,17 @@ entry:
 ; CHECK-NEXT:    [[VEC_ALLOC:%.*]] = getelementptr inbounds float, ptr [[FIXLEN_ALLOC]], <vscale x 16 x i64> [[TMP0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <vscale x 16 x float> @llvm.masked.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> [[VEC_ALLOC]], i32 4, <vscale x 16 x i1> shufflevector (<vscale x 16 x i1> insertelement (<vscale x 16 x i1> poison, i1 true, {{(i32|i64)}} 0), <vscale x 16 x i1> poison, <vscale x 16 x i32> zeroinitializer), <vscale x 16 x float> undef)
 ; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
-; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = load <vscale x 16 x float>, ptr addrspace(1) [[ARRAYIDX]], align 16
 ; CHECK-NEXT:    [[TMP4:%.*]] = fadd <vscale x 16 x float> [[TMP3]], [[TMP1]]
-; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> [[TMP4]], ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
 
 ; CHECK-LABEL: @__vecz_nxv4_vector_broadcast_regression(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CALL:%.*]] = tail call i64 @__mux_get_global_id(i32 0)
-; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <vscale x 16 x i32>, ptr addrspace(1) [[ARRAYIDX]], align 16
 ; CHECK-NEXT:    [[AND1_I_I_I1_I1:%.*]] = and <vscale x 16 x i32> [[TMP1]], shufflevector (<vscale x 16 x i32> insertelement (<vscale x 16 x i32> {{(undef|poison)}}, i32 2139095040, {{i32|i64}} 0), <vscale x 16 x i32> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer)
 ; CHECK-NEXT:    [[CMP_I_I_I2_I2:%.*]] = icmp ne <vscale x 16 x i32> [[AND1_I_I_I1_I1]], shufflevector (<vscale x 16 x i32> insertelement (<vscale x 16 x i32> {{(undef|poison)}}, i32 2139095040, {{i32|i64}} 0), <vscale x 16 x i32> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer)
@@ -132,7 +132,7 @@ entry:
 ; CHECK-NEXT:    [[TMP2:%.*]] = or <vscale x 16 x i1> [[CMP_I_I_I2_I2]], [[CMP3_I_I_I4_I4]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <vscale x 16 x i32> [[TMP1]] to <vscale x 16 x float>
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <vscale x 16 x i1> [[TMP2]], <vscale x 16 x float> [[TMP3]], <vscale x 16 x float> shufflevector (<vscale x 16 x float> insertelement (<vscale x 16 x float> {{(undef|poison)}}, float 0x7FF0000020000000, {{i32|i64}} 0), <vscale x 16 x float> {{(undef|poison)}}, <vscale x 16 x i32> zeroinitializer)
-; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> [[TMP4]], ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
 ;
@@ -156,12 +156,12 @@ entry:
 ; CHECK-NEXT:    [[TMP2:%.*]] = {{s|z}}ext{{( nneg)?}} <vscale x 16 x i32> [[IDX14]] to <vscale x 16 x i64>
 ; CHECK-NEXT:    [[VEC_ALLOC:%.*]] = getelementptr inbounds i32, ptr [[FIXLEN_ALLOC]], <vscale x 16 x i64> [[TMP2]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = call <vscale x 16 x i32> @llvm.masked.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> [[VEC_ALLOC]], i32 4, <vscale x 16 x i1> shufflevector (<vscale x 16 x i1> insertelement (<vscale x 16 x i1> poison, i1 true, {{i32|i64}} 0), <vscale x 16 x i1> poison, <vscale x 16 x i32> zeroinitializer), <vscale x 16 x i32> {{(undef|poison)}})
-; CHECK-NEXT:    [[ARRAYIDX4:%.*]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) [[OUT2:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX4:%.*]] = getelementptr <4 x i32>, ptr addrspace(1) [[OUT2:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x i32> [[TMP3]], ptr addrspace(1) [[ARRAYIDX4]], align 16
-; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[IN:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = load <vscale x 16 x float>, ptr addrspace(1) [[ARRAYIDX]], align 16
 ; CHECK-NEXT:    [[V46:%.*]] = fadd <vscale x 16 x float> [[TMP6]], [[TMP1]]
-; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
+; CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr <4 x float>, ptr addrspace(1) [[OUT:%.*]], i64 [[CALL]]
 ; CHECK-NEXT:    store <vscale x 16 x float> [[V46]], ptr addrspace(1) [[ARRAYIDX3]], align 16
 ; CHECK-NEXT:    ret void
 ;

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/extract_element.ll
@@ -95,8 +95,8 @@ entry:
 ; EE: [[ALLOC:%.*]] = alloca <vscale x 16 x float>, align 64
 ; EE: store <vscale x 16 x float> {{.*}}, ptr [[ALLOC]], align 64
 ; EE: [[IDX:%.*]] = sext i32 %idx to i64
-; EE: [[ADDR:%.*]] = getelementptr inbounds float, ptr [[ALLOC]], i64 [[IDX]]
-; EE: [[GATHER:%.*]] = call <vscale x 4 x float> @__vecz_b_interleaved_load4_4_u5nxv4fu3ptr(ptr nonnull [[ADDR]])
+; EE: [[ADDR:%.*]] = getelementptr float, ptr [[ALLOC]], i64 [[IDX]]
+; EE: [[GATHER:%.*]] = call <vscale x 4 x float> @__vecz_b_interleaved_load4_4_u5nxv4fu3ptr(ptr [[ADDR]])
 
 ; Both the vector and index are uniform, so check we're not unnecessarily packetizing 
 
@@ -120,13 +120,13 @@ entry:
 ; LLVM 16 deduces add/or equivalence and uses `or` instead.
 ; EE-UNI-VEC: [[T7:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i64> [[T6]], [[MOD]]
 
-; EE-UNI-VEC: [[T8:%.*]] = getelementptr inbounds float, ptr {{%.*}}, <vscale x 4 x i64> [[T7]]
+; EE-UNI-VEC: [[T8:%.*]] = getelementptr float, ptr {{%.*}}, <vscale x 4 x i64> [[T7]]
 ; EE-UNI-VEC: [[T9:%.*]] = call <vscale x 4 x float> @__vecz_b_gather_load4_u5nxv4fu9nxv4u3ptr(<vscale x 4 x ptr> [[T8]])
 ; EE-UNI-VEC: store <vscale x 4 x float> [[T9]], ptr addrspace(1) {{%.*}}, align 4
 
 ; EE-INDICES-LABEL: @__vecz_nxv4_extract_element_varying_indices(
 ; EE-INDICES: [[ALLOC:%.*]] = alloca <vscale x 16 x float>, align 64
-; EE-INDICES: [[T0:%.*]] = getelementptr inbounds i32, ptr addrspace(1) %idxs, i64 %call
+; EE-INDICES: [[T0:%.*]] = getelementptr i32, ptr addrspace(1) %idxs, i64 %call
 ; EE-INDICES: [[T2:%.*]] = load <vscale x 4 x i32>, ptr addrspace(1) [[T0]], align 4
 ; EE-INDICES: [[T3:%.*]] = and <vscale x 4 x i32> [[T2]], shufflevector (<vscale x 4 x i32> insertelement (<vscale x 4 x i32> {{(undef|poison)}}, i32 3, {{i32|i64}} 0), <vscale x 4 x i32> {{(undef|poison)}}, <vscale x 4 x i32> zeroinitializer)
 ; EE-INDICES: store <vscale x 16 x float> {{.*}}, ptr [[ALLOC]], align 64
@@ -134,7 +134,7 @@ entry:
 ; EE-INDICES: [[T4:%.*]] = shl <vscale x 4 x i32> [[STEP]], shufflevector (<vscale x 4 x i32> insertelement (<vscale x 4 x i32> {{(undef|poison)}}, i32 2, {{i32|i64}} 0), <vscale x 4 x i32> {{(undef|poison)}}, <vscale x 4 x i32> zeroinitializer)
 ; EE-INDICES: [[T5:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i32> [[T4]], [[T3]]
 ; EE-INDICES: [[IDX:%.*]] = sext <vscale x 4 x i32> [[T5]] to <vscale x 4 x i64>
-; EE-INDICES: [[ADDR:%.*]] = getelementptr inbounds float, ptr [[ALLOC]], <vscale x 4 x i64> [[IDX]]
+; EE-INDICES: [[ADDR:%.*]] = getelementptr float, ptr [[ALLOC]], <vscale x 4 x i64> [[IDX]]
 ; EE-INDICES: [[GATHER:%.*]] = call <vscale x 4 x float> @__vecz_b_gather_load4_u5nxv4fu9nxv4u3ptr(<vscale x 4 x ptr> [[ADDR]])
 
 ; Check we promote from i1 to i8 before doing our memops

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/insert_element.ll
@@ -85,8 +85,8 @@ entry:
 ; IE: [[VAL1:%.*]] = shufflevector <vscale x 4 x float> [[VAL0]], <vscale x 4 x float> poison, <vscale x 4 x i32> zeroinitializer
 ; IE: store <vscale x 16 x float> {{.*}}, ptr [[ALLOC]], align 64
 ; IE: [[IDX:%.*]] = sext i32 %idx to i64
-; IE: [[ADDR:%.*]] = getelementptr inbounds float, ptr [[ALLOC]], i64 [[IDX]]
-; IE: call void @__vecz_b_interleaved_store4_4_u5nxv4fu3ptr(<vscale x 4 x float> [[VAL1]], ptr nonnull [[ADDR]])
+; IE: [[ADDR:%.*]] = getelementptr float, ptr [[ALLOC]], i64 [[IDX]]
+; IE: call void @__vecz_b_interleaved_store4_4_u5nxv4fu3ptr(<vscale x 4 x float> [[VAL1]], ptr [[ADDR]])
 ; IE: = load <vscale x 16 x float>, ptr [[ALLOC]], align 64
 
 ; Both the vector and index are uniform, so check we're not unnecessarily packetizing
@@ -105,7 +105,7 @@ entry:
 ; IE-INDICES: [[T3:%.*]] = {{add|or}} {{(disjoint )?}}<vscale x 4 x i32> [[T2]], {{%.*}}
 
 ; IE-INDICES: [[T4:%.*]] = sext <vscale x 4 x i32> [[T3]] to <vscale x 4 x i64>
-; IE-INDICES: [[ADDR:%.*]] = getelementptr inbounds float, ptr %0, <vscale x 4 x i64> [[T4]]
+; IE-INDICES: [[ADDR:%.*]] = getelementptr float, ptr %0, <vscale x 4 x i64> [[T4]]
 ; IE-INDICES: call void @__vecz_b_scatter_store4_u5nxv4fu9nxv4u3ptr(<vscale x 4 x float> [[VAL]], <vscale x 4 x ptr> [[ADDR]])
 ; IE-INDICES: = load <vscale x 16 x float>, ptr [[ALLOC]], align 64
 

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/packetize_mask_varying.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/packetize_mask_varying.ll
@@ -45,7 +45,7 @@ if.end:
 ; make any difference whether it's a zext or sext, but LLVM 16 prefers zext.
 ; CHECK: [[idx2:%.*]] = {{s|z}}ext{{( nneg)?}} <vscale x 16 x i32> [[idx1]] to <vscale x 16 x i64>
 
-; CHECK: [[t1:%.*]] = getelementptr inbounds i8, ptr {{.*}}, <vscale x 16 x i64> [[idx2]]
+; CHECK: [[t1:%.*]] = getelementptr i8, ptr {{.*}}, <vscale x 16 x i64> [[idx2]]
 ; CHECK: [[t2:%.*]] = call <vscale x 16 x i8> @llvm.masked.gather.nxv16i8.nxv16p0(<vscale x 16 x ptr> [[t1]],
 ; CHECK: [[splat:%.*]] = trunc <vscale x 16 x i8> [[t2]] to <vscale x 16 x i1>
 ; CHECK: call void @__vecz_b_masked_store16_u6nxv16ju3ptru6nxv16b(<vscale x 16 x i32> {{.*}}, ptr %arrayidxz, <vscale x 16 x i1> [[splat]])

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select_scalar_vector.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/select_scalar_vector.ll
@@ -50,7 +50,7 @@ entry:
 ; make any difference whether it's a zext or sext, but LLVM 16 prefers zext.
 ; CHECK: [[sext2:%.*]] = {{s|z}}ext{{( nneg)?}} <vscale x 8 x i32> [[idx1]] to <vscale x 8 x i64>
 
-; CHECK: [[addrs:%.*]] = getelementptr inbounds i8, ptr [[alloc]], <vscale x 8 x i64> [[sext2]]
+; CHECK: [[addrs:%.*]] = getelementptr i8, ptr [[alloc]], <vscale x 8 x i64> [[sext2]]
 ; CHECK: [[gather:%.*]] = call <vscale x 8 x i8> @llvm.masked.gather.nxv8i8.nxv8p0(<vscale x 8 x ptr> [[addrs]],
 ; CHECK: [[cmp:%.*]] = trunc <vscale x 8 x i8> [[gather]] to <vscale x 8 x i1>
 ; CHECK: [[sel:%.*]] = select <vscale x 8 x i1> [[cmp]], <vscale x 8 x i32> [[rhs]], <vscale x 8 x i32> shufflevector (<vscale x 8 x i32> insertelement (<vscale x 8 x i32> {{(undef|poison)}}, i32 4, {{(i32|i64)}} 0), <vscale x 8 x i32> {{(undef|poison)}}, <vscale x 8 x i32> zeroinitializer)

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/shuffle.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/shuffle.ll
@@ -39,7 +39,7 @@ define spir_kernel void @do_shuffle_splat(i32* %aptr, <4 x i32>* %bptr, <4 x i32
 ; make any difference whether it's a zext or sext, but LLVM 16 prefers zext.
 ; CHECK: [[idx2:%.*]] = {{s|z}}ext{{( nneg)?}} <vscale x 16 x i32> [[idx1]] to <vscale x 16 x i64>
 
-; CHECK: [[alloc:%.*]] = getelementptr inbounds i32, ptr %{{.*}}, <vscale x 16 x i64> [[idx2]]
+; CHECK: [[alloc:%.*]] = getelementptr i32, ptr %{{.*}}, <vscale x 16 x i64> [[idx2]]
 ; CHECK: [[splat:%.*]] = call <vscale x 16 x i32> @llvm.masked.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> [[alloc]],
 ; CHECK: store <vscale x 16 x i32> [[splat]], ptr
 }

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
@@ -54,7 +54,7 @@ define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrs
 ; CHECK: [[STEPVEC:%.*]] = call <vscale x 4 x i32> @llvm.{{(experimental\.)?}}stepvector.nxv4i32()
 ; CHECK: [[LID:%.*]] = add <vscale x 4 x i32> [[SPLAT]], [[STEPVEC]]
 ; CHECK: [[EXT:%.*]] = sext i32 %call to i64
-; CHECK: %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
+; CHECK: %arrayidx = getelementptr i32, ptr addrspace(1) %out, i64 [[EXT]]
 ; CHECK: store <vscale x 4 x i32> [[LID]], ptr addrspace(1) %arrayidx
 }
 

--- a/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_loop.ll
+++ b/modules/compiler/vecz/test/lit/llvm/control_flow_conversion_uniform_loop.ll
@@ -167,7 +167,7 @@ declare i64 @__mux_get_global_id(i32)
 ; CHECK: for.body:
 ; CHECK: %add = add nsw i32 %storemerge, %a
 ; CHECK: %idxprom = sext i32 %add2 to i64
-; CHECK: %arrayidx = getelementptr inbounds i32, ptr %b, i64 %idxprom
+; CHECK: %arrayidx = getelementptr i32, ptr %b, i64 %idxprom
 ; CHECK: store i32 %add, ptr %arrayidx, align 4
 ; CHECK: %inc = add nsw i32 %storemerge, 1
 ; CHECK: br label %for.cond

--- a/modules/compiler/vecz/test/lit/llvm/extractelement_constant_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/extractelement_constant_index.ll
@@ -35,6 +35,6 @@ declare i64 @__mux_get_global_id(i32) #1
 
 ; CHECK: define spir_kernel void @__vecz_v4_extract_constant_index
 ; CHECK: call <4 x float> @__vecz_b_interleaved_load4_4_Dv4
-; CHECK: getelementptr inbounds float
+; CHECK: getelementptr float
 ; CHECK: store <4 x float>
 ; CHECK: ret void

--- a/modules/compiler/vecz/test/lit/llvm/load_add_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/load_add_store.ll
@@ -34,9 +34,9 @@ entry:
   ret void
 ; CHECK-LABEL: @__vecz_v4_load_add_store(ptr %aptr, ptr %bptr, ptr %zptr)
 ; CHECK: %idx = call i64 @__mux_get_global_id(i32 0)
-; CHECK: %arrayidxa = getelementptr inbounds i32, ptr %aptr, i64 %idx
-; CHECK: %arrayidxb = getelementptr inbounds i32, ptr %bptr, i64 %idx
-; CHECK: %arrayidxz = getelementptr inbounds i32, ptr %zptr, i64 %idx
+; CHECK: %arrayidxa = getelementptr i32, ptr %aptr, i64 %idx
+; CHECK: %arrayidxb = getelementptr i32, ptr %bptr, i64 %idx
+; CHECK: %arrayidxz = getelementptr i32, ptr %zptr, i64 %idx
 ; CHECK: %[[TMP0:.*]] = load <4 x i32>, ptr %arrayidxa, align 4
 ; CHECK: %[[TMP1:.*]] = load <4 x i32>, ptr %arrayidxb, align 4
 ; CHECK: %sum1 = add <4 x i32> %[[TMP0]], %[[TMP1]]

--- a/modules/compiler/vecz/test/lit/llvm/packetization_uniform_branch.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_uniform_branch.ll
@@ -91,12 +91,12 @@ declare i64 @__mux_get_global_id(i32)
 ; CHECK: br i1 %cmp, label %if.then, label %if.else
 
 ; CHECK: if.then:
-; CHECK: %[[GEP1:.+]] = getelementptr inbounds i32, ptr %b, <4 x i64>
+; CHECK: %[[GEP1:.+]] = getelementptr i32, ptr %b, <4 x i64>
 ; CHECK: store <4 x i32> <i32 11, i32 11, i32 11, i32 11>, ptr %{{.+}}, align 4
 ; CHECK: br label %if.end
 
 ; CHECK: if.else:
-; CHECK: %[[GEP2:.+]] = getelementptr inbounds i32, ptr %b, <4 x i64>
+; CHECK: %[[GEP2:.+]] = getelementptr i32, ptr %b, <4 x i64>
 ; CHECK: store <4 x i32> <i32 13, i32 13, i32 13, i32 13>, ptr %{{.+}}, align 4
 ; CHECK: br label %if.end
 

--- a/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
@@ -42,5 +42,5 @@ declare i64 @__mux_get_global_id(i32)
 ; Check if we can packetize GEPs on structs
 ; Note that we only need to packetize the non-uniform operands..
 ; CHECK: define spir_kernel void @__vecz_v4_test
-; CHECK: getelementptr inbounds %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2
-; CHECK: getelementptr inbounds %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2
+; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2
+; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2

--- a/modules/compiler/vecz/test/lit/llvm/pass_pipeline_printafter.ll
+++ b/modules/compiler/vecz/test/lit/llvm/pass_pipeline_printafter.ll
@@ -25,14 +25,14 @@ declare i64 @__mux_get_global_id(i32)
 ; CHECK: IR Dump After Simplify masked memory operations{{( on __vecz_v2_foo)?}}
 ; CHECK-NEXT: define spir_kernel void @__vecz_v2_foo(ptr addrspace(1) %out) #0 {
 ; CHECK-NEXT:   %idx = call i64 @__mux_get_global_id(i32 0)
-; CHECK-NEXT:   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 %idx
+; CHECK-NEXT:   %arrayidx = getelementptr i32, ptr addrspace(1) %out, i64 %idx
 ; CHECK-NEXT:   store i32 0, ptr addrspace(1) %arrayidx, align 4
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }
 
 ; CHECK: define spir_kernel void @__vecz_v2_foo(ptr addrspace(1) %out) {{.*}} {
 ; CHECK-NEXT:   %idx = call i64 @__mux_get_global_id(i32 0)
-; CHECK-NEXT:   %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 %idx
+; CHECK-NEXT:   %arrayidx = getelementptr i32, ptr addrspace(1) %out, i64 %idx
 ; CHECK-NEXT:   store <2 x i32> zeroinitializer, ptr addrspace(1) %arrayidx, align 4
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_instructions.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_instructions.ll
@@ -78,20 +78,20 @@ entry:
 ; CHECK: store i32 %[[ADD2]], ptr %[[C_1]]
 ; CHECK: store i32 %[[ADD3]], ptr %[[C_2]]
 ; CHECK: store i32 %[[ADD4]], ptr %[[C_3]]
-; CHECK: %arrayidx3 = getelementptr inbounds <4 x i32>, ptr %a, i64 1
-; CHECK: %[[A1_0:.+]] = getelementptr inbounds i32, ptr %arrayidx3, i32 0
-; CHECK: %[[A1_1:.+]] = getelementptr inbounds i32, ptr %arrayidx3, i32 1
-; CHECK: %[[A1_2:.+]] = getelementptr inbounds i32, ptr %arrayidx3, i32 2
-; CHECK: %[[A1_3:.+]] = getelementptr inbounds i32, ptr %arrayidx3, i32 3
+; CHECK: %arrayidx3 = getelementptr <4 x i32>, ptr %a, i64 1
+; CHECK: %[[A1_0:.+]] = getelementptr i32, ptr %arrayidx3, i32 0
+; CHECK: %[[A1_1:.+]] = getelementptr i32, ptr %arrayidx3, i32 1
+; CHECK: %[[A1_2:.+]] = getelementptr i32, ptr %arrayidx3, i32 2
+; CHECK: %[[A1_3:.+]] = getelementptr i32, ptr %arrayidx3, i32 3
 ; CHECK: %[[LA1_0:.+]] = load i32, ptr %[[A1_0]]
 ; CHECK: %[[LA1_1:.+]] = load i32, ptr %[[A1_1]]
 ; CHECK: %[[LA1_2:.+]] = load i32, ptr %[[A1_2]]
 ; CHECK: %[[LA1_3:.+]] = load i32, ptr %[[A1_3]]
-; CHECK: %arrayidx4 = getelementptr inbounds <4 x i32>, ptr %b, i64 1
-; CHECK: %[[B1_0:.+]] = getelementptr inbounds i32, ptr %arrayidx4, i32 0
-; CHECK: %[[B1_1:.+]] = getelementptr inbounds i32, ptr %arrayidx4, i32 1
-; CHECK: %[[B1_2:.+]] = getelementptr inbounds i32, ptr %arrayidx4, i32 2
-; CHECK: %[[B1_3:.+]] = getelementptr inbounds i32, ptr %arrayidx4, i32 3
+; CHECK: %arrayidx4 = getelementptr <4 x i32>, ptr %b, i64 1
+; CHECK: %[[B1_0:.+]] = getelementptr i32, ptr %arrayidx4, i32 0
+; CHECK: %[[B1_1:.+]] = getelementptr i32, ptr %arrayidx4, i32 1
+; CHECK: %[[B1_2:.+]] = getelementptr i32, ptr %arrayidx4, i32 2
+; CHECK: %[[B1_3:.+]] = getelementptr i32, ptr %arrayidx4, i32 3
 ; CHECK: %[[LB1_0:.+]] = load i32, ptr %[[B1_0]]
 ; CHECK: %[[LB1_1:.+]] = load i32, ptr %[[B1_1]]
 ; CHECK: %[[LB1_2:.+]] = load i32, ptr %[[B1_2]]
@@ -104,20 +104,20 @@ entry:
 ; CHECK: %[[SEXT11:.+]] = sext i1 %[[CMP6]] to i32
 ; CHECK: %[[SEXT12:.+]] = sext i1 %[[CMP8]] to i32
 ; CHECK: %[[SEXT13:.+]] = sext i1 %[[CMP9]] to i32
-; CHECK: %arrayidx5 = getelementptr inbounds <4 x i32>, ptr %c, i64 1
-; CHECK: %[[C1_0:.+]] = getelementptr inbounds i32, ptr %arrayidx5, i32 0
-; CHECK: %[[C1_1:.+]] = getelementptr inbounds i32, ptr %arrayidx5, i32 1
-; CHECK: %[[C1_2:.+]] = getelementptr inbounds i32, ptr %arrayidx5, i32 2
-; CHECK: %[[C1_3:.+]] = getelementptr inbounds i32, ptr %arrayidx5, i32 3
+; CHECK: %arrayidx5 = getelementptr <4 x i32>, ptr %c, i64 1
+; CHECK: %[[C1_0:.+]] = getelementptr i32, ptr %arrayidx5, i32 0
+; CHECK: %[[C1_1:.+]] = getelementptr i32, ptr %arrayidx5, i32 1
+; CHECK: %[[C1_2:.+]] = getelementptr i32, ptr %arrayidx5, i32 2
+; CHECK: %[[C1_3:.+]] = getelementptr i32, ptr %arrayidx5, i32 3
 ; CHECK: store i32 %[[SEXT10]], ptr %[[C1_0]]
 ; CHECK: store i32 %[[SEXT11]], ptr %[[C1_1]]
 ; CHECK: store i32 %[[SEXT12]], ptr %[[C1_2]]
 ; CHECK: store i32 %[[SEXT13]], ptr %[[C1_3]]
-; CHECK: %arrayidx6 = getelementptr inbounds <4 x i32>, ptr %a, i64 2
-; CHECK: %[[A2_0:.+]] = getelementptr inbounds i32, ptr %arrayidx6, i32 0
-; CHECK: %[[A2_1:.+]] = getelementptr inbounds i32, ptr %arrayidx6, i32 1
-; CHECK: %[[A2_2:.+]] = getelementptr inbounds i32, ptr %arrayidx6, i32 2
-; CHECK: %[[A2_3:.+]] = getelementptr inbounds i32, ptr %arrayidx6, i32 3
+; CHECK: %arrayidx6 = getelementptr <4 x i32>, ptr %a, i64 2
+; CHECK: %[[A2_0:.+]] = getelementptr i32, ptr %arrayidx6, i32 0
+; CHECK: %[[A2_1:.+]] = getelementptr i32, ptr %arrayidx6, i32 1
+; CHECK: %[[A2_2:.+]] = getelementptr i32, ptr %arrayidx6, i32 2
+; CHECK: %[[A2_3:.+]] = getelementptr i32, ptr %arrayidx6, i32 3
 ; CHECK: %[[LA2_0:.+]] = load i32, ptr %[[A2_0]]
 ; CHECK: %[[LA2_1:.+]] = load i32, ptr %[[A2_1]]
 ; CHECK: %[[LA2_2:.+]] = load i32, ptr %[[A2_2]]
@@ -130,11 +130,11 @@ entry:
 ; CHECK: %[[SEXT819:.+]] = sext i1 %[[CMP715]] to i32
 ; CHECK: %[[SEXT820:.+]] = sext i1 %[[CMP716]] to i32
 ; CHECK: %[[SEXT821:.+]] = sext i1 %[[CMP717]] to i32
-; CHECK: %arrayidx9 = getelementptr inbounds <4 x i32>, ptr %c, i64 2
-; CHECK: %[[C2_0:.+]] = getelementptr inbounds i32, ptr %arrayidx9, i32 0
-; CHECK: %[[C2_1:.+]] = getelementptr inbounds i32, ptr %arrayidx9, i32 1
-; CHECK: %[[C2_2:.+]] = getelementptr inbounds i32, ptr %arrayidx9, i32 2
-; CHECK: %[[C2_3:.+]] = getelementptr inbounds i32, ptr %arrayidx9, i32 3
+; CHECK: %arrayidx9 = getelementptr <4 x i32>, ptr %c, i64 2
+; CHECK: %[[C2_0:.+]] = getelementptr i32, ptr %arrayidx9, i32 0
+; CHECK: %[[C2_1:.+]] = getelementptr i32, ptr %arrayidx9, i32 1
+; CHECK: %[[C2_2:.+]] = getelementptr i32, ptr %arrayidx9, i32 2
+; CHECK: %[[C2_3:.+]] = getelementptr i32, ptr %arrayidx9, i32 3
 ; CHECK: store i32 %[[SEXT818]], ptr %[[C2_0]]
 ; CHECK: store i32 %[[SEXT819]], ptr %[[C2_1]]
 ; CHECK: store i32 %[[SEXT820]], ptr %[[C2_2]]

--- a/modules/compiler/vecz/test/lit/llvm/scalarize_mixed_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarize_mixed_gep.ll
@@ -42,5 +42,5 @@ define void @bar(i64** %ptrptrs, i64 %val) {
 ; gets scalarized/re-packetized correctly
 
 ; CHECK: define void @__vecz_v4_bar
-; CHECK: %[[ADDR:.+]] = getelementptr inbounds {{i64|i8}}, <4 x ptr> %{{.+}}, {{i64 2|i64 16}}
+; CHECK: %[[ADDR:.+]] = getelementptr {{i64|i8}}, <4 x ptr> %{{.+}}, {{i64 2|i64 16}}
 ; CHECK: call void @__vecz_b_scatter_store8_Dv4_mDv4_u3ptr(<4 x i64> %.splat{{.*}}, <4 x ptr> %[[ADDR]])

--- a/modules/compiler/vecz/test/lit/llvm/squash_float2_gather.ll
+++ b/modules/compiler/vecz/test/lit/llvm/squash_float2_gather.ll
@@ -44,12 +44,12 @@ attributes #2 = { nobuiltin nounwind }
 ;
 ; CHECK: void @__vecz_v4_squash
 ; CHECK:  %[[GID:.+]] = call i64 @__mux_get_global_id(i64 0) #[[ATTRS:[0-9]+]]
-; CHECK:  %[[IDX_PTR:.+]] = getelementptr inbounds i64, ptr addrspace(1) %idx, i64 %[[GID]]
+; CHECK:  %[[IDX_PTR:.+]] = getelementptr i64, ptr addrspace(1) %idx, i64 %[[GID]]
 ; CHECK:  %[[WIDE_LOAD:.+]] = load <4 x i64>, ptr addrspace(1) %[[IDX_PTR]], align 8
-; CHECK:  %[[DATA_PTR:.+]] = getelementptr inbounds <2 x float>, ptr addrspace(1) %data, <4 x i64> %[[WIDE_LOAD]]
+; CHECK:  %[[DATA_PTR:.+]] = getelementptr <2 x float>, ptr addrspace(1) %data, <4 x i64> %[[WIDE_LOAD]]
 ; CHECK:  %[[GATHER:.+]] = call <4 x i64> @__vecz_b_gather_load8_Dv4_mDv4_u3ptrU3AS1(<4 x ptr addrspace(1)> %[[DATA_PTR]])
 ; CHECK:  %[[UNSQUASH:.+]] = bitcast <4 x i64> %[[GATHER]] to <8 x float>
-; CHECK:  %[[OUTPUT_PTR:.+]] = getelementptr inbounds <2 x float>, ptr addrspace(1) %output, i64 %[[GID]]
+; CHECK:  %[[OUTPUT_PTR:.+]] = getelementptr <2 x float>, ptr addrspace(1) %output, i64 %[[GID]]
 ; CHECK:  store <8 x float> %[[UNSQUASH]], ptr addrspace(1) %[[OUTPUT_PTR]], align 8
 ; CHECK:  ret void
 

--- a/modules/compiler/vecz/test/lit/llvm/stride_analysis.ll
+++ b/modules/compiler/vecz/test/lit/llvm/stride_analysis.ll
@@ -30,48 +30,48 @@ entry:
 ; CHECK-NEXT: uniform
   %lduniform = load i8, ptr addrspace(1) %input, align 1
 
-; CHECK: Stride for %arrayidx0 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0
+; CHECK: Stride for %arrayidx0 = getelementptr i8, ptr addrspace(1) %input, i64 %globalid0
 ; CHECK-NEXT: linear stride of 1
   %arrayidx0 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0
   %ld0 = load i8, ptr addrspace(1) %arrayidx0, align 1
 
   %truncglobalid0 = trunc i64 %globalid0 to i32
 
-; CHECK: Stride for %arrayidx1 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %sexttruncglobalid0
+; CHECK: Stride for %arrayidx1 = getelementptr i8, ptr addrspace(1) %input, i64 %sexttruncglobalid0
 ; CHECK-NEXT: linear stride of 1
   %sexttruncglobalid0 = sext i32 %truncglobalid0 to i64
   %arrayidx1 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %sexttruncglobalid0
   %ld1 = load i8, ptr addrspace(1) %arrayidx1, align 1
 
-; CHECK: Stride for %arrayidx2 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %zexttruncglobalid0
+; CHECK: Stride for %arrayidx2 = getelementptr i8, ptr addrspace(1) %input, i64 %zexttruncglobalid0
 ; CHECK-NEXT: divergent
   %zexttruncglobalid0 = zext i32 %truncglobalid0 to i64
   %arrayidx2 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %zexttruncglobalid0
   %ld2 = load i8, ptr addrspace(1) %arrayidx2, align 1
 
-; CHECK: Stride for %arrayidx3 = getelementptr inbounds i32, ptr addrspace(1) %input, i64 %globalid0
+; CHECK: Stride for %arrayidx3 = getelementptr i32, ptr addrspace(1) %input, i64 %globalid0
 ; CHECK-NEXT: linear stride of 4
   %arrayidx3 = getelementptr inbounds i32, ptr addrspace(1) %input, i64 %globalid0
   %ld3 = load i8, ptr addrspace(1) %arrayidx3, align 1
 
-; CHECK: Stride for %arrayidx4 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0mul8
+; CHECK: Stride for %arrayidx4 = getelementptr i8, ptr addrspace(1) %input, i64 %globalid0mul8
 ; CHECK-NEXT: linear stride of 8
   %globalid0mul8 = mul i64 %globalid0, 8
   %arrayidx4 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0mul8
   %ld4 = load i8, ptr addrspace(1) %arrayidx4, align 1
 
-; CHECK: Stride for %arrayidx5 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0mul16
+; CHECK: Stride for %arrayidx5 = getelementptr i8, ptr addrspace(1) %input, i64 %globalid0mul16
 ; CHECK-NEXT: linear stride of 16
   %globalid0mul16 = mul i64 %globalid0mul8, 2
   %arrayidx5 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %globalid0mul16
   %ld5 = load i8, ptr addrspace(1) %arrayidx5, align 1
 
-; CHECK: Stride for %arrayidx6 = getelementptr inbounds i32, ptr addrspace(1) %input, i64 %globalid0mul8
+; CHECK: Stride for %arrayidx6 = getelementptr i32, ptr addrspace(1) %input, i64 %globalid0mul8
 ; CHECK-NEXT: linear stride of 32
   %arrayidx6 = getelementptr inbounds i32, ptr addrspace(1) %input, i64 %globalid0mul8
   %ld6 = load i32, ptr addrspace(1) %arrayidx6, align 1
 
-; CHECK: Stride for %arrayidx7 = getelementptr inbounds i16, ptr addrspace(1) %input, i64 %idxprom7
+; CHECK: Stride for %arrayidx7 = getelementptr i16, ptr addrspace(1) %input, i64 %idxprom7
 ; CHECK-NEXT: linear stride of 2
   %mul7 = mul i64 %localsize0, %groupid0
   %add7 = add i64 %mul7, %localid0
@@ -81,7 +81,7 @@ entry:
   %arrayidx7 = getelementptr inbounds i16, ptr addrspace(1) %input, i64 %idxprom7
   %ld7 = load i16, ptr addrspace(1) %arrayidx7, align 1
 
-; CHECK: Stride for %arrayidx8 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom8
+; CHECK: Stride for %arrayidx8 = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom8
 ; CHECK-NEXT: divergent
   %mul8 = mul i64 %localsize0, %groupid0
   %add8 = add i64 %mul8, %localid0
@@ -91,7 +91,7 @@ entry:
   %arrayidx8 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom8
   %ld8 = load i8, ptr addrspace(1) %arrayidx8, align 1
 
-; CHECK: Stride for %arrayidx9 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom9
+; CHECK: Stride for %arrayidx9 = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom9
 ; CHECK-NEXT: divergent
   %mul9 = mul i64 %groupid0, %localsize0
   %add9 = add nuw nsw i64 %localid0, 4294967295
@@ -115,7 +115,7 @@ entry:
   %conv = add i32 %0, -1
   %trunclocalsize0 = trunc i64 %localsize0 to i32
 
-; CHECK: Stride for %arrayidx_pre = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom_pre
+; CHECK: Stride for %arrayidx_pre = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom_pre
 ; CHECK-NEXT: divergent
   %idxprom_pre = zext i32 %conv to i64
   %arrayidx_pre = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom_pre
@@ -126,7 +126,7 @@ entry:
 for.body:
 ; The below is fundamentally the same stride calculation as %arrayidx_pre -
 ; make sure the loop and the PHI don't throw off the analysis.
-; CHECK: Stride for %arrayidx_loop = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom_loop
+; CHECK: Stride for %arrayidx_loop = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom_loop
 ; CHECK-NEXT: divergent
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %for.body ]
   %gx2.050.us = phi i32 [ %conv, %entry ], [ %conv26.us, %for.body ]
@@ -154,7 +154,7 @@ entry:
   %add = add i64 %mul, %localid0
   %addtrunc = trunc i64 %add to i32
 
-; CHECK: Stride for %arrayidx0 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom0
+; CHECK: Stride for %arrayidx0 = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom0
 ; CHECK-NEXT: divergent
   %idxprom0 = zext i32 %addtrunc to i64
   %arrayidx0 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom0
@@ -162,7 +162,7 @@ entry:
 
 ; The below is fundamentally the same stride calculation as %arrayidx0 - make
 ; sure the select doesn't throw off the analysis.
-; CHECK: Stride for %arrayidx1 = getelementptr inbounds i8, ptr addrspace(1) %input, i64 %idxprom1
+; CHECK: Stride for %arrayidx1 = getelementptr i8, ptr addrspace(1) %input, i64 %idxprom1
 ; CHECK-NEXT: divergent
   %sel1 = select i1 %cmp, i32 %addtrunc, i32 %addtrunc
   %idxprom1 = zext i32 %sel1 to i64

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_broadcast.ll
@@ -41,5 +41,5 @@ define spir_kernel void @sub_group_broadcast(i32 addrspace(1)* %in, i32 addrspac
 ; CHECK: [[BCAST:%.+]] = shufflevector <4 x i32> [[INS]], <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK: %idx = tail call i32 @__mux_get_sub_group_local_id()
 ; CHECK: [[EXT:%.*]] = sext i32 %idx to i64
-; CHECK: %arrayidx2 = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
+; CHECK: %arrayidx2 = getelementptr i32, ptr addrspace(1) %out, i64 [[EXT]]
 ; CHECK: store <4 x i32> [[BCAST]], ptr addrspace(1) %arrayidx2, align 4

--- a/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/subgroup_builtins.ll
@@ -50,7 +50,7 @@ define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrs
 ; CHECK: [[SPLAT:%.*]] = shufflevector <4 x i32> [[SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK: [[ID:%.*]] = or {{(disjoint )?}}<4 x i32> [[SPLAT]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK: [[EXT:%.*]] = sext i32 %call to i64
-; CHECK: %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %out, i64 [[EXT]]
+; CHECK: %arrayidx = getelementptr i32, ptr addrspace(1) %out, i64 [[EXT]]
 ; CHECK: store <4 x i32> [[ID]], ptr addrspace(1) %arrayidx
 }
 

--- a/modules/compiler/vecz/test/lit/llvm/uniform_address_base.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_address_base.ll
@@ -49,8 +49,8 @@ declare i64 @__mux_get_global_id(i32) local_unnamed_addr #1
 ; CHECK: define spir_kernel void @__vecz_v4_uniform_address_index
 ; CHECK: entry:
 ; CHECK: call i64 @__mux_get_global_id(i32 0)
-; CHECK-DAG: %[[INA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %in, i32 %[[X:.+]]
+; CHECK-DAG: %[[INA:.+]] = getelementptr i32, ptr addrspace(1) %in, i32 %[[X:.+]]
 ; CHECK-DAG: %[[LOAD:.+]] = load <4 x i32>, ptr addrspace(1) %[[INA]]
-; CHECK-DAG: %[[OUTA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %out, i32 %[[X:.+]]
+; CHECK-DAG: %[[OUTA:.+]] = getelementptr i32, ptr addrspace(1) %out, i32 %[[X:.+]]
 ; CHECK-DAG: store <4 x i32> %[[LOAD]], ptr addrspace(1) %[[OUTA]]
 ; CHECK-NOT: call <4 x i32>

--- a/modules/compiler/vecz/test/lit/llvm/uniform_address_index.ll
+++ b/modules/compiler/vecz/test/lit/llvm/uniform_address_index.ll
@@ -49,8 +49,8 @@ declare i64 @__mux_get_global_id(i32) local_unnamed_addr #1
 ; CHECK: define spir_kernel void @__vecz_v4_uniform_address_index
 ; CHECK: entry:
 ; CHECK: call i64 @__mux_get_global_id(i32 0)
-; CHECK-DAG: %[[INA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %in, i32 %[[X:.+]]
+; CHECK-DAG: %[[INA:.+]] = getelementptr i32, ptr addrspace(1) %in, i32 %[[X:.+]]
 ; CHECK-DAG: %[[LOAD:.+]] = load <4 x i32>, ptr addrspace(1) %[[INA]]
-; CHECK-DAG: %[[OUTA:.+]] = getelementptr inbounds i32, ptr addrspace(1) %out, i32 %[[X:.+]]
+; CHECK-DAG: %[[OUTA:.+]] = getelementptr i32, ptr addrspace(1) %out, i32 %[[X:.+]]
 ; CHECK-DAG: store <4 x i32> %[[LOAD]], ptr addrspace(1) %[[OUTA]]
 ; CHECK-NOT: call <4 x i32>


### PR DESCRIPTION
# Overview

[vecz] Clear getelementptr flags.

# Reason for change

If a getelementptr has inbounds/nusw/nuw flags, it is valid for the result to be out of bounds or to wrap so long as the result is not used to access any object. However, if we vectorize, multiple elements will all be loaded based on the first element's address, and in that we may add accesses, so we need to clear the inbounds/nusw/nuw flags unless we can prove they are still valid.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
