### PR TITLE
[RefSi] Explicitly specify -fuse-ld=lld.

### DIFF
--- a/examples/hals/hal_refsi_tutorial/cmake/FindCompiler.cmake
+++ b/examples/hals/hal_refsi_tutorial/cmake/FindCompiler.cmake
@@ -73,11 +73,13 @@ function(find_cc TRIPLE)
     if(TRIPLE STREQUAL "riscv32")
       set_property(GLOBAL PROPERTY RISCV_CC_FLAGS
         --target=${RISCV_TOOLCHAIN_TRIPLE}
+        -fuse-ld=lld
         -march=rv32gc
         -mno-relax)
     else()
       set_property(GLOBAL PROPERTY RISCV_CC_FLAGS
         --target=${RISCV_TOOLCHAIN_TRIPLE}
+        -fuse-ld=lld
         -march=rv64gc
         -mno-relax)
     endif()

--- a/examples/refsi/hal_refsi/cmake/FindCompiler.cmake
+++ b/examples/refsi/hal_refsi/cmake/FindCompiler.cmake
@@ -57,11 +57,13 @@ function(find_cc TRIPLE)
     if(TRIPLE STREQUAL "riscv32")
       set_property(GLOBAL PROPERTY RISCV_CC_FLAGS
         --target=${RISCV_TOOLCHAIN_TRIPLE}
+        -fuse-ld=lld
         -march=rv32gc
         -mno-relax)
     else()
       set_property(GLOBAL PROPERTY RISCV_CC_FLAGS
         --target=${RISCV_TOOLCHAIN_TRIPLE}
+        -fuse-ld=lld
         -march=rv64gc
         -mno-relax)
     endif()


### PR DESCRIPTION
# Overview

[RefSi] Explicitly specify -fuse-ld=lld.

# Reason for change

LLVM 21 changes clang --target=riscv to use a linker that cannot handle RISC-V targets or objects.

# Description of change

Specifying -fuse-ld=lld explicitly at least restores the RefSi Build.

# Anything else we should know?

This seems like a bad idea and hopefully they will revert that change, in which case this PR could be closed (if not merged) or reverted (if merged).

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
