### PR TITLE
Fix documentation.

### DIFF
--- a/.github/workflows/combined_docs/_config.yml
+++ b/.github/workflows/combined_docs/_config.yml
@@ -1,0 +1,1 @@
+keep_files: ["doc"]

--- a/.github/workflows/combined_docs/index.md
+++ b/.github/workflows/combined_docs/index.md
@@ -4,5 +4,5 @@ permalink: index.html
 layout: toplevel
 ---
 
-The majority of the general technical documentation for the oneAPI Construction Kit can be found <a href="ock/index.html">here</a>.
-For RFCS (request for comments) documentation, this can be found <a href="rfc-0000.html">here</a>
+- [General technical documentation for oneAPI Construction Kit](doc/)
+- [RFCs](rfcs/) (requests for comments)

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -31,52 +31,51 @@ jobs:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name == 'workflow_dispatch'  
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout OCK
         uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
-      - name: Install apt package
+      - name: Install prerequisites
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen virtualenv
 
-      - name: Install prerequisites
-        run: python -m pip install -r doc/requirements.txt
-
-      - name: Build Documentation
+      - name: Build OCK documentation
         working-directory: ${{github.workspace}}
         run: |
            cmake -DCMAKE_BUILD_TYPE=Debug -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF -DOCL_EXTENSION_cl_khr_il_program=OFF -Bbuild_doc
            cmake --build build_doc --target doc_html
-           mkdir docs
-           mv build_doc/doc/html docs/ock
 
-      - name: Checkout
+      - name: Checkout RFCs
         uses: actions/checkout@v5
         with:
           ref: rfcs
           path: rfcs
 
-      - name: Move rfcs to build_doc
+      - name: Prepare combined docs tree
         shell: bash
         run: |
-          mv rfcs/* docs
-          cp -r $GITHUB_WORKSPACE/.github/workflows/combined_docs/* docs
-
-          # TODO : Remove from original rfc docs
-          sed -i 's/permalink: index/permalink: rfc-0000/' docs/rfc-0000.md
-          sed -i 's/split.size == 2 %/split.size == 2 and page.rfc %/' docs/rfc-0000.md
+          cp -r $GITHUB_WORKSPACE/.github/workflows/combined_docs docs
+          mv rfcs docs
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      - name: Copy OCK documentation
+        shell: bash
+        run: |
+           mkdir _site
+           mv build_doc/doc/html _site/doc
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
 


### PR DESCRIPTION
# Overview

Fix documentation.

# Reason for change

We were including the rendered OCK documentation in the RFCs, and then rendering the RFCs, but the RFCs rendering process does not preserve the required files.

# Description of change

This commit changes the process to include the rendered OCK documentation unmodified.

This commit also restructures the documentation somewhat:

- OCK documentation ends up at /doc/.
- RFCs end up at /rfcs/.
- The landing page uses descriptive link text for both.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
