### PR TITLE
Split some risc-v jobs into two and run on standard github runner

### DIFF
--- a/.github/actions/do_build_opencl_cts/action.yml
+++ b/.github/actions/do_build_opencl_cts/action.yml
@@ -53,26 +53,22 @@ runs:
         done
         # do build
         set -x
+        mkdir $GITHUB_WORKSPACE/build
+        cd $GITHUB_WORKSPACE/build
         cmake -G Ninja $CMAKE_TOOLCHAIN $GITHUB_WORKSPACE/OpenCL-CTS \
           -DCMAKE_BUILD_TYPE=Release \
           -DOPENCL_LIBRARIES=OpenCL \
           -DCL_INCLUDE_DIR=$GITHUB_WORKSPACE/install_headers/include \
           -DCL_LIB_DIR=$GITHUB_WORKSPACE/install_icd/lib
         ninja -v
+        # remove some files to reduce the size and complexity of the upload
+        # (internal upload does not support filtering out)
+        find $GITHUB_WORKSPACE/build/test_conformance \( -name "*.o" -o -name "*.cmake" \) -delete
 
     - name: upload opencl cts artifacts
-      uses: actions/upload-artifact@v4
+      uses: ./.github/actions/upload_artifact
       with:
         name: opencl_cts_${{inputs.target}}
