### PR TITLE
Dependency pinning

### DIFF
--- a/.github/actions/build_portBLAS_action/action.yml
+++ b/.github/actions/build_portBLAS_action/action.yml
@@ -46,7 +46,7 @@ runs:
         tar -cvzf portBLAS_build.tar.gz portBLAS_build_dir
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: portBLAS_build
         path: portBLAS_build.tar.gz

--- a/.github/actions/build_portBLAS_action/action.yml
+++ b/.github/actions/build_portBLAS_action/action.yml
@@ -46,7 +46,7 @@ runs:
         tar -cvzf portBLAS_build.tar.gz portBLAS_build_dir
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: portBLAS_build
         path: portBLAS_build.tar.gz

--- a/.github/actions/build_portDNN_action/action.yml
+++ b/.github/actions/build_portDNN_action/action.yml
@@ -47,7 +47,7 @@ runs:
         tar -cvzf portDNN_build.tar.gz portDNN_build_dir
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: portDNN_build
         path: portDNN_build.tar.gz

--- a/.github/actions/build_portDNN_action/action.yml
+++ b/.github/actions/build_portDNN_action/action.yml
@@ -47,7 +47,7 @@ runs:
         tar -cvzf portDNN_build.tar.gz portDNN_build_dir
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: portDNN_build
         path: portDNN_build.tar.gz

--- a/.github/actions/build_vgg_resnet_action/action.yml
+++ b/.github/actions/build_vgg_resnet_action/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: '3.8'
 
@@ -88,7 +88,7 @@ runs:
         tar -cvzf network_artifacts.tar.gz vgg_data resnet_data Labrador_Retriever_Molly.jpg Labrador_Retriever_Molly.jpg.bin
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: network_build
         path: network_artifacts.tar.gz

--- a/.github/actions/build_vgg_resnet_action/action.yml
+++ b/.github/actions/build_vgg_resnet_action/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: setup python
-      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
 
@@ -88,7 +88,7 @@ runs:
         tar -cvzf network_artifacts.tar.gz vgg_data resnet_data Labrador_Retriever_Molly.jpg Labrador_Retriever_Molly.jpg.bin
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: network_build
         path: network_artifacts.tar.gz

--- a/.github/actions/setup_ubuntu_build/action.yml
+++ b/.github/actions/setup_ubuntu_build/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install prerequisites
-      shell: bash    
+      shell: bash
       run: |
         sudo apt-get install -y spirv-tools
         pip install lit
