### PR TITLE
[NFC] Silence CMake warnings when clang-tidy is installed.

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -432,9 +432,11 @@ if(TARGET ClangTools::clang-tidy)
     cmake_parse_arguments(ACT "" "" "DEPENDS" ${ARGN})
     if(TARGET tidy)
       foreach(entry ${ACT_UNPARSED_ARGUMENTS})
+        if(NOT entry MATCHES "\\.c(pp)?$")
+          continue()
+        endif()
         file(REAL_PATH "${entry}" entry BASE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-        get_filename_component(ext ${entry} EXT)
-        if(EXISTS ${entry} AND ext MATCHES "^\.c(pp)?$")
+        if(EXISTS ${entry})
           # In order to create a dependency graph for clang-tidy targets we
           # must use a symbolic file, this is a file which doesn't exist other
           # than to setup target dependencies.


### PR DESCRIPTION
# Overview

[NFC] Silence CMake warnings when clang-tidy is installed.

# Reason for change

add_ca_tidy intends to ignore arguments that are not C or C++ source files, but it checks this after calling file(REAL_PATH). This results in warnings for non-paths.

# Description of change

Since we already know we intend to skip those, skip them earlier.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
