### PR TITLE
[CI] Fix duplication of vector_swizzle entries in sycl cts test list

### DIFF
--- a/scripts/testing/sycl_cts/override_all.csv
+++ b/scripts/testing/sycl_cts/override_all.csv
@@ -1,1 +1,2 @@
 SYCL_CTS,test_event "event::wait does not report asynchronous errors",MayFail
+SYCL_CTS,test_handler "handler.parallel_for*",MayFail

--- a/scripts/testing/sycl_cts/override_native_cpu.csv
+++ b/scripts/testing/sycl_cts/override_native_cpu.csv
@@ -1,4 +1,3 @@
-SYCL_CTS,test_handler "handler.parallel_for*",MayFail
 SYCL_CTS,test_kernel "Behavior of kernel attribute*",MayFail
 SYCL_CTS,test_kernel "Test kernel info",XFail
 SYCL_CTS,test_math_builtin_api "math_builtin_common_base_*",XFail

--- a/scripts/testing/sycl_cts/tests.csv
+++ b/scripts/testing/sycl_cts/tests.csv
@@ -559,13 +559,13 @@ SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_byte
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_std_byte
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_int8_t
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_int32_t
-SYCL_CTS,test_vector_swizzles "vector_swizzles_bool*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_char*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_int*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_float*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_double*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_half*" --allow-running-no-tests
-SYCL_CTS,test_vector_swizzles "vector_swizzles_byte*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_std_byte*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_int8_t*"
-SYCL_CTS,test_vector_swizzles "vector_swizzles_int32_t*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_bool_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_char_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_float_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_double_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_half_*" --allow-running-no-tests
+SYCL_CTS,test_vector_swizzles "vector_swizzles_byte_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_std_byte_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int8_t_*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int32_t_*"


### PR DESCRIPTION
# Overview

Some of the entries duplicated patterns for vector_swizzle_int*.

Also moved handler.parallel_for* to a general MayFail since it was also failing on openCL variant of SYCL.
