### PR TITLE
[RELEASE] Prepare for 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # oneAPI Construction Kit Changes
 
-## TBD
+## Version 5.0.0
 
 Feature additions:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(ComputeAorta VERSION 4.0.0 LANGUAGES C CXX ASM)
+project(ComputeAorta VERSION 5.0.0 LANGUAGES C CXX ASM)
 
 # There's no situation where it's necessary to *not* generate this file and the
 # time difference to configure is about 0.1s


### PR DESCRIPTION
Feature additions:

* Support for LLVM 20 and 21 has been added.

Upgrade guidance:

* Support for degenerate subgroups has been removed. No in-tree target or template was using this, but custom targets may need to be updated.
* Support for LLVM versions before 20 has been removed.
* Vulkan API support has been removed and will no longer be supported for any versions. Users may fork from the 4.0.0 version if they wish to use it.
* The CMake option CA_ENABLE_API has been removed; OpenCL will always be enabled as the API.
* The mux spec has been bumped:
  * 0.81.0: the muxResetFence and muxResetSemaphore functions have been removed.
* Mux now enables only the "host" compiler and target by default. Non-host builds will need to specify the compiler and target explicitly. The `CA_(target)_ENABLED` variables which served as extra gates for various targets no longer have any effect.
