### PR TITLE
Fix nan() to return quiet NaN.

### DIFF
--- a/modules/compiler/builtins/abacus/source/abacus_math/nan.cpp
+++ b/modules/compiler/builtins/abacus/source/abacus_math/nan.cpp
@@ -21,9 +21,10 @@
 
 template <typename T>
 static inline T nan_helper() {
-  // Return NaN with all exponent bits and least significant bit set
-  const typename TypeTraits<T>::UnsignedType nanVal =
-      FPShape<T>::ExponentMask() | 0x1;
+  using UnsignedType = typename TypeTraits<T>::UnsignedType;
+  // Return NaN with all exponent bits and most significant mantissa bit set
+  const UnsignedType nanVal = UnsignedType(FPShape<T>::ExponentMask()) |
+                              (UnsignedType(1) << (FPShape<T>::Mantissa() - 1));
   return abacus::detail::cast::as<T>(nanVal);
 }
 


### PR DESCRIPTION
# Overview

Fix nan() to return quiet NaN.

# Reason for change

LLVM #139581 fixes minnum() and maxnum() to correctly handle sNaNs, which results in our Execution.Builtins_01_Fmin_Vector_Scalar_NaN test failing as our nan() was returning a signalling NaN. OpenCL requires it to return a quiet NaN.

# Description of change

This is conventionally indicated by the high mantissa bit, not the low bit, so set that instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
