### PR TITLE
Add refsi_tutorial start testing to PR testing

### DIFF
--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
@@ -5,6 +5,14 @@ inputs:
   cache_seed:
     type: boolean
     default: false
+  setup_new_target_params:
+    type: string
+    # default to end - this is most reflective of what needs tested most
+    default: '-f "refsi_wrapper_pass;clmul;replace_mem"'
+  tutorial_point:
+    type: string
+    # default to end - set to start and use empty setup_new_target_flags for start for most use cases
+    default: 'end'
 
 runs:
   using: "composite"
@@ -18,7 +26,7 @@ runs:
           virtualenv newenv
           source newenv/bin/activate
           pip install cookiecutter
-          scripts/setup_new_target_tutorial.sh -s end -e $GITHUB_WORKSPACE/refsi_tutorial -f "refsi_wrapper_pass;clmul;replace_mem" $PWD
+          scripts/setup_new_target_tutorial.sh -s ${{ inputs.tutorial_point }} -e $GITHUB_WORKSPACE/refsi_tutorial ${{ inputs.setup_new_target_flags}} $PWD
 
       - name: build refsi_tutorial
         uses: ./.github/actions/do_build_ock
@@ -31,10 +39,10 @@ runs:
           source_dir: $GITHUB_WORKSPACE/refsi_tutorial
           extra_flags: '-DCA_REFSI_TUTORIAL_ENABLED=ON -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=$GITHUB_WORKSPACE -DCA_EXTERNAL_REFSI_TUTORIAL_HAL_DIR=$GITHUB_WORKSPACE/refsi_tutorial/hal_refsi_tutorial'
 
-      - name: run test
-        if: inputs.cache_seed != 'true'
+      - name: run test (end only)
+        if: inputs.cache_seed != 'true' && inputs.tutorial_point == 'end'
         shell: bash
-         # Run just a quick UnitCL test for now, hal_tutorial causes some failures at present
+         # Run just a quick lit / UnitCL test for now, hal_tutorial causes some failures at present
         run: |
           ninja -Cbuild check-ock-refsi_tutorial-lit
           OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/oneAPIConstructionKit/lib/libCL.so \

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -409,3 +409,27 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: build ock
       uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial
+
+ # Based on: mr-run-ubuntu-gcc-x86_64-refsi-tutorial-start:
+  run-ubuntu-gcc-x86_64-refsi-tutorial-start:
+    if: contains(inputs.target_list, 'host_refsi_linux')
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+    timeout-minutes: 60
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: setup-ubuntu
+      uses: ./.github/actions/setup_build
+      with:
+        llvm_version: ${{ inputs.llvm_current }}
+        llvm_source: ${{ inputs.llvm_source}}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: build ock
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial
+      with:
+        setup_new_target_params: ''
+        tutorial_point: start


### PR DESCRIPTION
# Overview

Add refsi_tutorial start testing to PR testing

# Reason for change

The start of the tutorial was not currently being tested.

# Description of change

Added flags to the action to support the start case and added job to the run_ock_internal tests workflow.
