### PR TITLE
Remove the thread pool size limitation

### DIFF
--- a/modules/mux/targets/host/source/queue.cpp
+++ b/modules/mux/targets/host/source/queue.cpp
@@ -249,9 +249,10 @@ void commandNDRange(host::queue_s *queue, host::command_info_s *info) {
     return;
   }
 
-  constexpr size_t signal_count =
-      host::thread_pool_s::max_num_threads * slice_multiplier;
-  std::array<std::atomic<bool>, signal_count> signals;
+  const size_t signal_count =
+      host_device->thread_pool.num_threads() * slice_multiplier;
+
+  std::vector<std::atomic<bool>> signals(signal_count);
   std::atomic<uint32_t> queued(0);
   host_device->thread_pool.enqueue_range(
       [](void *const in, void *const info, void *, size_t index) {

--- a/modules/mux/targets/host/source/thread_pool.cpp
+++ b/modules/mux/targets/host/source/thread_pool.cpp
@@ -87,8 +87,7 @@ thread_pool_s::thread_pool_s() : stayAlive(true) {
   const size_t hw_threads = cargo::thread::hardware_concurrency();
   const size_t desired_threads =
       clamp(hw_threads - ca_free_hw_threads, 2, hw_threads);
-  const size_t max_threads = thread_pool_s::max_num_threads;
-  size_t debug_threads = thread_pool_s::max_num_threads;
+  size_t debug_threads = hw_threads;
 
   // Register the value of the CA_HOST_NUM_THREADS environment variable.
   // If the programmer has provided an override to the number of threads that
@@ -102,7 +101,8 @@ thread_pool_s::thread_pool_s() : stayAlive(true) {
   }
 
   // Must be set before num_threads() is called.
-  initialized_threads = std::min({desired_threads, max_threads, debug_threads});
+  initialized_threads = std::min({desired_threads, debug_threads});
+  pool.resize(num_threads());
   for (size_t i = 0, e = num_threads(); i < e; i++) {
     pool[i] = cargo::thread(threadFunc, this);
     pool[i].set_name("host:pool:" + std::to_string(i));


### PR DESCRIPTION
# Overview

Replace the static thread pool by a dynamic one

# Reason for change

Using a static thread pool require to set a limit to the number of thread available. In our case the 
thread pool is limited to 32. This limitation negatively impact the performance when targeting a CPU with a large number of cores. 


# Description of change

This PR replace the static thread pool by a dynamic thread pool which is allocate in the constructor of `thread_pool_s`. 
The number of initialized threads is now the minimum between `desired_threads` and `debug_threads`. 

(By removing the thread pool limitation, on the first socket (72 cores) of a NVIDIA Grace CPU,
We obtain 60%  speedup on the [projectile-sycl benchmark](https://github.com/zjin-lcf/HeCBench/tree/HeCBench-SYCL/src/projectile-sycl), with AdaptiveCpp using OCK as OpenCL backend)

This has no impact on runtime and avoids other, non stable, wraparound that could have been considered, namely either initializing static pool with a larger number (waste of memory space) or retrieving number of cores available at compile time (inadequate for cross compilation).