### PR TITLE
[CI] Do not hard-code OCK version number

### DIFF
--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -38,7 +38,7 @@ runs:
           # Run client
           cd $GITHUB_WORKSPACE/build_client
           exitcode=0
-          OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./bin/UnitCL || exitcode=$?
+          OCL_ICD_FILENAMES=$PWD/lib/libCL.so ./bin/UnitCL || exitcode=$?
           kill %1
           exit $exitcode
         else

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -139,7 +139,7 @@ As a simple test try running a simple UnitCL test (using the in-tree version):
 
 ```
   cd build_client
-  HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWDlib/libCL.so.4.0 \
+  HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWDlib/libCL.so \
     ./bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
 ```
 This should show as `PASSED`.
@@ -160,7 +160,7 @@ export LD_LIBRARY_PATH=<path_to_dpcpp_compiler_base>/lib:$PWD/lib:$LD_LIBRARY_PA
 export OCL_ICD_FILENAMES=$PWD/lib/libCL.so
 export ONEAPI_DEVICE_SELECTOR=*:fpga
 <path_to_dpcpp_compiler_base>/bin/clang++ -fsycl <path_to_ock>/examples/applications/simple-vector-add.cpp -o simple-vector-add
-HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./simple-vector-add
+HAL_REMOTE_PORT=<port_num> OCL_ICD_FILENAMES=$PWD/lib/libCL.so ./simple-vector-add
 ```
 
 This should show "The results are correct!".


### PR DESCRIPTION
# Overview

[CI] Do not hard-code OCK version number.

# Reason for change

As we are preparing for a 5.0 release, tests should not assume 4.0.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
