### PR TITLE
Fix interop failure false reporting on host_task_interop_api

### DIFF
--- a/scripts/testing/sycl_cts/override_native_cpu.csv
+++ b/scripts/testing/sycl_cts/override_native_cpu.csv
@@ -1,5 +1,4 @@
 SYCL_CTS,test_handler "handler.parallel_for*",MayFail
-SYCL_CTS,test_host_task host_task_interop_api,XFail
 SYCL_CTS,test_kernel "Test kernel info",XFail
 SYCL_CTS,test_kernel "Behavior of kernel attribute*",MayFail
 SYCL_CTS,test_opencl_interop opencl_interop_constructors,Ignore

--- a/scripts/testing/sycl_cts/tests.csv
+++ b/scripts/testing/sycl_cts/tests.csv
@@ -169,7 +169,7 @@ SYCL_CTS,test_hierarchical hierarchical_non_uniform_local_range
 SYCL_CTS,test_hierarchical hierarchical_private_memory
 SYCL_CTS,test_host_accessor
 SYCL_CTS,test_host_task "CUDA host task interop test" --allow-running-no-tests
-SYCL_CTS,test_host_task host_task_interop_api
+SYCL_CTS,test_host_task host_task_interop_api --allow-running-no-tests
 SYCL_CTS,test_host_task host_task_invoke_api
 SYCL_CTS,test_id "id provides a default constructor"
 SYCL_CTS,test_id "id provides specialized constructors for each dimensionality"


### PR DESCRIPTION

# Overview

Add --allow-running-no-tests as it rightly can not run it
