### PR TITLE
Fix TornadoVM testing.

### DIFF
--- a/.github/actions/do_build_tornado/action.yml
+++ b/.github/actions/do_build_tornado/action.yml
@@ -53,7 +53,7 @@ runs:
         pip install tqdm
         export JAVA_HOME=`readlink -f $(command -v java) | sed 's/\/bin\/java//'`
         export TORNADO_SDK=$GITHUB_WORKSPACE/TornadoVM_build/bin/sdk
-        export PATH=$PWD/apache-maven-3.9.3/bin:$PATH
+        export PATH=$PWD/apache-maven-3.9.3/bin:$TORNADO_SDK/bin:$PATH
         mvn -v
         java --version
         cd TornadoVM_build


### PR DESCRIPTION
# Overview

Fix TornadoVM testing.

# Reason for change

The build attempts to run a script from $TORNADO_SDK/bin without adding that to $PATH.

# Description of change

Add it on our end.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