@@ -32,7 +32,7 @@ runs:
       uses: llvm/actions/install-ninja@main
 
     - name: load llvm
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: llvm_install/**
         key: llvm-ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.arch }}-v${{ inputs.llvm_version}}-${{ inputs.llvm_build_type }}
@@ -40,10 +40,9 @@ runs:
 
       # note the PR testing usage should set 'save' to false, to avoid PR testing creating new caches on a branch
     - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@ed74d11c0b343532753ecead8a951bb09bb34bc9 # v1.2.14
       with:
         max-size: 200M
         key: sccache-build
         variant: sccache
         save: ${{ inputs.save }}
- 

--- a/.github/actions/setup_ubuntu_build/action.yml
+++ b/.github/actions/setup_ubuntu_build/action.yml
@@ -32,7 +32,7 @@ runs:
       uses: llvm/actions/install-ninja@main
 
     - name: load llvm
-      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache/restore@v4
       with:
         path: llvm_install/**
         key: llvm-ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.arch }}-v${{ inputs.llvm_version}}-${{ inputs.llvm_build_type }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,12 @@ version: 2
 updates:
 # Enable version updates for Github Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/build_portBLAS_action"
+      - "/.github/actions/build_portDNN_action"
+      - "/.github/actions/build_vgg_resnet_action"
+      - "/.github/actions/setup_ubuntu_build"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/workflows/build_pr_cache.yml
+++ b/.github/workflows/build_pr_cache.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       # installs tools, ninja and installs llvm (default 17, RelAssert) and sets up cache
       - name: setup-ubuntu

--- a/.github/workflows/build_pr_cache.yml
+++ b/.github/workflows/build_pr_cache.yml
@@ -7,7 +7,7 @@ on:
   # pull_request:
   #   paths:
   #     - '.github/workflows/build_pr_cache.yml'
-  #     - '.github/do_build_ock/**'  
+  #     - '.github/do_build_ock/**'
   push:
     branches:
       - main
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/build_pr_cache.yml'
       - '.github/actions/do_build_ock/**'
       - '.github/actions/setup_ubuntu_build/**'
-  
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -28,8 +28,8 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
       # installs tools, ninja and installs llvm (default 17, RelAssert) and sets up cache
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_ubuntu_build
@@ -52,10 +52,10 @@ jobs:
           build_dir: build_offline
           assemble_spirv_ll_lit_test_offline: ON
           build_targets:
-   
+
       - name: clean_build
         run:
           rm -rf ${{ github.workspace }}/build*
 
       - name: build riscv m1
-        uses: ./.github/actions/do_build_ock/do_build_m1  
+        uses: ./.github/actions/do_build_ock/do_build_m1

--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Cache llvm
         id: cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           path:
             llvm_install/**
@@ -68,14 +68,14 @@ jobs:
 
       - name: Checkout repo llvm
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
           ref: release/${{matrix.version}}.x
 
       - name: Checkout repo ock platform
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch != 'x86_64' }}
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
         with:
           sparse-checkout: |
             platform

--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/create_llvm.yml'
   pull_request:
     paths:
-      - '.github/workflows/create_llvm.yml'         
+      - '.github/workflows/create_llvm.yml'
   workflow_dispatch:
 
 permissions: {}
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Cache llvm
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path:
             llvm_install/**
@@ -68,18 +68,18 @@ jobs:
 
       - name: Checkout repo llvm
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           repository: llvm/llvm-project
           ref: release/${{matrix.version}}.x
 
       - name: Checkout repo ock platform
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch != 'x86_64' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           sparse-checkout: |
             platform
-          path: ock          
+          path: ock
 
       - name: Install Ninja
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
        # installs tools, ninja, installs llvm and sets up sccache
       - name: Setup ubuntu
@@ -32,7 +32,7 @@ jobs:
           llvm_build_type: Release
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: '3.8'
 
@@ -85,7 +85,7 @@ jobs:
           tar -czf ock_install.tar.gz install
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: riscv-build
           path: ock_install.tar.gz
@@ -101,7 +101,7 @@ jobs:
           fi
 
       - name: Create OCK pre-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
        # installs tools, ninja, installs llvm and sets up sccache
       - name: Setup ubuntu
@@ -32,7 +32,7 @@ jobs:
           llvm_build_type: Release
 
       - name: Setup python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -85,7 +85,7 @@ jobs:
           tar -czf ock_install.tar.gz install
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: riscv-build
           path: ock_install.tar.gz

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: 3.9
 
@@ -44,6 +44,6 @@ jobs:
           cmake --build build_doc --target doc_html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ${{github.workspace}}/build_doc/doc/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -44,6 +44,6 @@ jobs:
           cmake --build build_doc --target doc_html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{github.workspace}}/build_doc/doc/html

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
        # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup ubuntu
@@ -31,7 +31,7 @@ jobs:
           llvm_build_type: RelAssert
 
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: '3.8'
 
@@ -91,7 +91,7 @@ jobs:
           tar -cvzf ock_demo_artifacts.tar.gz ock_install_dir -C examples/technical_blogs/ock_demo_blog getting_started.md envvars
 
       - name: Upload OCK artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: ock_demo_build
           path: ock_demo_artifacts.tar.gz
@@ -101,10 +101,10 @@ jobs:
     needs: run_riscv_m1_ock_demo
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: ock_demo_build
 
@@ -122,10 +122,10 @@ jobs:
     needs: run_riscv_m1_ock_demo
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: ock_demo_build
 
@@ -145,15 +145,15 @@ jobs:
     needs: [run_riscv_m1_ock_demo, build_portDNN]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: ock_demo_build
 
       - name: Download portDNN build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: portDNN_build
 
@@ -174,22 +174,22 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Download OCK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: ock_demo_build
 
       - name: Download portDNN build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: portDNN_build
 
       - name: Download portBLAS build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: portBLAS_build
 
       - name: Download network artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
           name: network_build
 
@@ -208,7 +208,7 @@ jobs:
           tar -rf ock_demo_components.tar.gz portDNN_build.tar.gz portBLAS_build.tar.gz
 
       - name: Create OCK demo release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
        # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup ubuntu
@@ -31,7 +31,7 @@ jobs:
           llvm_build_type: RelAssert
 
       - name: setup python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -91,7 +91,7 @@ jobs:
           tar -cvzf ock_demo_artifacts.tar.gz ock_install_dir -C examples/technical_blogs/ock_demo_blog getting_started.md envvars
 
       - name: Upload OCK artifacts
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: ock_demo_build
           path: ock_demo_artifacts.tar.gz
@@ -101,10 +101,10 @@ jobs:
     needs: run_riscv_m1_ock_demo
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
 
@@ -122,10 +122,10 @@ jobs:
     needs: run_riscv_m1_ock_demo
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
 
@@ -145,15 +145,15 @@ jobs:
     needs: [run_riscv_m1_ock_demo, build_portDNN]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       - name: Download OCK artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
 
       - name: Download portDNN build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: portDNN_build
 
@@ -174,22 +174,22 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Download OCK artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: ock_demo_build
 
       - name: Download portDNN build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: portDNN_build
 
       - name: Download portBLAS build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: portBLAS_build
 
       - name: Download network artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: network_build
 

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_ubuntu_build
         with:
           llvm_version: 18
-          llvm_build_type: RelAssert        
-  
+          llvm_build_type: RelAssert
+
       # These need to match the configurations of build_pr_cache to use the cache effectively
       - name: build host x86_64 online release
         uses: ./.github/actions/do_build_ock
@@ -69,14 +69,14 @@ jobs:
           ninja -C build_offline check-ock-UnitCL
 
   # build and run riscv m1, execute UnitCL and lit tests
-  run_riscv_m1:  
+  run_riscv_m1:
 
     runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_ubuntu_build
@@ -85,7 +85,7 @@ jobs:
           llvm_build_type: RelAssert
 
       - name: build riscv M1
-        uses: ./.github/actions/do_build_ock/do_build_m1  
+        uses: ./.github/actions/do_build_ock/do_build_m1
 
       - name: run riscv M1 lit
         run:
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: setup-ubuntu-clang-format
         run:

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       # installs tools, ninja, installs llvm and sets up sccahe
       - name: setup-ubuntu
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@v4
 
       - name: setup-ubuntu-clang-format
         run:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
 
@@ -48,6 +48,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@461ef6c76dfe95d5c364de2f431ddbd31a417628 # v3.26.9
+        uses: github/codeql-action/upload-sarif@e2b3eafc8d227b0241d48be5f425d47c2d750a13 # v3.26.10
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/Template-Repo/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/Template-Repo)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/oneapi-construction-kit/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/oneapi-construction-kit)
 
 # oneAPI Construction Kit
 


### PR DESCRIPTION
# Overview

Pin external workflow actions to the commit hash. Also fix Scorecard badge.

# Reason for change

Pinning external workflow actions to the hashed version is a good practice to help against supply chain attacks. This change will raise the OpenSSF score too.

# Description of change

External workflow actions have been pinned to the commit hash. The only actions not pinned are `llvm/actions/install-ninja` and `llvm/actions/setup-windows` as they don't have releases.

Dependabot will open PRs in the future, whenever pinned actions need update. 

# Anything else we should know?

By default, PRs open by dependabot to update dependencies will be tagged to be reviewed by @codeplaysoftware/security-managers and @codeplaysoftware/ock-workflow-reviewers as the code owners. 

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
