### PR TITLE
Save kernel even after new program builds.

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/module.h
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/include/{{cookiecutter.target_name}}/module.h
@@ -76,7 +76,7 @@ class {{cookiecutter.target_name.capitalize()}}Module final : public compiler::B
       override;
 
   /// @see Module::createKernel
-  compiler::Kernel *createKernel(const std::string &name) override;
+  std::shared_ptr<compiler::Kernel> createKernel(const std::string &name) override;
 
   const {{cookiecutter.target_name.capitalize()}}Target &getTarget() const;
 

--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -200,7 +200,7 @@ compiler::Result {{cookiecutter.target_name.capitalize()}}Module::createBinary(c
 }
 
 // No deferred support so just return nullptr
-compiler::Kernel *{{cookiecutter.target_name.capitalize()}}Module::createKernel(const std::string &) { return nullptr; }
+std::shared_ptr<compiler::Kernel> {{cookiecutter.target_name.capitalize()}}Module::createKernel(const std::string &) { return nullptr; }
 
 const {{cookiecutter.target_name.capitalize()}}Target &{{cookiecutter.target_name.capitalize()}}Module::getTarget() const {
   return *static_cast<{{cookiecutter.target_name.capitalize()}}Target *>(&target);

--- a/modules/compiler/include/compiler/module.h
+++ b/modules/compiler/include/compiler/module.h
@@ -621,8 +621,7 @@ class Module {
   /// @param[in] name The name of the kernel.
   ///
   /// @return An object that represents a kernel contained within this module.
-  /// The lifetime of the `Kernel` object will be managed by `Module`.
-  virtual Kernel *getKernel(const std::string &name) = 0;
+  virtual std::shared_ptr<Kernel> getKernel(const std::string &name) = 0;
 
   /// @brief Compute the size of the serialized module.
   ///

--- a/modules/compiler/riscv/include/riscv/module.h
+++ b/modules/compiler/riscv/include/riscv/module.h
@@ -76,7 +76,8 @@ class RiscvModule : public compiler::BaseModule {
       compiler::utils::PassMachinery &) override;
 
   /// @see Module::createKernel
-  compiler::Kernel *createKernel(const std::string &name) override;
+  std::shared_ptr<compiler::Kernel> createKernel(
+      const std::string &name) override;
 
   const riscv::RiscvTarget &getTarget() const;
 

--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -166,7 +166,8 @@ compiler::Result RiscvModule::createBinary(
 }
 
 // No deferred support so just return nullptr
-compiler::Kernel *RiscvModule::createKernel(const std::string &) {
+std::shared_ptr<compiler::Kernel> RiscvModule::createKernel(
+    const std::string &) {
   return nullptr;
 }
 

--- a/modules/compiler/source/base/include/base/module.h
+++ b/modules/compiler/source/base/include/base/module.h
@@ -188,8 +188,7 @@ class BaseModule : public Module {
   /// @param[in] name The name of the kernel.
   ///
   /// @return An object that represents a kernel contained within this module.
-  /// The lifetime of the `Kernel` object will be managed by `Module`.
-  Kernel *getKernel(const std::string &name) override;
+  std::shared_ptr<Kernel> getKernel(const std::string &name) override;
 
   /// @brief Compute the size of the serialized module.
   ///
@@ -288,7 +287,7 @@ class BaseModule : public Module {
   /// @param[in] name The name of the kernel.
   ///
   /// @return An object that represents a kernel contained within this module.
-  virtual Kernel *createKernel(const std::string &name) = 0;
+  virtual std::shared_ptr<Kernel> createKernel(const std::string &name) = 0;
 
   /// @brief Add a diagnostic message to the log.
   ///
@@ -527,7 +526,7 @@ class BaseModule : public Module {
   // are called on the same name. If there are compiler resource conflicts
   // between creating kernels and scheduled kernels those are locked directly.
   std::mutex kernel_mutex;
-  std::map<std::string, std::unique_ptr<Kernel>> kernel_map;
+  std::map<std::string, std::shared_ptr<Kernel>> kernel_map;
 };  // class Module
 
 /// @}

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1871,7 +1871,7 @@ Result BaseModule::finalize(
   });
 }
 
-Kernel *BaseModule::getKernel(const std::string &name) {
+std::shared_ptr<Kernel> BaseModule::getKernel(const std::string &name) {
   if (!finalized_llvm_module) {
     return nullptr;
   }
@@ -1880,12 +1880,12 @@ Kernel *BaseModule::getKernel(const std::string &name) {
   const std::scoped_lock guard(kernel_mutex);
 
   if (kernel_map.count(name)) {
-    return kernel_map[name].get();
+    return kernel_map[name];
   }
 
-  auto *kernel = createKernel(name);
+  auto kernel = createKernel(name);
   if (kernel) {
-    kernel_map[name] = std::unique_ptr<Kernel>(kernel);
+    kernel_map[name] = kernel;
   }
   return kernel;
 }

--- a/modules/compiler/targets/host/include/host/module.h
+++ b/modules/compiler/targets/host/include/host/module.h
@@ -72,7 +72,8 @@ class HostModule : public compiler::BaseModule {
       compiler::utils::PassMachinery &) override;
 
   /// @see BaseModule::createKernel
-  compiler::Kernel *createKernel(const std::string &name) override;
+  std::shared_ptr<compiler::Kernel> createKernel(
+      const std::string &name) override;
 
   /// @see BaseModule::createPassMachinery
   std::unique_ptr<compiler::utils::PassMachinery> createPassMachinery(

--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -218,7 +218,8 @@ llvm::ModulePassManager HostModule::getLateTargetPasses(
   return static_cast<HostPassMachinery &>(pass_mach).getLateTargetPasses();
 }
 
-compiler::Kernel *HostModule::createKernel(const std::string &name) {
+std::shared_ptr<compiler::Kernel> HostModule::createKernel(
+    const std::string &name) {
   handler::GenericMetadata kernel_md(name, name, 0);
   std::unique_ptr<llvm::Module> kernel_module = target.withLLVMContextDo(
       [&](llvm::LLVMContext &C) -> std::unique_ptr<llvm::Module> {
@@ -266,7 +267,7 @@ compiler::Kernel *HostModule::createKernel(const std::string &name) {
   local_sizes[2] = std::min(4u, device_info->max_work_group_size_z);
 
   assert(kernel_md.local_memory_usage <= SIZE_MAX);
-  auto kernel = new HostKernel(
+  auto kernel = std::make_shared<HostKernel>(
       static_cast<HostTarget &>(target), getOptions(), kernel_module.release(),
       kernel_md.kernel_name, local_sizes,
       static_cast<size_t>(kernel_md.local_memory_usage));

--- a/modules/compiler/test/common.h
+++ b/modules/compiler/test/common.h
@@ -280,7 +280,7 @@ struct CompilerKernelTest : OpenCLCModuleTest {
   /// @brief Device object.
   mux_device_t device = nullptr;
   /// @brief Kernel object to test.
-  compiler::Kernel *kernel = nullptr;
+  std::shared_ptr<compiler::Kernel> kernel = nullptr;
 
   /// @brief Virtual method to setup any resources required by this fixture.
   void SetUp() override {
@@ -291,6 +291,12 @@ struct CompilerKernelTest : OpenCLCModuleTest {
     device = *optional_device;
     kernel = module->getKernel("nop");
     ASSERT_NE(nullptr, kernel);
+  }
+
+  /// @brief Virtual method to clean up any resources this fixture allocated.
+  void TearDown() override {
+    kernel.reset();
+    OpenCLCModuleTest::TearDown();
   }
 };
 

--- a/modules/compiler/test/kernel.cpp
+++ b/modules/compiler/test/kernel.cpp
@@ -26,7 +26,7 @@
 struct GetKernelTest : OpenCLCModuleTest {};
 
 TEST_P(GetKernelTest, GetKernel) {
-  auto *kernel = module->getKernel("nop");
+  auto kernel = module->getKernel("nop");
   if (optional_device) {
     ASSERT_NE(nullptr, kernel);
   } else {
@@ -39,7 +39,7 @@ TEST_P(GetKernelTest, PreferredLocalSize) {
     GTEST_SKIP();
   }
 
-  auto *kernel = module->getKernel("nop");
+  auto kernel = module->getKernel("nop");
   ASSERT_NE(nullptr, kernel);
 
   EXPECT_GE(kernel->preferred_local_size_x, 1u);
@@ -56,7 +56,7 @@ TEST_P(GetKernelTest, PreferredLocalSize) {
 }
 
 TEST_P(GetKernelTest, InvalidName) {
-  auto *kernel = module->getKernel("some_bad_name");
+  auto kernel = module->getKernel("some_bad_name");
   ASSERT_EQ(nullptr, kernel);
 }
 

--- a/source/cl/include/cl/kernel.h
+++ b/source/cl/include/cl/kernel.h
@@ -88,11 +88,16 @@ class MuxKernelWrapper {
   ///
   /// @param device OpenCL device.
   /// @param deferred_kernel Deferred compiled kernel to wrap.
-  MuxKernelWrapper(cl_device_id device, compiler::Kernel *deferred_kernel);
+  MuxKernelWrapper(cl_device_id device,
+                   std::shared_ptr<compiler::Kernel> deferred_kernel);
 
   /// @brief Queries whether this kernel's compilation is being deferred using a
   /// runtime compiler.
   bool supportsDeferredCompilation() const;
+
+  std::shared_ptr<compiler::Kernel> getDeferredKernel() const {
+    return deferred_kernel;
+  }
 
   /// @brief If this kernel supports specialization, this function causes the
   /// compiler to pre-cache a specific local size configuration.
@@ -212,7 +217,7 @@ class MuxKernelWrapper {
   mux_device_t mux_device;
   mux_allocator_info_t mux_allocator_info;
   mux_kernel_t precompiled_kernel;
-  compiler::Kernel *deferred_kernel;
+  std::shared_ptr<compiler::Kernel> deferred_kernel;
 };
 
 /// @brief Definition of the OpenCL kernel object.

--- a/source/cl/include/cl/program.h
+++ b/source/cl/include/cl/program.h
@@ -155,7 +155,7 @@ struct device_program {
     /// @brief An object that manages Mux kernels created from the Mux
     /// executable created when the module is finalized and deferred compilation
     /// is not supported.
-    cargo::optional<mux_kernel_cache> kernels;
+    std::shared_ptr<mux_kernel_cache> kernels;
 
     /// @brief Cached copy of an OpenCL binary. Populated lazily during
     /// binarySerialize.


### PR DESCRIPTION
# Overview

Save kernel even after new program builds.

# Reason for change

When a kernel is in a queue to be executed, we need to ensure that the code that is to be executed is preserved as well.

# Description of change

Depending on whether deferred compilation is in use, the code may be managed either by the deferred kernel, or by the kernel cache. This commit turns both into shared objects that can have their lifetime extended if needed.

# Anything else we should know?

This fixes a newly added test in OpenCL-CTS `test_compiler`.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
