### PR TITLE
Drop implicit permissions.

### DIFF
--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -66,6 +66,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  packages: read
+
 jobs:
   build_llvm_artefacts:
     name: Call PR testing on schedule

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -7,6 +7,8 @@ on:
     # Run Sun, Tues, Thurs Sat at 7pm
     - cron: '0 19 * * 0,2,4,6'
 
+permissions:
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -7,6 +7,9 @@ on:
     # Run Mon, Wed, Fri at 7pm
     - cron: '0 19 * * 1,3,5'
 
+permissions:
+  packages: read
+
 # To add another llvm planned testing, simply copy this file and set the llvm_version and llvm_branch variables
 # llvm_version is only used for tagging purposes, although ideally would be a number or main
 # We may want to delete the lowest version for planned_testing_caller_*.yml at that time.

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -16,6 +16,9 @@ on:
       - '.github/workflows/run_pr_tests_caller.yml'
       - 'CMakeLists.txt'
 
+permissions:
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
# Overview

Drop implicit permissions.

# Reason for change

The planned testing workflows were not setting permissions, causing them to run with more permissions than intended.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
