### PR TITLE
refract: match argument types earlier.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_extra/refract.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_extra/refract.cpp
@@ -22,8 +22,8 @@
 #include <abacus/abacus_type_traits.h>
 
 namespace {
-template <typename T, typename U>
-T refract(const T i, const T n, const U eta) {
+template <typename T>
+T refract(const T i, const T n, const typename TypeTraits<T>::ElementType eta) {
   typedef typename TypeTraits<T>::ElementType ElementType;
 
   const ElementType intermediate = __abacus_dot(n, i);


### PR DESCRIPTION
# Overview

refract: match argument types earlier.

# Reason for change

refract takes it eta parameter as a float even when I and N are double. However, in this case, we still want the eta * eta multiplication to be performed in double precision.

# Description of change

Change the internal implementation function to not have mismatched parameter types.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
