### PR TITLE
[NFC] Fix CMakeCache comments.

### DIFF
--- a/modules/compiler/targets/host/CMakeLists.txt
+++ b/modules/compiler/targets/host/CMakeLists.txt
@@ -188,8 +188,13 @@ if(CA_HOST_CROSS_COMPILERS)
     target_compile_definitions(compiler-host PRIVATE
     CA_HOST_TARGET_${HOST_ARCH_UPPER}_CPU="${CA_HOST_TARGET_${HOST_ARCH_UPPER}_CPU}")
   endif()
+  set(CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES_DESC
+    "Feature list that host ${HOST_ARCH_UPPER} should enable or disable as a comma separated + or - list")
+  if(HOST_ARCH_UPPER STREQUAL RISCV32 OR HOST_ARCH_UPPER STREQUAL RISCV64)
+    string(APPEND CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES_DESC " e.g. '+v,+zfh'")
+  endif()
   ca_option(CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES STRING
-    "Feature list that host ${HOST_ARCH_UPPER} should enable or disable as a comma separated + or - list e.g. '+v,+zfh'" "")
+    "${CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES_DESC}" "")
   if(CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES)
     message(STATUS "Features ${HOST_ARCH_UPPER} name ${CA_HOST_TARGET_${HOST_ARCH_UPPER}_FEATURES}")
     target_compile_definitions(compiler-host PRIVATE
@@ -236,8 +241,13 @@ if(CA_HOST_CROSS_COMPILERS)
           target_compile_definitions(compiler-host PRIVATE
           CA_HOST_TARGET_${CROSS_COMPILER}_CPU="${CA_HOST_TARGET_${CROSS_COMPILER}_CPU}")
         endif()
+        set(CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES_DESC
+          "Feature list that host ${CROSS_COMPILER} should enable or disable as a comma separated + or - list")
+        if(CROSS_COMPILER STREQUAL "RISCV32" OR CROSS_COMPILER STREQUAL "RISCV64")
+          string(APPEND CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES_DESC " e.g. '+v,+zfh'")
+        endif()
         ca_option(CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES STRING
-          "Feature list that host ${HOST_ARCH_UPPER} should enable or disable as a comma separated + or - list e.g. '+v,+zfh'" "")
+          "${CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES_DESC}" "")
         if(CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES)
           message(STATUS "Features ${CROSS_COMPILER} name ${CA_HOST_TARGET_${CROSS_COMPILER}_FEATURES}")
           target_compile_definitions(compiler-host PRIVATE


### PR DESCRIPTION
# Overview

[NFC] Fix CMakeCache comments.

# Reason for change

We were using the wrong host in the comment for e.g. CA_HOST_TARGET_AARCH64_FEATURES so that depending on configuration, we might document that as controlling RISCV64 features, and giving RISCV64-specific features as an example.

# Description of change

- Leave off "e.g. '+v,+zfh'" when the target is not RISC-V.
- For cross compilers, use the correct host.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
