### PR TITLE
Detect new way OpenCL CTS reports skipped tests.

### DIFF
--- a/scripts/testing/city_runner/cts.py
+++ b/scripts/testing/city_runner/cts.py
@@ -129,11 +129,16 @@ class CTSTestRun(TestRunBase):
             self.total_tests += total_tests
 
         # Special cases.
-        if self.return_code:
-            # Handle failures due to signals.
-            super(CTSTestRun, self).analyze_process_output()
-        else:
+        if self.return_code == 0:
             # Handle tests that do not print 'PASSED'.
             if self.test.executable.name.find("headers") >= 0:
                 # The 'headers' executable always returns zero.
                 self.status = "PASS"
+        elif self.return_code == 156:
+            # OpenCL CTS uses -100 as a magic value to indicate that a test
+            # was skipped. Because exit codes are returned as 8-bit unsigned
+            # values, we see this as 156.
+            self.status = "SKIP"
+        else:
+            # Handle failures due to signals.
+            super(CTSTestRun, self).analyze_process_output()


### PR DESCRIPTION
# Overview

Detect new way OpenCL CTS reports skipped tests.

# Reason for change

test_spir no longer returns with exit code 0, it returns with -100.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
