### PR TITLE
Run OpenCL CTS without RVV.

### DIFF
--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -15,9 +15,6 @@ inputs:
   split_index:
     description: "optional split index so this run can be done with different splits, current only 0 or 1"
     default: ''
-  cityrunner_args:
-    description: "optional extra arguments to pass to cityrunner"
-    default: ''
 
 runs:
   using: "composite"
@@ -53,7 +50,7 @@ runs:
         echo "Running OpenCL CTS tests with CTS file $CTS_CSV_FILE with filter $CTS_FILTER"
         PREPEND_PATH=()
         if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
-          PREPEND_PATH=(--prepend-path '/usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu')
+          PREPEND_PATH=(--prepend-path '/usr/bin/qemu-riscv64 -cpu rv64,zfh=true -L /usr/riscv64-linux-gnu')
         fi
         set -x
         # Build override file, all is done first, then the target specific.
@@ -79,5 +76,4 @@ runs:
           -e CL_PLATFORM_INDEX=0 \
           -s $CTS_CSV_FILE_PATH \
           -i $GITHUB_WORKSPACE/source/cl/scripts/$CTS_FILTER \
-          -o override_combined.csv \
-          ${{ inputs.cityrunner_args }}
+          -o override_combined.csv

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -397,7 +397,6 @@ jobs:
           target: host_riscv64_linux
           llvm_version: ${{ inputs.llvm_version }}
           split_index: ${{ matrix.split_index }}
-          cityrunner_args: "-e CA_HOST_TARGET_FEATURES=+v"
 
   build_dpcpp_native_x86_64:
     needs: [workflow_vars]


### PR DESCRIPTION
# Overview

Run OpenCL CTS without RVV.

# Reason for change

QEMU's emulation of RISC-V with RVV is significantly slower than RISC-V without RVV and results in OpenCL CTS timing out almost every time. The timeout is a hard timeout of 6 hours, we cannot increase that, and we cannot split up the tests further to cut back the time because some individual tests already need that long. While it would be nice if we could test RVV, at the moment it is doing more harm than good because it means it becomes pretty much impossible for our workflow to ever pass.

# Description of change

This commit changes our run of OpenCL CTS to not use RVV, and our invocation of QEmu to not enable RVV instructions. This reduces the run time to under four hours, allowing us to continue doing some RISC-V testing.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
