### PR TITLE
Reduce no virtualenv to warning.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -21,7 +21,7 @@ if(DOXYGEN STREQUAL "DOXYGEN-NOTFOUND")
   return()
 endif()
 
-find_program(VIRTUALENV virtualenv REQUIRED)
+find_program(VIRTUALENV virtualenv)
 if(VIRTUALENV STREQUAL "VIRTUALENV-NOTFOUND")
   message(WARNING
     "virtualenv not found, documentation generation disabled, "


### PR DESCRIPTION

# Overview

Reduce no virtualenv to warning.

# Reason for change

This already had code to output a warning of not being able to generate documentation if virtualenv did not exist. This never got triggered as REQUIRED was set on virtualenv, forcing everyone to install virtualenv.

# Description of change

This removes the REQUIRED from the use of find_program for virtualenv.
