### PR TITLE
lldLinkToBinary: disable subreg liveness.

### DIFF
--- a/modules/compiler/utils/source/lld_linker.cpp
+++ b/modules/compiler/utils/source/lld_linker.cpp
@@ -146,6 +146,18 @@ Expected<std::unique_ptr<MemoryBuffer>> lldLinkToBinary(
   }
 #endif  // NDEBUG
 
+#if LLVM_VERSION_LESS(20, 0)
+  // LLVM's register allocator has issues with early-clobbers if subreg liveness
+  // is enabled. The InitUndef pass documents this and attempts to work around
+  // it, but prior to <https://github.com/llvm/llvm-project/pull/90967>, the
+  // InitUndef pass would not work reliably when multiple functions were
+  // processed, because internal state from one function would be kept around
+  // when processing the next. As we have no good way of fixing the InitUndef
+  // pass in older LLVM versions, disable subreg liveness instead.
+  args.push_back("-mllvm");
+  args.push_back("-enable-subreg-liveness=false");
+#endif
+
   for (const auto &arg : additionalLinkArgs) {
     args.push_back(arg);
   }


### PR DESCRIPTION
# Overview

lldLinkToBinary: disable subreg liveness.

# Reason for change

On LLVM versions prior to LLVM 20, enabling subreg liveness would lead to invalid code generation if an instruction defined an early-clobber register, used another register, and the register allocator wrongly allocated the subregister of the other register as the early-clobber def.

# Description of change

Work around this by disabling subreg liveness.

# Anything else we should know?

This is done in lldLinkToBinary so that it does not affect host: at the moment, we only know this to be a problem with RISC-V, and only when RVV is enabled. On host, we do not yet provide a supported way of enabling RVV.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
