### PR TITLE
Add codeowners file to limit reviewers to known teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+@codeplaysoftware/ock-reviewers
+
+# limit the workflow to a subset of the overall reviewers for security reasons.
+.github @codeplaysoftware/ock-workflow-reviewers


### PR DESCRIPTION


# Overview

Add CODEOWNERS file under .github.

# Reason for change

Support limiting reviewers for security reasons.

# Description of change

This has overall reviewers (@codeplaysoftware/ock-reviewers) and workflow reviewers (@codeplaysoftware/ock-workflow-reviewers) for anything under .github.
