### PR TITLE
Split CTS further.

### DIFF
--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -63,7 +63,7 @@ runs:
              -o override_combined.csv -vv
         CTS_CSV_FILE_PATH=$GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE
         if [ "${{ inputs.split_index }}" != "" ]; then
-          split -n l/2 $GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE --additional-suffix=.csv -d 0
+          split -n r/4 $GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE --additional-suffix=.csv -d 0
           CTS_CSV_FILE_PATH=00${{ inputs.split_index }}.csv
         fi
         echo Using $CTS_CSV_FILE_PATH

--- a/.github/actions/run_sycl_cts/action.yml
+++ b/.github/actions/run_sycl_cts/action.yml
@@ -63,7 +63,7 @@ runs:
         exitcode=0
         set -x
         if [ "${{ inputs.split_index }}" != "" ]; then
-          split -n l/2 $CTS_CSV_FILE --additional-suffix=.csv -d 0;
+          split -n r/4 $CTS_CSV_FILE --additional-suffix=.csv -d 0;
           CTS_CSV_FILE=00${{ inputs.split_index }}.csv
           echo Using $CTS_CSV_FILE
         fi

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -41,6 +41,13 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a
       # pull request. Any parameters below this is intended for local testing
       # and should not be merged nor reviewed (other than checking it should not be merged).
+      test_tornado: false
+      test_sanitizers: false
+      test_remote_hal: false
+      test_sycl_cts: false
+      test_sycl_e2e: false
+      run_internal: false
+      target_list: '[ "host_riscv64_linux" ]'
 
   # This cleans up any caches which may have been created when running external tests
   clean_caches:

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -373,7 +373,7 @@ jobs:
     strategy:
       fail-fast: false  # let all matrix jobs complete
       matrix:
-        split_index: [ 0, 1 ]
+        split_index: [ 0, 1, 2, 3 ]
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:


### PR DESCRIPTION
# Overview

Split CTS further.

# Reason for change

The current strategy of splitting OpenCL CTS in two separate jobs for RISC-V is not quite sufficient, as both jobs take about six hours and they regularly cross the threshold to time out.

# Description of change

Split this in four separate jobs instead.

# Anything else we should know?

For consistency, the SYCL-CTS action is updated likewise even though this is no longer run for RISC-V.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
