### PR TITLE
Fix clc device selection on multi-device platform

### DIFF
--- a/modules/cargo/include/cargo/argument_parser.h
+++ b/modules/cargo/include/cargo/argument_parser.h
@@ -219,7 +219,7 @@ class argument {
     cargo::array_view<cargo::string_view> Choices;
   };
   union {
-    bool *Bool;
+    bool *Bool = {};
     cargo::string_view *Value;
     ChoiceT Choice;
     cargo::small_vector<cargo::string_view, 4> *Values;

--- a/source/cl/tools/clc/clc.h
+++ b/source/cl/tools/clc/clc.h
@@ -66,6 +66,9 @@ class driver {
   std::string input_file;
   /// @brief Path to the output file or `"-"` for `stdout`.
   cargo::string_view output_file;
+  /// @brief Device index to select from multiple devices. Takes precedence over
+  /// device name.
+  size_t device_idx;
   /// @brief Device name substring to select from multiple devices.
   cargo::string_view device_name_substring;
   /// @brief List of compile options passed to `clBuildProgram`.


### PR DESCRIPTION
If a platform reports multiple devices, they will all have the same name and --device selection will be ambiguous.

This adds a --device-idx cmd-line option to directly select by index.