-        path: |
-          test_conformance
-          !test_conformance/**/.*
-          !test_conformance/**/CMakeCache.txt
-          !test_conformance/**/CMakeFiles
-          !test_conformance/**/CMakeFiles/**
-          !test_conformance/**/*.cmake
-          !test_conformance/**/*.ninja
-          !test_conformance/test_common
-          !test_conformance/test_common/**
+        path: build/test_conformance
         retention-days: 7
-
+        needs_tar: 'true'

--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -12,6 +12,9 @@ inputs:
   llvm_version:
     description: 'llvm major version (e.g 19,20, main) - to be used for llvm specific fails'
     required: true
+  split_index:
+    description: "optional split index so this run can be done with different splits, current only 0 or 1"
+    default: ''
 
 runs:
   using: "composite"
@@ -21,6 +24,20 @@ runs:
       with:
         name: ock_${{inputs.target}}
         path: install_ock
+
+    - name: download icd artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: icd_${{inputs.target}}
+        path: install_icd
+
+    - name: Download opencl cts artefact
+      uses: ./.github/actions/download_artifact
+      with:
+        name: opencl_cts_${{inputs.target}}
+        path: $GITHUB_WORKSPACE/test_conformance
+        needs_tar: true
+        run_id: ${{ github.run_id }}
 
     - name: Run opencl cts
       shell: bash
@@ -41,6 +58,12 @@ runs:
         python3 scripts/testing/create_override_csv.py -d scripts/testing/opencl_cts \
              -k ${{ inputs.target }} llvm_${{ inputs.llvm_version }} \
              -o override_combined.csv -vv
+        CTS_CSV_FILE_PATH=$GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE
+        if [ "${{ inputs.split_index }}" != "" ]; then
+          split -n l/2 $GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE --additional-suffix=.csv -d 0
+          CTS_CSV_FILE_PATH=00${{ inputs.split_index }}.csv
+        fi
+        echo Using $CTS_CSV_FILE_PATH
 
         # $CTS_FILTER ignores certain test, so is treated differently to temporary fails.
         python3 -u $GITHUB_WORKSPACE/scripts/testing/run_cities.py -v \
@@ -51,6 +74,6 @@ runs:
           -e CLC_EXECUTABLE=$GITHUB_WORKSPACE/install_ock/bin/clc \
           -e OCL_ICD_FILENAMES=$GITHUB_WORKSPACE/install_ock/lib/libCL.so \
           -e CL_PLATFORM_INDEX=0 \
-          -s $GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE \
+          -s $CTS_CSV_FILE_PATH \
           -i $GITHUB_WORKSPACE/source/cl/scripts/$CTS_FILTER \
           -o override_combined.csv

--- a/.github/actions/run_sycl_cts/action.yml
+++ b/.github/actions/run_sycl_cts/action.yml
@@ -10,6 +10,9 @@ inputs:
   llvm_version:
     description: 'llvm major version (e.g 19,20, main) - to be used for llvm specific fails'
     required: true
+  split_index:
+    description: "optional split index so this run can be done with different splits, current only 0 or 1"
+    default: ''
 
 runs:
   using: "composite"
@@ -74,6 +77,11 @@ runs:
 
         exitcode=0
         set -x
+        if [ "${{ inputs.split_index }}" != "" ]; then
+          split -n l/2 $CTS_CSV_FILE --additional-suffix=.csv -d 0;
+          CTS_CSV_FILE=00${{ inputs.split_index }}.csv
+          echo Using $CTS_CSV_FILE
+        fi
         python3 $GITHUB_WORKSPACE/scripts/testing/run_cities.py \
           --color=always \
           --timeout $SYCL_CTS_TIMEOUT \
@@ -88,8 +96,10 @@ runs:
           -o override_combined.csv \
           $SYCL_CTS_FILTER || exitcode=$?
 
-        $GITHUB_WORKSPACE/scripts/testing/create_sycl_cts_test_lists.sh "${PREPEND_PATH[@]}" SYCL-CTS $CTS_CSV_FILE csv.txt cts_all.txt
-        set +x
-        # output a diff of the generated list csv.txt and cts_all.txt
-        diff -u csv.txt cts_all.txt || echo "WARNING - Missing some tests from sycl cts file based on test_all --list-tests - see > above"
+        if [ "${{ inputs.split_index }}" == "" ]; then
+          $GITHUB_WORKSPACE/scripts/testing/create_sycl_cts_test_lists.sh "${PREPEND_PATH[@]}" SYCL-CTS $CTS_CSV_FILE csv.txt cts_all.txt
+          set +x
+          # output a diff of the generated list csv.txt and cts_all.txt
+          diff -u csv.txt cts_all.txt || echo "WARNING - Missing some tests from sycl cts file based on test_all --list-tests - see > above"
+        fi
         exit $exitcode

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -259,16 +259,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-  build_run_opencl_cts:
-    if: inputs.test_opencl_cts
+  build_run_opencl_cts_x86_64_aarch64:
+    if: inputs.test_opencl_cts && (contains(inputs.target_list, 'host_x86_64_linux') || contains(inputs.target_list, 'host_aarch64_linux'))
     needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
       fail-fast: false  # let all matrix jobs complete
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
-        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64_riscv64) }}
+        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
 
-    runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || (contains(matrix.target, 'host_riscv64') && 'cp-ubuntu-24.04' || 'ubuntu-22.04') }}
+    runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     container:
       image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
              || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
@@ -297,6 +297,63 @@ jobs:
         with:
           target: ${{ matrix.target }}
           llvm_version: ${{ inputs.llvm_version }}
+
+  build_opencl_cts_riscv64:
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
+    runs-on: 'ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+    steps:
+      - name: clone ock
+        uses: actions/checkout@v4
+        with:
+          # scripts: for run_cities.py
+          # source: for CTS filter.csv files
+          # platform: for toolchain files
+          # .github for actions
+          sparse-checkout: |
+            scripts
+            source
+            platform
+            .github
+      - name : build and upload opencl_cts
+        uses: ./.github/actions/do_build_opencl_cts
+        with:
+          target: host_riscv64_linux
+
+  run_opencl_cts_riscv64:
+    if: inputs.test_opencl_cts
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu, build_opencl_cts_riscv64 ]
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      fail-fast: false  # let all matrix jobs complete
+      matrix:
+        split_index: [ 0, 1 ]
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+    steps:
+      - name: clone ock
+        uses: actions/checkout@v4
+        with:
+          # scripts: for run_cities.py
+          # source: for CTS filter.csv files
+          # platform: for toolchain files
+          # .github for actions          
+          sparse-checkout: |
+            scripts
+            source
+            platform
+            .github
+      - name : run opencl_cts
+        uses: ./.github/actions/run_opencl_cts
+        with:
+          target: host_riscv64_linux
+          llvm_version: ${{ inputs.llvm_version }}
+          split_index: ${{ matrix.split_index }}
 
   build_dpcpp_native_x86_64:
     needs: [workflow_vars]
@@ -724,7 +781,11 @@ jobs:
 
   run_sycl_cts_riscv64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_opencl_combine]
-    runs-on: 'cp-ubuntu-24.04' # note: the job will time-out (>6 hrs) if default github runners are used
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      fail-fast: false  # let all matrix jobs complete
+      matrix:
+        split_index: [ 0, 1 ]
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
@@ -740,6 +801,7 @@ jobs:
           target: host_riscv64_linux
           sycl_device: opencl
           llvm_version: ${{ inputs.llvm_version }}
+          split_index: ${{ matrix.split_index }}
 
   run_sycl_cts_riscv64_native_cpu:
     needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_native_cpu_combine]


### PR DESCRIPTION
# Overview

Split dome risc-v jobs into two and run on github runners

# Reason for change

Switch to using github runners to reduce self-hosted dependence.
