### PR TITLE
Remove max_device_infos limit in cookiecutter too

### DIFF
--- a/modules/mux/cookie/{{cookiecutter.target_name}}/source/device_info_get.cpp
+++ b/modules/mux/cookie/{{cookiecutter.target_name}}/source/device_info_get.cpp
@@ -23,14 +23,16 @@
 #include <{{cookiecutter.target_name}}/device_info_get.h>
 #include <{{cookiecutter.target_name}}/hal.h>
 
-#include <array>
 #include <cassert>
+#include <vector>
 
 namespace {{cookiecutter.target_name}} {
 
+std::vector<{{cookiecutter.target_name}}::device_info_s> device_infos;
+
 bool enumerate_device_infos() {
   // if we have a valid device_info we have already enumerated and can return
-  if (device_infos[0].is_valid()) {
+  if (!device_infos.empty()) {
     return true;
   }
   // load the hal library
@@ -44,13 +46,11 @@ bool enumerate_device_infos() {
     return false;
   }
   // enumerate all reported devices
-  uint32_t j = 0;
   for (uint32_t i = 0; i < hal_info.num_devices; ++i) {
-    assert(i < device_infos.size());
     const auto *hal_dev_info = hal->device_get_info(i);
 
     // update this device_info entry and continue
-    auto &dev_info = device_infos[j++];
+    auto &dev_info = device_infos.emplace_back();
     dev_info.update_from_hal_info(hal_dev_info);
     dev_info.hal_device_index = i;
     // device info should be valid at this point
@@ -58,10 +58,8 @@ bool enumerate_device_infos() {
   }
 
   // success if we have at least one device
-  return j > 0;
+  return !device_infos.empty();
 }
-
-std::array<{{cookiecutter.target_name}}::device_info_s, {{cookiecutter.target_name}}::max_device_infos> device_infos;
 
 cargo::array_view<{{cookiecutter.target_name}}::device_info_s> GetDeviceInfosArray() {
   // ensure our device infos have been enumerated


### PR DESCRIPTION
# Overview

Remove max_device_infos limit in cookiecutter too

# Reason for change

The cookiecutter target that we use for tutorials has its own version of device_info_get.cpp, but shares its device_info_get.h with the riscv target. Therefore, the change in commit 120ae08053 to device_info_get.cpp needs to be applied to the cookiecutter target as well.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
