### PR TITLE
Correct CODEOWNERS syntax.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-@uxlfoundation/ock-reviewers
+* @uxlfoundation/ock-reviewers
 
 # limit the workflow to a subset of the overall reviewers for security reasons.
 .github @uxlfoundation/ock-workflow-reviewers


### PR DESCRIPTION
# Overview

Correct CODEOWNERS syntax.

# Reason for change

We were intending for all changes to files outside of .github to need review by @uxlfoundation/ock-reviewers, but we left out the * causing it to have no effect. This caused a PR to go unreviewed.

# Description of change

Include the missing *.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
