### PR TITLE
[NFC] Remove more old debug info handling.

### DIFF
--- a/modules/compiler/compiler_pipeline/include/compiler/utils/barrier_regions.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/barrier_regions.h
@@ -38,7 +38,6 @@
 namespace llvm {
 class BasicBlock;
 class CallInst;
-class DbgDeclareInst;
 class FenceInst;
 class Function;
 class Instruction;
@@ -152,15 +151,6 @@ class Barrier {
   /// @brief replaces a subkernel with a given function
   void replaceSubkernel(llvm::Function *from, llvm::Function *to);
 
-  /// @brief Type containing list of debug intrinsics and the source variable
-  /// byte offset in the live variables struct.
-  // TODO CA-1115 llvm.dbg.declare is being deprecated
-  using debug_intrinsics_t =
-      llvm::SmallVector<std::pair<llvm::DbgDeclareInst *, unsigned>, 4>;
-  const debug_intrinsics_t &getDebugIntrinsics() const {
-    return debug_intrinsics_;
-  }
-
   using debug_variable_records_t =
       llvm::SmallVector<std::pair<llvm::DbgVariableRecord *, unsigned>, 4>;
   const debug_variable_records_t &getDebugDbgVariableRecords() const {
@@ -269,8 +259,6 @@ class Barrier {
   barrier_block_block_set_t barrier_successor_set_;
   /// @brief Map between barrier ids and call instructions invoking stubs
   debug_stub_map_t barrier_stub_call_map_;
-  /// @brief List of debug intrinsics and byte offsets into live variable struct
-  debug_intrinsics_t debug_intrinsics_;
   /// @brief List of debug DbgVariableRecords and byte offsets into live
   /// variable struct
   debug_variable_records_t debug_variable_records_;

--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -957,12 +957,6 @@ void compiler::utils::Barrier::MakeLiveVariableMemType() {
 
     // Check if the alloca has a debug info source variable attached. If
     // so record this and the matching byte offset into the struct.
-    auto DbgIntrinsics = findDbgDeclares(member.value);
-    for (auto DII : DbgIntrinsics) {
-      if (auto dbgDeclare = dyn_cast<DbgDeclareInst>(DII)) {
-        debug_intrinsics_.push_back(std::make_pair(dbgDeclare, offset));
-      }
-    }
     const auto DVRDeclares = findDVRDeclares(member.value);
     for (auto *const DVRDeclare : DVRDeclares) {
       debug_variable_records_.push_back(std::make_pair(DVRDeclare, offset));
@@ -1425,12 +1419,6 @@ BasicBlock *compiler::utils::Barrier::CloneBasicBlock(
 
   // Loop over all instructions, and copy them over.
   for (Instruction &i : *bb) {
-    // Don't clone over debug intrinsics since we're going to create them
-    // manually later.
-    if (isa<DbgDeclareInst>(&i)) {
-      continue;
-    }
-
     Instruction *new_inst = i.clone();
     if (i.hasName()) new_inst->setName(i.getName() + name_suffix);
     new_inst->insertInto(new_bb, new_bb->end());

--- a/modules/compiler/compiler_pipeline/source/pass_functions.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_functions.cpp
@@ -125,22 +125,6 @@ bool funcContainsDebugMetadata(const llvm::Function &func,
         vmap.MD()[loc].reset(loc);
         foundDI = true;
       }
-
-      if (auto DebugIntrinsic = llvm::dyn_cast<llvm::DbgInfoIntrinsic>(&Inst)) {
-        llvm::DILocalVariable *DIVar = nullptr;
-        if (auto DbgVarIntrinsic =
-                llvm::dyn_cast<llvm::DbgVariableIntrinsic>(DebugIntrinsic)) {
-          DIVar = DbgVarIntrinsic->getVariable();
-        } else {
-          continue;  // TODO CA-1115 - we don't handle DbgLabelInsts yet
-        }
-        if (DIVar) {
-          vmap.MD()[DIVar].reset(DIVar);
-          auto varLoc = DIVar->getScope();
-          vmap.MD()[varLoc].reset(varLoc);
-          foundDI = true;
-        }
-      }
     }
   }
 

--- a/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
@@ -234,10 +234,6 @@ struct ScheduleGenerator {
 
       DummyInst->eraseFromParent();
     };
-    for (auto debug_pair : barrier.getDebugIntrinsics()) {
-      RecreateDebugIntrinsic(debug_pair.first->getVariable(),
-                             debug_pair.second);
-    }
     for (auto debug_pair : barrier.getDebugDbgVariableRecords()) {
       RecreateDebugIntrinsic(debug_pair.first->getVariable(),
                              debug_pair.second);


### PR DESCRIPTION
# Overview

[NFC] Remove more old debug info handling.

# Reason for change

As more old debug info functions and types are being removed from LLVM 22, prepare for this by removing our handling of it, as we already know that regardless of LLVM version, we are already no longer using it.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

This is marked NFC because it is NFC for the LLVM versions that we support. For LLVM 22 which we do not yet support, it will not be NFC, it will fix the build.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
