### PR TITLE
Disable -Wunused-parameter.

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -172,6 +172,7 @@ list(APPEND CA_COMPILE_OPTIONS
     -Wall -Wextra         # Enable more warnings
     -Wcast-qual           # Enable warnings for casting away const
     -Wformat              # Enable printf format warnings
+    -Wno-unused-parameter # Disable unused parameter warnings
 
     $<$<NOT:$<BOOL:${MINGW}>>:
       -fPIC               # Emit position-independent code


### PR DESCRIPTION
# Overview

Disable -Wunused-parameter.

# Reason for change

Much of our code implicitly picks up -Wno-unused-parameter from LLVM's options, but not all. We do not want to force the warnings anywhere.

# Description of change

Add -Wno-unused-parameter explicitly ourselves too.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
