### PR TITLE
[LLVM 22] Loosen lit test.

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetize_struct_gep.ll
@@ -42,5 +42,5 @@ declare i64 @__mux_get_global_id(i32)
 ; Check if we can packetize GEPs on structs
 ; Note that we only need to packetize the non-uniform operands..
 ; CHECK: define spir_kernel void @__vecz_v4_test
-; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2
-; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}, i32 2
+; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}
+; CHECK: getelementptr %struct.T, ptr addrspace(1) %{{.+}}, <4 x i64> %{{.+}}


### PR DESCRIPTION
# Overview

[LLVM 22] Loosen lit test.

# Reason for change

On LLVM 22, InstCombine will split a getelementptr with multiple offsets into multiple separate getelementptr instructions.

# Description of change

Adjust the test to allow this.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
