### PR TITLE
Clear device kernels before program.

### DIFF
--- a/source/cl/source/kernel.cpp
+++ b/source/cl/source/kernel.cpp
@@ -602,7 +602,12 @@ _cl_kernel::_cl_kernel(cl_program program, std::string name,
   program->num_external_kernels++;  // Count implicit retain on creation.
 }
 
-_cl_kernel::~_cl_kernel() { cl::releaseInternal(program); }
+_cl_kernel::~_cl_kernel() {
+  // Clear the device kernels first because they reference the program.
+  device_kernel_map.clear();
+
+  cl::releaseInternal(program);
+}
 
 cargo::expected<cl_kernel, cl_int> _cl_kernel::create(
     cl_program program, std::string name, const compiler::KernelInfo *info) {


### PR DESCRIPTION
# Overview

Clear device kernels before program.

# Reason for change

Since #1021 allows device kernels to extend the lifetime of deferred kernels, and deferred kernels keep a reference to the program, that allows the possibility of memory errors when the program is released before the kernel is.

# Description of change

Ensure we forcibly clear device kernels first.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
