### PR TITLE
Do not build compiler-riscv-utils unnecessarily.

### DIFF
--- a/modules/compiler/riscv/CMakeLists.txt
+++ b/modules/compiler/riscv/CMakeLists.txt
@@ -14,6 +14,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# If the riscv target is disabled, then the compiler should be too.
+if(NOT TARGET riscv)
+  return()
+endif()
+
 # Check if riscv is enabled in the llvm install.
 # If so we can build this library
 find_library(LLVMRISCVCODEGEN LLVMRISCVCodeGen PATHS


### PR DESCRIPTION
# Overview

Do not build compiler-riscv-utils unnecessarily.

# Reason for change

We were building it whenever LLVM was built with RISC-V support. When we are not building RefSi, this will not be used and can lead to errors if required LLVM components are unavailable.

# Description of change

Skip the whole directory.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
