### PR TITLE
[AArch64] Fix stub call generation.

### DIFF
--- a/modules/loader/source/relocations.cpp
+++ b/modules/loader/source/relocations.cpp
@@ -419,19 +419,19 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
     // ip0 (the assembler temporary register, which is always free to use),
     // followed by a branch on ip0. This stub has a total size of 20 bytes.
 
-    // movz ip0, #:abs_g3:<addr>
+    // movz ip0, #:abs_g3:<addr>, lsl #48
     cargo::write_little_endian(setBitRange(uint32_t{0xD2E00010},
                                            static_cast<uint32_t>(getBitRange(
                                                symbol_target_address, 48, 16)),
                                            5, 16),
                                remaining->begin());
-    // movk ip0, #:abs_g2_nc:<addr>
+    // movk ip0, #:abs_g2_nc:<addr>, lsl #32
     cargo::write_little_endian(setBitRange(uint32_t{0xF2C00010},
                                            static_cast<uint32_t>(getBitRange(
                                                symbol_target_address, 32, 16)),
                                            5, 16),
                                remaining->begin() + 4);
-    // movk ip0, #:abs_g1_nc:<addr>
+    // movk ip0, #:abs_g1_nc:<addr>, lsl #16
     cargo::write_little_endian(setBitRange(uint32_t{0xF2A00010},
                                            static_cast<uint32_t>(getBitRange(
                                                symbol_target_address, 16, 16)),
@@ -447,7 +447,7 @@ bool resolveAArch64(const loader::Relocation &r, loader::ElfMap &map,
     cargo::write_little_endian(uint32_t{0xD61F0200}, remaining->begin() + 16);
     auto target = *map.getStubTargetAddress(r.section_index);
     map.shrinkRemainingStubSpace(r.section_index, 20);
-    return target + 4;
+    return target;
   };
 
   using namespace loader::RelocationTypes::AArch64;


### PR DESCRIPTION
# Overview

[AArch64] Fix stub call generation.

# Reason for change

If we encountered relocations that did not fit in a direct jump, we generate a trampoline that does a far jump to the real function. This trampoline contains four mov* instructions to load the individual bytes of the address to jump to, but then inexplicably skips over the first of those mov* instructions.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

This is not currently being hit in testing because we happen to load kernels in memory addresses that do not require trampolines, and even if we force the use of trampolines unnecessarily by adjusting the below R_AARCH64_CALL26/R_AARCH64_JUMP26 handling, it happens to be the case that the high byte already has the correct value.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
