### PR TITLE
[LLVM 21] Remove getLLVMContext()

### DIFF
--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/module.h
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/include/refsi_g1_wi/module.h
@@ -33,8 +33,8 @@ class RefSiG1Module final : public riscv::RiscvModule {
                 uint32_t &num_errors, std::string &log);
 
   /// @see Module::createPassMachinery
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery()
-      override;
+  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &) override;
 
   /// @see Module::getLateTargetPasses
   llvm::ModulePassManager getLateTargetPasses(

--- a/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
+++ b/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi/source/module.cpp
@@ -31,7 +31,7 @@ RefSiG1Module::RefSiG1Module(RefSiG1Target &target,
     : riscv::RiscvModule(target, context, num_errors, log) {}
 
 std::unique_ptr<compiler::utils::PassMachinery>
-RefSiG1Module::createPassMachinery() {
+RefSiG1Module::createPassMachinery(llvm::LLVMContext &C) {
   auto *TM = getTargetMachine();
   auto *Builtins = getTarget().getBuiltins();
   const auto &BaseContext = getTarget().getContext();
@@ -44,10 +44,8 @@ RefSiG1Module::createPassMachinery() {
         std::make_unique<RefSiG1BIMuxInfo>(),
         compiler::utils::createCLBuiltinInfo(Builtins));
   };
-  llvm::LLVMContext &Ctx = Builtins->getContext();
   return std::make_unique<RefSiG1PassMachinery>(
-      getTarget(), Ctx, TM, Info, Callback,
-      BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), C, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/module.h
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/include/refsi_m1/module.h
@@ -33,8 +33,8 @@ class RefSiM1Module final : public riscv::RiscvModule {
                 uint32_t &num_errors, std::string &log);
 
   /// @see Module::createPassMachinery
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery()
-      override;
+  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &) override;
 
   /// @see Module::getLateTargetPasses
   llvm::ModulePassManager getLateTargetPasses(

--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/module.cpp
@@ -31,7 +31,7 @@ RefSiM1Module::RefSiM1Module(RefSiM1Target &target,
     : riscv::RiscvModule(target, context, num_errors, log) {}
 
 std::unique_ptr<compiler::utils::PassMachinery>
-RefSiM1Module::createPassMachinery() {
+RefSiM1Module::createPassMachinery(llvm::LLVMContext &C) {
   auto *TM = getTargetMachine();
   auto *Builtins = getTarget().getBuiltins();
   const auto &BaseContext = getTarget().getContext();
@@ -44,10 +44,8 @@ RefSiM1Module::createPassMachinery() {
         std::make_unique<RefSiM1BIMuxInfo>(),
         compiler::utils::createCLBuiltinInfo(Builtins));
   };
-  llvm::LLVMContext &Ctx = Builtins->getContext();
   return std::make_unique<RefSiM1PassMachinery>(
-      getTarget(), Ctx, TM, Info, Callback,
-      BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), C, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/module.h
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/module.h
@@ -43,12 +43,12 @@ class {{cookiecutter.target_name.capitalize()}}Module final : public compiler::B
   void clear() override;
 
   /// @see Module::createBinary
-  compiler::Result createBinary(
-      cargo::array_view<std::uint8_t> &buffer) override;
+  compiler::Result createBinary(cargo::array_view<std::uint8_t> & buffer)
+      override;
 
   /// @see Module::createPassMachinery
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery()
-      override;
+  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &) override;
 
   /// @see BaseModule::initializePassMachineryForFrontend
   void initializePassMachineryForFrontend(compiler::utils::PassMachinery &,

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -103,99 +103,100 @@ compiler::Result {{cookiecutter.target_name.capitalize()}}Module::createBinary(c
 
   // Lock the context, this is necessary due to analysis/pass managers being
   // owned by the LLVMContext and we are making heavy use of both below.
-  std::lock_guard<compiler::BaseContext> contextLock(context);
-  // Numerous things below touch LLVM's global state, in particular
-  // retriggering command-line option parsing at various points. Ensure we
-  // avoid data races by locking the LLVM global mutex.
-  std::lock_guard<std::mutex> globalLock(compiler::utils::getLLVMGlobalMutex());
+  return target.withLLVMContextDo([&](llvm::LLVMContext &) -> compiler::Result {
+    // Numerous things below touch LLVM's global state, in particular
+    // retriggering command-line option parsing at various points. Ensure we
+    // avoid data races by locking the LLVM global mutex.
+    std::lock_guard<std::mutex> globalLock(compiler::utils::getLLVMGlobalMutex());
 
-  // Write to an Elf object
-  auto *TM = getTargetMachine();
-  llvm::SmallVector<char, 512> objectBinary;
-  llvm::raw_svector_ostream ostream(objectBinary);
+    // Write to an Elf object
+    auto *TM = getTargetMachine();
+    llvm::SmallVector<char, 512> objectBinary;
+    llvm::raw_svector_ostream ostream(objectBinary);
 
-  {
-    compiler::Result err = compiler::Result::FAILURE;
-    llvm::CrashRecoveryContext CRC;
-    llvm::CrashRecoveryContext::Enable();
-    bool crashed = !CRC.RunSafely([&] {
-      err = compiler::emitCodeGenFile(*finalized_llvm_module, TM, ostream);
-    });
-    llvm::CrashRecoveryContext::Disable();
-    if (crashed) {
-      return compiler::Result::FINALIZE_PROGRAM_FAILURE;
+    {
+      compiler::Result err = compiler::Result::FAILURE;
+      llvm::CrashRecoveryContext CRC;
+      llvm::CrashRecoveryContext::Enable();
+      bool crashed = !CRC.RunSafely([&] {
+        err = compiler::emitCodeGenFile(*finalized_llvm_module, TM, ostream);
+      });
+      llvm::CrashRecoveryContext::Disable();
+      if (crashed) {
+        return compiler::Result::FINALIZE_PROGRAM_FAILURE;
+      }
+      if (compiler::Result::SUCCESS != err) {
+        return err;
+      }
     }
-    if (compiler::Result::SUCCESS != err) {
-      return err;
+
+    llvm::ArrayRef<uint8_t> inputBinary{
+        reinterpret_cast<uint8_t *>(objectBinary.data()),
+        static_cast<std::size_t>(objectBinary.size())};
+
+    llvm::SmallVector<std::string, 4> lld_args;
+    // Set the entry point to the zero address to avoid a linker warning. The
+    // entry point will not be used directly.
+    lld_args.push_back("-e0");
+
+    if ({{cookiecutter.link_shared}}) {
+      lld_args.push_back("--shared");
     }
-  }
 
-  llvm::ArrayRef<uint8_t> inputBinary{
-      reinterpret_cast<uint8_t *>(objectBinary.data()),
-      static_cast<std::size_t>(objectBinary.size())};
-
-  llvm::SmallVector<std::string, 4> lld_args;
-  // Set the entry point to the zero address to avoid a linker warning. The
-  // entry point will not be used directly.
-  lld_args.push_back("-e0");
-
-  if ({{cookiecutter.link_shared}}) {
-    lld_args.push_back("--shared");
-  }
-
-  {
-    bool linkSuccess = false;
-    llvm::CrashRecoveryContext CRC;
-    llvm::CrashRecoveryContext::Enable();
-    bool crashed = !CRC.RunSafely([&] {
-      auto linkResult = compiler::utils::lldLinkToBinary(
-          inputBinary, getTarget().hal_device_info->linker_script,
-          getTarget().rt_lib, getTarget().rt_lib_size, lld_args);
-      if (auto E = linkResult.takeError()) {
-        std::string errStr = toString(std::move(E));
-        addBuildError(errStr);
-        if (auto callback = target.getNotifyCallbackFn()) {
-          callback(errStr.c_str(), /*data*/ nullptr, /*data_size*/ 0);
+    {
+      bool linkSuccess = false;
+      llvm::CrashRecoveryContext CRC;
+      llvm::CrashRecoveryContext::Enable();
+      bool crashed = !CRC.RunSafely([&] {
+        auto linkResult = compiler::utils::lldLinkToBinary(
+            inputBinary, getTarget().hal_device_info->linker_script,
+            getTarget().rt_lib, getTarget().rt_lib_size, lld_args);
+        if (auto E = linkResult.takeError()) {
+          std::string errStr = toString(std::move(E));
+          addBuildError(errStr);
+          if (auto callback = target.getNotifyCallbackFn()) {
+            callback(errStr.c_str(), /*data*/ nullptr, /*data_size*/ 0);
+          }
+          return;
         }
-        return;
+        auto size = (*linkResult)->getBufferSize();
+        if (cargo::success != object_code.alloc(size)) {
+          return;
+        }
+        std::memcpy(object_code.data(), (*linkResult)->getBufferStart(), size);
+        linkSuccess = true;
+      });
+      llvm::CrashRecoveryContext::Disable();
+      if (crashed || !linkSuccess) {
+        return compiler::Result::LINK_PROGRAM_FAILURE;
       }
-      auto size = (*linkResult)->getBufferSize();
-      if (cargo::success != object_code.alloc(size)) {
-        return;
-      }
-      std::memcpy(object_code.data(), (*linkResult)->getBufferStart(), size);
-      linkSuccess = true;
-    });
-    llvm::CrashRecoveryContext::Disable();
-    if (crashed || !linkSuccess) {
-      return compiler::Result::LINK_PROGRAM_FAILURE;
     }
-  }
 
-  // copy the generated ELF file to a specified path if desired
+    // copy the generated ELF file to a specified path if desired
 #if defined(CA_ENABLE_DEBUG_SUPPORT) || defined(CA_{{cookiecutter.target_name_capitals}}_DEMO_MODE)
-  if (!getTarget().env_debug_prefix.empty()) {
-    std::string env_name = getTarget().env_debug_prefix + "_SAVE_ELF_PATH";
-    if (const auto copyElfPath = llvm::sys::Process::GetEnv(env_name.c_str())) {
-      llvm::SmallVector<char, 8> resultPath;
-      std::error_code error;
-      llvm::raw_fd_ostream of(*copyElfPath, error);
-      if (error) {
-        llvm::errs() << "Unable to open ELF file " << *copyElfPath << " :\n";
-        llvm::errs() << "\t" << error.message() << "\n";
-      } else {
-        const uint8_t *elf_data = object_code.data();
-        of.write(reinterpret_cast<const char *>(elf_data), object_code.size());
-        llvm::errs() << "Writing ELF file  to " << *copyElfPath << "\n";
+    if (!getTarget().env_debug_prefix.empty()) {
+      std::string env_name = getTarget().env_debug_prefix + "_SAVE_ELF_PATH";
+      if (const auto copyElfPath = llvm::sys::Process::GetEnv(env_name.c_str())) {
+        llvm::SmallVector<char, 8> resultPath;
+        std::error_code error;
+        llvm::raw_fd_ostream of(*copyElfPath, error);
+        if (error) {
+          llvm::errs() << "Unable to open ELF file " << *copyElfPath << " :\n";
+          llvm::errs() << "\t" << error.message() << "\n";
+        } else {
+          const uint8_t *elf_data = object_code.data();
+          of.write(reinterpret_cast<const char *>(elf_data), object_code.size());
+          llvm::errs() << "Writing ELF file  to " << *copyElfPath << "\n";
+        }
       }
     }
-  }
 #endif
 
-  // return the binary buffer.
-  binary = object_code;
+    // return the binary buffer.
+    binary = object_code;
 
-  return compiler::Result::SUCCESS;
+    return compiler::Result::SUCCESS;
+  });
 }
 
 // No deferred support so just return nullptr
@@ -246,7 +247,7 @@ llvm::TargetMachine *{{cookiecutter.target_name.capitalize()}}Module::getTargetM
   }
 {% endif -%}
 
-std::unique_ptr<compiler::utils::PassMachinery> {{cookiecutter.target_name.capitalize()}}Module::createPassMachinery() {
+std::unique_ptr<compiler::utils::PassMachinery> {{cookiecutter.target_name.capitalize()}}Module::createPassMachinery(llvm::LLVMContext &C) {
   auto *TM = getTargetMachine();
   auto *Builtins = getTarget().getBuiltins();
   const auto &BaseContext = getTarget().getContext();
@@ -261,10 +262,8 @@ std::unique_ptr<compiler::utils::PassMachinery> {{cookiecutter.target_name.capit
     return compiler::utils::BuiltinInfo(compiler::utils::createCLBuiltinInfo(Builtins));
 {% endif -%}
   };
-  llvm::LLVMContext &Ctx = Builtins->getContext();
   return std::make_unique<{{cookiecutter.target_name.capitalize()}}PassMachinery>(
-      getTarget(), Ctx, TM, Info, Callback,
-      BaseContext.isLLVMVerifyEachEnabled(),
+      getTarget(), C, TM, Info, Callback, BaseContext.isLLVMVerifyEachEnabled(),
       BaseContext.getLLVMDebugLoggingLevel(),
       BaseContext.isLLVMTimePassesEnabled());
 }

--- a/modules/compiler/include/compiler/context.h
+++ b/modules/compiler/include/compiler/context.h
@@ -78,26 +78,6 @@ class Context {
   /// otherwise returns an error string.
   virtual cargo::expected<spirv::SpecializableConstantsMap, std::string>
   getSpecializableConstants(cargo::array_view<const uint32_t> code) = 0;
-
-  /// @brief Locks the underlying mutex, used to control access to the
-  /// underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::lock`.
-  virtual void lock() = 0;
-
-  /// @brief Attempts to acquire the lock on the underlying mutex, used to
-  /// control access to the underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::try_lock`.
-  ///
-  /// @return Returns true if the lock was acquired, false otherwise.
-  virtual bool try_lock() = 0;
-
-  /// @brief Unlocks the underlying mutex, used to control access to the
-  /// underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::unlock`.
-  virtual void unlock() = 0;
 };  // class Context
 /// @}
 }  // namespace compiler

--- a/modules/compiler/riscv/include/riscv/module.h
+++ b/modules/compiler/riscv/include/riscv/module.h
@@ -47,8 +47,8 @@ class RiscvModule : public compiler::BaseModule {
       cargo::array_view<std::uint8_t> &buffer) override;
 
   /// @see Module::createPassMachinery
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery()
-      override;
+  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &) override;
 
   /// @see BaseModule::initializePassMachineryForFrontend
   void initializePassMachineryForFrontend(

--- a/modules/compiler/source/base/include/base/context.h
+++ b/modules/compiler/source/base/include/base/context.h
@@ -56,26 +56,6 @@ class BaseContext : public Context {
   cargo::expected<spirv::SpecializableConstantsMap, std::string>
   getSpecializableConstants(cargo::array_view<const uint32_t> code) override;
 
-  /// @brief Locks the underlying mutex, used to control access to the
-  /// underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::lock`.
-  void lock() override;
-
-  /// @brief Attempts to acquire the lock on the underlying mutex, used to
-  /// control access to the underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::try_lock`.
-  ///
-  /// @return Returns true if the lock was acquired, false otherwise.
-  bool try_lock() override;
-
-  /// @brief Unlocks the underlying mutex, used to control access to the
-  /// underlying LLVM context.
-  ///
-  /// Forwards to `std::mutex::unlock`.
-  void unlock() override;
-
   bool isLLVMVerifyEachEnabled() const { return llvm_verify_each; }
 
   bool isLLVMTimePassesEnabled() const { return llvm_time_passes; }
@@ -85,9 +65,6 @@ class BaseContext : public Context {
   }
 
  private:
-  /// @brief Mutex for accessing the BaseContext.
-  std::mutex base_context_mutex;
-
   /// @brief True if compiler passes should be individually verified.
   ///
   /// If false, the default is to verify before/after each pass pipeline.

--- a/modules/compiler/source/base/include/base/module.h
+++ b/modules/compiler/source/base/include/base/module.h
@@ -139,6 +139,7 @@ class BaseModule : public Module {
   /// @brief Compile an OpenCL C program to an LLVM module.
   ///
   /// @param[in] instance clang CompilerInstance.
+  /// @param[in] llvm_context LLVM context.
   /// @param[in] device_profile Device profile string. Should be either
   /// FULL_PROFILE or EMBEDDED_PROFILE.
   /// @param[in] source OpenCL C source code string.
@@ -151,8 +152,8 @@ class BaseModule : public Module {
   ///
   /// @return Return the compiled LLVM module, or nullptr on failure.
   std::unique_ptr<llvm::Module> compileOpenCLCToIR(
-      clang::CompilerInstance &instance, cargo::string_view device_profile,
-      cargo::string_view source,
+      clang::CompilerInstance &instance, llvm::LLVMContext &llvm_context,
+      cargo::string_view device_profile, cargo::string_view source,
       cargo::array_view<compiler::InputHeader> input_headers,
       uint32_t *num_errors = nullptr, ModuleState *new_state = nullptr);
 
@@ -214,7 +215,8 @@ class BaseModule : public Module {
   ModuleState getState() const override final { return state; }
 
   /// @brief Return a new pass machinery to be used for the compilation pipeline
-  virtual std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery();
+  virtual std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &);
 
   /// @brief Initialize a pass machinery for running in BaseModule's frontend
   /// pipelines.
@@ -250,20 +252,20 @@ class BaseModule : public Module {
   /// restoring the old one on scope exit.
   struct ScopedDiagnosticHandler {
     ScopedDiagnosticHandler(
-        BaseModule &base_module,
+        BaseModule &base_module, llvm::LLVMContext &context,
         DiagnosticHandler::DiagnosticFilterTy filter_fn = nullptr)
         : base_module(base_module),
-          old_handler(
-              base_module.target.getLLVMContext().getDiagnosticHandler()) {
-      base_module.target.getLLVMContext().setDiagnosticHandler(
+          context(context),
+          old_handler(context.getDiagnosticHandler()) {
+      context.setDiagnosticHandler(
           std::make_unique<DiagnosticHandler>(base_module, filter_fn));
     }
     ~ScopedDiagnosticHandler() {
       // Reinstate the old diagnostic handler
-      base_module.target.getLLVMContext().setDiagnosticHandler(
-          std::move(old_handler));
+      context.setDiagnosticHandler(std::move(old_handler));
     }
     BaseModule &base_module;
+    llvm::LLVMContext &context;
     std::unique_ptr<llvm::DiagnosticHandler> old_handler;
   };
 
@@ -471,7 +473,7 @@ class BaseModule : public Module {
   /// file must already have been prepared before calling this function.
   ///
   /// @param[in] instance Clang compiler instance.
-  void loadBuiltinsPCH(clang::CompilerInstance &instance);
+  void loadBuiltinsPCH(clang::CompilerInstance &instance, llvm::LLVMContext &C);
 
   /// @brief Run this module through the OpenCL frontend pipeline, optionally
   /// running early and late LLVM passes as part of this pipeline. A late fast

--- a/modules/compiler/source/base/source/context.cpp
+++ b/modules/compiler/source/base/source/context.cpp
@@ -83,10 +83,4 @@ BaseContext::getSpecializableConstants(cargo::array_view<const uint32_t> code) {
   }
   return {std::move(constants_map)};
 }
-
-void BaseContext::lock() { base_context_mutex.lock(); }
-
-bool BaseContext::try_lock() { return base_context_mutex.try_lock(); }
-
-void BaseContext::unlock() { base_context_mutex.unlock(); }
 }  // namespace compiler

--- a/modules/compiler/targets/host/include/host/module.h
+++ b/modules/compiler/targets/host/include/host/module.h
@@ -75,8 +75,8 @@ class HostModule : public compiler::BaseModule {
   compiler::Kernel *createKernel(const std::string &name) override;
 
   /// @see BaseModule::createPassMachinery
-  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery()
-      override;
+  std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(
+      llvm::LLVMContext &) override;
 
   /// @see BaseModule::initializePassMachineryForFinalize
   void initializePassMachineryForFinalize(

--- a/modules/compiler/targets/host/include/host/target.h
+++ b/modules/compiler/targets/host/include/host/target.h
@@ -51,10 +51,10 @@ class HostTarget : public compiler::BaseTarget {
   std::unique_ptr<compiler::Module> createModule(uint32_t &num_errors,
                                                  std::string &log) override;
 
-  /// @see BaseTarget::getLLVMContext
-  llvm::LLVMContext &getLLVMContext() override;
-  /// @see BaseTarget::getLLVMContext
-  const llvm::LLVMContext &getLLVMContext() const override;
+  /// @see BaseTarget::withLLVMContextDo
+  void withLLVMContextDo(void (*)(llvm::LLVMContext &, void *),
+                         void *) override;
+  using BaseTarget::withLLVMContextDo;
 
   /// @see BaseTarget::getBuiltins
   llvm::Module *getBuiltins() const override;

--- a/modules/compiler/tools/muxc/muxc.h
+++ b/modules/compiler/tools/muxc/muxc.h
@@ -18,7 +18,7 @@
 
 #include <base/base_module_pass_machinery.h>
 #include <base/context.h>
-#include <compiler/target.h>
+#include <base/target.h>
 #include <mux/mux.hpp>
 
 namespace muxc {
@@ -57,7 +57,7 @@ class driver {
   /// @brief Compiler context to drive compilation.
   std::unique_ptr<compiler::Context> CompilerContext;
   /// @brief Compiler target to drive compilation.
-  std::unique_ptr<compiler::Target> CompilerTarget;
+  std::unique_ptr<compiler::BaseTarget> CompilerTarget;
   /// @brief LLVM context. Used unless CompilerTarget is set, in which case we
   /// use its LLVMContext.
   std::unique_ptr<llvm::LLVMContext> LLVMCtx;

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -475,29 +475,8 @@ _cl_program::_cl_program(cl_context context)
 }
 
 _cl_program::~_cl_program() {
-  // This guard needs a variable name, otherwise it is destroyed just after
-  // being created. Resource acquisition is required here, as clearing the
-  // binaries changes the context, while the context may be accessed at the
-  // same time by other _cl_program destructors and Compile and Link calls.
-  // The scoping ensures that the resource (context) is released before its
-  // possible destruction by the ReleaseInternal call.
-  {
-    std::unique_lock<std::mutex> guard(context->mutex, std::defer_lock);
-    std::unique_lock<compiler::Context> context_guard;
-    if (context->getCompilerContext()) {
-      context_guard = std::unique_lock<compiler::Context>{
-          *context->getCompilerContext(), std::defer_lock};
-
-      // We need to use std::lock here to avoid a deadlock scenario when using
-      // two mutexes.
-      std::lock(guard, context_guard);
-    } else {
-      guard.lock();
-    }
-
-    // Clear the programs first because they use our cl_context
-    programs.clear();
-  }
+  // Clear the programs first because they use our cl_context
+  programs.clear();
 
   // Explicitly destruct union members where appropriate.
   switch (type) {


### PR DESCRIPTION
# Overview

[LLVM 21] Remove getLLVMContext()

# Reason for change

LLVM 21 removes ThreadSafeContext::getContext() in favor of ThreadSafeContext::withContextDo() which takes care of locking, and highlights that the locking we were previously doing was wrong: ThreadSafeContext provided us with a mutex to use to give us exclusive access to the context, and we did not use it, we used our own instead.

# Description of change

Fixing this requires a refactoring.

* compiler::BaseContext is updated to no longer support locking.
* BaseTarget::getLLVMContext is removed.
* BaseTarget::withLLVMContextDo is added, analogous to LLVM's new withContextDo function, along with a convenience overload to allow returning values.
* Functions are updated to use BaseTarget::withLLVMContextDo instead of std::lock_guard\<compiler::BaseContext\> according to the general principle that functions that take an LLVM context or LLVM module directly need to be called with the lock already held, functions that do not take an LLVM context or LLVM module need to use withLLVMContextDo as appropriate.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
