### PR TITLE
Switch cp-graviton to ubuntu-22.04-arm

### DIFF
--- a/.github/actions/do_build_sycl_cts/action.yml
+++ b/.github/actions/do_build_sycl_cts/action.yml
@@ -98,7 +98,6 @@ runs:
         JOPT="4"
         ARCHOPT="x86_64"
         if [[ "${{inputs.target}}" =~ .*aarch64.* ]] ; then
-          JOPT="2" # needed for cp-graviton runner
           ARCHOPT="aarch64"
         fi
         EXCLUDE_SUBSET=""

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -212,7 +212,6 @@ jobs:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
 
-    # Todo: Get working for cp-graviton
     runs-on: ${{ matrix.target == 'host_x86_64_linux' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     steps:
       - name: clone ock platform
@@ -655,7 +654,7 @@ jobs:
 
   run_sycl_cts_aarch64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_aarch64, build_sycl_cts_aarch64_opencl_combine]
-    runs-on: 'cp-graviton'
+    runs-on: 'ubuntu-22.04-arm'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
       volumes:
@@ -674,7 +673,7 @@ jobs:
 
   run_sycl_cts_aarch64_native_cpu:
     needs: [workflow_vars, build_dpcpp_native_aarch64, build_sycl_cts_aarch64_native_cpu_combine]
-    runs-on: 'cp-graviton'
+    runs-on: 'ubuntu-22.04-arm'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
       volumes:


### PR DESCRIPTION


# Overview

Switch to the github runners for aarch64.

# Reason for change

We no longer have access to cp-graviton. 
