### PR TITLE
[LLVM TIP] Fix use of ConvertDebugDeclareToDebugValue

### DIFF
--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -181,11 +181,6 @@ bool BasicMem2RegPass::promoteAlloca(AllocaInst *Alloca) const {
     if (StoreInst *Store = dyn_cast<StoreInst>(U)) {
       StoredValue = Store->getValueOperand();
       ToDelete.push_back(Store);
-      DIBuilder DIB(*Alloca->getModule(), /*AllowUnresolved*/ false);
-      auto DbgIntrinsics = findDbgDeclares(Alloca);
-      for (auto oldDII : DbgIntrinsics) {
-        ConvertDebugDeclareToDebugValue(oldDII, Store, DIB);
-      }
       break;
     }
   }


### PR DESCRIPTION
# Overview

The function ConvertDebugDeclareToDebugValue() has changed to not accept DbgVariableIntrinsic and cases where this was used in conjunction with findDbgDeclares() have been remove in llvm PR #149037. We no longer generate old style debug, so we just remove the code altogether.

