### PR TITLE
Update documentation to no longer refer to Ubuntu 20.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and external components.
    oneAPI Construction Kit was previously referred to as ComputeAorta and referred to as acronym `CA`. As a result, references to ComputeAorta or CA may be present in some oneAPI Construction Kit's documentation and code.
 
 ## Get started with the oneAPI Construction Kit
-This section provides the minimum system requirements for building the oneAPI Construction Kit on Ubuntu 20.04. For Windows platform dependencies and build instructions please refer to the [developer guide](doc/developer-guide.md). There is a [blog post](https://codeplay.com/portal/blogs/2023/06/05/introducing-the-oneapi-construction-kit) demonstrating how to build the kit for a simulated RISC-V target. You can also find the documentation on [Codeplay's developer website](https://developer.codeplay.com/products/oneapi/construction-kit/home/).
+This section provides the minimum system requirements for building the oneAPI Construction Kit on Ubuntu 22.04. For Windows platform dependencies and build instructions please refer to the [developer guide](doc/developer-guide.md). There is a [blog post](https://codeplay.com/portal/blogs/2023/06/05/introducing-the-oneapi-construction-kit) demonstrating how to build the kit for a simulated RISC-V target. You can also find the documentation on [Codeplay's developer website](https://developer.codeplay.com/products/oneapi/construction-kit/home/).
 
 ### Platform Dependencies
 * [GCC](https://gcc.gnu.org/)

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -7,7 +7,6 @@ Platform Dependencies
 Each supported platform has a set of dependencies which are required in order to
 build the oneAPI Construction Kit.
 
-* `Ubuntu 20.04`_
 * `Ubuntu 22.04`_
 * `Ubuntu 24.04`_
 * `Windows 10`_
@@ -16,7 +15,7 @@ Once the platform dependencies have been installed please read the
 :doc:`/developer-guide` for more information about building and contributing to
 the oneAPI Construction Kit.
 
-Ubuntu 20.04
+Ubuntu 22.04
 ------------
 
 On an x86-64 host system these are the minimum requirements to build
@@ -33,7 +32,7 @@ configuration.
    $ sudo apt update
    $ sudo apt install -y build-essential git cmake libtinfo-dev python3
 
-Recommended for Ubuntu 20.04
+Recommended for Ubuntu 22.04
 ............................
 
 * `Ninja`_ is a useful, fast, build tool. To use it pass ``-GNinja`` to
@@ -67,12 +66,12 @@ terminal info library.
 
 .. code-block:: console
 
-   $ sudo apt install -y gcc-9-multilib g++-9-multilib libc6-dev:i386 lib32tinfo-dev
+   $ sudo apt install -y gcc-11-multilib g++-11-multilib libc6-dev:i386 lib32tinfo-dev
 
 .. warning::
    The ``gcc-multilib`` and ``g++-multilib`` packages conflict with the Arm and
    AArch64 toolchain packages below. To install the 32 bit libraries at the same
-   time use ``gcc-9-multilib``, ``g++-9-multilib``, and ``libc6-dev:i386`` that
+   time use ``gcc-11-multilib``, ``g++-11-multilib``, and ``libc6-dev:i386`` that
    ``gcc-multilib`` and ``g++-multilib`` depend on but do not conflict with the
    Arm and AArch64 toolchain packages.
 
@@ -84,7 +83,7 @@ toolchain.
 
 .. code-block:: console
 
-   $ sudo apt install -y gcc-9-arm-linux-gnueabihf g++-9-arm-linux-gnueabihf
+   $ sudo apt install -y gcc-11-arm-linux-gnueabihf g++-11-arm-linux-gnueabihf
 
 Arm 64-bit (AArch64) Cross Compile
 ..................................
@@ -93,13 +92,7 @@ Install the AArch64 toolchain.
 
 .. code-block:: console
 
-   $ sudo apt install -y gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu
-
-Ubuntu 22.04
-------------
-
-This is fully supported. This is recommended for the `RISC-V` host target. gcc
-version 11 is recommended for this operating system.
+   $ sudo apt install -y gcc-11-aarch64-linux-gnu g++-11-aarch64-linux-gnu
 
 Ubuntu 24.04
 ------------
@@ -181,7 +174,7 @@ Follow the build instructions, or install the pre-built binaries in the
 repository. It's harder to pin down versions of `SPIRV-Tools`_ since they don't
 do releases, but we should support any commit from after January 2019.
 
-Ubuntu 20.04 and later users can install ``spirv-tools`` from the package repository:
+Ubuntu 22.04 and later users can install ``spirv-tools`` from the package repository:
 
 .. code-block:: console
 

--- a/doc/overview/tutorials/creating-new-hal/initial-setup.rst
+++ b/doc/overview/tutorials/creating-new-hal/initial-setup.rst
@@ -47,7 +47,7 @@ Installing a RISC-V toolchain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A RISC-V toolchain or GNU RISC-V toolchain is required to build the RefSi HAL.
-When using Ubuntu 20.04 the toolchain can be simply installed using the Ubuntu
+When using Ubuntu 22.04 the toolchain can be simply installed using the Ubuntu
 package manager without additional CMake setup.
 
 For other Linux systems, you'll need to set the CMake variable,
@@ -69,14 +69,14 @@ configuring the ``RISCV_TOOLCHAIN_TRIPLE`` CMake variable for clang or
 
 See 'Other Linux system' for an example.
 
-Ubuntu 20.04
+Ubuntu 22.04
 ~~~~~~~~~~~~
 
 The following packages need to be installed:
 
 .. code:: console
 
-    $ sudo apt install gcc-9-riscv64-linux-gnu g++-9-riscv64-linux-gnu
+    $ sudo apt install gcc-11-riscv64-linux-gnu g++-11-riscv64-linux-gnu
 
 Other Linux system
 ~~~~~~~~~~~~~~~~~~

--- a/doc/overview/tutorials/creating-new-hal/kernel-compilation.rst
+++ b/doc/overview/tutorials/creating-new-hal/kernel-compilation.rst
@@ -35,7 +35,7 @@ An offline approach was chosen for clik, which allows using an off-the-shelf
 compiler such as GCC or Clang for compiling kernels (which are written in C) and
 keeping the runtime library (as well as build times) as small as possible. In
 this tutorial, we are using the 64-bit RISC-V variant of the GCC compiler which
-is part of the Ubuntu 20.04 OS for compiling clik kernels to RISC-V binaries.
+is part of the Ubuntu 22.04 OS for compiling clik kernels to RISC-V binaries.
 
 In the RefSi skeleton HAL, the step that is responsible for compiling kernels
 (the ``hal_refsi_tutorial_compile_kernel_source`` and

--- a/examples/technical_blogs/ock_demo_blog/getting_started.md
+++ b/examples/technical_blogs/ock_demo_blog/getting_started.md
@@ -35,7 +35,7 @@ OCK demo package contains the build and install directories of all components. A
 - [oneAPI toolkit](https://github.com/intel/llvm/releases)
 
 The above repositories can be built for dpc++ following their respective build instructions.
-All of the following instructions have been tested on Ubuntu:20.04.
+All of the following instructions have been tested on Ubuntu:22.04.
 
 You'll need to extract the files from the archive file and and oneAPI nighlty release needs to be
 downloaded from `intel/llvm`:


### PR DESCRIPTION
# Overview

Update documentation to no longer refer to Ubuntu 20.04.

# Reason for change

Ubuntu 20.04 reaches EOL at the end of the month, so we should no longer be suggesting that users use it.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
