### PR TITLE
Remove env_vars.cpp XFail.

### DIFF
--- a/scripts/testing/sycl_e2e/override_host_aarch64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_host_aarch64_linux.csv
@@ -7,7 +7,6 @@ SYCL,Basic/built-ins/marray_math.cpp,XFail
 SYCL,Basic/built-ins/vec_common.cpp,XFail
 SYCL,Basic/built-ins/vec_geometric.cpp,XFail
 SYCL,Basic/built-ins/vec_math.cpp,XFail
-SYCL,Config/env_vars.cpp,XFail
 SYCL,DeviceLib/built-ins/marray_integer.cpp,XFail
 SYCL,DeviceLib/built-ins/vector_relational.cpp,XFail
 SYCL,DotProduct/dot_product_int_test.cpp,XFail


### PR DESCRIPTION
# Overview

Remove env_vars.cpp XFail.

# Reason for change

This test now passes.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-21](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
