### PR TITLE
[LLVM 22] Adjust for createSourceManager change.

### DIFF
--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1278,7 +1278,11 @@ clang::FrontendInputFile BaseModule::prepareOpenCLInputFile(
   populateOpenCLOpts(instance, opencl_opts);
 
   instance.createFileManager();
+#if LLVM_VERSION_GREATER_EQUAL(22, 0)
+  instance.createSourceManager();
+#else
   instance.createSourceManager(instance.getFileManager());
+#endif
 
   auto addIncludeFile = [&](const std::string &name, const void *data,
                             const size_t size) {


### PR DESCRIPTION
# Overview

[LLVM 22] Adjust for createSourceManager change.

# Reason for change

LLVM 22 removes the FileMgr parameter from CompilerInstance::createSourceManager.

# Description of change

Remove the corresponding argument when we call it to match.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
