### PR TITLE
Fix UnitCL warning llvm 20 on whitespace in a literal operator declaration

### DIFF
--- a/source/cl/test/UnitCL/include/kts/execution.h
+++ b/source/cl/test/UnitCL/include/kts/execution.h
@@ -242,7 +242,7 @@ struct ExecutionWithParam
                            FIXTURE::getParamName);
 
 // User defined ULP literal
-constexpr cl_ulong operator"" _ULP(unsigned long long int ulp) {
+constexpr cl_ulong operator""_ULP(unsigned long long int ulp) {
   return static_cast<cl_ulong>(ulp);
 }
 


### PR DESCRIPTION
# Overview

Fix UnitCL warning llvm 20 on whitespace in a literal operator declaration

# Reason for change

Warning stopped us building with clang-20. Fixed by removing whitespace
