### PR TITLE
Enable CodeQL SAST

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,99 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '19 9 * * 3'
+
+permissions: {}
+
+jobs:
+  analyze-host-x86_64-release:
+    name: Analyze host x86_64 release
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # installs tools, ninja and installs llvm (default 17, RelAssert) and sets up cache
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          save: true
+          llvm_version: 18
+          llvm_build_type: RelAssert
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL (${{ matrix.name }})
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - name: build host x86_64 release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          build_targets:
+
+      - name: build host x86_64 offline
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          extra_flags: -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_EXTERNAL_CLC=${{ github.workspace }}/build/bin/clc
+          build_dir: build_offline
+          assemble_spirv_ll_lit_test_offline: ON
+          build_targets:
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:c-cpp"
+
+  analyze-riscv-m1:
+    name: Analyze riscv m1
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # installs tools, ninja and installs llvm (default 17, RelAssert) and sets up cache
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_ubuntu_build
+        with:
+          save: true
+          llvm_version: 18
+          llvm_build_type: RelAssert
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL (${{ matrix.name }})
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - name: build riscv m1
+        uses: ./.github/actions/do_build_ock/do_build_m1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:c-cpp"
+


### PR DESCRIPTION
# Overview

Add a workflow to run CodeQL on main branch and pull requests. 

# Reason for change

CodeQL is a static application security testing (SAST) toolchain that allows to automate security checks and integrate them into our development workflows. 

# Description of change

Enabling CodeQL will run the scan process on main branch and pull requests. Results are accessible through the project `Security` tab. 

Workflow requires building the source code so it uses similar jobs to the ones defined in the `build_pr_cache.yml` workflow. 

# Anything else we should know?

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
