### PR TITLE
[UnitCL] Fix C11Atomics_73_*, C11Atomics_74_*, C11Atomics_75_*

### DIFF
--- a/source/cl/test/UnitCL/source/C11Atomics.cpp
+++ b/source/cl/test/UnitCL/source/C11Atomics.cpp
@@ -2365,7 +2365,7 @@ class WeakGlobalSingle : public C11AtomicTestBase {
       return desired_values[index];
     };
     kts::Reference1D<cl_int> bool_output_reference =
-        [success_index, weak_exchange_failed](size_t index) {
+        [success_index, &weak_exchange_failed](size_t index) {
           return index == success_index && !weak_exchange_failed;
         };
 


### PR DESCRIPTION
# Overview

[UnitCL] Fix C11Atomics_73_*, C11Atomics_74_*, C11Atomics_75_*

# Reason for change

These tests test atomic_compare_exchange_weak_explicit which is allowed to fail for no clear reason. The test tries to account for this by detecting output differences, using that to set a weak_exchange_failed boolean, and using that weak_exchange_failed boolean to detect where the result of atomic_compare_exchange_weak_explicit does not match expectations. That is, in output_reference, it does:

          if (value == expected_values[success_index]) {
            weak_exchange_failed = true;
            return true;
          }

Then, bool_output_reference is:

        [success_index, weak_exchange_failed](size_t index) {
          return index == success_index && !weak_exchange_failed;
        };

The problem here is that bool_output_reference is constructed capturing weak_exchange_failed by value, so it will never pick up the updated value even if it was detected that the weak exchange had failed.

# Description of change

To fix this, capture it by reference instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
