### PR TITLE
Remove LLVM build directory during sanitizer tests.

### DIFF
--- a/.github/actions/do_build_run_sanitizers/action.yml
+++ b/.github/actions/do_build_run_sanitizers/action.yml
@@ -85,6 +85,7 @@ runs:
             -DCMAKE_CXX_COMPILER=/usr/bin/clang++-20
         echo Install LLVM
         cmake --build $GITHUB_WORKSPACE/external/build --target install -- -j2
+        rm -rf $GITHUB_WORKSPACE/external/build
 
     - name: Build OCK
       shell: 'bash'


### PR DESCRIPTION
# Overview

Remove LLVM build directory during sanitizer tests.

# Reason for change

Jobs are failing due to running out of disk space.

# Description of change

We no longer need the LLVM build directory once that build has completed, so free up some disk space by removing that.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
